### PR TITLE
NetworkedVar OnValueChanged called for everyone

### DIFF
--- a/MLAPI/Data/NetworkedVar.cs
+++ b/MLAPI/Data/NetworkedVar.cs
@@ -89,7 +89,10 @@ namespace MLAPI
                 if (!EqualityComparer<T>.Default.Equals(InternalValue, value))
                 {
                     isDirty = true;
+                    T previousValue = InternalValue;
                     InternalValue = value;
+                    if (OnValueChanged != null)
+                        OnValueChanged(previousValue, InternalValue);
                 }
             }
         }


### PR DESCRIPTION
Make NetworkedVar OnValueChanged event be called for the setter of the value as well.