### PR TITLE
custom types for BitWriter and BitReader

### DIFF
--- a/MLAPI/MLAPI.csproj
+++ b/MLAPI/MLAPI.csproj
@@ -115,6 +115,7 @@
     <Compile Include="NetworkingManagerComponents\Binary\BitReaderDeprecated.cs" />
     <Compile Include="NetworkingManagerComponents\Binary\BinaryHelpers.cs" />
     <Compile Include="NetworkingManagerComponents\Binary\ByteBool.cs" />
+    <Compile Include="NetworkingManagerComponents\Binary\IBitWritable.cs" />
     <Compile Include="NetworkingManagerComponents\Binary\ResourcePool.cs" />
     <Compile Include="NetworkingManagerComponents\Binary\UIntFloat.cs" />
     <Compile Include="NetworkingManagerComponents\Core\LogHelper.cs" />

--- a/MLAPI/NetworkingManagerComponents/Binary/BitReader.cs
+++ b/MLAPI/NetworkingManagerComponents/Binary/BitReader.cs
@@ -127,6 +127,11 @@ namespace MLAPI.Serialization
                 return ReadRotation(3);
             if (type == typeof(char))
                 return ReadCharPacked();
+            if (type == typeof(IBitWritable)) {
+                object instance = Activator.CreateInstance(type);
+                ((IBitWritable)instance).Read(this);
+                return instance;
+            }
             throw new ArgumentException("BitReader cannot read type " + type.Name);
         }
 

--- a/MLAPI/NetworkingManagerComponents/Binary/BitReader.cs
+++ b/MLAPI/NetworkingManagerComponents/Binary/BitReader.cs
@@ -130,7 +130,7 @@ namespace MLAPI.Serialization
             if (type == typeof(IBitWritable))
             {
                 object instance = Activator.CreateInstance(type);
-                ((IBitWritable)instance).Read(this);
+                ((IBitWritable)instance).Read(this.source);
                 return instance;
             }
             if (type.IsEnum)

--- a/MLAPI/NetworkingManagerComponents/Binary/BitReader.cs
+++ b/MLAPI/NetworkingManagerComponents/Binary/BitReader.cs
@@ -127,7 +127,8 @@ namespace MLAPI.Serialization
                 return ReadRotation(3);
             if (type == typeof(char))
                 return ReadCharPacked();
-            if (type == typeof(IBitWritable)) {
+            if (type == typeof(IBitWritable))
+            {
                 object instance = Activator.CreateInstance(type);
                 ((IBitWritable)instance).Read(this);
                 return instance;

--- a/MLAPI/NetworkingManagerComponents/Binary/BitWriter.cs
+++ b/MLAPI/NetworkingManagerComponents/Binary/BitWriter.cs
@@ -147,7 +147,7 @@ namespace MLAPI.Serialization
             }
             else if(value is IBitWritable)
             {
-                ((IBitWritable)value).Write(this);
+                ((IBitWritable)value).Write(this.sink);
                 return;
             } 
             else if (value.GetType().IsEnum) 

--- a/MLAPI/NetworkingManagerComponents/Binary/BitWriter.cs
+++ b/MLAPI/NetworkingManagerComponents/Binary/BitWriter.cs
@@ -145,6 +145,11 @@ namespace MLAPI.Serialization
                 WriteCharPacked((char)value);
                 return;
             }
+            else if(value is IBitWritable)
+            {
+                ((IBitWritable)value).Write(this);
+                return;
+            } 
 
             throw new ArgumentException("BitWriter cannot write type " + value.GetType().Name);
         }

--- a/MLAPI/NetworkingManagerComponents/Binary/IBitWritable.cs
+++ b/MLAPI/NetworkingManagerComponents/Binary/IBitWritable.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MLAPI.Serialization { 
+    interface IBitWritable {
+        void Write(BitWriter writer);
+        void Read(BitReader reader);
+    }
+}

--- a/MLAPI/NetworkingManagerComponents/Binary/IBitWritable.cs
+++ b/MLAPI/NetworkingManagerComponents/Binary/IBitWritable.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace MLAPI.Serialization { 
-    interface IBitWritable {
+namespace MLAPI.Serialization 
+{ 
+    interface IBitWritable 
+    {
         void Write(BitWriter writer);
         void Read(BitReader reader);
     }

--- a/MLAPI/NetworkingManagerComponents/Binary/IBitWritable.cs
+++ b/MLAPI/NetworkingManagerComponents/Binary/IBitWritable.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 
@@ -7,7 +8,7 @@ namespace MLAPI.Serialization
 { 
     public interface IBitWritable 
     {
-        void Write(BitWriter writer);
-        void Read(BitReader reader);
+        void Write(Stream stream);
+        void Read(Stream stream);
     }
 }

--- a/MLAPI/NetworkingManagerComponents/Binary/IBitWritable.cs
+++ b/MLAPI/NetworkingManagerComponents/Binary/IBitWritable.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace MLAPI.Serialization 
 { 
-    interface IBitWritable 
+    public interface IBitWritable 
     {
         void Write(BitWriter writer);
         void Read(BitReader reader);

--- a/MLAPI/NetworkingManagerComponents/Core/NetworkSceneManager.cs
+++ b/MLAPI/NetworkingManagerComponents/Core/NetworkSceneManager.cs
@@ -56,7 +56,8 @@ namespace MLAPI.Components
             CurrentSceneIndex = sceneNameToIndex[sceneName];
             isSwitching = true;
             lastScene = SceneManager.GetActiveScene();
-            AsyncOperation sceneLoad = SceneManager.LoadSceneAsync(sceneName, LoadSceneMode.Additive);
+            nextScene = SceneManager.GetSceneByName(sceneName);
+            AsyncOperation sceneLoad = SceneManager.LoadSceneAsync(nextScene.buildIndex, LoadSceneMode.Additive);
             sceneLoad.completed += OnSceneLoaded;
 
             using (PooledBitStream stream = PooledBitStream.Get())
@@ -92,16 +93,16 @@ namespace MLAPI.Components
             }
             SpawnManager.DestroySceneObjects();
             lastScene = SceneManager.GetActiveScene();
-            AsyncOperation sceneLoad = SceneManager.LoadSceneAsync(sceneIndexToString[sceneIndex], LoadSceneMode.Additive);
+            nextScene = SceneManager.GetSceneByName(sceneIndexToString[sceneIndex]);
+            AsyncOperation sceneLoad = SceneManager.LoadSceneAsync(nextScene.buildIndex, LoadSceneMode.Additive);
             sceneLoad.completed += OnSceneLoaded;
         }
 
         private static void OnSceneLoaded(AsyncOperation operation)
         {
             SceneManager.SetActiveScene(nextScene);
+            
             List<NetworkedObject> objectsToKeep = SpawnManager.SpawnedObjectsList;
-            //The last loaded scene
-            nextScene = SceneManager.GetSceneAt(SceneManager.sceneCount - 1);
             for (int i = 0; i < objectsToKeep.Count; i++)
             {
                 SceneManager.MoveGameObjectToScene(objectsToKeep[i].gameObject, nextScene);


### PR DESCRIPTION
Add possibility to make simple custom types that can be handled by the BitWriter/BitReader.

This opens up possibility to add simple custom types to the default NetworkedVar system and the simple version of rpc's.