### PR TITLE
fix problem with scene switching.

### DIFF
--- a/MLAPI/NetworkingManagerComponents/Core/NetworkSceneManager.cs
+++ b/MLAPI/NetworkingManagerComponents/Core/NetworkSceneManager.cs
@@ -56,8 +56,9 @@ namespace MLAPI.Components
             CurrentSceneIndex = sceneNameToIndex[sceneName];
             isSwitching = true;
             lastScene = SceneManager.GetActiveScene();
+            
+            AsyncOperation sceneLoad = SceneManager.LoadSceneAsync(sceneName, LoadSceneMode.Additive);
             nextScene = SceneManager.GetSceneByName(sceneName);
-            AsyncOperation sceneLoad = SceneManager.LoadSceneAsync(nextScene.buildIndex, LoadSceneMode.Additive);
             sceneLoad.completed += OnSceneLoaded;
 
             using (PooledBitStream stream = PooledBitStream.Get())

--- a/MLAPI/NetworkingManagerComponents/Core/NetworkSceneManager.cs
+++ b/MLAPI/NetworkingManagerComponents/Core/NetworkSceneManager.cs
@@ -94,8 +94,10 @@ namespace MLAPI.Components
             }
             SpawnManager.DestroySceneObjects();
             lastScene = SceneManager.GetActiveScene();
-            nextScene = SceneManager.GetSceneByName(sceneIndexToString[sceneIndex]);
-            AsyncOperation sceneLoad = SceneManager.LoadSceneAsync(nextScene.buildIndex, LoadSceneMode.Additive);
+
+            string sceneName = sceneIndexToString[sceneIndex];
+            AsyncOperation sceneLoad = SceneManager.LoadSceneAsync(sceneName, LoadSceneMode.Additive);
+            nextScene = SceneManager.GetSceneByName(sceneName);
             sceneLoad.completed += OnSceneLoaded;
         }
 

--- a/MLAPI/NetworkingManagerComponents/Core/NetworkSceneManager.cs
+++ b/MLAPI/NetworkingManagerComponents/Core/NetworkSceneManager.cs
@@ -94,10 +94,9 @@ namespace MLAPI.Components
             }
             SpawnManager.DestroySceneObjects();
             lastScene = SceneManager.GetActiveScene();
-
-            string sceneName = sceneIndexToString[sceneIndex];
-            AsyncOperation sceneLoad = SceneManager.LoadSceneAsync(sceneName, LoadSceneMode.Additive);
-            nextScene = SceneManager.GetSceneByName(sceneName);
+            
+            AsyncOperation sceneLoad = SceneManager.LoadSceneAsync(sceneIndex, LoadSceneMode.Additive);
+            nextScene = SceneManager.GetSceneByName(sceneIndexToString[sceneIndex]);
             sceneLoad.completed += OnSceneLoaded;
         }
 


### PR DESCRIPTION
get scene by name looks through scenes loaded or scenes being loaded, therefor the scene will be fetched after loading is initiated.