### PR TITLE
make it back as before using a string instead of sceneIndex.

### DIFF
--- a/MLAPI/NetworkingManagerComponents/Core/NetworkSceneManager.cs
+++ b/MLAPI/NetworkingManagerComponents/Core/NetworkSceneManager.cs
@@ -94,9 +94,10 @@ namespace MLAPI.Components
             }
             SpawnManager.DestroySceneObjects();
             lastScene = SceneManager.GetActiveScene();
-            
-            AsyncOperation sceneLoad = SceneManager.LoadSceneAsync(sceneIndex, LoadSceneMode.Additive);
-            nextScene = SceneManager.GetSceneByName(sceneIndexToString[sceneIndex]);
+
+            string sceneName = sceneIndexToString[sceneIndex];
+            AsyncOperation sceneLoad = SceneManager.LoadSceneAsync(sceneName, LoadSceneMode.Additive);
+            nextScene = SceneManager.GetSceneByName(sceneName);
             sceneLoad.completed += OnSceneLoaded;
         }
 


### PR DESCRIPTION
make it back as before using a string instead of sceneIndex as sceneIndex probably is MLAPI's scene index and not unitys.