### PR TITLE
Prevent remove event from being sent if nothing was removed.

### DIFF
--- a/MLAPI/Data/NetworkedCollections/NetworkedList.cs
+++ b/MLAPI/Data/NetworkedCollections/NetworkedList.cs
@@ -274,9 +274,9 @@ namespace MLAPI.NetworkedVar.Collections
                             break;
                         case NetworkedListEvent<T>.EventType.Remove:
                             {
-                                T value = (T)reader.ReadObjectPacked(typeof(T)); //BOX
-                                int index = list.IndexOf(value);
-                                list.RemoveAt(index); 
+                                int index = reader.ReadInt32Packed();
+                                T value = list[index];
+                                list.RemoveAt(index);
 
                                 if (OnListChanged != null)
                                 {
@@ -426,22 +426,29 @@ namespace MLAPI.NetworkedVar.Collections
         }
 
         /// <inheritdoc />
-        public bool Remove(T item)
+        public bool Remove(T item) 
         {
             if (NetworkingManager.singleton.isServer)
-                list.Remove(item);
-            
-            NetworkedListEvent<T> listEvent = new NetworkedListEvent<T>() 
             {
-                eventType = NetworkedListEvent<T>.EventType.Remove,
-                value = item
-            };
-            dirtyEvents.Add(listEvent);
+                int removeIndex = list.IndexOf(item);
+                if(removeIndex != -1) 
+                {
+                    list.RemoveAt(removeIndex);
 
-            if (NetworkingManager.singleton.isServer && OnListChanged != null)
-                OnListChanged(listEvent);
+                    NetworkedListEvent<T> listEvent = new NetworkedListEvent<T>() 
+                    {
+                        eventType = NetworkedListEvent<T>.EventType.Remove,
+                        index = removeIndex
+                    };
+                    dirtyEvents.Add(listEvent);
 
-            return true;
+                    if (NetworkingManager.singleton.isServer && OnListChanged != null)
+                        OnListChanged(listEvent);
+
+                    return true;
+                }
+            }
+            return false;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Change behavior of NetworkedList.Remove function to only send the Remove event to the clients if the element actually was removed.

Change the sent data of the remove event to include the index of the removed element instead of the element to prevent a cast that box the value in the read function.