### PR TITLE
docs: Add syncsets

### DIFF
--- a/docs/_pages/features.html
+++ b/docs/_pages/features.html
@@ -184,6 +184,18 @@ sectionid: features
                     <td><i class="fa fa-check" aria-hidden="true" style="color:green"></i></td>
                 </tr>
                 <tr>
+                    <td>Synced HashSet</td>
+                    <td><i class="fa fa-times" aria-hidden="true" style="color:red"></i></td>
+                    <td><i class="fa fa-check" aria-hidden="true" style="color:green"></i></td>
+                    <td><i class="fa fa-times" aria-hidden="true" style="color:red"></i></td>
+                </tr>
+                <tr>
+                    <td>Synced SortedSet</td>
+                    <td><i class="fa fa-times" aria-hidden="true" style="color:red"></i></td>
+                    <td><i class="fa fa-check" aria-hidden="true" style="color:green"></i></td>
+                    <td><i class="fa fa-times" aria-hidden="true" style="color:red"></i></td>
+                </tr>
+                <tr>
                     <td>SyncedDictionary</td>
                     <td><i class="fa fa-check" aria-hidden="true" style="color:green"></i></td>
                     <td><i class="fa fa-check" aria-hidden="true" style="color:green"></i></td>

--- a/docs/_pages/features.html
+++ b/docs/_pages/features.html
@@ -184,14 +184,8 @@ sectionid: features
                     <td><i class="fa fa-check" aria-hidden="true" style="color:green"></i></td>
                 </tr>
                 <tr>
-                    <td>Synced HashSet</td>
-                    <td><i class="fa fa-times" aria-hidden="true" style="color:red"></i></td>
+                    <td>SyncedSet</td>
                     <td><i class="fa fa-check" aria-hidden="true" style="color:green"></i></td>
-                    <td><i class="fa fa-times" aria-hidden="true" style="color:red"></i></td>
-                </tr>
-                <tr>
-                    <td>Synced SortedSet</td>
-                    <td><i class="fa fa-times" aria-hidden="true" style="color:red"></i></td>
                     <td><i class="fa fa-check" aria-hidden="true" style="color:green"></i></td>
                     <td><i class="fa fa-times" aria-hidden="true" style="color:red"></i></td>
                 </tr>


### PR DESCRIPTION
Both Mirror and MLAPI support sync sets.

Note that the IList, ISet, IDictionary mentioned in #192  is no longer needed because Mirror now supports generic ILIst, ISet and IDictionary implementations too. 