### PR TITLE
docs(website): Clarify the Installer docs section

### DIFF
--- a/docs/_docs/getting-started/installation.md
+++ b/docs/_docs/getting-started/installation.md
@@ -4,7 +4,7 @@ permalink: /wiki/installation/
 ---
 
 ### Installer
-To get started with the MLAPI. You need to install the library. The easiest way is to use the Editor installer. Simply download the MLAPI_Installer unity package from the [here](https://github.com/TwoTenPvP/MLAPI/releases). Then press window at the top of your editor and select MLAPI. Once in the MLAPI window, select the version you wish to use and press install.
+To get started with the MLAPI. You need to install the library. The easiest way is to use the Editor installer. Simply download the MLAPI_Installer Unity package from [here](https://github.com/TwoTenPvP/MLAPI/releases), double click it to import it into Unity, and once that's done select Window > MLAPI from Unity's top menu bar. Once in the MLAPI window, select the version you wish to use and press install.
 
 
 ![Video showing the install process](https://i.imgur.com/zN63DlJ.gif)


### PR DESCRIPTION
This fixes a small typo and adds more explicit details on how to get MLAPI installed (even though the gif is fairly detailed already, to have the supporting text be just as much).

Not entirely sure what changed in the last Installation line, quickly edited this using the web-based Github editor so I imagine there's some linebreak difference? (\r\n vs \n or something)