### PR TITLE
Stop NetworkedBehaviourUpdate from running if SpawnedObjectsList is empty.

### DIFF
--- a/MLAPI/Core/NetworkedObject.cs
+++ b/MLAPI/Core/NetworkedObject.cs
@@ -515,6 +515,9 @@ namespace MLAPI
         private static int _lastProcessedObject = 0;
         internal static void NetworkedBehaviourUpdate()
         {
+            if (SpawnManager.SpawnedObjectsList.Count == 0)
+                return;
+
             int amountToProcess = NetworkingManager.Singleton.NetworkConfig.MaxObjectUpdatesPerTick <= 0 ? SpawnManager.SpawnedObjectsList.Count : Mathf.Max(NetworkingManager.Singleton.NetworkConfig.MaxObjectUpdatesPerTick, SpawnManager.SpawnedObjectsList.Count);
 
             for (int i = 0; i < amountToProcess; i++)


### PR DESCRIPTION
Fixes a case with soft-sync or connecting without scene change where the SpawnedObjectsList is automatically assumed to be populated and have something at index zero.