### PR TITLE
fix(core): correct network time by half the RTT

### DIFF
--- a/MLAPI/Messaging/InternalMessageHandler.cs
+++ b/MLAPI/Messaging/InternalMessageHandler.cs
@@ -432,7 +432,7 @@ namespace MLAPI.Messaging
                 float netTime = reader.ReadSinglePacked();
                 ulong msDelay = NetworkingManager.Singleton.NetworkConfig.NetworkTransport.GetCurrentRtt(clientId);
                 
-                NetworkingManager.Singleton.NetworkTime = netTime + (msDelay / 1000f);
+                NetworkingManager.Singleton.NetworkTime = netTime + (msDelay / 2f / 1000f);
             }
         }
 


### PR DESCRIPTION
`NetworkTransport.GetCurrentRtt` returns the round trip time for a message to go to the given client and a response to come back.  However, the time sync message is one-way, so it's only delayed by half this time (on average).