### PR TITLE
fix(core): work around an IL2CPP bug with RPC delegates.

### DIFF
--- a/MLAPI/Core/NetworkedBehaviour.cs
+++ b/MLAPI/Core/NetworkedBehaviour.cs
@@ -150,21 +150,21 @@ namespace MLAPI
             CacheAttributes();
             NetworkedVarInit();
         }
-        
-        /// <summary>                                                                               
-        /// Gets called when SyncedVars gets updated                                                
-        /// </summary>                                                                              
+
+        /// <summary>
+        /// Gets called when SyncedVars gets updated
+        /// </summary>
         public virtual void OnSyncVarUpdate()
-        {                                                                                                  
-            
-        }                                                                                                  
-        /// <summary>                                                                                      
-        /// Gets called when the local client gains ownership of this object                               
-        /// </summary>                                                                                     
-        public virtual void OnGainedOwnership()                                                            
-        {                                                                                                 
-            
-        }                                                                                                  
+        {
+
+        }
+        /// <summary>
+        /// Gets called when the local client gains ownership of this object
+        /// </summary>
+        public virtual void OnGainedOwnership()
+        {
+
+        }
         /// <summary>
         /// Gets called when we loose ownership of this object
         /// </summary>
@@ -200,19 +200,19 @@ namespace MLAPI
         internal readonly List<INetworkedVar> networkedVarFields = new List<INetworkedVar>();
         private static readonly Dictionary<Type, FieldInfo[]> fieldTypes = new Dictionary<Type, FieldInfo[]>();
 
-        
+
         private static FieldInfo[] GetFieldInfoForType(Type type)
         {
             if (!fieldTypes.ContainsKey(type))
                 fieldTypes.Add(type, GetFieldInfoForTypeRecursive(type));
-            
+
             return fieldTypes[type];
         }
-        
-        
-        private static FieldInfo[] GetFieldInfoForTypeRecursive(Type type, List<FieldInfo> list = null) 
+
+
+        private static FieldInfo[] GetFieldInfoForTypeRecursive(Type type, List<FieldInfo> list = null)
         {
-            if (list == null) 
+            if (list == null)
             {
                 list = new List<FieldInfo>();
                 list.AddRange(type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance));
@@ -250,7 +250,7 @@ namespace MLAPI
                         instance = (INetworkedVar)Activator.CreateInstance(fieldType, true);
                         sortedFields[i].SetValue(this, instance);
                     }
-                    
+
                     instance.SetNetworkedBehaviour(this);
                     networkedVarFields.Add(instance);
                 }
@@ -273,7 +273,7 @@ namespace MLAPI
                 channelMappedVarIndexes[firstLevelIndex[channel]].Add(i);
             }
         }
-        
+
         private readonly List<int> networkedVarIndexesToReset = new List<int>();
         private readonly HashSet<int> networkedVarIndexesToResetSet = new HashSet<int>();
         internal void NetworkedVarUpdate()
@@ -281,12 +281,12 @@ namespace MLAPI
             if (!networkedVarInit)
                 NetworkedVarInit();
 
-            if (!CouldHaveDirtyVars()) 
+            if (!CouldHaveDirtyVars())
                 return;
 
             networkedVarIndexesToReset.Clear();
             networkedVarIndexesToResetSet.Clear();
-            
+
             for (int i = 0; i < (IsServer ? NetworkingManager.Singleton.ConnectedClientsList.Count : 1); i++)
             {
                 // Do this check here to prevent doing all the expensive dirty checks
@@ -322,8 +322,8 @@ namespace MLAPI
 
                                     bool isDirty = networkedVarFields[k].IsDirty(); //cache this here. You never know what operations users will do in the dirty methods
                                     bool shouldWrite = isDirty && (!IsServer || networkedVarFields[k].CanClientRead(clientId));
-                                    
-                                    
+
+
                                     if (NetworkingManager.Singleton.NetworkConfig.EnsureNetworkedVarLengthSafety)
                                     {
                                         if (!shouldWrite)
@@ -346,7 +346,7 @@ namespace MLAPI
                                             {
                                                 networkedVarFields[k].WriteDelta(varStream);
                                                 varStream.PadStream();
-                                                
+
                                                 writer.WriteUInt16Packed((ushort)varStream.Length);
                                                 stream.CopyFrom(varStream);
                                             }
@@ -387,7 +387,7 @@ namespace MLAPI
         {
             for (int i = 0; i < networkedVarFields.Count; i++)
             {
-                if (networkedVarFields[i].IsDirty()) 
+                if (networkedVarFields[i].IsDirty())
                     return true;
             }
 
@@ -402,18 +402,18 @@ namespace MLAPI
                 for (int i = 0; i < networkedVarList.Count; i++)
                 {
                     ushort varSize = 0;
-                    
+
                     if (NetworkingManager.Singleton.NetworkConfig.EnsureNetworkedVarLengthSafety)
                     {
                         varSize = reader.ReadUInt16Packed();
-                        
+
                         if (varSize == 0)
                             continue;
                     }
                     else
                     {
                         if (!reader.ReadBool())
-                            continue;   
+                            continue;
                     }
 
                     if (NetworkingManager.Singleton.IsServer && !networkedVarList[i].CanClientWrite(clientId))
@@ -428,25 +428,25 @@ namespace MLAPI
                         {
                             //This client wrote somewhere they are not allowed. This is critical
                             //We can't just skip this field. Because we don't actually know how to dummy read
-                            //That is, we don't know how many bytes to skip. Because the interface doesn't have a 
+                            //That is, we don't know how many bytes to skip. Because the interface doesn't have a
                             //Read that gives us the value. Only a Read that applies the value straight away
                             //A dummy read COULD be added to the interface for this situation, but it's just being too nice.
                             //This is after all a developer fault. A critical error should be fine.
                             // - TwoTen
 
                             if (LogHelper.CurrentLogLevel <= LogLevel.Error) LogHelper.LogError("Client wrote to NetworkedVar without permission. No more variables can be read. This is critical. " + (logInstance != null ? ("NetworkId: " + logInstance.NetworkId + " BehaviourIndex: " + logInstance.NetworkedObject.GetOrderIndex(logInstance) + " VariableIndex: " + i) : string.Empty));
-                            return;   
+                            return;
                         }
                     }
 
                     long readStartPos = stream.Position;
-                    
+
                     networkedVarList[i].ReadDelta(stream, NetworkingManager.Singleton.IsServer);
 
                     if (NetworkingManager.Singleton.NetworkConfig.EnsureNetworkedVarLengthSafety)
                     {
                         (stream as BitStream).SkipPadBits();
-                        
+
                         if (stream.Position > (readStartPos + varSize))
                         {
                             if (LogHelper.CurrentLogLevel <= LogLevel.Normal) LogHelper.LogWarning("Var delta read too far. " + (stream.Position - (readStartPos + varSize)) + " bytes." + (logInstance != null ? ("NetworkId: " + logInstance.NetworkId + " BehaviourIndex: " + logInstance.NetworkedObject.GetOrderIndex(logInstance) + " VariableIndex: " + i) : string.Empty));
@@ -469,20 +469,20 @@ namespace MLAPI
                 for (int i = 0; i < networkedVarList.Count; i++)
                 {
                     ushort varSize = 0;
-                    
+
                     if (NetworkingManager.Singleton.NetworkConfig.EnsureNetworkedVarLengthSafety)
                     {
                         varSize = reader.ReadUInt16Packed();
-                        
+
                         if (varSize == 0)
                             continue;
                     }
                     else
                     {
                         if (!reader.ReadBool())
-                            continue;   
+                            continue;
                     }
-                    
+
                     if (NetworkingManager.Singleton.IsServer && !networkedVarList[i].CanClientWrite(clientId))
                     {
                         if (NetworkingManager.Singleton.NetworkConfig.EnsureNetworkedVarLengthSafety)
@@ -495,27 +495,27 @@ namespace MLAPI
                         {
                             //This client wrote somewhere they are not allowed. This is critical
                             //We can't just skip this field. Because we don't actually know how to dummy read
-                            //That is, we don't know how many bytes to skip. Because the interface doesn't have a 
+                            //That is, we don't know how many bytes to skip. Because the interface doesn't have a
                             //Read that gives us the value. Only a Read that applies the value straight away
                             //A dummy read COULD be added to the interface for this situation, but it's just being too nice.
                             //This is after all a developer fault. A critical error should be fine.
                             // - TwoTen
                             if (LogHelper.CurrentLogLevel <= LogLevel.Error) LogHelper.LogError("Client wrote to NetworkedVar without permission. No more variables can be read. This is critical. " + (logInstance != null ? ("NetworkId: " + logInstance.NetworkId + " BehaviourIndex: " + logInstance.NetworkedObject.GetOrderIndex(logInstance) + " VariableIndex: " + i) : string.Empty));
-                            return;   
+                            return;
                         }
                     }
 
                     long readStartPos = stream.Position;
-                    
+
                     networkedVarList[i].ReadField(stream);
-                    
+
                     if (NetworkingManager.Singleton.NetworkConfig.EnsureNetworkedVarLengthSafety)
                     {
                         if (stream is BitStream bitStream)
                         {
                             bitStream.SkipPadBits();
                         }
-                        
+
                         if (stream.Position > (readStartPos + varSize))
                         {
                             if (LogHelper.CurrentLogLevel <= LogLevel.Normal) LogHelper.LogWarning("Var update read too far. " + (stream.Position - (readStartPos + varSize)) + " bytes." + (logInstance != null ? ("NetworkId: " + logInstance.NetworkId + " BehaviourIndex: " + logInstance.NetworkedObject.GetOrderIndex(logInstance) + " VariableIndex: " + i) : string.Empty));
@@ -562,7 +562,7 @@ namespace MLAPI
                             {
                                 networkedVarList[j].WriteField(varStream);
                                 varStream.PadStream();
-                                                
+
                                 writer.WriteUInt16Packed((ushort)varStream.Length);
                                 varStream.CopyTo(stream);
                             }
@@ -572,7 +572,7 @@ namespace MLAPI
                             networkedVarList[j].WriteField(stream);
                         }
                     }
-                }   
+                }
             }
         }
 
@@ -586,31 +586,31 @@ namespace MLAPI
                 for (int j = 0; j < networkedVarList.Count; j++)
                 {
                     ushort varSize = 0;
-                    
+
                     if (NetworkingManager.Singleton.NetworkConfig.EnsureNetworkedVarLengthSafety)
                     {
                         varSize = reader.ReadUInt16Packed();
-                        
+
                         if (varSize == 0)
                             continue;
                     }
                     else
                     {
                         if (!reader.ReadBool())
-                            continue;   
+                            continue;
                     }
 
                     long readStartPos = stream.Position;
-                    
+
                     networkedVarList[j].ReadField(stream);
-                    
+
                     if (NetworkingManager.Singleton.NetworkConfig.EnsureNetworkedVarLengthSafety)
                     {
                         if (stream is BitStream bitStream)
                         {
                             bitStream.SkipPadBits();
                         }
-                        
+
                         if (stream.Position > (readStartPos + varSize))
                         {
                             if (LogHelper.CurrentLogLevel <= LogLevel.Normal) LogHelper.LogWarning("Var data read too far. " + (stream.Position - (readStartPos + varSize)) + " bytes.");
@@ -622,7 +622,7 @@ namespace MLAPI
                             stream.Position = readStartPos + varSize;
                         }
                     }
-                }   
+                }
             }
         }
 
@@ -636,11 +636,14 @@ namespace MLAPI
         private static readonly Dictionary<ulong, string> HashResults = new Dictionary<ulong, string>();
         private static readonly Dictionary<MethodInfo, ulong> methodInfoHashTable = new Dictionary<MethodInfo, ulong>();
         private static readonly StringBuilder methodInfoStringBuilder = new StringBuilder();
+#if ENABLE_IL2CPP
+        private static object[] perfParameters = new object[2];
+#endif
 
         private ulong HashMethodName(string name)
         {
             HashSize mode = NetworkingManager.Singleton.NetworkConfig.RpcHashSize;
-            
+
             if (mode == HashSize.VarIntTwoBytes)
                 return name.GetStableHash16();
             if (mode == HashSize.VarIntFourBytes)
@@ -650,7 +653,7 @@ namespace MLAPI
 
             return 0;
         }
-        
+
         private ulong HashMethod(MethodInfo method)
         {
             if (methodInfoHashTable.ContainsKey(method))
@@ -660,7 +663,7 @@ namespace MLAPI
             else
             {
                 ulong val = HashMethodName(GetHashableMethodSignature(method));
-                
+
                 methodInfoHashTable.Add(method, val);
 
                 return val;
@@ -673,7 +676,7 @@ namespace MLAPI
             methodInfoStringBuilder.Append(method.Name);
 
             ParameterInfo[] parameters = method.GetParameters();
-                
+
             for (int i = 0; i < parameters.Length; i++)
             {
                 methodInfoStringBuilder.Append(parameters[i].ParameterType.Name);
@@ -682,9 +685,9 @@ namespace MLAPI
             return methodInfoStringBuilder.ToString();
         }
 
-        private MethodInfo[] GetNetworkedBehaviorChildClassesMethods(Type type, List<MethodInfo> list = null) 
+        private MethodInfo[] GetNetworkedBehaviorChildClassesMethods(Type type, List<MethodInfo> list = null)
         {
-            if (list == null) 
+            if (list == null)
             {
                 list = new List<MethodInfo>();
                 list.AddRange(type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance));
@@ -707,7 +710,7 @@ namespace MLAPI
         private void CacheAttributes()
         {
             Type type = GetType();
-            
+
             CachedClientRpcs.Add(this, new Dictionary<ulong, ClientRPCAttribute>());
             CachedServerRpcs.Add(this, new Dictionary<ulong, ServerRPCAttribute>());
 
@@ -733,7 +736,11 @@ namespace MLAPI
                     if (parameters.Length == 2 && parameters[0].ParameterType == typeof(ulong) && parameters[1].ParameterType == typeof(Stream) && methods[i].ReturnType == typeof(void))
                     {
                         //use delegate
+#if ENABLE_IL2CPP
+                        attributes[0].perfMethod = methods[i];
+#else
                         attributes[0].rpcDelegate = (RpcDelegate)Delegate.CreateDelegate(typeof(RpcDelegate), this, methods[i].Name);
+#endif
                     }
                     else
                     {
@@ -746,7 +753,7 @@ namespace MLAPI
                     }
 
                     ulong nameHash = HashMethodName(methods[i].Name);
-                    
+
                     if (HashResults.ContainsKey(nameHash) && HashResults[nameHash] != methods[i].Name)
                     {
                         if (LogHelper.CurrentLogLevel <= LogLevel.Error) LogHelper.LogError($"Hash collision detected for RPC method. The method \"{methods[i].Name}\" collides with the method \"{HashResults[nameHash]}\". This can be solved by increasing the amount of bytes to use for hashing in the NetworkConfig or changing the name of one of the conflicting methods.");
@@ -765,7 +772,7 @@ namespace MLAPI
                         string hashableMethodSignature = GetHashableMethodSignature(methods[i]);
 
                         ulong methodHash = HashMethodName(hashableMethodSignature);
-                    
+
                         if (HashResults.ContainsKey(methodHash) && HashResults[methodHash] != hashableMethodSignature)
                         {
                             if (LogHelper.CurrentLogLevel <= LogLevel.Error) LogHelper.LogError($"Hash collision detected for RPC method. The method \"{hashableMethodSignature}\" collides with the method \"{HashResults[methodHash]}\". This can be solved by increasing the amount of bytes to use for hashing in the NetworkConfig or changing the name of one of the conflicting methods.");
@@ -774,10 +781,10 @@ namespace MLAPI
                         {
                             HashResults.Add(methodHash, hashableMethodSignature);
                         }
-                        CachedServerRpcs[this].Add(methodHash, attributes[0]);   
+                        CachedServerRpcs[this].Add(methodHash, attributes[0]);
                     }
                 }
-                
+
                 if (methods[i].IsDefined(typeof(ClientRPCAttribute), true))
                 {
                     ClientRPCAttribute[] attributes = (ClientRPCAttribute[])methods[i].GetCustomAttributes(typeof(ClientRPCAttribute), true);
@@ -790,7 +797,11 @@ namespace MLAPI
                     if (parameters.Length == 2 && parameters[0].ParameterType == typeof(ulong) && parameters[1].ParameterType == typeof(Stream) && methods[i].ReturnType == typeof(void))
                     {
                         //use delegate
-                        attributes[0].rpcDelegate = (RpcDelegate)Delegate.CreateDelegate(typeof(RpcDelegate), this, methods[i].Name);
+#if ENABLE_IL2CPP
+                        attributes[0].perfMethod = methods[i];
+#else
+                        attributes[0].rpcDelegate = (RpcDelegate) Delegate.CreateDelegate(typeof(RpcDelegate), this, methods[i].Name);
+#endif
                     }
                     else
                     {
@@ -798,13 +809,13 @@ namespace MLAPI
                         {
                             if (LogHelper.CurrentLogLevel <= LogLevel.Error) LogHelper.LogWarning("Invalid return type of RPC. Has to be either void or RpcResponse<T> with a serializable type");
                         }
-                        
+
                         attributes[0].reflectionMethod = new ReflectionMethod(methods[i]);
                     }
 
 
                     ulong nameHash = HashMethodName(methods[i].Name);
-                    
+
                     if (HashResults.ContainsKey(nameHash) && HashResults[nameHash] != methods[i].Name)
                     {
                         if (LogHelper.CurrentLogLevel <= LogLevel.Error) LogHelper.LogError($"Hash collision detected for RPC method. The method \"{methods[i].Name}\" collides with the method \"{HashResults[nameHash]}\". This can be solved by increasing the amount of bytes to use for hashing in the NetworkConfig or changing the name of one of the conflicting methods.");
@@ -823,7 +834,7 @@ namespace MLAPI
                         string hashableMethodSignature = GetHashableMethodSignature(methods[i]);
 
                         ulong methodHash = HashMethodName(hashableMethodSignature);
-                    
+
                         if (HashResults.ContainsKey(methodHash) && HashResults[methodHash] != hashableMethodSignature)
                         {
                             if (LogHelper.CurrentLogLevel <= LogLevel.Error) LogHelper.LogError($"Hash collision detected for RPC method. The method \"{hashableMethodSignature}\" collides with the method \"{HashResults[methodHash]}\". This can be solved by increasing the amount of bytes to use for hashing in the NetworkConfig or changing the name of one of the conflicting methods.");
@@ -834,7 +845,7 @@ namespace MLAPI
                         }
                         CachedClientRpcs[this].Add(methodHash, attributes[0]);
                     }
-                }     
+                }
             }
         }
 
@@ -845,10 +856,10 @@ namespace MLAPI
                 if (LogHelper.CurrentLogLevel <= LogLevel.Normal) LogHelper.LogWarning("ServerRPC request method not found");
                 return null;
             }
-            
+
             return InvokeServerRPCLocal(hash, senderClientId, stream);
         }
-        
+
         internal object OnRemoteClientRPC(ulong hash, ulong senderClientId, Stream stream)
         {
             if (!CachedClientRpcs.ContainsKey(this) || !CachedClientRpcs[this].ContainsKey(hash))
@@ -856,7 +867,7 @@ namespace MLAPI
                 if (LogHelper.CurrentLogLevel <= LogLevel.Normal) LogHelper.LogWarning("ClientRPC request method not found");
                 return null;
             }
-            
+
             return InvokeClientRPCLocal(hash, senderClientId, stream);
         }
 
@@ -864,7 +875,7 @@ namespace MLAPI
         {
             if (!CachedServerRpcs.ContainsKey(this) || !CachedServerRpcs[this].ContainsKey(hash))
                 return null;
-            
+
             ServerRPCAttribute rpc = CachedServerRpcs[this][hash];
 
             if (rpc.RequireOwnership && senderClientId != OwnerClientId)
@@ -885,14 +896,23 @@ namespace MLAPI
                     if (rpc.reflectionMethod != null)
                     {
                         ExecutingRpcSender = senderClientId;
-                        
+
                         return rpc.reflectionMethod.Invoke(this, userStream);
                     }
 
-                    if (rpc.rpcDelegate != null)
+#if ENABLE_IL2CPP
+                    if (rpc.perfMethod != null)
+                    {
+                        perfParameters[0] = senderClientId;
+                        perfParameters[1] = userStream;
+                        rpc.perfMethod.Invoke(this, perfParameters);
+                    }
+#else
+          if (rpc.rpcDelegate != null)
                     {
                         rpc.rpcDelegate(senderClientId, userStream);
                     }
+#endif
 
                     return null;
                 }
@@ -904,16 +924,25 @@ namespace MLAPI
                 if (rpc.reflectionMethod != null)
                 {
                     ExecutingRpcSender = senderClientId;
-                    
+
                     return rpc.reflectionMethod.Invoke(this, stream);
                 }
 
-                if (rpc.rpcDelegate != null)
-                {
-                    rpc.rpcDelegate(senderClientId, stream);
-                }
+#if ENABLE_IL2CPP
+                    if (rpc.perfMethod != null)
+                    {
+                        perfParameters[0] = senderClientId;
+                        perfParameters[1] = stream;
+                        rpc.perfMethod.Invoke(this, perfParameters);
+                    }
+#else
+                    if (rpc.rpcDelegate != null)
+                    {
+                        rpc.rpcDelegate(senderClientId, stream);
+                    }
+#endif
 
-                return null;
+                    return null;
             }
         }
 
@@ -921,7 +950,7 @@ namespace MLAPI
         {
             if (!CachedClientRpcs.ContainsKey(this) || !CachedClientRpcs[this].ContainsKey(hash))
                 return null;
-            
+
             ClientRPCAttribute rpc = CachedClientRpcs[this][hash];
 
             if (stream.Position != 0)
@@ -937,10 +966,19 @@ namespace MLAPI
                         return rpc.reflectionMethod.Invoke(this, userStream);
                     }
 
+#if ENABLE_IL2CPP
+                    if (rpc.perfMethod != null)
+                    {
+                        perfParameters[0] = senderClientId;
+                        perfParameters[1] = userStream;
+                        rpc.perfMethod.Invoke(this, perfParameters);
+                    }
+#else
                     if (rpc.rpcDelegate != null)
                     {
                         rpc.rpcDelegate(senderClientId, userStream);
                     }
+#endif
 
                     return null;
                 }
@@ -952,15 +990,24 @@ namespace MLAPI
                     return rpc.reflectionMethod.Invoke(this, stream);
                 }
 
-                if (rpc.rpcDelegate != null)
-                {
-                    rpc.rpcDelegate(senderClientId, stream);
-                }
+#if ENABLE_IL2CPP
+                    if (rpc.perfMethod != null)
+                    {
+                        perfParameters[0] = senderClientId;
+                        perfParameters[1] = stream;
+                        rpc.perfMethod.Invoke(this, perfParameters);
+                    }
+#else
+                    if (rpc.rpcDelegate != null)
+                    {
+                      rpc.rpcDelegate(senderClientId, stream);
+                    }
+#endif
 
-                return null;
+                    return null;
             }
         }
-        
+
         //Technically boxed writes are not needed. But save LOC for the non performance sends.
         internal void SendServerRPCBoxed(ulong hash, string channel, SecuritySendFlags security, params object[] parameters)
         {
@@ -973,12 +1020,12 @@ namespace MLAPI
                     {
                         writer.WriteObjectPacked(parameters[i]);
                     }
-                    
+
                     SendServerRPCPerformance(hash, stream, channel, security);
                 }
             }
         }
-        
+
         internal RpcResponse<T> SendServerRPCBoxedResponse<T>(ulong hash, string channel, SecuritySendFlags security, params object[] parameters)
         {
             using (PooledBitStream stream = PooledBitStream.Get())
@@ -989,12 +1036,12 @@ namespace MLAPI
                     {
                         writer.WriteObjectPacked(parameters[i]);
                     }
-                    
+
                     return SendServerRPCPerformanceResponse<T>(hash, stream, channel, security);
                 }
             }
         }
-        
+
         internal void SendClientRPCBoxedToClient(ulong hash, ulong clientId, string channel, SecuritySendFlags security, params object[] parameters)
         {
             using (PooledBitStream stream = PooledBitStream.Get())
@@ -1009,7 +1056,7 @@ namespace MLAPI
                 }
             }
         }
-        
+
         internal RpcResponse<T> SendClientRPCBoxedResponse<T>(ulong hash, ulong clientId, string channel, SecuritySendFlags security, params object[] parameters)
         {
             using (PooledBitStream stream = PooledBitStream.Get())
@@ -1020,12 +1067,12 @@ namespace MLAPI
                     {
                         writer.WriteObjectPacked(parameters[i]);
                     }
-                    
+
                     return SendClientRPCPerformanceResponse<T>(hash, clientId, stream, channel, security);
                 }
             }
         }
-        
+
         internal void SendClientRPCBoxed(ulong hash, List<ulong> clientIds, string channel, SecuritySendFlags security, params object[] parameters)
         {
             using (PooledBitStream stream = PooledBitStream.Get())
@@ -1087,7 +1134,7 @@ namespace MLAPI
                 }
             }
         }
-        
+
         internal RpcResponse<T> SendServerRPCPerformanceResponse<T>(ulong hash, Stream messageStream, string channel, SecuritySendFlags security)
         {
             if (!IsClient && IsRunning)
@@ -1106,7 +1153,7 @@ namespace MLAPI
                     writer.WriteUInt64Packed(NetworkId);
                     writer.WriteUInt16Packed(NetworkedObject.GetOrderIndex(this));
                     writer.WriteUInt64Packed(hash);
-                    
+
                     if (!IsHost) writer.WriteUInt64Packed(responseId);
 
                     stream.CopyFrom(messageStream);
@@ -1115,7 +1162,7 @@ namespace MLAPI
                     {
                         messageStream.Position = 0;
                         object result = InvokeServerRPCLocal(hash, NetworkingManager.Singleton.LocalClientId, messageStream);
-                        
+
                         return new RpcResponse<T>()
                         {
                             Id = responseId,
@@ -1127,7 +1174,7 @@ namespace MLAPI
                         };
                     }
                     else
-                    {                        
+                    {
                         RpcResponse<T> response = new RpcResponse<T>()
                         {
                             Id = responseId,
@@ -1136,9 +1183,9 @@ namespace MLAPI
                             Type = typeof(T),
                             ClientId = NetworkingManager.Singleton.ServerClientId
                         };
-            
+
                         ResponseMessageManager.Add(response.Id, response);
-                        
+
                         InternalMessageSender.Send(NetworkingManager.Singleton.ServerClientId, MLAPIConstants.MLAPI_SERVER_RPC_REQUEST, string.IsNullOrEmpty(channel) ? "MLAPI_DEFAULT_MESSAGE" : channel, stream, security, null);
 
                         return response;
@@ -1148,7 +1195,7 @@ namespace MLAPI
         }
 
         internal void SendClientRPCPerformance(ulong hash,  List<ulong> clientIds, Stream messageStream, string channel, SecuritySendFlags security)
-        {            
+        {
             if (!IsServer && IsRunning)
             {
                 //We are NOT a server.
@@ -1175,7 +1222,7 @@ namespace MLAPI
                                 if (LogHelper.CurrentLogLevel <= LogLevel.Developer) LogHelper.LogWarning("Silently suppressed ClientRPC because a target in the bulk list was not an observer");
                                 continue;
                             }
-                            
+
                             if (IsHost && NetworkingManager.Singleton.ConnectedClientsList[i].ClientId == NetworkingManager.Singleton.LocalClientId)
                             {
                                 messageStream.Position = 0;
@@ -1196,7 +1243,7 @@ namespace MLAPI
                                 if (LogHelper.CurrentLogLevel <= LogLevel.Normal) LogHelper.LogWarning("Cannot send ClientRPC to client without visibility to the object");
                                 continue;
                             }
-                            
+
                             if (IsHost && clientIds[i] == NetworkingManager.Singleton.LocalClientId)
                             {
                                 messageStream.Position = 0;
@@ -1266,7 +1313,7 @@ namespace MLAPI
                 if (LogHelper.CurrentLogLevel <= LogLevel.Normal) LogHelper.LogWarning("Only clients and host can invoke ClientRPC");
                 return;
             }
-            
+
             if (!this.NetworkedObject.observers.Contains(clientId))
             {
                 if (LogHelper.CurrentLogLevel <= LogLevel.Normal) LogHelper.LogWarning("Cannot send ClientRPC to client without visibility to the object");
@@ -1295,7 +1342,7 @@ namespace MLAPI
                 }
             }
         }
-        
+
         internal RpcResponse<T> SendClientRPCPerformanceResponse<T>(ulong hash, ulong clientId, Stream messageStream, string channel, SecuritySendFlags security)
         {
             if (!IsServer && IsRunning)
@@ -1310,9 +1357,9 @@ namespace MLAPI
                 if (LogHelper.CurrentLogLevel <= LogLevel.Normal) LogHelper.LogWarning("Cannot send ClientRPC to client without visibility to the object");
                 return null;
             }
-            
+
             ulong responseId = ResponseMessageManager.GenerateMessageId();
-            
+
             using (PooledBitStream stream = PooledBitStream.Get())
             {
                 using (PooledBitWriter writer = PooledBitWriter.Get(stream))
@@ -1320,7 +1367,7 @@ namespace MLAPI
                     writer.WriteUInt64Packed(NetworkId);
                     writer.WriteUInt16Packed(NetworkedObject.GetOrderIndex(this));
                     writer.WriteUInt64Packed(hash);
-                    
+
                     if (!(IsHost && clientId == NetworkingManager.Singleton.LocalClientId)) writer.WriteUInt64Packed(responseId);
 
                     stream.CopyFrom(messageStream);
@@ -1329,7 +1376,7 @@ namespace MLAPI
                     {
                         messageStream.Position = 0;
                         object result = InvokeClientRPCLocal(hash, NetworkingManager.Singleton.LocalClientId, messageStream);
-                        
+
                         return new RpcResponse<T>()
                         {
                             Id = responseId,
@@ -1350,17 +1397,17 @@ namespace MLAPI
                             Type = typeof(T),
                             ClientId = clientId
                         };
-            
+
                         ResponseMessageManager.Add(response.Id, response);
-                        
+
                         InternalMessageSender.Send(clientId, MLAPIConstants.MLAPI_CLIENT_RPC_REQUEST, string.IsNullOrEmpty(channel) ? "MLAPI_DEFAULT_MESSAGE" : channel, stream, security, null);
-                        
+
                         return response;
                     }
                 }
             }
         }
-        #endregion
+#endregion
 
         /// <summary>
         /// Gets the local instance of a object with a given NetworkId

--- a/MLAPI/Messaging/ClientRPCAttribute.cs
+++ b/MLAPI/Messaging/ClientRPCAttribute.cs
@@ -11,6 +11,10 @@ namespace MLAPI.Messaging
     public class ClientRPCAttribute : Attribute
     {
         internal ReflectionMethod reflectionMethod;
+#if ENABLE_IL2CPP
+        internal System.Reflection.MethodInfo perfMethod;
+#else
         internal RpcDelegate rpcDelegate;
-    }
+#endif
+  }
 }

--- a/MLAPI/Messaging/ServerRPCAttribute.cs
+++ b/MLAPI/Messaging/ServerRPCAttribute.cs
@@ -15,6 +15,10 @@ namespace MLAPI.Messaging
         /// </summary>
         public bool RequireOwnership = true;
         internal ReflectionMethod reflectionMethod;
+#if ENABLE_IL2CPP
+        internal System.Reflection.MethodInfo perfMethod;
+#else
         internal RpcDelegate rpcDelegate;
-    }
+#endif
+  }
 }


### PR DESCRIPTION
I tested this code in my project and it fixes the problem.  I used `#if ENABLE_IL2CPP` to limit the performance impact only to situations where the workaround is needed.

Apologies for the trailing whitespace diff spam -- Visual Studio went a bit crazy.
