### PR TITLE
fix(core): improve accuracy of NetworkTime and smear changes on resync.

### DIFF
--- a/MLAPI-Editor/NetworkingManagerEditor.cs
+++ b/MLAPI-Editor/NetworkingManagerEditor.cs
@@ -32,6 +32,7 @@ public class NetworkingManagerEditor : Editor
     private SerializedProperty connectionApprovalProperty;
     private SerializedProperty secondsHistoryProperty;
     private SerializedProperty enableTimeResyncProperty;
+    private SerializedProperty timeResyncIntervalProperty;
     private SerializedProperty enableNetworkedVarProperty;
     private SerializedProperty ensureNetworkedVarLengthSafetyProperty;
     private SerializedProperty forceSamePrefabsProperty;
@@ -108,6 +109,7 @@ public class NetworkingManagerEditor : Editor
         connectionApprovalProperty = networkConfigProperty.FindPropertyRelative("ConnectionApproval");
         secondsHistoryProperty = networkConfigProperty.FindPropertyRelative("SecondsHistory");
         enableTimeResyncProperty = networkConfigProperty.FindPropertyRelative("EnableTimeResync");
+        timeResyncIntervalProperty = networkConfigProperty.FindPropertyRelative("TimeResyncInterval");
         enableNetworkedVarProperty = networkConfigProperty.FindPropertyRelative("EnableNetworkedVar");
         ensureNetworkedVarLengthSafetyProperty = networkConfigProperty.FindPropertyRelative("EnsureNetworkedVarLengthSafety");
         forceSamePrefabsProperty = networkConfigProperty.FindPropertyRelative("ForceSamePrefabs");
@@ -144,6 +146,7 @@ public class NetworkingManagerEditor : Editor
         connectionApprovalProperty = networkConfigProperty.FindPropertyRelative("ConnectionApproval");
         secondsHistoryProperty = networkConfigProperty.FindPropertyRelative("SecondsHistory");
         enableTimeResyncProperty = networkConfigProperty.FindPropertyRelative("EnableTimeResync");
+        timeResyncIntervalProperty = networkConfigProperty.FindPropertyRelative("TimeResyncInterval");
         enableNetworkedVarProperty = networkConfigProperty.FindPropertyRelative("EnableNetworkedVar");
         ensureNetworkedVarLengthSafetyProperty = networkConfigProperty.FindPropertyRelative("EnsureNetworkedVarLengthSafety");
         forceSamePrefabsProperty = networkConfigProperty.FindPropertyRelative("ForceSamePrefabs");
@@ -277,7 +280,8 @@ public class NetworkingManagerEditor : Editor
             }
             
             EditorGUILayout.PropertyField(enableTimeResyncProperty);
-            
+            EditorGUILayout.PropertyField(timeResyncIntervalProperty);
+
             EditorGUILayout.LabelField("Performance", EditorStyles.boldLabel);
             EditorGUILayout.PropertyField(receiveTickrateProperty);
             EditorGUILayout.PropertyField(maxReceiveEventsPerTickRateProperty);

--- a/MLAPI/Configuration/NetworkConfig.cs
+++ b/MLAPI/Configuration/NetworkConfig.cs
@@ -96,6 +96,11 @@ namespace MLAPI.Configuration
         [Tooltip("Enable this to resync the NetworkedTime after the initial sync")]
         public bool EnableTimeResync = false;
         /// <summary>
+        /// If time resync is turned on, this specifies the interval between syncs in seconds.
+        /// </summary>
+        [Tooltip("The amount of seconds between resyncs of NetworkedTime, if enabled")]
+        public int TimeResyncInterval = 30;
+        /// <summary>
         /// Whether or not to enable the NetworkedVar system. This system runs in the Update loop and will degrade performance, but it can be a huge convenience.
         /// Only turn it off if you have no need for the NetworkedVar system.
         /// </summary>

--- a/MLAPI/Messaging/InternalMessageHandler.cs
+++ b/MLAPI/Messaging/InternalMessageHandler.cs
@@ -206,9 +206,7 @@ namespace MLAPI.Messaging
                 Guid sceneSwitchProgressGuid = new Guid(reader.ReadByteArray());
 
                 float netTime = reader.ReadSinglePacked();
-                ulong msDelay = NetworkingManager.Singleton.NetworkConfig.NetworkTransport.GetCurrentRtt(clientId);
-                
-                NetworkingManager.Singleton.NetworkTime = netTime + (msDelay / 1000f);
+                NetworkingManager.Singleton.UpdateNetworkTime(clientId, netTime);
 
                 NetworkingManager.Singleton.ConnectedClients.Add(NetworkingManager.Singleton.LocalClientId, new NetworkedClient() { ClientId = NetworkingManager.Singleton.LocalClientId });
 
@@ -430,9 +428,7 @@ namespace MLAPI.Messaging
             using (PooledBitReader reader = PooledBitReader.Get(stream))
             {
                 float netTime = reader.ReadSinglePacked();
-                ulong msDelay = NetworkingManager.Singleton.NetworkConfig.NetworkTransport.GetCurrentRtt(clientId);
-                
-                NetworkingManager.Singleton.NetworkTime = netTime + (msDelay / 1000f);
+                NetworkingManager.Singleton.UpdateNetworkTime(clientId, netTime);
             }
         }
 
@@ -644,5 +640,6 @@ namespace MLAPI.Messaging
         {
             NetworkingManager.Singleton.InvokeOnIncomingCustomMessage(clientId, stream);
         }
+
     }
 }

--- a/MLAPI/Messaging/InternalMessageSender.cs
+++ b/MLAPI/Messaging/InternalMessageSender.cs
@@ -33,7 +33,7 @@ namespace MLAPI.Messaging
             }
         }
 
-        internal static void Send(byte messageType, string channelName, BitStream messageStream, SecuritySendFlags flags, NetworkedObject targetObject)
+        internal static void Send(byte messageType, string channelName, BitStream messageStream, SecuritySendFlags flags, NetworkedObject targetObject, bool skipQueue = false)
         {
             bool encrypted = ((flags & SecuritySendFlags.Encrypted) == SecuritySendFlags.Encrypted) && NetworkingManager.Singleton.NetworkConfig.EnableEncryption;
             bool authenticated = ((flags & SecuritySendFlags.Authenticated) == SecuritySendFlags.Authenticated) && NetworkingManager.Singleton.NetworkConfig.EnableEncryption;
@@ -63,7 +63,7 @@ namespace MLAPI.Messaging
                             continue;
                         }
                         
-                        NetworkingManager.Singleton.NetworkConfig.NetworkTransport.Send(NetworkingManager.Singleton.ConnectedClientsList[i].ClientId, new ArraySegment<byte>(stream.GetBuffer(), 0, (int)stream.Length), channelName, false);
+                        NetworkingManager.Singleton.NetworkConfig.NetworkTransport.Send(NetworkingManager.Singleton.ConnectedClientsList[i].ClientId, new ArraySegment<byte>(stream.GetBuffer(), 0, (int)stream.Length), channelName, skipQueue);
                     }
                     NetworkProfiler.EndEvent();
                 }


### PR DESCRIPTION
This PR improves `NetworkTime` handling in the following ways:
1. `NetworkTime` is derived from `Time.unscaledTime` rather than being incremented manually.  This improves accuracy when the game is moved to the background.
2. Time is synced based on `Time.realtimeSinceStartup` to best represent when the packet is actually sent and received, rather than the time at which the frame started.
3. Only half the RTT is used to offset the time received from the network, since the packet only had to travel one way.
4. Time resync packets skip the queue to avoid unnecessary delays.
5. When a time resync updates `NetworkTime`, the change is smeared over multiple frames to avoid having a very small or even negative (!) delta between consecutive values.  This can prevent some crazy bugs in user code, and smooth out the acceleration/deceleration of interpolated movement.
6. It's possible to explicitly configure the time resync interval.

Note that even with all those changes the initial time sync (on approval) is likely to be off by as much as a second, due to the overhead of the big approval packet and the fact that RTT may not have had a chance to be computed yet.  For code that cares about time sync I suggest setting the resync interval to something low, on the order of a few seconds. 
