### PR TITLE
fix(core): fix small bugs introduced by style fixes.

### DIFF
--- a/MLAPI/Messaging/ReflectionMethod.cs
+++ b/MLAPI/Messaging/ReflectionMethod.cs
@@ -53,8 +53,6 @@ namespace MLAPI.Messaging
                 serverTarget = false;
             }
 
-            parameterTypes = new Type[parameters.Length];
-
             if (parameters.Length == 2 && method.ReturnType == typeof(void) && parameters[0].ParameterType == typeof(ulong) && parameters[1].ParameterType == typeof(Stream))
             {
                 useDelegate = true;
@@ -63,6 +61,7 @@ namespace MLAPI.Messaging
             {
                 useDelegate = false;
 
+                parameterTypes = new Type[parameters.Length];
                 parameterRefs = new object[parameters.Length];
 
                 for (int i = 0; i < parameters.Length; i++)

--- a/MLAPI/Messaging/RpcTypeDefinition.cs
+++ b/MLAPI/Messaging/RpcTypeDefinition.cs
@@ -52,7 +52,7 @@ namespace MLAPI.Messaging
 
             while (type != null && type != limitType)
             {
-                list.AddRange(type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance));
+                list.AddRange(type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly));
 
                 type = type.BaseType;
             }


### PR DESCRIPTION
Two small fixes for things that got broken when fixing styles on my previous PR:

1. You're unnecessarily allocating the `parameterTypes` array when `useDelegate` is `true`.

2. You lost `BindingFlags.DeclaredOnly` in `GetAllMethods`.  It's necessary, since you're walking the inheritance hierarchy manually and don't want to get all the methods inherited from `NetworkedBehaviour`!  Without this flag, I either get dictionary key conflicts or a super-long startup time as each type takes a few seconds to process hundreds of methods.
