### PR TITLE
fix(core): spawn objects under the correct parent.

### DIFF
--- a/MLAPI/Core/NetworkingManager.cs
+++ b/MLAPI/Core/NetworkingManager.cs
@@ -1080,7 +1080,14 @@ namespace MLAPI
                             writer.WriteBool(_observedObjects[i].IsPlayerObject);
                             writer.WriteUInt64Packed(_observedObjects[i].NetworkId);
                             writer.WriteUInt64Packed(_observedObjects[i].OwnerClientId);
-                            NetworkedObject parent = _observedObjects[i].transform.parent?.GetComponent<NetworkedObject>();
+
+                            NetworkedObject parent = null;
+
+                            if (_observedObjects[i].transform.parent != null)
+                            {
+                                parent = _observedObjects[i].transform.parent.GetComponent<NetworkedObject>();
+                            }
+
                             if (parent == null)
                             {
                                 writer.WriteBool(false);

--- a/MLAPI/Core/NetworkingManager.cs
+++ b/MLAPI/Core/NetworkingManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -527,7 +527,7 @@ namespace MLAPI
             
             ConnectedClientsList.Add(ConnectedClients[hostClientId]);
 
-            NetworkedObject netObject = SpawnManager.CreateLocalNetworkedObject(false, 0, (prefabHash == null ? NetworkConfig.PlayerPrefabHash : prefabHash.Value), position, rotation);
+            NetworkedObject netObject = SpawnManager.CreateLocalNetworkedObject(false, 0, (prefabHash == null ? NetworkConfig.PlayerPrefabHash : prefabHash.Value), null, position, rotation);
             SpawnManager.SpawnNetworkedObjectLocally(netObject, SpawnManager.GetNetworkObjectId(), false, true, hostClientId, payloadStream, payloadStream != null, payloadStream == null ? 0 : (int)payloadStream.Length, false, false);
             
             if (netObject.CheckObjectVisibility == null || netObject.CheckObjectVisibility(hostClientId))
@@ -1045,7 +1045,7 @@ namespace MLAPI
                 ConnectedClients.Add(clientId, client);
                 ConnectedClientsList.Add(client);
                 
-                NetworkedObject netObject = SpawnManager.CreateLocalNetworkedObject(false, 0, (prefabHash == null ? NetworkConfig.PlayerPrefabHash : prefabHash.Value), position, rotation);
+                NetworkedObject netObject = SpawnManager.CreateLocalNetworkedObject(false, 0, (prefabHash == null ? NetworkConfig.PlayerPrefabHash : prefabHash.Value), null, position, rotation);
                 SpawnManager.SpawnNetworkedObjectLocally(netObject, SpawnManager.GetNetworkObjectId(), false, true, clientId, null, false, 0, false, false);
                 
                 ConnectedClients[clientId].PlayerObject = netObject;
@@ -1080,6 +1080,16 @@ namespace MLAPI
                             writer.WriteBool(_observedObjects[i].IsPlayerObject);
                             writer.WriteUInt64Packed(_observedObjects[i].NetworkId);
                             writer.WriteUInt64Packed(_observedObjects[i].OwnerClientId);
+                            NetworkedObject parent = _observedObjects[i].transform.parent?.GetComponent<NetworkedObject>();
+                            if (parent == null)
+                            {
+                                writer.WriteBool(false);
+                            }
+                            else
+                            {
+                                writer.WriteBool(true);
+                                writer.WriteUInt64Packed(parent.NetworkId);
+                            }
 
                             if (NetworkConfig.UsePrefabSync)
                             {

--- a/MLAPI/Core/NetworkingManager.cs
+++ b/MLAPI/Core/NetworkingManager.cs
@@ -70,7 +70,7 @@ namespace MLAPI
         /// <summary>
         /// The clientId the server calls the local client by, only valid for clients
         /// </summary>
-        public ulong LocalClientId 
+        public ulong LocalClientId
         {
             get
             {
@@ -248,13 +248,13 @@ namespace MLAPI
             {
                 if (LogHelper.CurrentLogLevel <= LogLevel.Normal) LogHelper.LogWarning("The NetworkingManager cannot be a NetworkedObject. This will lead to weird side effects.");
             }
-            
+
             if (!NetworkConfig.RegisteredScenes.Contains(SceneManager.GetActiveScene().name))
             {
                 if (LogHelper.CurrentLogLevel <= LogLevel.Normal) LogHelper.LogWarning("The active scene is not registered as a networked scene. The MLAPI has added it");
                 NetworkConfig.RegisteredScenes.Add(SceneManager.GetActiveScene().name);
             }
-            
+
             for (int i = 0; i < NetworkConfig.NetworkedPrefabs.Count; i++)
             {
                 if (NetworkConfig.NetworkedPrefabs[i] != null && NetworkConfig.NetworkedPrefabs[i].Prefab != null)
@@ -269,10 +269,10 @@ namespace MLAPI
                     }
                 }
             }
-            
+
             // TODO: Show which two prefab generators that collide
             HashSet<ulong> hashes = new HashSet<ulong>();
-            
+
             for (int i = 0; i < NetworkConfig.NetworkedPrefabs.Count; i++)
             {
                 if (hashes.Contains(NetworkConfig.NetworkedPrefabs[i].Hash))
@@ -298,7 +298,7 @@ namespace MLAPI
         private void Init(bool server)
         {
             if (LogHelper.CurrentLogLevel <= LogLevel.Developer) LogHelper.LogInfo("Init()");
-            
+
             LocalClientId = 0;
             networkTimeOffset = 0f;
             currentNetworkTimeOffset = 0f;
@@ -328,11 +328,11 @@ namespace MLAPI
                 if (LogHelper.CurrentLogLevel <= LogLevel.Error) LogHelper.LogError("No transport has been selected!");
                 return;
             }
-            
+
             try
             {
                 string pfx = NetworkConfig.ServerBase64PfxCertificate.Trim();
-                
+
                 if (server && NetworkConfig.EnableEncryption && NetworkConfig.SignKeyExchange && !string.IsNullOrEmpty(pfx))
                 {
                     try
@@ -358,7 +358,7 @@ namespace MLAPI
             }
 
             NetworkConfig.RegisteredScenes.Sort();
-            
+
             for (int i = 0; i < NetworkConfig.RegisteredScenes.Count; i++)
             {
                 NetworkSceneManager.registeredSceneNames.Add(NetworkConfig.RegisteredScenes[i]);
@@ -372,7 +372,7 @@ namespace MLAPI
             {
                 NetworkConfig.NetworkedPrefabs[i].Prefab.GetComponent<NetworkedObject>().ValidateHash();
             }
-            
+
             NetworkConfig.NetworkTransport.Init();
         }
 
@@ -423,7 +423,7 @@ namespace MLAPI
 
             Init(false);
             NetworkConfig.NetworkTransport.StartClient();
-            
+
             IsServer = false;
             IsClient = true;
             IsListening = true;
@@ -437,20 +437,20 @@ namespace MLAPI
             if (LogHelper.CurrentLogLevel <= LogLevel.Developer) LogHelper.LogInfo("StopServer()");
             HashSet<ulong> disconnectedIds = new HashSet<ulong>();
             //Don't know if I have to disconnect the clients. I'm assuming the NetworkTransport does all the cleaning on shtudown. But this way the clients get a disconnect message from server (so long it does't get lost)
-            
+
             foreach (KeyValuePair<ulong, NetworkedClient> pair in ConnectedClients)
             {
                 if (!disconnectedIds.Contains(pair.Key))
                 {
                     disconnectedIds.Add(pair.Key);
-                    
+
 					if (pair.Key == NetworkConfig.NetworkTransport.ServerClientId)
                         continue;
 
                     NetworkConfig.NetworkTransport.DisconnectRemoteClient(pair.Key);
                 }
             }
-            
+
             foreach (KeyValuePair<ulong, PendingClient> pair in PendingClients)
             {
                 if(!disconnectedIds.Contains(pair.Key))
@@ -462,7 +462,7 @@ namespace MLAPI
                     NetworkConfig.NetworkTransport.DisconnectRemoteClient(pair.Key);
                 }
             }
-            
+
             IsServer = false;
             Shutdown();
         }
@@ -510,7 +510,7 @@ namespace MLAPI
                     if (LogHelper.CurrentLogLevel <= LogLevel.Normal) LogHelper.LogWarning("No ConnectionApproval callback defined. Connection approval will timeout");
                 }
             }
-            
+
             Init(true);
             NetworkConfig.NetworkTransport.StartServer();
 
@@ -519,22 +519,22 @@ namespace MLAPI
             IsListening = true;
 
             ulong hostClientId = NetworkConfig.NetworkTransport.ServerClientId;
-            
+
             ConnectedClients.Add(hostClientId, new NetworkedClient()
             {
                 ClientId = hostClientId
             });
-            
+
             ConnectedClientsList.Add(ConnectedClients[hostClientId]);
 
             NetworkedObject netObject = SpawnManager.CreateLocalNetworkedObject(false, 0, (prefabHash == null ? NetworkConfig.PlayerPrefabHash : prefabHash.Value), null, position, rotation);
             SpawnManager.SpawnNetworkedObjectLocally(netObject, SpawnManager.GetNetworkObjectId(), false, true, hostClientId, payloadStream, payloadStream != null, payloadStream == null ? 0 : (int)payloadStream.Length, false, false);
-            
+
             if (netObject.CheckObjectVisibility == null || netObject.CheckObjectVisibility(hostClientId))
             {
                 netObject.observers.Add(hostClientId);
             }
-            
+
             SpawnManager.ServerSpawnSceneObjectsOnStartSweep();
 
             if (OnServerStarted != null)
@@ -557,13 +557,13 @@ namespace MLAPI
                     Application.runInBackground = true;
             }
         }
-        
+
         private void OnDestroy()
         {
             if (Singleton != null && Singleton == this)
             {
                 Singleton = null;
-                Shutdown();  
+                Shutdown();
             }
         }
 
@@ -596,14 +596,14 @@ namespace MLAPI
                     {
                         NetworkedObject.NetworkedBehaviourUpdate();
                     }
-                    
+
                     foreach (KeyValuePair<ulong, NetworkedClient> pair in ConnectedClients)
                     {
                         NetworkConfig.NetworkTransport.FlushSendQueue(pair.Key);
-                        
+
                         if (LogHelper.CurrentLogLevel <= LogLevel.Developer) LogHelper.LogInfo("Send Pending Queue: " + pair.Key);
                     }
-                    
+
                     lastSendTickTime = NetworkTime;
                 }
                 if ((NetworkTime - lastReceiveTickTime >= (1f / NetworkConfig.ReceiveTickrate)) || NetworkConfig.ReceiveTickrate <= 0)
@@ -791,7 +791,7 @@ namespace MLAPI
             {
                 yield return null;
             }
-            
+
             if (PendingClients.ContainsKey(clientId) && !ConnectedClients.ContainsKey(clientId))
             {
                 // Timeout
@@ -814,7 +814,7 @@ namespace MLAPI
             {
                 inputStream.SetLength(data.Count + data.Offset);
                 inputStream.Position = data.Offset;
-                
+
                 using (BitStream messageStream = MessagePacker.UnwrapMessage(inputStream, clientId, out byte messageType, out SecuritySendFlags security))
                 {
                     if (messageStream == null)
@@ -951,7 +951,7 @@ namespace MLAPI
         {
             if (PendingClients.ContainsKey(clientId))
                 PendingClients.Remove(clientId);
-            
+
             if (ConnectedClients.ContainsKey(clientId))
             {
                 if (IsServer)
@@ -968,7 +968,7 @@ namespace MLAPI
                             Destroy(ConnectedClients[clientId].PlayerObject.gameObject);
                         }
                     }
-                    
+
                     for (int i = 0; i < ConnectedClients[clientId].OwnedObjects.Count; i++)
                     {
                         if (ConnectedClients[clientId].OwnedObjects[i] != null)
@@ -1007,7 +1007,7 @@ namespace MLAPI
                         break;
                     }
                 }
-                
+
                 ConnectedClients.Remove(clientId);
             }
         }
@@ -1024,14 +1024,14 @@ namespace MLAPI
                 }
             }
         }
-        
+
         private readonly List<NetworkedObject> _observedObjects = new List<NetworkedObject>();
 
         internal void HandleApproval(ulong clientId, ulong? prefabHash, bool approved, Vector3? position, Quaternion? rotation)
         {
             if(approved)
             {
-                // Inform new client it got approved   
+                // Inform new client it got approved
                 byte[] aesKey = PendingClients.ContainsKey(clientId) ? PendingClients[clientId].AesKey : null;
                 if (PendingClients.ContainsKey(clientId))
                     PendingClients.Remove(clientId);
@@ -1044,14 +1044,14 @@ namespace MLAPI
                 };
                 ConnectedClients.Add(clientId, client);
                 ConnectedClientsList.Add(client);
-                
+
                 NetworkedObject netObject = SpawnManager.CreateLocalNetworkedObject(false, 0, (prefabHash == null ? NetworkConfig.PlayerPrefabHash : prefabHash.Value), null, position, rotation);
                 SpawnManager.SpawnNetworkedObjectLocally(netObject, SpawnManager.GetNetworkObjectId(), false, true, clientId, null, false, 0, false, false);
-                
+
                 ConnectedClients[clientId].PlayerObject = netObject;
 
                 _observedObjects.Clear();
-                
+
                 for (int i = 0; i < SpawnManager.SpawnedObjectsList.Count; i++)
                 {
                     if (clientId == ServerClientId || SpawnManager.SpawnedObjectsList[i].CheckObjectVisibility == null || SpawnManager.SpawnedObjectsList[i].CheckObjectVisibility(clientId))
@@ -1060,19 +1060,19 @@ namespace MLAPI
 
                         SpawnManager.SpawnedObjectsList[i].observers.Add(clientId);
                     }
-                } 
+                }
 
                 using (PooledBitStream stream = PooledBitStream.Get())
                 {
                     using (PooledBitWriter writer = PooledBitWriter.Get(stream))
                     {
                         writer.WriteUInt64Packed(clientId);
-                        
+
                         writer.WriteUInt32Packed(NetworkSceneManager.currentSceneIndex);
                         writer.WriteByteArray(NetworkSceneManager.currentSceneSwitchProgressGuid.ToByteArray());
 
                         writer.WriteSinglePacked(Time.realtimeSinceStartup);
-                        
+
                         writer.WriteUInt32Packed((uint)_observedObjects.Count);
 
                         for (int i = 0; i < _observedObjects.Count; i++)
@@ -1083,7 +1083,7 @@ namespace MLAPI
 
                             NetworkedObject parent = null;
 
-                            if (_observedObjects[i].transform.parent != null)
+                            if (!_observedObjects[i].AlwaysReplicateAsRoot && _observedObjects[i].transform.parent != null)
                             {
                                 parent = _observedObjects[i].transform.parent.GetComponent<NetworkedObject>();
                             }
@@ -1148,7 +1148,7 @@ namespace MLAPI
                     using (PooledBitStream stream = PooledBitStream.Get())
                     {
                         using (PooledBitWriter writer = PooledBitWriter.Get(stream))
-                        {    
+                        {
                             writer.WriteBool(true);
                             writer.WriteUInt64Packed(ConnectedClients[clientId].PlayerObject.GetComponent<NetworkedObject>().NetworkId);
                             writer.WriteUInt64Packed(clientId);
@@ -1180,7 +1180,7 @@ namespace MLAPI
                             {
                                 ConnectedClients[clientId].PlayerObject.WriteNetworkedVarData(stream, clientPair.Key);
                             }
-                            
+
                             InternalMessageSender.Send(clientPair.Key, MLAPIConstants.MLAPI_ADD_OBJECT, "MLAPI_INTERNAL", stream, SecuritySendFlags.None, null);
                         }
                     }

--- a/MLAPI/Messaging/InternalMessageHandler.cs
+++ b/MLAPI/Messaging/InternalMessageHandler.cs
@@ -231,6 +231,10 @@ namespace MLAPI.Messaging
                             bool isPlayerObject = continuationReader.ReadBool();
                             ulong networkId = continuationReader.ReadUInt64Packed();
                             ulong ownerId = continuationReader.ReadUInt64Packed();
+                            bool hasParent = continuationReader.ReadBool();
+                            ulong? parentNetworkId = null;
+                            if (hasParent)
+                                parentNetworkId = continuationReader.ReadUInt64Packed();
 
                             ulong prefabHash;
                             ulong instanceId;
@@ -261,7 +265,7 @@ namespace MLAPI.Messaging
                             Vector3 pos = new Vector3(continuationReader.ReadSinglePacked(), continuationReader.ReadSinglePacked(), continuationReader.ReadSinglePacked());
                             Quaternion rot = Quaternion.Euler(continuationReader.ReadSinglePacked(), continuationReader.ReadSinglePacked(), continuationReader.ReadSinglePacked());
 
-                            NetworkedObject netObject = SpawnManager.CreateLocalNetworkedObject(softSync, instanceId, prefabHash, pos, rot);
+                            NetworkedObject netObject = SpawnManager.CreateLocalNetworkedObject(softSync, instanceId, prefabHash, parentNetworkId, pos, rot);
                             SpawnManager.SpawnNetworkedObjectLocally(netObject, networkId, softSync, isPlayerObject, ownerId, continuationStream, false, 0, true, false);
                         }
 
@@ -306,6 +310,12 @@ namespace MLAPI.Messaging
                 bool isPlayerObject = reader.ReadBool();
                 ulong networkId = reader.ReadUInt64Packed();
                 ulong ownerId = reader.ReadUInt64Packed();
+                bool hasParent = reader.ReadBool();
+                ulong? parentNetworkId = null;
+                if (hasParent)
+                {
+                    parentNetworkId = reader.ReadUInt64Packed();
+                }
                 
                 ulong prefabHash;
                 ulong instanceId;
@@ -339,7 +349,7 @@ namespace MLAPI.Messaging
                 bool hasPayload = reader.ReadBool();
                 int payLoadLength = hasPayload ? reader.ReadInt32Packed() : 0;
                 
-                NetworkedObject netObject = SpawnManager.CreateLocalNetworkedObject(softSync, instanceId, prefabHash, pos, rot);
+                NetworkedObject netObject = SpawnManager.CreateLocalNetworkedObject(softSync, instanceId, prefabHash, parentNetworkId, pos, rot);
                 SpawnManager.SpawnNetworkedObjectLocally(netObject, networkId, softSync, isPlayerObject, ownerId, stream, hasPayload, payLoadLength, true, false);
             }
         }

--- a/MLAPI/Messaging/InternalMessageHandler.cs
+++ b/MLAPI/Messaging/InternalMessageHandler.cs
@@ -233,8 +233,11 @@ namespace MLAPI.Messaging
                             ulong ownerId = continuationReader.ReadUInt64Packed();
                             bool hasParent = continuationReader.ReadBool();
                             ulong? parentNetworkId = null;
+
                             if (hasParent)
+                            {
                                 parentNetworkId = continuationReader.ReadUInt64Packed();
+                            }
 
                             ulong prefabHash;
                             ulong instanceId;
@@ -312,6 +315,7 @@ namespace MLAPI.Messaging
                 ulong ownerId = reader.ReadUInt64Packed();
                 bool hasParent = reader.ReadBool();
                 ulong? parentNetworkId = null;
+
                 if (hasParent)
                 {
                     parentNetworkId = reader.ReadUInt64Packed();

--- a/MLAPI/SceneManagement/NetworkSceneManager.cs
+++ b/MLAPI/SceneManagement/NetworkSceneManager.cs
@@ -27,7 +27,7 @@ namespace MLAPI.SceneManagement
         /// Event that is invoked when the scene is switched
         /// </summary>
         public static event SceneSwitchedDelegate OnSceneSwitched;
-        
+
         internal static readonly HashSet<string> registeredSceneNames = new HashSet<string>();
         internal static readonly Dictionary<string, uint> sceneNameToIndex = new Dictionary<string, uint>();
         internal static readonly Dictionary<uint, string> sceneIndexToString = new Dictionary<uint, string>();
@@ -53,7 +53,7 @@ namespace MLAPI.SceneManagement
         internal static uint CurrentActiveSceneIndex { get; private set; } = 0;
 
         /// <summary>
-        /// Adds a scene during runtime. 
+        /// Adds a scene during runtime.
         /// The index is REQUIRED to be unique AND the same across all instances.
         /// </summary>
         /// <param name="sceneName">Scene name.</param>
@@ -90,7 +90,7 @@ namespace MLAPI.SceneManagement
                 if (LogHelper.CurrentLogLevel <= LogLevel.Normal) LogHelper.LogWarning("The scene " + sceneName + " is not registered as a switchable scene.");
                 return null;
             }
-            
+
             SpawnManager.ServerDestroySpawnedSceneObjects(); //Destroy current scene objects before switching.
             isSwitching = true;
             lastScene = SceneManager.GetActiveScene();
@@ -98,10 +98,10 @@ namespace MLAPI.SceneManagement
             SceneSwitchProgress switchSceneProgress = new SceneSwitchProgress();
             sceneSwitchProgresses.Add(switchSceneProgress.guid, switchSceneProgress);
             currentSceneSwitchProgressGuid = switchSceneProgress.guid;
-            
+
             // Move ALL networked objects to the temp scene
             MoveObjectsToDontDestroyOnLoad();
-            
+
             isSpawnedObjectsPendingInDontDestroyOnLoad = true;
 
             // Switch scene
@@ -109,9 +109,9 @@ namespace MLAPI.SceneManagement
             nextSceneName = sceneName;
 
             sceneLoad.completed += (AsyncOperation asyncOp2) => { OnSceneLoaded(switchSceneProgress.guid, null); };
-            
-            switchSceneProgress.SetSceneLoadOperation(sceneLoad);  
-            
+
+            switchSceneProgress.SetSceneLoadOperation(sceneLoad);
+
             return switchSceneProgress;
         }
 
@@ -129,14 +129,14 @@ namespace MLAPI.SceneManagement
             }
 
             lastScene = SceneManager.GetActiveScene();
-                        
+
             // Move ALL networked objects to the temp scene
             MoveObjectsToDontDestroyOnLoad();
-            
+
             isSpawnedObjectsPendingInDontDestroyOnLoad = true;
 
             string sceneName = sceneIndexToString[sceneIndex];
-            
+
             AsyncOperation sceneLoad = SceneManager.LoadSceneAsync(sceneName, LoadSceneMode.Single);
             nextSceneName = sceneName;
 
@@ -157,7 +157,7 @@ namespace MLAPI.SceneManagement
             {
                 return; //This scene is already loaded. This usually happends at first load
             }
-            
+
             lastScene = SceneManager.GetActiveScene();
             string sceneName = sceneIndexToString[sceneIndex];
             nextSceneName = sceneName;
@@ -165,7 +165,7 @@ namespace MLAPI.SceneManagement
 
             isSpawnedObjectsPendingInDontDestroyOnLoad = true;
             SceneManager.LoadScene(sceneName);
-            
+
             using (PooledBitStream stream = PooledBitStream.Get())
             {
                 using (PooledBitWriter writer = PooledBitWriter.Get(stream))
@@ -174,7 +174,7 @@ namespace MLAPI.SceneManagement
                     InternalMessageSender.Send(NetworkingManager.Singleton.ServerClientId, MLAPIConstants.MLAPI_CLIENT_SWITCH_SCENE_COMPLETED, "MLAPI_INTERNAL", stream, SecuritySendFlags.None, null);
                 }
             }
-            
+
             isSwitching = false;
         }
 
@@ -183,12 +183,12 @@ namespace MLAPI.SceneManagement
             CurrentActiveSceneIndex = sceneNameToIndex[nextSceneName];
             Scene nextScene = SceneManager.GetSceneByName(nextSceneName);
             SceneManager.SetActiveScene(nextScene);
-            
+
             // Move all objects to the new scene
             MoveObjectsToScene(nextScene);
-            
+
             isSpawnedObjectsPendingInDontDestroyOnLoad = false;
-            
+
             currentSceneIndex = CurrentActiveSceneIndex;
 
             if (NetworkingManager.Singleton.IsServer)
@@ -208,19 +208,19 @@ namespace MLAPI.SceneManagement
 
             {
                 NetworkedObject[] networkedObjects = MonoBehaviour.FindObjectsOfType<NetworkedObject>();
-            
+
                 for (int i = 0; i < networkedObjects.Length; i++)
                 {
                     if (networkedObjects[i].IsSceneObject == null)
                     {
                         SpawnManager.SpawnNetworkedObjectLocally(networkedObjects[i], SpawnManager.GetNetworkObjectId(), true, false, null, null, false, 0, false, true);
-                    
+
                         newSceneObjects.Add(networkedObjects[i]);
                     }
                 }
             }
 
-            
+
             for (int j = 0; j < NetworkingManager.Singleton.ConnectedClientsList.Count; j++)
             {
                 if (NetworkingManager.Singleton.ConnectedClientsList[j].ClientId != NetworkingManager.Singleton.ServerClientId)
@@ -251,7 +251,7 @@ namespace MLAPI.SceneManagement
 
                                     NetworkedObject parent = null;
 
-                                    if (newSceneObjects[i].transform.parent != null)
+                                    if (!newSceneObjects[i].AlwaysReplicateAsRoot && newSceneObjects[i].transform.parent != null)
                                     {
                                         parent = newSceneObjects[i].transform.parent.GetComponent<NetworkedObject>();
                                     }
@@ -290,12 +290,12 @@ namespace MLAPI.SceneManagement
                                 }
                             }
                         }
-                        
+
                         InternalMessageSender.Send(NetworkingManager.Singleton.ConnectedClientsList[j].ClientId, MLAPIConstants.MLAPI_SWITCH_SCENE, "MLAPI_INTERNAL", stream, SecuritySendFlags.None, null);
                     }
                 }
             }
-            
+
             //Tell server that scene load is completed
             if (NetworkingManager.Singleton.IsHost)
             {
@@ -303,7 +303,7 @@ namespace MLAPI.SceneManagement
             }
 
             isSwitching = false;
-            
+
             if (OnSceneSwitched != null)
             {
                 OnSceneSwitched();
@@ -315,7 +315,7 @@ namespace MLAPI.SceneManagement
             if (NetworkingManager.Singleton.NetworkConfig.UsePrefabSync)
             {
                 SpawnManager.DestroySceneObjects();
-                
+
                 using (PooledBitReader reader = PooledBitReader.Get(objectStream))
                 {
                     uint newObjectsCount = reader.ReadUInt32Packed();
@@ -337,7 +337,7 @@ namespace MLAPI.SceneManagement
 
                         Vector3 position = new Vector3(reader.ReadSinglePacked(), reader.ReadSinglePacked(), reader.ReadSinglePacked());
                         Quaternion rotation = Quaternion.Euler(reader.ReadSinglePacked(), reader.ReadSinglePacked(), reader.ReadSinglePacked());
-                        
+
                         NetworkedObject networkedObject = SpawnManager.CreateLocalNetworkedObject(false, 0, prefabHash, parentNetworkId, position, rotation);
                         SpawnManager.SpawnNetworkedObjectLocally(networkedObject, networkId, true, isPlayerObject, owner, objectStream, false, 0, true, false);
                     }
@@ -373,7 +373,7 @@ namespace MLAPI.SceneManagement
                     }
                 }
             }
-            
+
             using (PooledBitStream stream = PooledBitStream.Get())
             {
                 using (PooledBitWriter writer = PooledBitWriter.Get(stream))
@@ -383,9 +383,9 @@ namespace MLAPI.SceneManagement
                     InternalMessageSender.Send(NetworkingManager.Singleton.ServerClientId, MLAPIConstants.MLAPI_CLIENT_SWITCH_SCENE_COMPLETED, "MLAPI_INTERNAL", stream, SecuritySendFlags.None, networkedObject);
                 }
             }
-            
+
             isSwitching = false;
-            
+
             if (OnSceneSwitched != null)
             {
                 OnSceneSwitched();
@@ -398,14 +398,14 @@ namespace MLAPI.SceneManagement
         }
 
         // Called on server
-        internal static void OnClientSwitchSceneCompleted(ulong clientId, Guid switchSceneGuid) 
+        internal static void OnClientSwitchSceneCompleted(ulong clientId, Guid switchSceneGuid)
         {
-            if (switchSceneGuid == Guid.Empty) 
+            if (switchSceneGuid == Guid.Empty)
             {
                 //If Guid is empty it means the client has loaded the start scene of the server and the server would never have a switchSceneProgresses created for the start scene.
                 return;
             }
-            if (!sceneSwitchProgresses.ContainsKey(switchSceneGuid)) 
+            if (!sceneSwitchProgresses.ContainsKey(switchSceneGuid))
             {
                 return;
             }
@@ -414,7 +414,7 @@ namespace MLAPI.SceneManagement
         }
 
 
-        internal static void RemoveClientFromSceneSwitchProgresses(ulong clientId) 
+        internal static void RemoveClientFromSceneSwitchProgresses(ulong clientId)
         {
             foreach (SceneSwitchProgress switchSceneProgress in sceneSwitchProgresses.Values)
             {
@@ -423,10 +423,10 @@ namespace MLAPI.SceneManagement
         }
 
         private static void MoveObjectsToDontDestroyOnLoad()
-        {            
+        {
             // Move ALL networked objects to the temp scene
             List<NetworkedObject> objectsToKeep = SpawnManager.SpawnedObjectsList;
-            
+
             for (int i = 0; i < objectsToKeep.Count; i++)
             {
                 //In case an object has been set as a child of another object it has to be unchilded in order to be moved from one scene to another.
@@ -434,16 +434,16 @@ namespace MLAPI.SceneManagement
                 {
                     objectsToKeep[i].gameObject.transform.parent = null;
                 }
-                
+
                 MonoBehaviour.DontDestroyOnLoad(objectsToKeep[i].gameObject);
             }
         }
-        
+
         private static void MoveObjectsToScene(Scene scene)
-        {            
+        {
             // Move ALL networked objects to the temp scene
             List<NetworkedObject> objectsToKeep = SpawnManager.SpawnedObjectsList;
-            
+
             for (int i = 0; i < objectsToKeep.Count; i++)
             {
                 //In case an object has been set as a child of another object it has to be unchilded in order to be moved from one scene to another.
@@ -451,7 +451,7 @@ namespace MLAPI.SceneManagement
                 {
                     objectsToKeep[i].gameObject.transform.parent = null;
                 }
-                
+
                 SceneManager.MoveGameObjectToScene(objectsToKeep[i].gameObject, scene);
             }
         }

--- a/MLAPI/SceneManagement/NetworkSceneManager.cs
+++ b/MLAPI/SceneManagement/NetworkSceneManager.cs
@@ -248,7 +248,14 @@ namespace MLAPI.SceneManagement
                                     writer.WriteBool(newSceneObjects[i].IsPlayerObject);
                                     writer.WriteUInt64Packed(newSceneObjects[i].NetworkId);
                                     writer.WriteUInt64Packed(newSceneObjects[i].OwnerClientId);
-                                    NetworkedObject parent = newSceneObjects[i].transform.parent?.GetComponent<NetworkedObject>();
+
+                                    NetworkedObject parent = null;
+
+                                    if (newSceneObjects[i].transform.parent != null)
+                                    {
+                                        parent = newSceneObjects[i].transform.parent.GetComponent<NetworkedObject>();
+                                    }
+
                                     if (parent == null)
                                     {
                                         writer.WriteBool(false);
@@ -320,6 +327,7 @@ namespace MLAPI.SceneManagement
                         ulong owner = reader.ReadUInt64Packed();
                         bool hasParent = reader.ReadBool();
                         ulong? parentNetworkId = null;
+
                         if (hasParent)
                         {
                             parentNetworkId = reader.ReadUInt64Packed();
@@ -352,6 +360,7 @@ namespace MLAPI.SceneManagement
                         ulong owner = reader.ReadUInt64Packed();
                         bool hasParent = reader.ReadBool();
                         ulong? parentNetworkId = null;
+
                         if (hasParent)
                         {
                             parentNetworkId = reader.ReadUInt64Packed();

--- a/MLAPI/Spawning/SpawnManager.cs
+++ b/MLAPI/Spawning/SpawnManager.cs
@@ -41,7 +41,7 @@ namespace MLAPI.Spawning
         /// </summary>
         /// <param name="networkedObject">The networked object to be destroy</param>
         public delegate void DestroyHandlerDelegate(NetworkedObject networkedObject);
-        
+
         internal static readonly Dictionary<ulong, SpawnHandlerDelegate> customSpawnHandlers = new Dictionary<ulong, SpawnHandlerDelegate>();
         internal static readonly Dictionary<ulong, DestroyHandlerDelegate> customDestroyHandlers = new Dictionary<ulong, DestroyHandlerDelegate>();
 
@@ -87,7 +87,7 @@ namespace MLAPI.Spawning
         {
             customSpawnHandlers.Remove(prefabHash);
         }
-        
+
         /// <summary>
         /// Removes the custom destroy handler for a specific prefab hash
         /// </summary>
@@ -96,7 +96,7 @@ namespace MLAPI.Spawning
         {
             customDestroyHandlers.Remove(prefabHash);
         }
-        
+
         internal static readonly Queue<ReleasedNetworkId> releasedNetworkObjectIds = new Queue<ReleasedNetworkId>();
         private static ulong networkObjectIdCounter;
         internal static ulong GetNetworkObjectId()
@@ -147,7 +147,7 @@ namespace MLAPI.Spawning
         {
             return generator.GetStableHash64();
         }
-        
+
         /// <summary>
         /// Returns the local player object or null if one does not exist
         /// </summary>
@@ -179,13 +179,13 @@ namespace MLAPI.Spawning
             {
                 throw new SpawnStateException("Object is not spawned");
             }
-            
+
             for (int i = NetworkingManager.Singleton.ConnectedClients[netObject.OwnerClientId].OwnedObjects.Count - 1; i > -1; i--)
             {
                 if (NetworkingManager.Singleton.ConnectedClients[netObject.OwnerClientId].OwnedObjects[i] == netObject)
                     NetworkingManager.Singleton.ConnectedClients[netObject.OwnerClientId].OwnedObjects.RemoveAt(i);
             }
-            
+
 			netObject._ownerClientId = null;
 
             using (PooledBitStream stream = PooledBitStream.Get())
@@ -211,13 +211,13 @@ namespace MLAPI.Spawning
             {
                 throw new SpawnStateException("Object is not spawned");
             }
-            
+
             for (int i = NetworkingManager.Singleton.ConnectedClients[netObject.OwnerClientId].OwnedObjects.Count - 1; i > -1; i--)
             {
                 if (NetworkingManager.Singleton.ConnectedClients[netObject.OwnerClientId].OwnedObjects[i] == netObject)
                     NetworkingManager.Singleton.ConnectedClients[netObject.OwnerClientId].OwnedObjects.RemoveAt(i);
             }
-            
+
             NetworkingManager.Singleton.ConnectedClients[clientId].OwnedObjects.Add(netObject);
             netObject.OwnerClientId = clientId;
 
@@ -232,7 +232,7 @@ namespace MLAPI.Spawning
                 }
             }
         }
-        
+
         // Only ran on Client
         internal static NetworkedObject CreateLocalNetworkedObject(bool softCreate, ulong instanceId, ulong prefabHash, ulong? parentNetworkId, Vector3? position, Quaternion? rotation)
         {
@@ -241,6 +241,10 @@ namespace MLAPI.Spawning
             if (parentNetworkId != null && SpawnedObjects.ContainsKey(parentNetworkId.Value))
             {
                 parent = SpawnedObjects[parentNetworkId.Value];
+            }
+            else if (parentNetworkId != null)
+            {
+                if (LogHelper.CurrentLogLevel <= LogLevel.Normal) LogHelper.LogWarning("Cannot find parent. Parent objects always have to be spawned and replicated BEFORE the child");
             }
 
             if (NetworkingManager.Singleton.NetworkConfig.UsePrefabSync || !softCreate)
@@ -285,7 +289,7 @@ namespace MLAPI.Spawning
             {
                 // SoftSync them by mapping
                 if (!pendingSoftSyncObjects.ContainsKey(instanceId))
-                {   
+                {
                     // TODO: Fix this message
                     if (LogHelper.CurrentLogLevel <= LogLevel.Error) LogHelper.LogError("Cannot find pending soft sync object. Is the projects the same?");
                     return null;
@@ -315,10 +319,10 @@ namespace MLAPI.Spawning
             {
                 throw new SpawnStateException("Object is already spawned");
             }
-            
-            
+
+
             if (readNetworkedVar && NetworkingManager.Singleton.NetworkConfig.EnableNetworkedVar) netObject.SetNetworkedVarData(dataStream);
-            
+
             netObject.IsSpawned = true;
 
             netObject.IsSceneObject = sceneObject;
@@ -336,7 +340,7 @@ namespace MLAPI.Spawning
             {
                 if (NetworkingManager.Singleton.IsServer)
                 {
-                    if (playerObject) 
+                    if (playerObject)
                     {
                         NetworkingManager.Singleton.ConnectedClients[ownerClientId.Value].PlayerObject = netObject;
                     }
@@ -348,7 +352,7 @@ namespace MLAPI.Spawning
                 else if (playerObject && ownerClientId.Value == NetworkingManager.Singleton.LocalClientId)
                 {
                     NetworkingManager.Singleton.ConnectedClients[ownerClientId.Value].PlayerObject = netObject;
-                }   
+                }
             }
 
             if (NetworkingManager.Singleton.IsServer)
@@ -361,9 +365,9 @@ namespace MLAPI.Spawning
                     }
                 }
             }
-            
+
             netObject.ResetNetworkedStartInvoked();
-            
+
             if (readPayload)
             {
                 using (PooledBitStream payloadStream = PooledBitStream.Get())
@@ -385,7 +389,7 @@ namespace MLAPI.Spawning
             using (PooledBitStream stream = PooledBitStream.Get())
             {
                 WriteSpawnCallForObject(stream, clientId, netObject, payload);
-                
+
                 InternalMessageSender.Send(clientId, MLAPIConstants.MLAPI_ADD_OBJECT, "MLAPI_INTERNAL", stream, SecuritySendFlags.None, null);
             }
         }
@@ -463,7 +467,7 @@ namespace MLAPI.Spawning
             {
                 throw new SpawnStateException("Object is not spawned");
             }
-            
+
             if (!NetworkingManager.Singleton.IsServer)
             {
                 throw new NotServerException("Only server unspawn objects");
@@ -508,7 +512,7 @@ namespace MLAPI.Spawning
         internal static void DestroyNonSceneObjects()
         {
             NetworkedObject[] netObjects = MonoBehaviour.FindObjectsOfType<NetworkedObject>();
-            
+
             for (int i = 0; i < netObjects.Length; i++)
             {
                 if (netObjects[i].IsSceneObject != null && netObjects[i].IsSceneObject.Value == false)
@@ -529,7 +533,7 @@ namespace MLAPI.Spawning
         internal static void DestroySceneObjects()
         {
             NetworkedObject[] netObjects = MonoBehaviour.FindObjectsOfType<NetworkedObject>();
-            
+
             for (int i = 0; i < netObjects.Length; i++)
             {
                 if (netObjects[i].IsSceneObject == null || netObjects[i].IsSceneObject.Value == true)
@@ -550,7 +554,7 @@ namespace MLAPI.Spawning
         internal static void ServerSpawnSceneObjectsOnStartSweep()
         {
             NetworkedObject[] networkedObjects = MonoBehaviour.FindObjectsOfType<NetworkedObject>();
-            
+
             for (int i = 0; i < networkedObjects.Length; i++)
             {
                 if (networkedObjects[i].IsSceneObject == null)
@@ -559,7 +563,7 @@ namespace MLAPI.Spawning
                 }
             }
         }
-        
+
         internal static void ClientCollectSoftSyncSceneObjectSweep(NetworkedObject[] networkedObjects)
         {
             if (networkedObjects == null)
@@ -573,7 +577,7 @@ namespace MLAPI.Spawning
                 }
             }
         }
-        
+
         internal static void OnDestroyObject(ulong networkId, bool destroyGameObject)
         {
             if (NetworkingManager.Singleton == null)
@@ -582,8 +586,8 @@ namespace MLAPI.Spawning
             //Removal of spawned object
             if (!SpawnedObjects.ContainsKey(networkId))
                 return;
-            
-			if (!SpawnedObjects[networkId].IsOwnedByServer && !SpawnedObjects[networkId].IsPlayerObject && 
+
+			if (!SpawnedObjects[networkId].IsOwnedByServer && !SpawnedObjects[networkId].IsPlayerObject &&
 			    NetworkingManager.Singleton.ConnectedClients.ContainsKey(SpawnedObjects[networkId].OwnerClientId))
             {
                 //Someone owns it.
@@ -603,9 +607,9 @@ namespace MLAPI.Spawning
                     {
                         NetworkId = networkId,
                         ReleaseTime = Time.unscaledTime
-                    });   
+                    });
                 }
-                
+
                 if (SpawnedObjects[networkId] != null)
                 {
                     using (PooledBitStream stream = PooledBitStream.Get())
@@ -621,7 +625,7 @@ namespace MLAPI.Spawning
             }
 
             GameObject go = SpawnedObjects[networkId].gameObject;
-            
+
             if (destroyGameObject && go != null)
             {
                 if (customDestroyHandlers.ContainsKey(SpawnedObjects[networkId].PrefabHash))
@@ -634,9 +638,9 @@ namespace MLAPI.Spawning
                     MonoBehaviour.Destroy(go);
                 }
             }
-            
+
             SpawnedObjects.Remove(networkId);
-            
+
             for (int i = SpawnedObjectsList.Count - 1; i > -1; i--)
             {
                 if (SpawnedObjectsList[i].NetworkId == networkId)

--- a/MLAPI/Spawning/SpawnManager.cs
+++ b/MLAPI/Spawning/SpawnManager.cs
@@ -404,7 +404,7 @@ namespace MLAPI.Spawning
 
                 NetworkedObject parent = null;
 
-                if (netObject.transform.parent != null)
+                if (!netObject.AlwaysReplicateAsRoot && netObject.transform.parent != null)
                 {
                     parent = netObject.transform.parent.GetComponent<NetworkedObject>();
                 }

--- a/MLAPI/Spawning/SpawnManager.cs
+++ b/MLAPI/Spawning/SpawnManager.cs
@@ -268,6 +268,11 @@ namespace MLAPI.Spawning
 
                     NetworkedObject networkedObject = ((position == null && rotation == null) ? MonoBehaviour.Instantiate(prefab) : MonoBehaviour.Instantiate(prefab, position.GetValueOrDefault(Vector3.zero), rotation.GetValueOrDefault(Quaternion.identity))).GetComponent<NetworkedObject>();
 
+                    if (parent != null)
+                    {
+                        networkedObject.transform.SetParent(parent.transform, true);
+                    }
+
                     if (NetworkSceneManager.isSpawnedObjectsPendingInDontDestroyOnLoad)
                     {
                         GameObject.DontDestroyOnLoad(networkedObject.gameObject);
@@ -286,10 +291,15 @@ namespace MLAPI.Spawning
                     return null;
                 }
 
-                NetworkedObject netObject = pendingSoftSyncObjects[instanceId];
+                NetworkedObject networkedObject = pendingSoftSyncObjects[instanceId];
                 pendingSoftSyncObjects.Remove(instanceId);
 
-                return netObject;
+                if (parent != null)
+                {
+                    networkedObject.transform.SetParent(parent.transform, true);
+                }
+
+                return networkedObject;
             }
         }
 


### PR DESCRIPTION
This will spawn an object under the same parent, if the parent is also a network object.  If the parent is missing, it will log an error and _not_ create the child -- we may want to log a warning and create anyway, I don't know.  Either way, this change likely breaks backwards compatibility.

I didn't add an option to specify a parent when spawning the player object, mostly because I don't use the player object myself and have no idea if that would be useful or not.

BTW, this change was a bit of a pain to write because similar pieces of code are scattered all over the place, and the code to write/read a given message isn't colocated.  Food for future refactoring, perhaps.
