### PR TITLE
fix(core): further improve precision of time sync.

### DIFF
--- a/MLAPI/Messaging/InternalMessageHandler.cs
+++ b/MLAPI/Messaging/InternalMessageHandler.cs
@@ -206,7 +206,7 @@ namespace MLAPI.Messaging
                 Guid sceneSwitchProgressGuid = new Guid(reader.ReadByteArray());
 
                 float netTime = reader.ReadSinglePacked();
-                NetworkingManager.Singleton.UpdateNetworkTime(clientId, netTime, receiveTime, onlyIfNotInitialized: true);
+                NetworkingManager.Singleton.UpdateNetworkTime(clientId, netTime, receiveTime, true);
 
                 NetworkingManager.Singleton.ConnectedClients.Add(NetworkingManager.Singleton.LocalClientId, new NetworkedClient() { ClientId = NetworkingManager.Singleton.LocalClientId });
 

--- a/MLAPI/Messaging/InternalMessageHandler.cs
+++ b/MLAPI/Messaging/InternalMessageHandler.cs
@@ -196,7 +196,7 @@ namespace MLAPI.Messaging
             }
         }
 
-        internal static void HandleConnectionApproved(ulong clientId, Stream stream)
+        internal static void HandleConnectionApproved(ulong clientId, Stream stream, float receiveTime)
         {
             using (PooledBitReader reader = PooledBitReader.Get(stream))
             {
@@ -206,7 +206,7 @@ namespace MLAPI.Messaging
                 Guid sceneSwitchProgressGuid = new Guid(reader.ReadByteArray());
 
                 float netTime = reader.ReadSinglePacked();
-                NetworkingManager.Singleton.UpdateNetworkTime(clientId, netTime);
+                NetworkingManager.Singleton.UpdateNetworkTime(clientId, netTime, receiveTime, onlyIfNotInitialized: true);
 
                 NetworkingManager.Singleton.ConnectedClients.Add(NetworkingManager.Singleton.LocalClientId, new NetworkedClient() { ClientId = NetworkingManager.Singleton.LocalClientId });
 
@@ -437,12 +437,12 @@ namespace MLAPI.Messaging
             }
         }
 
-        internal static void HandleTimeSync(ulong clientId, Stream stream)
+        internal static void HandleTimeSync(ulong clientId, Stream stream, float receiveTime)
         {
             using (PooledBitReader reader = PooledBitReader.Get(stream))
             {
                 float netTime = reader.ReadSinglePacked();
-                NetworkingManager.Singleton.UpdateNetworkTime(clientId, netTime);
+                NetworkingManager.Singleton.UpdateNetworkTime(clientId, netTime, receiveTime);
             }
         }
 

--- a/MLAPI/Transports/Transport.cs
+++ b/MLAPI/Transports/Transport.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using UnityEngine;
 
 namespace MLAPI.Transports
@@ -81,7 +81,22 @@ namespace MLAPI.Transports
         /// <param name="payload">The incoming data payload</param>
         /// <returns>Returns the event type</returns>
         public abstract NetEventType PollEvent(out ulong clientId, out string channelName, out ArraySegment<byte> payload);
-        
+
+        /// <summary>
+        /// Polls for incoming events, with an extra output parameter to report the precise time the event was received.
+        /// THIS METHOD IS OPTIONAL.  If you do implement in, you can just provide an empty stub implementation for the old PollEvent method.
+        /// </summary>
+        /// <param name="clientId">The clientId this event is for</param>
+        /// <param name="channelName">The channel the data arrived at. This is usually used when responding to things like RPCs</param>
+        /// <param name="payload">The incoming data payload</param>
+        /// <param name="receiveTime">The time the event was received, as reported by Time.realtimeSinceStartup.</param>
+        /// <returns>Returns the event type</returns>
+        public virtual NetEventType PollEvent(out ulong clientId, out string channelName, out ArraySegment<byte> payload, out float receiveTime)
+        {
+            receiveTime = Time.realtimeSinceStartup;
+            return PollEvent(out clientId, out channelName, out payload);
+        }
+
         /// <summary>
         /// Connects client to server
         /// </summary>


### PR DESCRIPTION
Two main changes:
1. Fire off a separate time sync packet before the potentially big client approval message.
2. Update the `Transport` SPI to optionally provide a more precise reception time for events.

The change to `Transport ` is backwards-compatible but introduces extra complexity.  It could be simplified if you're willing to break backwards compatibility and update all the transports.
