### PR TITLE
Fix NetworkedObject sorting in editor extension 

### DIFF
--- a/MLAPI-Editor/PostProcessScene.cs
+++ b/MLAPI-Editor/PostProcessScene.cs
@@ -16,7 +16,7 @@ namespace UnityEditor
             traverseSortedObjects.Sort((x, y) =>
             {
                 List<int> xSiblingIndex = x.TraversedSiblingIndex();
-                List<int> ySiblingIndex = x.TraversedSiblingIndex();
+                List<int> ySiblingIndex = y.TraversedSiblingIndex();
 
                 while (xSiblingIndex.Count > 0 && ySiblingIndex.Count > 0)
                 {


### PR DESCRIPTION
I noticed that when hosting from the unity editor with softsync that a built version of the game could not connect. However connections between two built versions of the game (on the same build) worked fine. This was due to the editor extension producing an unreliable list of NetworkedInstanceIds. Fixing the sort of NetworkedObjects resolved the issue.