### PR TITLE
NetworkedObject component related

### DIFF
--- a/docs/_docs/troubleshooting/common-mistakes.md
+++ b/docs/_docs/troubleshooting/common-mistakes.md
@@ -28,3 +28,4 @@ NullReferenceException: Object reference not set to an instance of an object
 
 #### Solution
 You most likely forgot to add the `NetworkingManager` component to a game object in your scene.
+You most likely forgot to add the `NetworkedObject` component on your Default player prefab.


### PR DESCRIPTION
Added a solution to another scenario where the user might get a Null reference exception even when NetworkingManager component is present in the scene.