### PR TITLE
feat(core): add NetworkedBehaviour.HasNetworkedObject getter

### DIFF
--- a/MLAPI/Core/NetworkedBehaviour.cs
+++ b/MLAPI/Core/NetworkedBehaviour.cs
@@ -124,9 +124,11 @@ namespace MLAPI
         {
             get
             {
-                if (_networkedObject == null) {
+                if (_networkedObject == null)
+                {
                     _networkedObject = GetComponentInParent<NetworkedObject>();
                 }
+                
                 return _networkedObject != null;
             }
         }

--- a/MLAPI/Core/NetworkedBehaviour.cs
+++ b/MLAPI/Core/NetworkedBehaviour.cs
@@ -117,6 +117,19 @@ namespace MLAPI
                 return _networkedObject;
             }
         }
+        /// <summary>
+        /// Gets whether or not this NetworkedBehaviour instance has a NetworkedObject owner.
+        /// </summary>
+        public bool HasNetworkedObject
+        {
+            get
+            {
+                if (_networkedObject == null) {
+                    _networkedObject = GetComponentInParent<NetworkedObject>();
+                }
+                return _networkedObject != null;
+            }
+        }
 
         private NetworkedObject _networkedObject = null;
         /// <summary>


### PR DESCRIPTION
I know this looks weird and useless, but in my project I derive all behaviors from (subclasses of) `NetworkedBehaviour` for convenience, even when they're not attached to a `NetworkedObject`.  It's thus useful to be able to check in those abstract superclasses whether the behavior is really networked or not without raising and catching an exception.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/midlevel/mlapi/300)
<!-- Reviewable:end -->
