### PR TITLE
perf: Prioritize non-weak streams over weak referenced streams.

### DIFF
--- a/MLAPI/Serialization/Pooled/BitStreamPool.cs
+++ b/MLAPI/Serialization/Pooled/BitStreamPool.cs
@@ -19,26 +19,26 @@ namespace MLAPI.Serialization.Pooled
         /// <returns>An expandable PooledBitStream</returns>
         public static PooledBitStream GetStream()
         {
-            if (overflowStreams.Count > 0)
-            {
-                if (LogHelper.CurrentLogLevel <= LogLevel.Developer) LogHelper.LogInfo("Retrieving PooledBitStream from overflow pool. Recent burst?");
-
-                object weakStream = null;
-                while (overflowStreams.Count > 0 && ((weakStream = overflowStreams.Dequeue().Target) == null)) ;
-
-                if (weakStream != null)
-                {
-                    PooledBitStream strongStream = (PooledBitStream)weakStream;
-
-                    strongStream.SetLength(0);
-                    strongStream.Position = 0;
-
-                    return strongStream;
-                }
-            }
-
             if (streams.Count == 0)
             {
+                if (overflowStreams.Count > 0)
+                {
+                    if (LogHelper.CurrentLogLevel <= LogLevel.Developer) LogHelper.LogInfo("Retrieving PooledBitStream from overflow pool. Recent burst?");
+
+                    object weakStream = null;
+                    while (overflowStreams.Count > 0 && ((weakStream = overflowStreams.Dequeue().Target) == null)) ;
+
+                    if (weakStream != null)
+                    {
+                        PooledBitStream strongStream = (PooledBitStream)weakStream;
+
+                        strongStream.SetLength(0);
+                        strongStream.Position = 0;
+
+                        return strongStream;
+                    }
+                }
+                
                 if (createdStreams == 254)
                 {
                     if (LogHelper.CurrentLogLevel <= LogLevel.Normal) LogHelper.LogWarning("255 streams have been created. Did you forget to dispose?");


### PR DESCRIPTION
If we prioritize pulling from the overflow streams (as it was before), it's possible for us to retain the weak references for a lot longer than is desirable as we will keep accessing them. It's therefore preferable to return a stream from the normal queue to allow the GC time to clean the weak references, and only return an overflow value if there is no other option.