### PR TITLE
messaging-system.md - example code error fix

### DIFF
--- a/docs/_docs/the-basics/messaging-system.md
+++ b/docs/_docs/the-basics/messaging-system.md
@@ -195,7 +195,7 @@ private void Start()
 private void Start()
 {
     //Receiving
-    CustomMessagingManager.RegisterNamedMessageHandler("myMessageName", (senderClientId, stream)
+    CustomMessagingManager.RegisterNamedMessageHandler("myMessageName", (senderClientId, stream) =>
     {
         using (PooledBitReader reader = PooledBitReader.Get(stream))
         {


### PR DESCRIPTION
Fixed broken lambda expression in named message example code: missing "=>".