### PR TITLE
Remove cleaning custom spawn/destroy handlers

### DIFF
--- a/MLAPI/Core/NetworkingManager.cs
+++ b/MLAPI/Core/NetworkingManager.cs
@@ -347,8 +347,6 @@ namespace MLAPI
             SpawnManager.SpawnedObjectsList.Clear();
             SpawnManager.releasedNetworkObjectIds.Clear();
             SpawnManager.pendingSoftSyncObjects.Clear();
-            SpawnManager.customSpawnHandlers.Clear();
-            SpawnManager.customDestroyHandlers.Clear();
             NetworkSceneManager.registeredSceneNames.Clear();
             NetworkSceneManager.sceneIndexToString.Clear();
             NetworkSceneManager.sceneNameToIndex.Clear();


### PR DESCRIPTION
No reason to cleaning these handlers. Now implementing own pooling system is harder because initialization must be done after ServerStart()/ClientStart()/HostStart().