### PR TITLE
Fix destroying object with custom handlers

### DIFF
--- a/MLAPI/Spawning/SpawnManager.cs
+++ b/MLAPI/Spawning/SpawnManager.cs
@@ -525,6 +525,7 @@ namespace MLAPI.Spawning
                     {
                         customDestroyHandlers[SpawnedObjectsList[i].PrefabHash](SpawnedObjectsList[i]);
                         SpawnManager.OnDestroyObject(SpawnedObjectsList[i].NetworkId, false);
+                        i--;
                     }
                     else
                     {


### PR DESCRIPTION
To explain I have image:
![image](https://user-images.githubusercontent.com/21161208/79932583-1f8ef700-844e-11ea-9ab0-dcd73cf69ea4.png)

If you invoke **SpawnManager.OnDestroyObject**, the object will be removed from list. That's why the next element is not on **i+1** position, but on **i** position. It's the simplest optimal solution.

For **MonoBehaviour.Destroy** it's works correctly. Unity probably invoke **OnDestroyed()** later.