### PR TITLE
fix: reader.ReadRotationPacked() "w" reconstruction

### DIFF
--- a/MLAPI/Serialization/BitReader.cs
+++ b/MLAPI/Serialization/BitReader.cs
@@ -374,7 +374,7 @@ namespace MLAPI.Serialization
             float y = ReadSinglePacked();
             float z = ReadSinglePacked();
 
-            float w = Mathf.Sqrt(1 - ((Mathf.Pow(x, 2) - (Mathf.Pow(y, 2) - (Mathf.Pow(z, 2))))));
+            float w = Mathf.Sqrt(1f - Mathf.Pow(x, 2) - Mathf.Pow(y, 2) - Mathf.Pow(z, 2));
 
             return new Quaternion(x, y, z, w);
         }


### PR DESCRIPTION
The correct formula to reconstruct w is 
> w = sqrt( 1 - x^2 - y^2 - z^2 )

but in code was

> w = sqrt(1 - x^2 + y^2 - z^2)