### PR TITLE
Host-Migrationa ddon

### DIFF
--- a/MLAPI-Editor/NetworkingManagerEditor.cs
+++ b/MLAPI-Editor/NetworkingManagerEditor.cs
@@ -30,6 +30,7 @@ public class NetworkingManagerEditor : Editor
     private SerializedProperty clientConnectionBufferTimeoutProperty;
     private SerializedProperty connectionApprovalProperty;
     private SerializedProperty secondsHistoryProperty;
+    private SerializedProperty enableHostMigrationProperty;
     private SerializedProperty enableTimeResyncProperty;
     private SerializedProperty timeResyncIntervalProperty;
     private SerializedProperty enableNetworkedVarProperty;
@@ -111,6 +112,7 @@ public class NetworkingManagerEditor : Editor
         clientConnectionBufferTimeoutProperty = networkConfigProperty.FindPropertyRelative("ClientConnectionBufferTimeout");
         connectionApprovalProperty = networkConfigProperty.FindPropertyRelative("ConnectionApproval");
         secondsHistoryProperty = networkConfigProperty.FindPropertyRelative("SecondsHistory");
+        enableHostMigrationProperty = networkConfigProperty.FindPropertyRelative("EnableHostMigration");
         enableTimeResyncProperty = networkConfigProperty.FindPropertyRelative("EnableTimeResync");
         timeResyncIntervalProperty = networkConfigProperty.FindPropertyRelative("TimeResyncInterval");
         enableNetworkedVarProperty = networkConfigProperty.FindPropertyRelative("EnableNetworkedVar");
@@ -152,6 +154,7 @@ public class NetworkingManagerEditor : Editor
         clientConnectionBufferTimeoutProperty = networkConfigProperty.FindPropertyRelative("ClientConnectionBufferTimeout");
         connectionApprovalProperty = networkConfigProperty.FindPropertyRelative("ConnectionApproval");
         secondsHistoryProperty = networkConfigProperty.FindPropertyRelative("SecondsHistory");
+        enableHostMigrationProperty = networkConfigProperty.FindPropertyRelative("EnableHostMigration");
         enableTimeResyncProperty = networkConfigProperty.FindPropertyRelative("EnableTimeResync");
         timeResyncIntervalProperty = networkConfigProperty.FindPropertyRelative("TimeResyncInterval");
         enableNetworkedVarProperty = networkConfigProperty.FindPropertyRelative("EnableNetworkedVar");
@@ -293,6 +296,7 @@ public class NetworkingManagerEditor : Editor
                 }
             }
 
+            EditorGUILayout.PropertyField(enableHostMigrationProperty);
             EditorGUILayout.PropertyField(enableTimeResyncProperty);
 
             using (new EditorGUI.DisabledScope(!networkingManager.NetworkConfig.EnableTimeResync))

--- a/MLAPI/Configuration/MLAPIConstants.cs
+++ b/MLAPI/Configuration/MLAPIConstants.cs
@@ -31,6 +31,9 @@ namespace MLAPI.Configuration
         internal const byte MLAPI_DESTROY_OBJECTS = 21;
         internal const byte MLAPI_NAMED_MESSAGE = 22;
         internal const byte MLAPI_SYNCED_VAR = 23;
+        internal const byte MLAPI_CLIENT_CONNECTED = 24;
+        internal const byte MLAPI_CLIENT_DISCONNECTED = 25;
+        internal const byte MLAPI_CLIENT_NETWORKID = 26;
         internal const byte INVALID = 32;
 
         internal static readonly string[] MESSAGE_NAMES = {
@@ -58,9 +61,9 @@ namespace MLAPI.Configuration
             "MLAPI_DESTROY_OBJECTS",
             "MLAPI_NAMED_MESSAGE",
             "MLAPI_SYNCED_VAR",
-            "",
-            "",
-            "",
+            "MLAPI_CLIENT_CONNECTED",
+            "MLAPI_CLIENT_DISCONNECTED",
+            "MLAPI_CLIENT_NETWORKID",
             "",
             "",
             "",

--- a/MLAPI/Configuration/MLAPIConstants.cs
+++ b/MLAPI/Configuration/MLAPIConstants.cs
@@ -31,7 +31,8 @@ namespace MLAPI.Configuration
         internal const byte MLAPI_DESTROY_OBJECTS = 21;
         internal const byte MLAPI_NAMED_MESSAGE = 22;
         internal const byte MLAPI_SYNCED_VAR = 23;
-        internal const byte MLAPI_CLIENT_DISCONNECTED = 24;
+        internal const byte MLAPI_CLIENT_CONNECTED = 24;
+        internal const byte MLAPI_CLIENT_DISCONNECTED = 25;
         internal const byte INVALID = 32;
 
         internal static readonly string[] MESSAGE_NAMES = new string[33] {
@@ -59,8 +60,8 @@ namespace MLAPI.Configuration
             "MLAPI_DESTROY_OBJECTS",
             "MLAPI_NAMED_MESSAGE",
             "MLAPI_SYNCED_VAR",
+            "MLAPI_CLIENT_CONNECTED",
             "MLAPI_CLIENT_DISCONNECTED",
-            "",
             "",
             "",
             "",

--- a/MLAPI/Configuration/MLAPIConstants.cs
+++ b/MLAPI/Configuration/MLAPIConstants.cs
@@ -31,12 +31,10 @@ namespace MLAPI.Configuration
         internal const byte MLAPI_DESTROY_OBJECTS = 21;
         internal const byte MLAPI_NAMED_MESSAGE = 22;
         internal const byte MLAPI_SYNCED_VAR = 23;
-        internal const byte MLAPI_CLIENT_CONNECTED = 24;
-        internal const byte MLAPI_CLIENT_DISCONNECTED = 25;
-        internal const byte MLAPI_CLIENT_NETWORKID = 26;
+        internal const byte MLAPI_CLIENT_DISCONNECTED = 24;
         internal const byte INVALID = 32;
 
-        internal static readonly string[] MESSAGE_NAMES = {
+        internal static readonly string[] MESSAGE_NAMES = new string[33] {
             "MLAPI_CERTIFICATE_HAIL", // 0
             "MLAPI_CERTIFICATE_HAIL_RESPONSE",
             "MLAPI_GREETINGS",
@@ -61,9 +59,9 @@ namespace MLAPI.Configuration
             "MLAPI_DESTROY_OBJECTS",
             "MLAPI_NAMED_MESSAGE",
             "MLAPI_SYNCED_VAR",
-            "MLAPI_CLIENT_CONNECTED",
             "MLAPI_CLIENT_DISCONNECTED",
-            "MLAPI_CLIENT_NETWORKID",
+            "",
+            "",
             "",
             "",
             "",

--- a/MLAPI/Configuration/NetworkConfig.cs
+++ b/MLAPI/Configuration/NetworkConfig.cs
@@ -176,6 +176,11 @@ namespace MLAPI.Configuration
         [Tooltip("The amount of time a message should be buffered for without being consumed. If it is not consumed within this time, it will be dropped")]
         public float MessageBufferTimeout = 20f;
         /// <summary>
+        /// Whether or not host migration should be enabled. This will synchronize states over all clients so the host can be migrated.
+        /// </summary>
+        [Tooltip("Whether or not host migration should be enabled. This will synchronize states over clients so the host can be migrated.")]
+        public bool EnableHostMigration = false;
+        /// <summary>
         /// Whether or not to enable the ECDHE key exchange to allow for encryption and authentication of messages
         /// </summary>
         [Tooltip("Whether or not to enable the ECDHE key exchange to allow for encryption and authentication of messages")]

--- a/MLAPI/Core/DisconnectAction.cs
+++ b/MLAPI/Core/DisconnectAction.cs
@@ -1,0 +1,21 @@
+namespace MLAPI
+{
+    /// <summary>
+    /// Represents an action when disconnected from a host
+    /// </summary>
+    public enum DisconnectAction
+    {
+        /// <summary>
+        /// Shutdown mlapi
+        /// </summary>
+        Shutdown,
+        /// <summary>
+        /// Migrate to a new host
+        /// </summary>
+        Migrate,
+        /// <summary>
+        /// Become the new host
+        /// </summary>
+        Host
+    }
+}

--- a/MLAPI/Core/NetworkedObject.cs
+++ b/MLAPI/Core/NetworkedObject.cs
@@ -63,6 +63,9 @@ namespace MLAPI
 
         internal ulong? _ownerClientId = null;
 
+        // Represents if this object is pending to be reclaimed
+        public bool PendingClaim { get; internal set; }
+
         /// <summary>
         /// InstanceId is the id that is unique to the object and scene for a scene object when UsePrefabSync is false.
         /// If UsePrefabSync is true or if it's used on non scene objects, this has no effect.

--- a/MLAPI/Core/NetworkedObject.cs
+++ b/MLAPI/Core/NetworkedObject.cs
@@ -383,6 +383,19 @@ namespace MLAPI
             }
         }
 
+        internal void SpawnWithCurrentState()
+        {
+            SpawnManager.SpawnNetworkedObjectLocally(this, SpawnManager.GetNetworkObjectId(), false, IsPlayerObject, OwnerClientId, null, false, 0, false, DestroyWithScene);
+
+            for (int i = 0; i < NetworkingManager.Singleton.ConnectedClientsList.Count; i++)
+            {
+                if (observers.Contains(NetworkingManager.Singleton.ConnectedClientsList[i].ClientId))
+                {
+                    SpawnManager.SendSpawnCallForObject(NetworkingManager.Singleton.ConnectedClientsList[i].ClientId, this, null);
+                }
+            }
+        }
+
         /// <summary>
         /// Spawns this GameObject across the network. Can only be called from the Server
         /// </summary>
@@ -415,6 +428,11 @@ namespace MLAPI
         public void UnSpawn()
         {
             SpawnManager.UnSpawnObject(this);
+        }
+
+        internal void SetPendingMigration()
+        {
+            SpawnManager.SetPendingMigration(this);
         }
 
         /// <summary>

--- a/MLAPI/Core/NetworkingManager.cs
+++ b/MLAPI/Core/NetworkingManager.cs
@@ -27,6 +27,10 @@ using MLAPI.Exceptions;
 using MLAPI.Transports.Tasks;
 using MLAPI.Messaging.Buffering;
 
+// TODO:
+// OnDisconnect
+
+
 namespace MLAPI
 {
     /// <summary>
@@ -994,6 +998,11 @@ namespace MLAPI
                         }
                     }
 
+                    else if (IsHostMigrationEnabled)
+                    {
+
+                    }
+
                     else
                     {
                         IsConnectedClient = false;
@@ -1144,6 +1153,10 @@ namespace MLAPI
                         break;
                     case MLAPIConstants.MLAPI_SYNCED_VAR:
                         if (IsClient) InternalMessageHandler.HandleSyncedVar(clientId, messageStream);
+                        break;
+                    case MLAPIConstants.MLAPI_CLIENT_CONNECTED:
+                        if (IsClient && IsHostMigrationEnabled)
+                            InternalMessageHandler.HandleClientConnected(clientId, messageStream);
                         break;
                     case MLAPIConstants.MLAPI_CLIENT_DISCONNECTED:
                         if (IsClient && IsHostMigrationEnabled)
@@ -1311,7 +1324,6 @@ namespace MLAPI
                 {
                     using (PooledBitWriter writer = PooledBitWriter.Get(stream))
                     {
-                        writer.WriteBit(true);
                         writer.WriteUInt64Packed(clientId);
 
                         if (NetworkConfig.EnableSceneManagement)
@@ -1420,9 +1432,8 @@ namespace MLAPI
                         {
                             using (PooledBitWriter writer = PooledBitWriter.Get(stream))
                             {
-                                writer.WriteBit(false);
                                 writer.WriteUInt64Packed(clientId);
-                                InternalMessageSender.Send(clientPair.Key, MLAPIConstants.MLAPI_CONNECTION_APPROVED, "MLAPI_INTERNAL", stream, SecuritySendFlags.None, null);
+                                InternalMessageSender.Send(clientPair.Key, MLAPIConstants.MLAPI_CLIENT_CONNECTED, "MLAPI_INTERNAL", stream, SecuritySendFlags.None, null);
                             }
                         }
                     }

--- a/MLAPI/Core/NetworkingManager.cs
+++ b/MLAPI/Core/NetworkingManager.cs
@@ -42,14 +42,6 @@ namespace MLAPI
         private float networkTimeOffset;
         private float currentNetworkTimeOffset;
         /// <summary>
-        /// The time it takes to send a message to the connected server and back
-        /// </summary>
-        public float RTT() => IsClient ? RTT(ServerClientId) : 0f;
-        /// <summary>
-        /// The time it takes to send a message to the connected peer and back
-        /// </summary>
-        public float RTT(ulong clientId) => NetworkConfig.NetworkTransport != null ? NetworkConfig.NetworkTransport.GetCurrentRtt(clientId) : 0f;
-        /// <summary>
         /// Gets or sets if the NetworkingManager should be marked as DontDestroyOnLoad
         /// </summary>
         [HideInInspector]

--- a/MLAPI/Core/NetworkingManager.cs
+++ b/MLAPI/Core/NetworkingManager.cs
@@ -530,31 +530,29 @@ namespace MLAPI
             HashSet<ulong> disconnectedIds = new HashSet<ulong>();
             //Don't know if I have to disconnect the clients. I'm assuming the NetworkTransport does all the cleaning on shtudown. But this way the clients get a disconnect message from server (so long it does't get lost)
 
-            if (!IsHostMigrationEnabled)
+            foreach (KeyValuePair<ulong, NetworkedClient> pair in ConnectedClients)
             {
-                foreach (KeyValuePair<ulong, NetworkedClient> pair in ConnectedClients)
+                if (!disconnectedIds.Contains(pair.Key))
                 {
-                    if (!disconnectedIds.Contains(pair.Key))
-                    {
-                        disconnectedIds.Add(pair.Key);
+                    disconnectedIds.Add(pair.Key);
 
-                        if (pair.Key == NetworkConfig.NetworkTransport.ServerClientId)
-                            continue;
+                    if (pair.Key == NetworkConfig.NetworkTransport.ServerClientId)
+                        continue;
 
-                        NetworkConfig.NetworkTransport.DisconnectRemoteClient(pair.Key);
-                    }
+                    NetworkConfig.NetworkTransport.DisconnectRemoteClient(pair.Key);
                 }
+            }
 
-                foreach (KeyValuePair<ulong, PendingClient> pair in PendingClients)
+            foreach (KeyValuePair<ulong, PendingClient> pair in PendingClients)
+            {
+                if (!disconnectedIds.Contains(pair.Key))
                 {
-                    if (!disconnectedIds.Contains(pair.Key))
-                    {
-                        disconnectedIds.Add(pair.Key);
-                        if (pair.Key == NetworkConfig.NetworkTransport.ServerClientId)
-                            continue;
+                    disconnectedIds.Add(pair.Key);
 
-                        NetworkConfig.NetworkTransport.DisconnectRemoteClient(pair.Key);
-                    }
+                    if (pair.Key == NetworkConfig.NetworkTransport.ServerClientId)
+                        continue;
+
+                    NetworkConfig.NetworkTransport.DisconnectRemoteClient(pair.Key);
                 }
             }
 

--- a/MLAPI/Core/NetworkingManager.cs
+++ b/MLAPI/Core/NetworkingManager.cs
@@ -203,9 +203,14 @@ namespace MLAPI
             }
         }
         /// <summary>
+        /// Delegate type called for handling with disconnection from host.
+        /// </summary>
+        /// <param name="newHost">The new host information for connecting, usually an id.</param>
+        public delegate DisconnectAction DisconnectedHostDelegate(out object newHost);
+        /// <summary>
         /// The callback to invoke once the local client disconnects. This callback is only ran when host migration is possible.
         /// </summary>
-        public Func<DisconnectAction> OnDisconnectedHostCallback = null;
+        public DisconnectedHostDelegate OnDisconnectedHostCallback = null;
         /// <summary>
         /// The current NetworkingConfiguration
         /// </summary>
@@ -1011,7 +1016,7 @@ namespace MLAPI
 
                     else if (IsHostMigrationEnabled && OnDisconnectedHostCallback != null)
                     {
-                        DisconnectAction action = OnDisconnectedHostCallback();
+                        DisconnectAction action = OnDisconnectedHostCallback(out object clientid);
 
                         switch (action)
                         {

--- a/MLAPI/Core/NetworkingManager.cs
+++ b/MLAPI/Core/NetworkingManager.cs
@@ -690,6 +690,9 @@ namespace MLAPI
                 }
             }
 
+            // Setup the networkId counter
+            SpawnManager.SyncronizeNetworkIdCounters();
+
             // Renew transport as host
             SocketTasks tasks = NetworkConfig.NetworkTransport.StartServer();
 

--- a/MLAPI/Core/NetworkingManager.cs
+++ b/MLAPI/Core/NetworkingManager.cs
@@ -27,10 +27,6 @@ using MLAPI.Exceptions;
 using MLAPI.Transports.Tasks;
 using MLAPI.Messaging.Buffering;
 
-// TODO:
-// OnDisconnect
-
-
 namespace MLAPI
 {
     /// <summary>

--- a/MLAPI/HostMigration/HostMigrationManager.cs
+++ b/MLAPI/HostMigration/HostMigrationManager.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+
+namespace MLAPI.HostMigration
+{
+    public class HostMigrationManager
+    {
+        public static HostMigrationManager Singleton => NetworkingManager.Singleton.HostMigrationManager;
+
+        internal readonly List<MigratableHost> MigratableHosts = new List<MigratableHost>();
+    }
+}

--- a/MLAPI/HostMigration/HostMigrationManager.cs
+++ b/MLAPI/HostMigration/HostMigrationManager.cs
@@ -7,6 +7,13 @@ namespace MLAPI.HostMigration
     {
         public static HostMigrationManager Singleton => NetworkingManager.Singleton.HostMigrationManager;
 
+        /// <summary>
+        /// Gets Whether or not we are syncing for host migration.
+        /// </summary>
+        public bool IsHostMigrationEnabled { get; internal set; }
+
+        internal ulong? IsMigratingFromClientId = null;
+
         internal readonly List<MigratableHost> MigratableHosts = new List<MigratableHost>();
     }
 }

--- a/MLAPI/HostMigration/MigratableHost.cs
+++ b/MLAPI/HostMigration/MigratableHost.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace MLAPI.HostMigration
+{
+    public struct MigratableHost
+    {
+        public ulong ClientId;
+    }
+}

--- a/MLAPI/MLAPI.csproj
+++ b/MLAPI/MLAPI.csproj
@@ -18,4 +18,7 @@
       <Private>false</Private>
     </Reference>
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="HostMigration\" />
+  </ItemGroup>
 </Project>

--- a/MLAPI/Messaging/InternalMessageHandler.cs
+++ b/MLAPI/Messaging/InternalMessageHandler.cs
@@ -204,21 +204,6 @@ namespace MLAPI.Messaging
         {
             using (PooledBitReader reader = PooledBitReader.Get(stream))
             {
-                bool initialConnection = reader.ReadBit();
-
-                if (!initialConnection)
-                {
-                    if (NetworkingManager.Singleton.IsHostMigrationEnabled)
-                    {
-                        ulong newClientId = reader.ReadUInt64Packed();
-                        NetworkedClient newClient = new NetworkedClient() { ClientId = newClientId };
-                        NetworkingManager.Singleton.ConnectedClients.Add(newClientId, newClient);
-                        NetworkingManager.Singleton.ConnectedClientsList.Add(newClient);
-                    }
-
-                    return;
-                }
-
                 NetworkingManager.Singleton.LocalClientId = reader.ReadUInt64Packed();
 
                 uint sceneIndex = 0;
@@ -362,6 +347,17 @@ namespace MLAPI.Messaging
                 {
                     DelayedSpawnAction(stream);
                 }
+            }
+        }
+
+        internal static void HandleClientConnected(ulong clientId, Stream stream)
+        {
+            using (PooledBitReader reader = PooledBitReader.Get(stream))
+            {
+                ulong newClientId = reader.ReadUInt64Packed();
+                NetworkedClient newClient = new NetworkedClient() { ClientId = newClientId };
+                NetworkingManager.Singleton.ConnectedClients.Add(newClientId, newClient);
+                NetworkingManager.Singleton.ConnectedClientsList.Add(newClient);
             }
         }
 

--- a/MLAPI/Messaging/InternalMessageHandler.cs
+++ b/MLAPI/Messaging/InternalMessageHandler.cs
@@ -189,14 +189,23 @@ namespace MLAPI.Messaging
                 if (NetworkingManager.Singleton.NetworkConfig.ConnectionApproval)
                 {
                     byte[] connectionBuffer = reader.ReadByteArray();
+
+                    bool migrating = reader.ReadBool();
+
+                    ulong? oldClientId = migrating ? new ulong?(reader.ReadUInt64Packed()) : null;
+
                     NetworkingManager.Singleton.InvokeConnectionApproval(connectionBuffer, clientId, (createPlayerObject, playerPrefabHash, approved, position, rotation) =>
                     {
-                        NetworkingManager.Singleton.HandleApproval(clientId, createPlayerObject, playerPrefabHash, approved, position, rotation);
+                        NetworkingManager.Singleton.HandleApproval(clientId, createPlayerObject, playerPrefabHash, approved, position, rotation, oldClientId);
                     });
                 }
                 else
                 {
-                    NetworkingManager.Singleton.HandleApproval(clientId, NetworkingManager.Singleton.NetworkConfig.CreatePlayerPrefab, null, true, null, null);
+                    bool migrating = reader.ReadBool();
+
+                    ulong? oldClientId = migrating ? new ulong?(reader.ReadUInt64Packed()) : null;
+
+                    NetworkingManager.Singleton.HandleApproval(clientId, NetworkingManager.Singleton.NetworkConfig.CreatePlayerPrefab, null, true, null, null, oldClientId);
                 }
             }
         }

--- a/MLAPI/SceneManagement/NetworkSceneManager.cs
+++ b/MLAPI/SceneManagement/NetworkSceneManager.cs
@@ -363,7 +363,6 @@ namespace MLAPI.SceneManagement
 
                         NetworkedObject networkedObject = SpawnManager.CreateLocalNetworkedObject(false, 0, prefabHash, parentNetworkId, position, rotation);
                         SpawnManager.SpawnNetworkedObjectLocally(networkedObject, networkId, true, isPlayerObject, owner, objectStream, false, 0, true, false);
-                        if (NetworkingManager.Singleton.IsHostMigrationEnabled) SpawnManager.SetNetworkObjectIdCounter(networkId);
                         Queue<BufferManager.BufferedMessage> bufferQueue = BufferManager.ConsumeBuffersForNetworkId(networkId);
 
                         // Apply buffered messages
@@ -408,7 +407,6 @@ namespace MLAPI.SceneManagement
 
                         NetworkedObject networkedObject = SpawnManager.CreateLocalNetworkedObject(true, instanceId, 0, parentNetworkId, null, null);
                         SpawnManager.SpawnNetworkedObjectLocally(networkedObject, networkId, true, isPlayerObject, owner, objectStream, false, 0, true, false);
-                        if (NetworkingManager.Singleton.IsHostMigrationEnabled) SpawnManager.SetNetworkObjectIdCounter(networkId);
                         Queue<BufferManager.BufferedMessage> bufferQueue = BufferManager.ConsumeBuffersForNetworkId(networkId);
 
                         // Apply buffered messages

--- a/MLAPI/SceneManagement/NetworkSceneManager.cs
+++ b/MLAPI/SceneManagement/NetworkSceneManager.cs
@@ -363,7 +363,7 @@ namespace MLAPI.SceneManagement
 
                         NetworkedObject networkedObject = SpawnManager.CreateLocalNetworkedObject(false, 0, prefabHash, parentNetworkId, position, rotation);
                         SpawnManager.SpawnNetworkedObjectLocally(networkedObject, networkId, true, isPlayerObject, owner, objectStream, false, 0, true, false);
-
+                        if (NetworkingManager.Singleton.IsHostMigrationEnabled) SpawnManager.SetNetworkObjectIdCounter(networkId);
                         Queue<BufferManager.BufferedMessage> bufferQueue = BufferManager.ConsumeBuffersForNetworkId(networkId);
 
                         // Apply buffered messages
@@ -408,7 +408,7 @@ namespace MLAPI.SceneManagement
 
                         NetworkedObject networkedObject = SpawnManager.CreateLocalNetworkedObject(true, instanceId, 0, parentNetworkId, null, null);
                         SpawnManager.SpawnNetworkedObjectLocally(networkedObject, networkId, true, isPlayerObject, owner, objectStream, false, 0, true, false);
-
+                        if (NetworkingManager.Singleton.IsHostMigrationEnabled) SpawnManager.SetNetworkObjectIdCounter(networkId);
                         Queue<BufferManager.BufferedMessage> bufferQueue = BufferManager.ConsumeBuffersForNetworkId(networkId);
 
                         // Apply buffered messages

--- a/MLAPI/SceneManagement/NetworkSceneManager.cs
+++ b/MLAPI/SceneManagement/NetworkSceneManager.cs
@@ -192,6 +192,7 @@ namespace MLAPI.SceneManagement
             }
 
             isSwitching = false;
+            currentSceneIndex = CurrentActiveSceneIndex;
         }
 
         private static void OnSceneLoaded(Guid switchSceneGuid, Stream objectStream)

--- a/MLAPI/Spawning/SpawnManager.cs
+++ b/MLAPI/Spawning/SpawnManager.cs
@@ -114,6 +114,36 @@ namespace MLAPI.Spawning
             }
         }
 
+        internal static void SyncronizeNetworkIdCounters()
+        {
+            networkObjectIdCounter = 0;
+            releasedNetworkObjectIds.Clear();
+
+            ulong highestNetworkId = 0;
+
+            for (int i = 0; i < SpawnedObjectsList.Count; i++)
+            {
+                if (SpawnedObjectsList[i].NetworkId > highestNetworkId)
+                {
+                    highestNetworkId = SpawnedObjectsList[i].NetworkId;
+                }
+            }
+
+            for (ulong i = 0; i < highestNetworkId; i++)
+            {
+                if (!SpawnedObjects.ContainsKey(i))
+                {
+                    releasedNetworkObjectIds.Enqueue(new ReleasedNetworkId()
+                    {
+                        NetworkId = i,
+                        ReleaseTime = Time.unscaledTime
+                    });
+                }
+            }
+
+            networkObjectIdCounter = highestNetworkId + 1;
+        }
+
         /// <summary>
         /// Gets the prefab index of a given prefab hash
         /// </summary>

--- a/MLAPI/Spawning/SpawnManager.cs
+++ b/MLAPI/Spawning/SpawnManager.cs
@@ -108,28 +108,13 @@ namespace MLAPI.Spawning
             }
             else
             {
-                networkObjectIdCounter++;
-
-                if (NetworkingManager.Singleton.IsHostMigrationEnabled)
-                {
-                    foreach (KeyValuePair<ulong, NetworkedClient> clientPair in NetworkingManager.Singleton.ConnectedClients)
-                    {
-                        if (clientPair.Key != NetworkingManager.Singleton.ServerClientId)
-                        {
-                            using (PooledBitStream stream = PooledBitStream.Get())
-                            {
-                                using (PooledBitWriter writer = PooledBitWriter.Get(stream))
-                                {
-                                    writer.WriteUInt64Packed(networkObjectIdCounter);
-                                    InternalMessageSender.Send(clientPair.Key, MLAPIConstants.MLAPI_CLIENT_NETWORKID, "MLAPI_INTERNAL", stream, SecuritySendFlags.None, null);
-                                }
-                            }
-                        }
-                    }
-                }
-
-                return networkObjectIdCounter;
+                return ++networkObjectIdCounter;
             }
+        }
+
+        internal static void SetNetworkObjectIdCounter(ulong counter)
+        {
+            networkObjectIdCounter = counter + 5;
         }
 
         /// <summary>

--- a/MLAPI/Transports/NetEventType.cs
+++ b/MLAPI/Transports/NetEventType.cs
@@ -1,4 +1,4 @@
-﻿namespace MLAPI.Transports
+namespace MLAPI.Transports
 {
     /// <summary>
     /// Represents a netEvent when polling
@@ -17,6 +17,10 @@
         /// A client disconnected, or client disconnected from server
         /// </summary>
         Disconnect,
+        /// <summary>
+        /// A host migrated
+        /// </summary>
+        HostMigrate,
         /// <summary>
         /// No new event
         /// </summary>

--- a/MLAPI/Transports/NetEventType.cs
+++ b/MLAPI/Transports/NetEventType.cs
@@ -18,10 +18,6 @@ namespace MLAPI.Transports
         /// </summary>
         Disconnect,
         /// <summary>
-        /// A host migrated
-        /// </summary>
-        HostMigrate,
-        /// <summary>
         /// No new event
         /// </summary>
         Nothing

--- a/MLAPI/Transports/Transport.cs
+++ b/MLAPI/Transports/Transport.cs
@@ -184,13 +184,5 @@ namespace MLAPI.Transports
         /// Initializes the transport
         /// </summary>
         public abstract void Init();
-
-        /// <summary>
-        /// Raises a transport event
-        /// </summary>
-        protected virtual void RaiseTransportEvent(NetEventType type, ulong clientId, string channelName, ArraySegment<byte> payload, float receiveTime)
-        {
-            OnTransportEvent(type, clientId, channelName, payload, receiveTime);
-        }
     }
 }

--- a/MLAPI/Transports/Transport.cs
+++ b/MLAPI/Transports/Transport.cs
@@ -33,6 +33,12 @@ namespace MLAPI.Transports
         /// <value><c>true</c> if is supported; otherwise, <c>false</c>.</value>
         public virtual bool IsSupported => true;
 
+        /// <summary>
+        /// Gets a value indicating whether this <see cref="T:MLAPI.Transports.Transport"/> supports HostMigration.
+        /// </summary>
+        /// <value><c>true</c> if is supported; otherwise, <c>false</c>.</value>
+        public virtual bool IsHostMigrationSupported => false;
+
         private TransportChannel[] _channelsCache = null;
 
         internal void ResetChannelCache()
@@ -178,5 +184,13 @@ namespace MLAPI.Transports
         /// Initializes the transport
         /// </summary>
         public abstract void Init();
+
+        /// <summary>
+        /// Raises a transport event
+        /// </summary>
+        protected virtual void RaiseTransportEvent(NetEventType type, ulong clientId, string channelName, ArraySegment<byte> payload, float receiveTime)
+        {
+            OnTransportEvent(type, clientId, channelName, payload, receiveTime);
+        }
     }
 }


### PR DESCRIPTION
Checklist of features:
* [x] Take over game as host
* [ ] Client migrate to new host
* [ ] Host migrates to new host (this is for the case where the original host disconnects. Then a client takes the new host, fails to become the host (for example, because of it not being reachable), then it once again becomes a client and migrates). This is a low prio edge case but is very useful
* [ ] API Cleanup
* [ ] Security to prevent taking over someone elses object
* [ ] Fix reimporting of X509 Certificate when becoming host (not useful for a lot of cases, but should work anyways)

 - TwoTen & DatBlindArcher