### PR TITLE
refactor(owner): IsOwner is true when OnGainedOwnership is called

### DIFF
--- a/MLAPI-Editor/MLAPI-Editor.csproj
+++ b/MLAPI-Editor/MLAPI-Editor.csproj
@@ -7,6 +7,10 @@
     <Product>MLAPI-Editor</Product>
     <LangVersion>7</LangVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net35|AnyCPU'">
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MLAPI\MLAPI.csproj" />
   </ItemGroup>
@@ -22,4 +26,7 @@
       <Private>false</Private>
     </Reference>
   </ItemGroup>
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="copy /Y $(TargetDir)\$(TargetName).dll  H:\Projects\notruf2019_new\programming\n2019Plugins\BuildSolution\Plugins&#xD;&#xA;copy /Y $(TargetDir)\$(TargetName).pdb  H:\Projects\notruf2019_new\programming\n2019Plugins\BuildSolution\Plugins" />
+  </Target>
 </Project>

--- a/MLAPI/MLAPI.csproj
+++ b/MLAPI/MLAPI.csproj
@@ -8,6 +8,10 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFrameworks>net35;net471;net45;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net35|AnyCPU'">
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
 
   <ItemGroup>
     <Reference Include="System.Security" Condition="$(TargetFramework) != 'netstandard2.0'" />
@@ -18,4 +22,8 @@
       <Private>false</Private>
     </Reference>
   </ItemGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="copy /Y $(TargetDir)\$(TargetName).dll  H:\Projects\notruf2019_new\programming\n2019Plugins\BuildSolution\Plugins&#xD;&#xA;copy /Y $(TargetDir)\$(TargetName).pdb  H:\Projects\notruf2019_new\programming\n2019Plugins\BuildSolution\Plugins" />
+  </Target>
 </Project>

--- a/MLAPI/Messaging/InternalMessageHandler.cs
+++ b/MLAPI/Messaging/InternalMessageHandler.cs
@@ -453,12 +453,13 @@ namespace MLAPI.Messaging
                     //We are current owner.
                     SpawnManager.SpawnedObjects[networkId].InvokeBehaviourOnLostOwnership();
                 }
+                // set new owner before notifying NetworkedObjects to ensure that IsOwner is true
+                SpawnManager.SpawnedObjects[networkId].OwnerClientId = ownerClientId;
                 if (ownerClientId == NetworkingManager.Singleton.LocalClientId)
                 {
                     //We are new owner.
                     SpawnManager.SpawnedObjects[networkId].InvokeBehaviourOnGainedOwnership();
                 }
-                SpawnManager.SpawnedObjects[networkId].OwnerClientId = ownerClientId;
             }
         }
 


### PR DESCRIPTION
I had some weird effects when changing game units because my code relied on the "IsOwner" property to toggle physics and/or AI control. After stepping through the source I noticed that ownerClientID was set AFTER the OnGainedOwnerShip methods were called.
I would argue that OnGain_ed_ implies that the ownership transfer has already been completed - I know semantics ;)
Oh, and of course, maybe there is a really good reason why it was done this way that I fail to see.

Please be kind as this is my first pull request that I've ever done in my life.