### PR TITLE
bypass NetworkTransform::update() if transform unchanged

### DIFF
--- a/MLAPI/Core/NetworkingManager.cs
+++ b/MLAPI/Core/NetworkingManager.cs
@@ -921,7 +921,7 @@ namespace MLAPI
                 if (IsServer && (NetworkConfig.EnableEncryption && PendingClients.ContainsKey(clientId) && PendingClients[clientId].ConnectionState == PendingClient.State.PendingHail && messageType != MLAPIConstants.MLAPI_CERTIFICATE_HAIL_RESPONSE) ||
                     (PendingClients.ContainsKey(clientId) && PendingClients[clientId].ConnectionState == PendingClient.State.PendingConnection && messageType != MLAPIConstants.MLAPI_CONNECTION_REQUEST))
                 {
-                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("Message recieved from clientId " + clientId + " before it has been accepted");
+                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("Message received from clientId " + clientId + " before it has been accepted");
                     return;
                 }
 

--- a/MLAPI/Messaging/InternalMessageHandler.cs
+++ b/MLAPI/Messaging/InternalMessageHandler.cs
@@ -533,7 +533,7 @@ namespace MLAPI.Messaging
 
                     if (instance == null)
                     {
-                        if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("NetworkedVarDelta message recieved for a non existant behaviour. NetworkId: " + networkId + ", behaviourIndex: " + orderIndex);
+                        if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("NetworkedVarDelta message received for a non existant behaviour. NetworkId: " + networkId + ", behaviourIndex: " + orderIndex);
                     }
                     else
                     {
@@ -542,11 +542,11 @@ namespace MLAPI.Messaging
                 }
                 else if (NetworkingManager.Singleton.IsServer || !NetworkingManager.Singleton.NetworkConfig.EnableMessageBuffering)
                 {
-                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("NetworkedVarDelta message recieved for a non existant object with id: " + networkId + ". This delta was lost.");
+                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("NetworkedVarDelta message received for a non existant object with id: " + networkId + ". This delta was lost.");
                 }
                 else
                 {
-                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("NetworkedVarDelta message recieved for a non existant object with id: " + networkId + ". This delta will be buffered and might be recovered.");
+                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("NetworkedVarDelta message received for a non existant object with id: " + networkId + ". This delta will be buffered and might be recovered.");
                     bufferCallback(networkId, bufferPreset);
                 }
             }
@@ -571,7 +571,7 @@ namespace MLAPI.Messaging
 
                     if (instance == null)
                     {
-                        if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("NetworkedVarUpdate message recieved for a non existant behaviour. NetworkId: " + networkId + ", behaviourIndex: " + orderIndex);
+                        if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("NetworkedVarUpdate message received for a non existant behaviour. NetworkId: " + networkId + ", behaviourIndex: " + orderIndex);
                     }
                     else
                     {
@@ -580,11 +580,11 @@ namespace MLAPI.Messaging
                 }
                 else if (NetworkingManager.Singleton.IsServer || !NetworkingManager.Singleton.NetworkConfig.EnableMessageBuffering)
                 {
-                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("NetworkedVarUpdate message recieved for a non existant object with id: " + networkId + ". This delta was lost.");
+                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("NetworkedVarUpdate message received for a non existant object with id: " + networkId + ". This delta was lost.");
                 }
                 else
                 {
-                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("NetworkedVarUpdate message recieved for a non existant object with id: " + networkId + ". This delta will be buffered and might be recovered.");
+                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("NetworkedVarUpdate message received for a non existant object with id: " + networkId + ". This delta will be buffered and might be recovered.");
                     bufferCallback(networkId, bufferPreset);
                 }
             }
@@ -602,14 +602,14 @@ namespace MLAPI.Messaging
                     NetworkedBehaviour instance = SpawnManager.SpawnedObjects[networkId].GetBehaviourAtOrderIndex(orderIndex);
                     if (instance == null)
                     {
-                        if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("SyncedVar message recieved for a non existant behaviour");
+                        if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("SyncedVar message received for a non existant behaviour");
                         return;
                     }
                     NetworkedBehaviour.HandleSyncedVarValue(instance.syncedVars, stream, clientId, instance);
                 }
                 else
                 {
-                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("SyncedVar message recieved for a non existant object with id: " + networkId);
+                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("SyncedVar message received for a non existant object with id: " + networkId);
                     return;
                 }
             }
@@ -629,7 +629,7 @@ namespace MLAPI.Messaging
 
                     if (behaviour == null)
                     {
-                        if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("ServerRPC message recieved for a non existant behaviour. NetworkId: " + networkId + ", behaviourIndex: " + behaviourId);
+                        if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("ServerRPC message received for a non existant behaviour. NetworkId: " + networkId + ", behaviourIndex: " + behaviourId);
                     }
                     else
                     {
@@ -638,7 +638,7 @@ namespace MLAPI.Messaging
                 }
                 else if (NetworkingManager.Singleton.IsServer || !NetworkingManager.Singleton.NetworkConfig.EnableMessageBuffering)
                 {
-                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("ServerRPC message recieved for a non existant object with id: " + networkId + ". This message is lost.");
+                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("ServerRPC message received for a non existant object with id: " + networkId + ". This message is lost.");
                 }
             }
         }
@@ -658,7 +658,7 @@ namespace MLAPI.Messaging
 
                     if (behaviour == null)
                     {
-                        if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("ServerRPCRequest message recieved for a non existant behaviour. NetworkId: " + networkId + ", behaviourIndex: " + behaviourId);
+                        if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("ServerRPCRequest message received for a non existant behaviour. NetworkId: " + networkId + ", behaviourIndex: " + behaviourId);
                     }
                     else
                     {
@@ -678,7 +678,7 @@ namespace MLAPI.Messaging
                 }
                 else
                 {
-                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("ServerRPCRequest message recieved for a non existant object with id: " + networkId + ". This message is lost.");
+                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("ServerRPCRequest message received for a non existant object with id: " + networkId + ". This message is lost.");
                 }
             }
         }
@@ -701,7 +701,7 @@ namespace MLAPI.Messaging
                 }
                 else
                 {
-                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("ServerRPCResponse message recieved for a non existant responseId: " + responseId + ". This response is lost.");
+                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("ServerRPCResponse message received for a non existant responseId: " + responseId + ". This response is lost.");
                 }
             }
         }
@@ -720,7 +720,7 @@ namespace MLAPI.Messaging
 
                     if (behaviour == null)
                     {
-                        if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("ClientRPC message recieved for a non existant behaviour. NetworkId: " + networkId + ", behaviourIndex: " + behaviourId);
+                        if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("ClientRPC message received for a non existant behaviour. NetworkId: " + networkId + ", behaviourIndex: " + behaviourId);
                     }
                     else
                     {
@@ -729,11 +729,11 @@ namespace MLAPI.Messaging
                 }
                 else if (NetworkingManager.Singleton.IsServer || !NetworkingManager.Singleton.NetworkConfig.EnableMessageBuffering)
                 {
-                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("ClientRPC message recieved for a non existant object with id: " + networkId + ". This message is lost.");
+                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("ClientRPC message received for a non existant object with id: " + networkId + ". This message is lost.");
                 }
                 else
                 {
-                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("ClientRPC message recieved for a non existant object with id: " + networkId + ". This message will be buffered and might be recovered.");
+                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("ClientRPC message received for a non existant object with id: " + networkId + ". This message will be buffered and might be recovered.");
                     bufferCallback(networkId, bufferPreset);
                 }
             }
@@ -754,7 +754,7 @@ namespace MLAPI.Messaging
 
                     if (behaviour == null)
                     {
-                        if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("ClientRPCRequest message recieved for a non existant behaviour. NetworkId: " + networkId + ", behaviourIndex: " + behaviourId);
+                        if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("ClientRPCRequest message received for a non existant behaviour. NetworkId: " + networkId + ", behaviourIndex: " + behaviourId);
                     }
                     else
                     {
@@ -774,11 +774,11 @@ namespace MLAPI.Messaging
                 }
                 else if (NetworkingManager.Singleton.IsServer || !NetworkingManager.Singleton.NetworkConfig.EnableMessageBuffering)
                 {
-                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("ClientRPCRequest message recieved for a non existant object with id: " + networkId + ". This message is lost.");
+                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("ClientRPCRequest message received for a non existant object with id: " + networkId + ". This message is lost.");
                 }
                 else
                 {
-                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("ClientRPCRequest message recieved for a non existant object with id: " + networkId + ". This message will be buffered and might be recovered.");
+                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("ClientRPCRequest message received for a non existant object with id: " + networkId + ". This message will be buffered and might be recovered.");
                     bufferCallback(networkId, bufferPreset);
                 }
             }

--- a/MLAPI/Profiling/ProfilerTickData.cs
+++ b/MLAPI/Profiling/ProfilerTickData.cs
@@ -108,7 +108,7 @@ namespace MLAPI.Profiling
         /// </summary>
         public int EventId;
         /// <summary>
-        /// The amount of bytes that were sent and / or recieved during this tick
+        /// The amount of bytes that were sent and / or received during this tick
         /// </summary>
         public uint Bytes
         {

--- a/MLAPI/Prototyping/NetworkedNavMeshAgent.cs
+++ b/MLAPI/Prototyping/NetworkedNavMeshAgent.cs
@@ -31,7 +31,7 @@ namespace MLAPI.Prototyping
         /// <summary>
         /// The percentage to lerp on corrections
         /// </summary>
-        [Tooltip("Everytime a correction packet is recieved. This is the percentage (between 0 & 1) that we will move towards the goal.")]
+        [Tooltip("Everytime a correction packet is received. This is the percentage (between 0 & 1) that we will move towards the goal.")]
         public float DriftCorrectionPercentage = 0.1f;
         /// <summary>
         /// Should we warp on destination change

--- a/MLAPI/Prototyping/NetworkedTransform.cs
+++ b/MLAPI/Prototyping/NetworkedTransform.cs
@@ -77,7 +77,7 @@ namespace MLAPI.Prototyping
         private Vector3 lastSentPos;
         private Quaternion lastSentRot;
 
-        private float lastRecieveTime;
+        private float lastReceiveTime;
         
         /// <summary>
         /// Enables range based send rate
@@ -171,12 +171,12 @@ namespace MLAPI.Prototyping
                     float sendDelay = (IsServer || !EnableRange || !AssumeSyncedSends || NetworkingManager.Singleton.ConnectedClients[NetworkingManager.Singleton.LocalClientId].PlayerObject == null) ? (1f / FixedSendsPerSecond) : GetTimeForLerp(transform.position, NetworkingManager.Singleton.ConnectedClients[NetworkingManager.Singleton.LocalClientId].PlayerObject.transform.position);
                     lerpT += Time.unscaledDeltaTime / sendDelay;
 
-                    if (ExtrapolatePosition && Time.unscaledTime - lastRecieveTime < sendDelay * MaxSendsToExtrapolate)
+                    if (ExtrapolatePosition && Time.unscaledTime - lastReceiveTime < sendDelay * MaxSendsToExtrapolate)
                         transform.position = Vector3.LerpUnclamped(lerpStartPos, lerpEndPos, lerpT);
                     else
                         transform.position = Vector3.Lerp(lerpStartPos, lerpEndPos, lerpT);
 
-                    if (ExtrapolatePosition && Time.unscaledTime - lastRecieveTime < sendDelay * MaxSendsToExtrapolate)
+                    if (ExtrapolatePosition && Time.unscaledTime - lastReceiveTime < sendDelay * MaxSendsToExtrapolate)
                         transform.rotation = Quaternion.SlerpUnclamped(lerpStartRot, lerpEndRot, lerpT);
                     else
                         transform.rotation = Quaternion.Slerp(lerpStartRot, lerpEndRot, lerpT);
@@ -195,7 +195,7 @@ namespace MLAPI.Prototyping
 
             if (InterpolatePosition && (!IsServer || InterpolateServer))
             {
-                lastRecieveTime = Time.unscaledTime;
+                lastReceiveTime = Time.unscaledTime;
                 lerpStartPos = transform.position;
                 lerpStartRot = transform.rotation;
                 lerpEndPos = position;

--- a/MLAPI/Prototyping/NetworkedTransform.cs
+++ b/MLAPI/Prototyping/NetworkedTransform.cs
@@ -141,6 +141,8 @@ namespace MLAPI.Prototyping
 
         private void Update()
         {
+            if (!transform.hasChanged) return;
+
             if (IsOwner)
             {
                 if (NetworkingManager.Singleton.NetworkTime - lastSendTime >= (1f / FixedSendsPerSecond) && (Vector3.Distance(transform.position, lastSentPos) > MinMeters || Quaternion.Angle(transform.rotation, lastSentRot) > MinDegrees))
@@ -182,6 +184,8 @@ namespace MLAPI.Prototyping
             }
 
             if (IsServer && EnableRange && EnableNonProvokedResendChecks) CheckForMissedSends();
+
+            transform.hasChanged = false;
         }
 
         [ClientRPC]

--- a/docs/_api/ProfilerTick.md
+++ b/docs/_api/ProfilerTick.md
@@ -15,7 +15,7 @@ permalink: /api/profiler-tick/
 	<h3 markdown="1">Public Properties</h3>
 	<div style="line-height: 1;">
 		<h4 markdown="1"><b>public ``uint`` Bytes { get; }</b></h4>
-		<p>The amount of bytes that were sent and / or recieved during this tick</p>
+		<p>The amount of bytes that were sent and / or received during this tick</p>
 	</div>
 </div>
 <br>

--- a/docs/_docs/advanced-topics/network-profiler-window.md
+++ b/docs/_docs/advanced-topics/network-profiler-window.md
@@ -11,7 +11,7 @@ The first toggle states if the NetworkProfiler should be recording. The second f
 
 
 #### Profiler block
-Each column represents one (or more ticks). If the tick has no events, multiple ticks may be combined and you will see only a number in an empty box. If there were events, the events are not combined and each column will have every event for that tick. At the very bottom, there is a smaller box with information about the Tick, such as what tick type it is and in what frame it occured. A tick can be of type Receive or Event. In each Tick (column) there can be one or more boxes. Each box represents an event that occurd. Events can be of type Send or Receive. Receive would indicate that the MLAPI recieved some amount of bytes while Send means that the MLAPI sent off a certain amount of bytes. Each block will state the type of message, the size in bytes, and what channel something was done over.
+Each column represents one (or more ticks). If the tick has no events, multiple ticks may be combined and you will see only a number in an empty box. If there were events, the events are not combined and each column will have every event for that tick. At the very bottom, there is a smaller box with information about the Tick, such as what tick type it is and in what frame it occured. A tick can be of type Receive or Event. In each Tick (column) there can be one or more boxes. Each box represents an event that occurd. Events can be of type Send or Receive. Receive would indicate that the MLAPI received some amount of bytes while Send means that the MLAPI sent off a certain amount of bytes. Each block will state the type of message, the size in bytes, and what channel something was done over.
 
 #### Usage
 [YouTube Video](https://youtu.be/-icRrZGg6r8)


### PR DESCRIPTION
if an object hasn't moved at all, no point in having to compute distance / rotation