### PR TITLE
fix: NetworkConfig exclude registered scenes list from hash if scene managment is disabled

### DIFF
--- a/MLAPI/Configuration/NetworkConfig.cs
+++ b/MLAPI/Configuration/NetworkConfig.cs
@@ -344,7 +344,7 @@ namespace MLAPI.Configuration
                     writer.WriteUInt16Packed(ProtocolVersion);
                     writer.WriteString(MLAPIConstants.MLAPI_PROTOCOL_VERSION);
 
-                    if (!AllowRuntimeSceneChanges)
+                    if (EnableSceneManagement && !AllowRuntimeSceneChanges)
                     {
                         for (int i = 0; i < RegisteredScenes.Count; i++)
                         {


### PR DESCRIPTION
Currently if 'Enable Scene Management' is set to false MLAPI prints a NetworkConfiguration
mismatch warning on connection if the server and client have a different registered scenes list.