### PR TITLE
Adjusted LogWarning message for ClientRPC Call

### DIFF
--- a/MLAPI/Core/NetworkedBehaviour.cs
+++ b/MLAPI/Core/NetworkedBehaviour.cs
@@ -1244,7 +1244,7 @@ namespace MLAPI
             if (!IsServer && IsRunning)
             {
                 //We are NOT a server.
-                if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("Only clients and host can invoke ClientRPC");
+                if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("Only server and host can invoke ClientRPC");
                 return;
             }
 
@@ -1281,7 +1281,7 @@ namespace MLAPI
             if (!IsServer && IsRunning)
             {
                 //We are NOT a server.
-                if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("Only clients and host can invoke ClientRPC");
+                if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("Only server and host can invoke ClientRPC");
                 return;
             }
 
@@ -1319,7 +1319,7 @@ namespace MLAPI
             if (!IsServer && IsRunning)
             {
                 //We are NOT a server.
-                if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("Only clients and host can invoke ClientRPC");
+                if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("Only server and host can invoke ClientRPC");
                 return;
             }
 
@@ -1357,7 +1357,7 @@ namespace MLAPI
             if (!IsServer && IsRunning)
             {
                 //We are NOT a server.
-                if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("Only clients and host can invoke ClientRPC");
+                if (NetworkLog.CurrentLogLevel <= LogLevel.Normal) NetworkLog.LogWarning("Only server and host can invoke ClientRPC");
                 return null;
             }
 


### PR DESCRIPTION
The Warning when a ClientRPC was called as non Server/Host was wrong