### PR TITLE
fixed zero sent bytes recorded when profiling client

### DIFF
--- a/MLAPI/Profiling/NetworkProfiler.cs
+++ b/MLAPI/Profiling/NetworkProfiler.cs
@@ -126,7 +126,7 @@ namespace MLAPI.Profiling
             if (!IsRunning)
                 return;
             if (CurrentTick == null)
-                return;
+                StartTick(eventType);
 
             string messageName = messageType < MLAPIConstants.MESSAGE_NAMES.Length ? MLAPIConstants.MESSAGE_NAMES[messageType] : "INVALID_MESSAGE_TYPE";
 
@@ -138,7 +138,7 @@ namespace MLAPI.Profiling
             if (!IsRunning)
                 return;
             if (CurrentTick == null)
-                return;
+                StartTick(eventType);
 
             CurrentTick.StartEvent(eventType, bytes, channelName, messageName);
         }


### PR DESCRIPTION
NetworkProfiler CurrentTick is not present at the time the message is sent.

related issue #368 