### PR TITLE
fix: Fix a duplicate value bug with NetworkedList/Dictionary when run…

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/NetworkedVar/Collections/NetworkedDictionary.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/NetworkedVar/Collections/NetworkedDictionary.cs
@@ -385,7 +385,14 @@ namespace MLAPI.NetworkedVar.Collections
             set
             {
                 if (NetworkingManager.Singleton.IsServer)
+                {
                     dictionary[key] = value;
+                    if (NetworkingManager.Singleton.ConnectedClients.Count == 0)
+                    {
+                        dirtyEvents.Clear();
+                        return;
+                    }
+                }
 
                 NetworkedDictionaryEvent<TKey, TValue> dictionaryEvent = new NetworkedDictionaryEvent<TKey, TValue>()
                 {
@@ -416,7 +423,14 @@ namespace MLAPI.NetworkedVar.Collections
         public void Add(TKey key, TValue value)
         {
             if (NetworkingManager.Singleton.IsServer)
+            {
                 dictionary.Add(key, value);
+                if (NetworkingManager.Singleton.ConnectedClients.Count == 0)
+                {
+                    dirtyEvents.Clear();
+                    return;
+                }
+            }
 
             NetworkedDictionaryEvent<TKey, TValue> dictionaryEvent = new NetworkedDictionaryEvent<TKey, TValue>()
             {
@@ -434,7 +448,14 @@ namespace MLAPI.NetworkedVar.Collections
         public void Add(KeyValuePair<TKey, TValue> item)
         {
             if (NetworkingManager.Singleton.IsServer)
+            {
                 dictionary.Add(item);
+                if (NetworkingManager.Singleton.ConnectedClients.Count == 0)
+                {
+                    dirtyEvents.Clear();
+                    return;
+                }
+            }
 
             NetworkedDictionaryEvent<TKey, TValue> dictionaryEvent = new NetworkedDictionaryEvent<TKey, TValue>()
             {
@@ -452,7 +473,14 @@ namespace MLAPI.NetworkedVar.Collections
         public void Clear()
         {
             if (NetworkingManager.Singleton.IsServer)
+            {
                 dictionary.Clear();
+                if (NetworkingManager.Singleton.ConnectedClients.Count == 0)
+                {
+                    dirtyEvents.Clear();
+                    return;
+                }
+            }
 
             NetworkedDictionaryEvent<TKey, TValue> dictionaryEvent = new NetworkedDictionaryEvent<TKey, TValue>()
             {
@@ -492,7 +520,14 @@ namespace MLAPI.NetworkedVar.Collections
         public bool Remove(TKey key)
         {
             if (NetworkingManager.Singleton.IsServer)
+            {
                 dictionary.Remove(key);
+                if (NetworkingManager.Singleton.ConnectedClients.Count == 0)
+                {
+                    dirtyEvents.Clear();
+                    return true;
+                }
+            }
 
             TValue value;
             dictionary.TryGetValue(key, out value);
@@ -516,7 +551,14 @@ namespace MLAPI.NetworkedVar.Collections
         public bool Remove(KeyValuePair<TKey, TValue> item)
         {
             if (NetworkingManager.Singleton.IsServer)
+            {
                 dictionary.Remove(item);
+                if (NetworkingManager.Singleton.ConnectedClients.Count == 0)
+                {
+                    dirtyEvents.Clear();
+                    return true;
+                }
+            }
 
             NetworkedDictionaryEvent<TKey, TValue> dictionaryEvent = new NetworkedDictionaryEvent<TKey, TValue>()
             {

--- a/com.unity.multiplayer.mlapi/Runtime/NetworkedVar/Collections/NetworkedList.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/NetworkedVar/Collections/NetworkedList.cs
@@ -1,8 +1,9 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using MLAPI.Serialization;
 using MLAPI.Serialization.Pooled;
+using UnityEngine;
 
 namespace MLAPI.NetworkedVar.Collections
 {
@@ -406,7 +407,15 @@ namespace MLAPI.NetworkedVar.Collections
         public void Add(T item)
         {
             if (NetworkingManager.Singleton.IsServer)
+            {
                 list.Add(item);
+                if (NetworkingManager.Singleton.ConnectedClients.Count == 0)
+                {
+                    dirtyEvents.Clear();
+                    return;
+                }
+            }
+
 
             NetworkedListEvent<T> listEvent = new NetworkedListEvent<T>()
             {
@@ -424,7 +433,14 @@ namespace MLAPI.NetworkedVar.Collections
         public void Clear()
         {
             if (NetworkingManager.Singleton.IsServer)
+            {
                 list.Clear();
+                if (NetworkingManager.Singleton.ConnectedClients.Count == 0)
+                {
+                    dirtyEvents.Clear();
+                    return;
+                }
+            }
 
             NetworkedListEvent<T> listEvent = new NetworkedListEvent<T>()
             {
@@ -452,7 +468,14 @@ namespace MLAPI.NetworkedVar.Collections
         public bool Remove(T item)
         {
             if (NetworkingManager.Singleton.IsServer)
+            {
                 list.Remove(item);
+                if (NetworkingManager.Singleton.ConnectedClients.Count == 0)
+                {
+                    dirtyEvents.Clear();
+                    return true;
+                }
+            }
 
             NetworkedListEvent<T> listEvent = new NetworkedListEvent<T>()
             {
@@ -483,7 +506,14 @@ namespace MLAPI.NetworkedVar.Collections
         public void Insert(int index, T item)
         {
             if (NetworkingManager.Singleton.IsServer)
+            {
                 list.Insert(index, item);
+                if (NetworkingManager.Singleton.ConnectedClients.Count == 0)
+                {
+                    dirtyEvents.Clear();
+                    return;
+                }
+            }
 
             NetworkedListEvent<T> listEvent = new NetworkedListEvent<T>()
             {
@@ -501,7 +531,14 @@ namespace MLAPI.NetworkedVar.Collections
         public void RemoveAt(int index)
         {
             if (NetworkingManager.Singleton.IsServer)
+            {
                 list.RemoveAt(index);
+                if (NetworkingManager.Singleton.ConnectedClients.Count == 0)
+                {
+                    dirtyEvents.Clear();
+                    return;
+                }
+            }
 
             NetworkedListEvent<T> listEvent = new NetworkedListEvent<T>()
             {
@@ -522,7 +559,14 @@ namespace MLAPI.NetworkedVar.Collections
             set
             {
                 if (NetworkingManager.Singleton.IsServer)
+                {
                     list[index] = value;
+                    if (NetworkingManager.Singleton.ConnectedClients.Count == 0)
+                    {
+                        dirtyEvents.Clear();
+                        return;
+                    }
+                }
 
                 NetworkedListEvent<T> listEvent = new NetworkedListEvent<T>()
                 {


### PR DESCRIPTION
This fixes a bug described in the two linked issues.

The core issue is that NetworkedList/Dictionary collect dirty changes, send them out each tick and then clear that dirty list. But when running in server mode with no client connected the dirty check of the list gets skipped. This causes the values to stay in the dirtyEvent list and once the first client connects he will receive both:
- The current state of the list with all items.
- A series of operations generated from the dirtyEvent list.
This causes the client to end up with a List/Dictionary where every value exists twice.

There are definitely better ways to solve this in the long term and NetworkedList/Dictionary might need a larger overall but this gets rid of a high user pain bug.