### PR TITLE
fix: null-check this ptr in scene manager OnValidate()

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -217,8 +217,12 @@ namespace MLAPI
 #if UNITY_EDITOR
                 UnityEditor.EditorApplication.delayCall += () =>
                 {
-                    UnityEditor.EditorUtility.SetDirty(this);
-                    UnityEditor.SceneManagement.EditorSceneManager.MarkSceneDirty(activeScene);
+                    // 'this' is sometimes invalid by the time the delayed call executes
+                    if (this != null && activeScene != null)
+                    {
+                        UnityEditor.EditorUtility.SetDirty(this);
+                        UnityEditor.SceneManagement.EditorSceneManager.MarkSceneDirty(activeScene);
+                    }
                 };
 #endif
             }


### PR DESCRIPTION
This fixes the error seen when the Boss Room loads.  Evidently 'this' is cleaned up by the time the callback fires