### PR TITLE
refactor!: NetworkPrefabHandler to replace Custom Spawn/Destroy Handlers

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -56,6 +56,7 @@ namespace MLAPI
 
         internal RpcQueueContainer RpcQueueContainer { get; private set; }
         internal NetworkTickSystem NetworkTickSystem { get; private set; }
+        public NetworkPrefabHandler PrefabHandler { get; private set; }
 
         /// <summary>
         /// A synchronized time, represents the time in seconds since the server application started. Is replicated across all clients
@@ -598,6 +599,11 @@ namespace MLAPI
             Singleton = this;
 
             OnSingletonReady?.Invoke();
+        }
+
+        private void Awake()
+        {
+            PrefabHandler = new NetworkPrefabHandler();
         }
 
         private void OnEnable()
@@ -1324,9 +1330,9 @@ namespace MLAPI
                 {
                     if (ConnectedClients[clientId].PlayerObject != null)
                     {
-                        if (SpawnManager.CustomDestroyHandlers.ContainsKey(ConnectedClients[clientId].PlayerObject.GlobalObjectIdHash))
+                        if (PrefabHandler.ContainsHandler(ConnectedClients[clientId].PlayerObject.GlobalObjectIdHash))
                         {
-                            SpawnManager.CustomDestroyHandlers[ConnectedClients[clientId].PlayerObject.GlobalObjectIdHash](ConnectedClients[clientId].PlayerObject);
+                            PrefabHandler.HandleNetworkPrefabDestroy(ConnectedClients[clientId].PlayerObject);
                             SpawnManager.OnDestroyObject(ConnectedClients[clientId].PlayerObject.NetworkObjectId, false);
                         }
                         else
@@ -1341,9 +1347,10 @@ namespace MLAPI
                         {
                             if (!ConnectedClients[clientId].OwnedObjects[i].DontDestroyWithOwner)
                             {
-                                if (SpawnManager.CustomDestroyHandlers.ContainsKey(ConnectedClients[clientId].OwnedObjects[i].GlobalObjectIdHash))
+
+                                if (PrefabHandler.ContainsHandler(ConnectedClients[clientId].OwnedObjects[i].GlobalObjectIdHash))
                                 {
-                                    SpawnManager.CustomDestroyHandlers[ConnectedClients[clientId].OwnedObjects[i].GlobalObjectIdHash](ConnectedClients[clientId].OwnedObjects[i]);
+                                    PrefabHandler.HandleNetworkPrefabDestroy(ConnectedClients[clientId].OwnedObjects[i]);
                                     SpawnManager.OnDestroyObject(ConnectedClients[clientId].OwnedObjects[i].NetworkObjectId, false);
                                 }
                                 else

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
@@ -333,7 +333,7 @@ namespace MLAPI
 
         private void OnDestroy()
         {
-            if (NetworkManager.Singleton != null && NetworkManager.Singleton.SpawnManager.SpawnedObjects.ContainsKey(NetworkObjectId))
+            if (NetworkManager.Singleton != null && NetworkManager.Singleton.SpawnManager != null && NetworkManager.Singleton.SpawnManager.SpawnedObjects.ContainsKey(NetworkObjectId))
             {
                 NetworkManager.Singleton.SpawnManager.OnDestroyObject(NetworkObjectId, false);
             }

--- a/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkPrefabHandler.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkPrefabHandler.cs
@@ -20,7 +20,7 @@ namespace MLAPI.Spawning
     public class NetworkPrefabHandler
     {
         /// <summary>
-        ///
+        /// Links a network prefab asset to a class with the INetworkPrefabInstanceHandler interface
         /// </summary>
         private readonly Dictionary<uint, INetworkPrefabInstanceHandler> m_PrefabAssetToPrefabHandler = new Dictionary<uint, INetworkPrefabInstanceHandler>();
 

--- a/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkPrefabHandler.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkPrefabHandler.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace MLAPI.Spawning
+{
+    /// <summary>
+    /// Interface for customizing asset spawn and destroy handlers
+    /// NOTE: Custom spawn and destroy handlers are only invoked on clients
+    /// </summary>
+    public interface INetworkPrefabInstanceHandler
+    {
+        NetworkObject HandleNetworkPrefabSpawn(ulong ownerClientId, Vector3 position, Quaternion rotation);
+        void HandleNetworkPrefabDestroy(NetworkObject networkObject);
+    }
+
+    /// <summary>
+    /// Primary handler to add or remove customized spawn and destroy handlers for a network prefab (i.e. a prefab with a NetworkObject component)
+    /// </summary>
+    public class NetworkPrefabHandler
+    {
+        /// <summary>
+        ///
+        /// </summary>
+        private readonly Dictionary<uint, INetworkPrefabInstanceHandler> m_PrefabAssetToPrefabHandler = new Dictionary<uint, INetworkPrefabInstanceHandler>();
+
+        /// <summary>
+        /// Links the custom prefab instance's GlobalNetworkObjectId to the original prefab asset's GlobalNetworkObjectId.  (Needed for HandleNetworkPrefabDestroy)
+        /// [PrefabInstance][PrefabAsset]
+        /// </summary>
+        private readonly Dictionary<uint, uint> m_PrefabInstanceToPrefabAsset = new Dictionary<uint, uint>();
+
+        public bool AddHandler(GameObject networkPrefabAsset, INetworkPrefabInstanceHandler instanceHandler)
+        {
+            return AddHandler(networkPrefabAsset.GetComponent<NetworkObject>().GlobalObjectIdHash, instanceHandler);
+        }
+
+        public bool AddHandler(NetworkObject prefabAssetNetworkObject, INetworkPrefabInstanceHandler instanceHandler)
+        {
+            return AddHandler(prefabAssetNetworkObject.GlobalObjectIdHash, instanceHandler);
+        }
+
+        public bool AddHandler(uint networkPrefabHash, INetworkPrefabInstanceHandler instanceHandler)
+        {
+            if (!m_PrefabAssetToPrefabHandler.ContainsKey(networkPrefabHash))
+            {
+                m_PrefabAssetToPrefabHandler.Add(networkPrefabHash, instanceHandler);
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool RemoveHandler(GameObject networkPrefabAsset)
+        {
+            return RemoveHandler(networkPrefabAsset.GetComponent<NetworkObject>().GlobalObjectIdHash);
+        }
+
+        public bool RemoveHandler(NetworkObject networkObject)
+        {
+            return RemoveHandler(networkObject.GlobalObjectIdHash);
+        }
+
+        public bool RemoveHandler(uint networkPrefabHash)
+        {
+            if (m_PrefabInstanceToPrefabAsset.ContainsValue(networkPrefabHash))
+            {
+                uint networkPrefabHashKey = 0;
+                foreach (var kvp in m_PrefabInstanceToPrefabAsset)
+                {
+                    if (kvp.Value == networkPrefabHash)
+                    {
+                        networkPrefabHashKey = kvp.Key;
+                        break;
+                    }
+                }
+                m_PrefabInstanceToPrefabAsset.Remove(networkPrefabHashKey);
+            }
+
+            return m_PrefabAssetToPrefabHandler.Remove(networkPrefabHash);
+        }
+
+        internal bool ContainsHandler(GameObject networkPrefab)
+        {
+            return ContainsHandler(networkPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash);
+        }
+
+        internal bool ContainsHandler(NetworkObject networkObject)
+        {
+            return ContainsHandler(networkObject.GlobalObjectIdHash);
+        }
+
+        internal bool ContainsHandler(uint networkPrefabHash)
+        {
+            return m_PrefabAssetToPrefabHandler.ContainsKey(networkPrefabHash) || m_PrefabInstanceToPrefabAsset.ContainsKey(networkPrefabHash);
+        }
+
+        internal NetworkObject HandleNetworkPrefabSpawn(uint networkPrefabAssetHash, ulong ownerClientId, Vector3 position, Quaternion rotation)
+        {
+            if (m_PrefabAssetToPrefabHandler.ContainsKey(networkPrefabAssetHash))
+            {
+                var networkObjectInstance = m_PrefabAssetToPrefabHandler[networkPrefabAssetHash].HandleNetworkPrefabSpawn(ownerClientId, position, rotation);
+                if (networkObjectInstance != null && !m_PrefabInstanceToPrefabAsset.ContainsKey(networkObjectInstance.GlobalObjectIdHash))
+                {
+                    m_PrefabInstanceToPrefabAsset.Add(networkObjectInstance.GlobalObjectIdHash, networkPrefabAssetHash);
+                }
+
+                return networkObjectInstance;
+            }
+
+            return null;
+        }
+
+        internal void HandleNetworkPrefabDestroy(NetworkObject networkObjectInstance)
+        {
+            var networkObjectInstanceHash = networkObjectInstance.GlobalObjectIdHash;
+            if (m_PrefabInstanceToPrefabAsset.ContainsKey(networkObjectInstanceHash))
+            {
+                var networkPrefabAssetHash = m_PrefabInstanceToPrefabAsset[networkObjectInstanceHash];
+                if (m_PrefabAssetToPrefabHandler.ContainsKey(networkPrefabAssetHash))
+                {
+                    m_PrefabAssetToPrefabHandler[networkPrefabAssetHash].HandleNetworkPrefabDestroy(networkObjectInstance);
+                }
+            }
+        }
+    }
+}

--- a/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkPrefabHandler.cs.meta
+++ b/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkPrefabHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 03b691ec0c2fc1a44bc560431e6c2745
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
@@ -31,22 +31,6 @@ namespace MLAPI.Spawning
         /// </summary>
         public readonly HashSet<NetworkObject> SpawnedObjectsList = new HashSet<NetworkObject>();
 
-        /// <summary>
-        /// The delegate used when spawning a NetworkObject
-        /// </summary>
-        /// <param name="ownerClientId">The owner client id of the object that is being spawned</param>
-        /// <param name="position">The position to spawn the object at</param>
-        /// <param name="rotation">The rotation to spawn the object with</param>
-        public delegate NetworkObject SpawnHandlerDelegate(ulong ownerClientId, Vector3 position, Quaternion rotation);
-
-        /// <summary>
-        /// The delegate used when destroying NetworkObjects
-        /// </summary>
-        /// <param name="networkObject">The NetworkObject to be destroy</param>
-        public delegate void DestroyHandlerDelegate(NetworkObject networkObject);
-
-        internal readonly Dictionary<uint, SpawnHandlerDelegate> CustomSpawnHandlers = new Dictionary<uint, SpawnHandlerDelegate>();
-        internal readonly Dictionary<uint, DestroyHandlerDelegate> CustomDestroyHandlers = new Dictionary<uint, DestroyHandlerDelegate>();
 
         /// <summary>
         /// Gets the NetworkManager associated with this SpawnManager.
@@ -56,58 +40,6 @@ namespace MLAPI.Spawning
         internal NetworkSpawnManager(NetworkManager networkManager)
         {
             NetworkManager = networkManager;
-        }
-
-        /// <summary>
-        /// Registers a delegate for spawning NetworkPrefabs, useful for object pooling
-        /// </summary>
-        /// <param name="prefabHash">The prefab hash to spawn</param>
-        /// <param name="handler">The delegate handler</param>
-        public void RegisterSpawnHandler(uint prefabHash, SpawnHandlerDelegate handler)
-        {
-            if (CustomSpawnHandlers.ContainsKey(prefabHash))
-            {
-                CustomSpawnHandlers[prefabHash] = handler;
-            }
-            else
-            {
-                CustomSpawnHandlers.Add(prefabHash, handler);
-            }
-        }
-
-        /// <summary>
-        /// Registers a delegate for destroying NetworkObjects, useful for object pooling
-        /// </summary>
-        /// <param name="prefabHash">The prefab hash to destroy</param>
-        /// <param name="handler">The delegate handler</param>
-        public void RegisterDestroyHandler(uint prefabHash, DestroyHandlerDelegate handler)
-        {
-            if (CustomDestroyHandlers.ContainsKey(prefabHash))
-            {
-                CustomDestroyHandlers[prefabHash] = handler;
-            }
-            else
-            {
-                CustomDestroyHandlers.Add(prefabHash, handler);
-            }
-        }
-
-        /// <summary>
-        /// Unregisters the custom spawn handler for a specific prefab hash
-        /// </summary>
-        /// <param name="prefabHash">The prefab hash of the prefab spawn handler that is to be removed</param>
-        public void UnregisterSpawnHandler(uint prefabHash)
-        {
-            CustomSpawnHandlers.Remove(prefabHash);
-        }
-
-        /// <summary>
-        /// Unregisters the custom destroy handler for a specific prefab hash
-        /// </summary>
-        /// <param name="prefabHash">The prefab hash of the prefab destroy handler that is to be removed</param>
-        public void UnregisterDestroyHandler(uint prefabHash)
-        {
-            CustomDestroyHandlers.Remove(prefabHash);
         }
 
         internal readonly Queue<ReleasedNetworkId> ReleasedNetworkObjectIds = new Queue<ReleasedNetworkId>();
@@ -269,9 +201,9 @@ namespace MLAPI.Spawning
             if (!NetworkManager.NetworkConfig.EnableSceneManagement || NetworkManager.NetworkConfig.UsePrefabSync || !softCreate)
             {
                 // Create the object
-                if (CustomSpawnHandlers.ContainsKey(prefabHash))
+                if (NetworkManager.PrefabHandler.ContainsHandler(prefabHash))
                 {
-                    var networkObject = CustomSpawnHandlers[prefabHash](ownerClientId, position.GetValueOrDefault(Vector3.zero), rotation.GetValueOrDefault(Quaternion.identity));
+                    var networkObject = NetworkManager.PrefabHandler.HandleNetworkPrefabSpawn(prefabHash, ownerClientId, position.GetValueOrDefault(Vector3.zero), rotation.GetValueOrDefault(Quaternion.identity));
 
                     if (parentNetworkObject != null)
                     {
@@ -563,10 +495,10 @@ namespace MLAPI.Spawning
             {
                 if ((sobj.IsSceneObject != null && sobj.IsSceneObject == true) || sobj.DestroyWithScene)
                 {
-                    if (CustomDestroyHandlers.ContainsKey(sobj.GlobalObjectIdHash))
+                    if (NetworkManager.PrefabHandler.ContainsHandler(sobj))
                     {
                         SpawnedObjectsList.Remove(sobj);
-                        CustomDestroyHandlers[sobj.GlobalObjectIdHash](sobj);
+                        NetworkManager.PrefabHandler.HandleNetworkPrefabDestroy(sobj);
                         OnDestroyObject(sobj.NetworkObjectId, false);
                     }
                     else
@@ -586,9 +518,10 @@ namespace MLAPI.Spawning
             {
                 if (networkObjects[i].IsSceneObject != null && networkObjects[i].IsSceneObject.Value == false)
                 {
-                    if (CustomDestroyHandlers.ContainsKey(networkObjects[i].GlobalObjectIdHash))
+                    if (NetworkManager.PrefabHandler.ContainsHandler(networkObjects[i]))
                     {
-                        CustomDestroyHandlers[networkObjects[i].GlobalObjectIdHash](networkObjects[i]);
+                        NetworkManager.PrefabHandler.HandleNetworkPrefabDestroy(networkObjects[i]);
+
                         OnDestroyObject(networkObjects[i].NetworkObjectId, false);
                     }
                     else
@@ -607,9 +540,9 @@ namespace MLAPI.Spawning
             {
                 if (networkObjects[i].IsSceneObject == null || networkObjects[i].IsSceneObject.Value == true)
                 {
-                    if (CustomDestroyHandlers.ContainsKey(networkObjects[i].GlobalObjectIdHash))
+                    if (NetworkManager.PrefabHandler.ContainsHandler(networkObjects[i]))
                     {
-                        CustomDestroyHandlers[networkObjects[i].GlobalObjectIdHash](networkObjects[i]);
+                        NetworkManager.PrefabHandler.HandleNetworkPrefabDestroy(networkObjects[i]);
                         OnDestroyObject(networkObjects[i].NetworkObjectId, false);
                     }
                     else
@@ -743,9 +676,9 @@ namespace MLAPI.Spawning
 
             if (destroyGameObject && gobj != null)
             {
-                if (CustomDestroyHandlers.ContainsKey(sobj.GlobalObjectIdHash))
+                if (NetworkManager.PrefabHandler.ContainsHandler(sobj))
                 {
-                    CustomDestroyHandlers[sobj.GlobalObjectIdHash](sobj);
+                    NetworkManager.PrefabHandler.HandleNetworkPrefabDestroy(sobj);
                     OnDestroyObject(networkId, false);
                 }
                 else

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkPrefabHandlerTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkPrefabHandlerTests.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using NUnit.Framework;
+using MLAPI.Spawning;
+
+namespace MLAPI.RuntimeTests
+{
+    /// <summary>
+    /// The NetworkPrefabHandler unit tests validates:
+    /// Registering with GameObject, NetworkObject, or GlobalObjectHashId
+    /// Newly assigned rotation or position values for newly spawned NetworkObject instances are valid
+    /// Destroying a newly spawned NetworkObject instance works
+    /// Removing a INetworkPrefabInstanceHandler is removed and can be verified (very last check)
+    /// </summary>
+    public class NetworkPrefabHandlerTests:IDisposable
+    {
+        [Test]
+        public void NetworkPrefabHandlerClass()
+        {
+            //Only used to create a network object based game asset
+            Assert.IsTrue(NetworkManagerHelper.StartNetworkManager());
+
+            Guid baseObjectID = NetworkManagerHelper.AddGameNetworkObject("NetworkPrefabHandlerTestObject");
+            NetworkObject baseObject = NetworkManagerHelper.InstantiatedNetworkObjects[baseObjectID];
+
+            var networkPrefabHandler = new NetworkPrefabHandler();
+            var networkPrefaInstanceHandler = new NetworkPrefaInstanceHandler(baseObject);
+
+            var prefabPosition = new Vector3(1.0f, 5.0f, 3.0f);
+            var prefabRotation = new Quaternion(1.0f, 0.5f, 0.4f, 0.1f);
+
+            //Register via GameObject
+            var gameObjectRegistered = networkPrefabHandler.AddHandler(baseObject.gameObject, networkPrefaInstanceHandler);
+
+            //Test result of registering via GameObject reference
+            Assert.True(gameObjectRegistered);
+
+            var spawnedObject = networkPrefabHandler.HandleNetworkPrefabSpawn(baseObject.GlobalObjectIdHash, 0, prefabPosition, prefabRotation);
+
+            //Test that something was instantiated
+            Assert.NotNull(spawnedObject);
+
+            //Test that this is indeed an instance of our original object
+            Assert.True(spawnedObject.name.Contains("NetworkPrefabHandlerTestObject"));
+
+            //Test for position and rotation
+            Assert.True(prefabPosition == spawnedObject.transform.position);
+            Assert.True(prefabRotation == spawnedObject.transform.rotation);
+
+            networkPrefabHandler.HandleNetworkPrefabDestroy(spawnedObject);     //Destroy our prefab instance
+            networkPrefabHandler.RemoveHandler(baseObject);                     //Remove our handler
+
+            //Register via NetworkObject
+            gameObjectRegistered = networkPrefabHandler.AddHandler(baseObject, networkPrefaInstanceHandler);
+
+            //Test result of registering via NetworkObject reference
+            Assert.True(gameObjectRegistered);
+
+            //Change it up
+            prefabPosition = new Vector3(2.0f, 1.0f, 5.0f);
+            prefabRotation = new Quaternion(4.0f, 1.5f, 5.4f, 5.1f);
+
+            spawnedObject = networkPrefabHandler.HandleNetworkPrefabSpawn(baseObject.GlobalObjectIdHash, 0, prefabPosition, prefabRotation);
+
+            //Test that something was instantiated
+            Assert.NotNull(spawnedObject);
+
+            //Test that this is indeed an instance of our original object
+            Assert.True(spawnedObject.name.Contains("NetworkPrefabHandlerTestObject"));
+
+            //Test for position and rotation
+            Assert.True(prefabPosition == spawnedObject.transform.position);
+            Assert.True(prefabRotation == spawnedObject.transform.rotation);
+
+            networkPrefabHandler.HandleNetworkPrefabDestroy(spawnedObject);     //Destroy our prefab instance
+            networkPrefabHandler.RemoveHandler(baseObject);                     //Remove our handler
+
+            //Register via GlobalObjectHashId
+            gameObjectRegistered = networkPrefabHandler.AddHandler(baseObject.GlobalObjectIdHash, networkPrefaInstanceHandler);
+
+            //Test result of registering via GlobalObjectHashId reference
+            Assert.True(gameObjectRegistered);
+
+            //Change it up
+            prefabPosition = new Vector3(6.0f, 4.0f,1.0f);
+            prefabRotation = new Quaternion(3f, 2f, 4f, 1f);
+
+            spawnedObject = networkPrefabHandler.HandleNetworkPrefabSpawn(baseObject.GlobalObjectIdHash, 0, prefabPosition, prefabRotation);
+
+            //Test that something was instantiated
+            Assert.NotNull(spawnedObject);
+
+            //Test that this is indeed an instance of our original object
+            Assert.True(spawnedObject.name.Contains("NetworkPrefabHandlerTestObject"));
+
+            //Test for position and rotation
+            Assert.True(prefabPosition == spawnedObject.transform.position);
+            Assert.True(prefabRotation == spawnedObject.transform.rotation);
+
+            networkPrefabHandler.HandleNetworkPrefabDestroy(spawnedObject);     //Destroy our prefab instance
+            networkPrefabHandler.RemoveHandler(baseObject);                     //Remove our handler
+
+            Assert.False(networkPrefaInstanceHandler.StillHasInstances());
+        }
+
+        public void Dispose()
+        {
+            //Stop, shutdown, and destroy
+            NetworkManagerHelper.ShutdownNetworkManager();
+        }
+
+        public NetworkPrefabHandlerTests()
+        {
+            //Create, instantiate, and host
+            NetworkManagerHelper.StartNetworkManager();
+        }
+    }
+
+
+    /// <summary>
+    /// The Prefab instance handler to use for this test
+    /// </summary>
+    public class NetworkPrefaInstanceHandler:INetworkPrefabInstanceHandler
+    {
+        private NetworkObject m_NetworkObject;
+
+        private List<NetworkObject> m_Instances;
+
+        public NetworkObject HandleNetworkPrefabSpawn(ulong ownerClientId, Vector3 position, Quaternion rotation)
+        {
+            var networkObjectInstance = UnityEngine.Object.Instantiate(m_NetworkObject.gameObject).GetComponent<NetworkObject>();
+            networkObjectInstance.transform.position = position;
+            networkObjectInstance.transform.rotation = rotation;
+            m_Instances.Add(networkObjectInstance);
+            return networkObjectInstance;
+        }
+
+        public void HandleNetworkPrefabDestroy(NetworkObject networkObject)
+        {
+            var instancesContainsNetworkObject = m_Instances.Contains(networkObject);
+            Assert.True(instancesContainsNetworkObject);
+
+            if(instancesContainsNetworkObject)
+            {
+                m_Instances.Remove(networkObject);
+                UnityEngine.Object.Destroy(networkObject.gameObject);
+            }
+        }
+
+        public bool StillHasInstances()
+        {
+            return (m_Instances.Count > 0);
+        }
+
+        public NetworkPrefaInstanceHandler(NetworkObject networkObject)
+        {
+            m_NetworkObject = networkObject;
+            m_Instances = new List<NetworkObject>();
+        }
+    }
+}

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkPrefabHandlerTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkPrefabHandlerTests.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
-using NUnit.Framework;
 using MLAPI.Spawning;
+using NUnit.Framework;
+
+
 
 namespace MLAPI.RuntimeTests
 {
@@ -13,7 +15,7 @@ namespace MLAPI.RuntimeTests
     /// Destroying a newly spawned NetworkObject instance works
     /// Removing a INetworkPrefabInstanceHandler is removed and can be verified (very last check)
     /// </summary>
-    public class NetworkPrefabHandlerTests:IDisposable
+    public class NetworkPrefabHandlerTests
     {
         [Test]
         public void NetworkPrefabHandlerClass()
@@ -104,16 +106,18 @@ namespace MLAPI.RuntimeTests
             Assert.False(networkPrefaInstanceHandler.StillHasInstances());
         }
 
-        public void Dispose()
-        {
-            //Stop, shutdown, and destroy
-            NetworkManagerHelper.ShutdownNetworkManager();
-        }
-
-        public NetworkPrefabHandlerTests()
+        [SetUp]
+        public void Setup()
         {
             //Create, instantiate, and host
             NetworkManagerHelper.StartNetworkManager();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            //Stop, shutdown, and destroy
+            NetworkManagerHelper.ShutdownNetworkManager();
         }
     }
 

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkPrefabHandlerTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkPrefabHandlerTests.cs
@@ -8,7 +8,7 @@ namespace MLAPI.RuntimeTests
 {
     /// <summary>
     /// The NetworkPrefabHandler unit tests validates:
-    /// Registering with GameObject, NetworkObject, or GlobalObjectHashId
+    /// Registering with GameObject, NetworkObject, or GlobalObjectIdHash
     /// Newly assigned rotation or position values for newly spawned NetworkObject instances are valid
     /// Destroying a newly spawned NetworkObject instance works
     /// Removing a INetworkPrefabInstanceHandler is removed and can be verified (very last check)
@@ -76,10 +76,10 @@ namespace MLAPI.RuntimeTests
             networkPrefabHandler.HandleNetworkPrefabDestroy(spawnedObject);     //Destroy our prefab instance
             networkPrefabHandler.RemoveHandler(baseObject);                     //Remove our handler
 
-            //Register via GlobalObjectHashId
+            //Register via GlobalObjectIdHash
             gameObjectRegistered = networkPrefabHandler.AddHandler(baseObject.GlobalObjectIdHash, networkPrefaInstanceHandler);
 
-            //Test result of registering via GlobalObjectHashId reference
+            //Test result of registering via GlobalObjectIdHash reference
             Assert.True(gameObjectRegistered);
 
             //Change it up

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkPrefabHandlerTests.cs.meta
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkPrefabHandlerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 590750036c5d65c43bbc696071aa3541
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/RpcQueueTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/RpcQueueTests.cs
@@ -122,7 +122,7 @@ namespace MLAPI.RuntimeTests
             var indexOffset = 0;
             ulong senderNetworkId = 1;
 
-            //Create ficticious list of clients to send to
+            //Create fictitious list of clients to send to
             ulong[] psuedoClients = new ulong[] { 0 };
 
             var randomGeneratedDataArray = preCalculatedBufferValues.ToArray();

--- a/testproject/Assets/ManualTests/RpcTesting.unity
+++ b/testproject/Assets/ManualTests/RpcTesting.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641275, b: 0.5748172, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -189,271 +189,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &292910119
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1207168972}
-    m_Modifications:
-    - target: {fileID: 2956145122089128464, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 1207168974}
-    - target: {fileID: 2956145122089128464, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: OnCreateServer
-      objectReference: {fileID: 0}
-    - target: {fileID: 2956145122089128464, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: ClientCounterBehaviour, Assembly-CSharp
-      objectReference: {fileID: 0}
-    - target: {fileID: 2956145122089128465, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2956145122089128465, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2956145122089128465, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: 2956145122546206394, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 1207168974}
-    - target: {fileID: 2956145122546206394, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: OnCreateClient
-      objectReference: {fileID: 0}
-    - target: {fileID: 2956145122546206394, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: ClientCounterBehaviour, Assembly-CSharp
-      objectReference: {fileID: 0}
-    - target: {fileID: 2956145122546206395, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2956145122546206395, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2956145122546206395, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -90
-      objectReference: {fileID: 0}
-    - target: {fileID: 2956145122569088795, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_Color.b
-      value: 0.02745098
-      objectReference: {fileID: 0}
-    - target: {fileID: 2956145122569088795, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.42745098
-      objectReference: {fileID: 0}
-    - target: {fileID: 2956145122569088795, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.7764706
-      objectReference: {fileID: 0}
-    - target: {fileID: 2956145122624039697, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 1207168974}
-    - target: {fileID: 2956145122624039697, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: OnCreateHost
-      objectReference: {fileID: 0}
-    - target: {fileID: 2956145122624039697, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: ClientCounterBehaviour, Assembly-CSharp
-      objectReference: {fileID: 0}
-    - target: {fileID: 2956145122624039702, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2956145122624039702, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2956145122624039702, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2956145123247517488, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_Color.b
-      value: 0.02745098
-      objectReference: {fileID: 0}
-    - target: {fileID: 2956145123247517488, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.42745098
-      objectReference: {fileID: 0}
-    - target: {fileID: 2956145123247517488, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.7764706
-      objectReference: {fileID: 0}
-    - target: {fileID: 2956145123293580337, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_Color.b
-      value: 0.025542913
-      objectReference: {fileID: 0}
-    - target: {fileID: 2956145123293580337, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.42492437
-      objectReference: {fileID: 0}
-    - target: {fileID: 2956145123293580337, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.7735849
-      objectReference: {fileID: 0}
-    - target: {fileID: 6633621479308595792, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6633621479308595792, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6633621479308595792, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 6633621479308595792, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6633621479308595792, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6633621479308595792, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6633621479308595792, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6633621479308595792, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 320
-      objectReference: {fileID: 0}
-    - target: {fileID: 6633621479308595792, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 320
-      objectReference: {fileID: 0}
-    - target: {fileID: 6633621479308595792, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6633621479308595792, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6633621479308595792, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6633621479308595792, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6633621479308595792, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6633621479308595792, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6633621479308595792, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6633621479308595792, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6633621479308595792, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -160
-      objectReference: {fileID: 0}
-    - target: {fileID: 6633621479308595792, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6633621479308595792, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6633621479308595792, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6963777608485144162, guid: 4a604aa67024b7d40912bb9a43751f74,
-        type: 3}
-      propertyPath: m_Name
-      value: ConnectionModeButtons
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4a604aa67024b7d40912bb9a43751f74, type: 3}
---- !u!4 &292910120 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 292910119}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &292910121 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 6963777608485144162, guid: 4a604aa67024b7d40912bb9a43751f74,
-    type: 3}
-  m_PrefabInstance: {fileID: 292910119}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &521221616
 GameObject:
   m_ObjectHideFlags: 0
@@ -612,6 +347,176 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1041651791
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1207168972}
+    m_Modifications:
+    - target: {fileID: 2956145122089128464, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1207168974}
+    - target: {fileID: 2956145122089128464, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: OnCreateServer
+      objectReference: {fileID: 0}
+    - target: {fileID: 2956145122089128464, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: ClientCounterBehaviour, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 2956145122546206394, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1207168974}
+    - target: {fileID: 2956145122546206394, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: OnCreateClient
+      objectReference: {fileID: 0}
+    - target: {fileID: 2956145122546206394, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: ClientCounterBehaviour, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 2956145122624039697, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1207168974}
+    - target: {fileID: 2956145122624039697, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: OnCreateHost
+      objectReference: {fileID: 0}
+    - target: {fileID: 2956145122624039697, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: ClientCounterBehaviour, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6963777608485144162, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_Name
+      value: ConnectionModeButtons
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d725b5588e1b956458798319e6541d84, type: 3}
+--- !u!224 &1041651792 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+    type: 3}
+  m_PrefabInstance: {fileID: 1041651791}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1207168968
 GameObject:
   m_ObjectHideFlags: 0
@@ -707,7 +612,7 @@ RectTransform:
   m_Children:
   - {fileID: 1859881228}
   - {fileID: 521221617}
-  - {fileID: 292910120}
+  - {fileID: 1041651792}
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -728,7 +633,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 12432352355802425919
+  GlobalObjectIdHash: 1844309308
   AlwaysReplicateAsRoot: 0
   DontDestroyWithOwner: 0
 --- !u!114 &1207168974
@@ -745,7 +650,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_CounterTextObject: {fileID: 1859881229}
   m_ClientProgressBar: {fileID: 521221618}
-  m_ConnectionModeButtonParent: {fileID: 292910121}
+  m_ConnectionModeButtonParent: {fileID: 1705962118}
 --- !u!1 &1544159781
 GameObject:
   m_ObjectHideFlags: 0
@@ -907,8 +812,7 @@ MonoBehaviour:
     - Prefab: {fileID: 4700706668509470175, guid: 7eeaaf9e50c0afc4dab93584a54fb0d6,
         type: 3}
       IsPlayer: 1
-    PlayerPrefabHash:
-      id: 0
+    PlayerPrefabHash: 315939022
     CreatePlayerPrefab: 1
     ReceiveTickrate: 64
     NetworkTickIntervalSec: 0.05
@@ -931,12 +835,6 @@ MonoBehaviour:
     EnableMessageBuffering: 1
     MessageBufferTimeout: 20
     EnableNetworkLogs: 1
-  references:
-    version: 1
-    00000000:
-      type: {class: NullableBoolSerializable, ns: MLAPI.Configuration, asm: Unity.Multiplayer.MLAPI.Runtime}
-      data:
-        Value: 10036444387826810186
 --- !u!4 &1574548687
 Transform:
   m_ObjectHideFlags: 0
@@ -951,6 +849,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1705962118 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6963777608485144162, guid: d725b5588e1b956458798319e6541d84,
+    type: 3}
+  m_PrefabInstance: {fileID: 1041651791}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1859881227
 GameObject:
   m_ObjectHideFlags: 0

--- a/testproject/Assets/Prefabs/ConnectionModeButtons.prefab
+++ b/testproject/Assets/Prefabs/ConnectionModeButtons.prefab
@@ -1,0 +1,676 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2956145122089128470
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2956145122089128465}
+  - component: {fileID: 2956145122089128466}
+  - component: {fileID: 2956145122089128467}
+  - component: {fileID: 2956145122089128464}
+  m_Layer: 5
+  m_Name: Create Server
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2956145122089128465
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2956145122089128470}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2956145123293580342}
+  m_Father: {fileID: 6633621479308595792}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2956145122089128466
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2956145122089128470}
+  m_CullTransparentMesh: 1
+--- !u!114 &2956145122089128467
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2956145122089128470}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.2, g: 0.2, b: 0.2, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &2956145122089128464
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2956145122089128470}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2956145122089128467}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: 
+        m_MethodName: CreateServer
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &2956145122546206392
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2956145122546206395}
+  - component: {fileID: 2956145122546206372}
+  - component: {fileID: 2956145122546206373}
+  - component: {fileID: 2956145122546206394}
+  m_Layer: 5
+  m_Name: Join Game
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2956145122546206395
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2956145122546206392}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2956145123247517489}
+  m_Father: {fileID: 6633621479308595792}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -143}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2956145122546206372
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2956145122546206392}
+  m_CullTransparentMesh: 1
+--- !u!114 &2956145122546206373
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2956145122546206392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.1981132, g: 0.1981132, b: 0.1981132, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &2956145122546206394
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2956145122546206392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2956145122546206373}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: 
+        m_MethodName: JoinGame
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &2956145122569088793
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2956145122569088792}
+  - component: {fileID: 2956145122569088794}
+  - component: {fileID: 2956145122569088795}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2956145122569088792
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2956145122569088793}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2956145122624039702}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2956145122569088794
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2956145122569088793}
+  m_CullTransparentMesh: 1
+--- !u!114 &2956145122569088795
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2956145122569088793}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.5058824, b: 0.003921569, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Create Host
+--- !u!1 &2956145122624039703
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2956145122624039702}
+  - component: {fileID: 2956145122624039699}
+  - component: {fileID: 2956145122624039696}
+  - component: {fileID: 2956145122624039697}
+  m_Layer: 5
+  m_Name: Create Host
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2956145122624039702
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2956145122624039703}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2956145122569088792}
+  m_Father: {fileID: 6633621479308595792}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -70}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2956145122624039699
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2956145122624039703}
+  m_CullTransparentMesh: 1
+--- !u!114 &2956145122624039696
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2956145122624039703}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.2, g: 0.2, b: 0.2, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &2956145122624039697
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2956145122624039703}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2956145122624039696}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: 
+        m_MethodName: CreateHost
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &2956145123247517494
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2956145123247517489}
+  - component: {fileID: 2956145123247517491}
+  - component: {fileID: 2956145123247517488}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2956145123247517489
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2956145123247517494}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2956145122546206395}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2956145123247517491
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2956145123247517494}
+  m_CullTransparentMesh: 1
+--- !u!114 &2956145123247517488
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2956145123247517494}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.5058824, b: 0.003921569, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Join Game
+--- !u!1 &2956145123293580343
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2956145123293580342}
+  - component: {fileID: 2956145123293580336}
+  - component: {fileID: 2956145123293580337}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2956145123293580342
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2956145123293580343}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2956145122089128465}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2956145123293580336
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2956145123293580343}
+  m_CullTransparentMesh: 1
+--- !u!114 &2956145123293580337
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2956145123293580343}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.5058824, b: 0.003921569, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Create Server
+--- !u!1 &6963777608485144162
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6633621479308595792}
+  m_Layer: 5
+  m_Name: ConnectionModeButtons
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6633621479308595792
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6963777608485144162}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2956145122546206395}
+  - {fileID: 2956145122624039702}
+  - {fileID: 2956145122089128465}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}

--- a/testproject/Assets/Prefabs/ConnectionModeButtons.prefab.meta
+++ b/testproject/Assets/Prefabs/ConnectionModeButtons.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d725b5588e1b956458798319e6541d84
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
**This PR is directly tied to [MTT-622](https://jira.unity3d.com/browse/MTT-622)** 
Due to the changes in the GlobalObjectHashId, a refactor the custom spawn and destroy handlers for NetworkSpawnManager is required.
In order to maintain the same functionality/features while taking future architectural changes into consideration, a new class called NetworkPrefabHandler will be created.
This PR also restores the ConnectionModeButtons.prefab being deleted in [PR-694](https://github.com/Unity-Technologies/com.unity.multiplayer.mlapi/pull/694/files)