### PR TITLE
fix: correct the math behind ranged single/double read/write methods in reader/writer impls

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Serialization/NetworkReader.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Serialization/NetworkReader.cs
@@ -429,7 +429,7 @@ namespace MLAPI.Serialization
                 read |= (uint)ReadByte() << (i << 3);
             }
 
-            return (((float)read / ((0x100 * bytes) - 1)) * (minValue + maxValue)) - minValue;
+            return ((float)read / ((0x100 * bytes) - 1) * (maxValue - minValue)) + minValue;
         }
 
         /// <summary>
@@ -452,7 +452,7 @@ namespace MLAPI.Serialization
                 read |= (ulong)ReadByte() << (i << 3);
             }
 
-            return (((double)read / ((0x100 * bytes) - 1)) * (minValue + maxValue)) - minValue;
+            return ((double)read / ((0x100 * bytes) - 1) * (maxValue - minValue)) + minValue;
         }
 
         /// <summary>

--- a/com.unity.multiplayer.mlapi/Runtime/Serialization/NetworkWriter.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Serialization/NetworkWriter.cs
@@ -446,7 +446,7 @@ namespace MLAPI.Serialization
                 throw new ArgumentOutOfRangeException("Given value does not match the given constraints!");
             }
 
-            uint result = (uint)(((value + minValue) / (maxValue + minValue)) * ((0x100 * bytes) - 1));
+            uint result = (uint)((value - minValue) / (maxValue - minValue) * ((0x100 * bytes) - 1));
             for (int i = 0; i < bytes; ++i)
             {
                 m_Sink.WriteByte((byte)(result >> (i << 3)));
@@ -472,7 +472,7 @@ namespace MLAPI.Serialization
                 throw new ArgumentOutOfRangeException("Given value does not match the given constraints!");
             }
 
-            ulong result = (ulong)(((value + minValue) / (maxValue + minValue)) * ((0x100 * bytes) - 1));
+            ulong result = (ulong)((value - minValue) / (maxValue - minValue) * ((0x100 * bytes) - 1));
             for (int i = 0; i < bytes; ++i)
             {
                 WriteByte((byte)(result >> (i << 3)));

--- a/com.unity.multiplayer.mlapi/Tests/Editor/NetworkBufferTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/NetworkBufferTests.cs
@@ -352,9 +352,9 @@ namespace MLAPI.EditorTests
             var inNetworkBufferA = new NetworkBuffer(rawBufferBytesA);
             var inNetworkReaderA = new NetworkReader(inNetworkBufferA);
 
-            Assert.That(inNetworkReaderA.ReadRangedSingle(rangeMinA, rangeMaxA, rangeBytesA), Is.EqualTo(randFloatValueA));
-            Assert.That(inNetworkReaderA.ReadRangedSingle(rangeMinA, rangeMaxA, rangeBytesA), Is.EqualTo(rangeMinA));
-            Assert.That(inNetworkReaderA.ReadRangedSingle(rangeMinA, rangeMaxA, rangeBytesA), Is.EqualTo(rangeMaxA));
+            Assert.That(Math.Abs(randFloatValueA - inNetworkReaderA.ReadRangedSingle(rangeMinA, rangeMaxA, rangeBytesA)), Is.LessThan(1.6f));
+            Assert.That(Math.Abs(rangeMinA - inNetworkReaderA.ReadRangedSingle(rangeMinA, rangeMaxA, rangeBytesA)), Is.LessThan(1.6f));
+            Assert.That(Math.Abs(rangeMaxA - inNetworkReaderA.ReadRangedSingle(rangeMinA, rangeMaxA, rangeBytesA)), Is.LessThan(1.6f));
 
 
 
@@ -376,9 +376,9 @@ namespace MLAPI.EditorTests
             var inNetworkBufferB = new NetworkBuffer(rawBufferBytesB);
             var inNetworkReaderB = new NetworkReader(inNetworkBufferB);
 
-            Assert.That(inNetworkReaderB.ReadRangedSingle(rangeMinB, rangeMaxB, rangeBytesB), Is.EqualTo(randFloatValueB));
-            Assert.That(inNetworkReaderB.ReadRangedSingle(rangeMinB, rangeMaxB, rangeBytesB), Is.EqualTo(rangeMinB));
-            Assert.That(inNetworkReaderB.ReadRangedSingle(rangeMinB, rangeMaxB, rangeBytesB), Is.EqualTo(rangeMaxB));
+            Assert.That(Math.Abs(randFloatValueB - inNetworkReaderB.ReadRangedSingle(rangeMinB, rangeMaxB, rangeBytesB)), Is.LessThan(0.4f));
+            Assert.That(Math.Abs(rangeMinB - inNetworkReaderB.ReadRangedSingle(rangeMinB, rangeMaxB, rangeBytesB)), Is.LessThan(0.4f));
+            Assert.That(Math.Abs(rangeMaxB - inNetworkReaderB.ReadRangedSingle(rangeMinB, rangeMaxB, rangeBytesB)), Is.LessThan(0.4f));
         }
 
         [Test]
@@ -402,9 +402,9 @@ namespace MLAPI.EditorTests
             var inNetworkBufferA = new NetworkBuffer(rawBufferBytesA);
             var inNetworkReaderA = new NetworkReader(inNetworkBufferA);
 
-            Assert.That(inNetworkReaderA.ReadRangedDouble(rangeMinA, rangeMaxA, rangeBytesA), Is.EqualTo(randDoubleValueA));
-            Assert.That(inNetworkReaderA.ReadRangedDouble(rangeMinA, rangeMaxA, rangeBytesA), Is.EqualTo(rangeMinA));
-            Assert.That(inNetworkReaderA.ReadRangedDouble(rangeMinA, rangeMaxA, rangeBytesA), Is.EqualTo(rangeMaxA));
+            Assert.That(Math.Abs(randDoubleValueA - inNetworkReaderA.ReadRangedDouble(rangeMinA, rangeMaxA, rangeBytesA)), Is.LessThan(1.6f));
+            Assert.That(Math.Abs(rangeMinA - inNetworkReaderA.ReadRangedDouble(rangeMinA, rangeMaxA, rangeBytesA)), Is.LessThan(1.6f));
+            Assert.That(Math.Abs(rangeMaxA - inNetworkReaderA.ReadRangedDouble(rangeMinA, rangeMaxA, rangeBytesA)), Is.LessThan(1.6f));
 
 
 
@@ -426,9 +426,9 @@ namespace MLAPI.EditorTests
             var inNetworkBufferB = new NetworkBuffer(rawBufferBytesB);
             var inNetworkReaderB = new NetworkReader(inNetworkBufferB);
 
-            Assert.That(inNetworkReaderB.ReadRangedDouble(rangeMinB, rangeMaxB, rangeBytesB), Is.EqualTo(randDoubleValueB));
-            Assert.That(inNetworkReaderB.ReadRangedDouble(rangeMinB, rangeMaxB, rangeBytesB), Is.EqualTo(rangeMinB));
-            Assert.That(inNetworkReaderB.ReadRangedDouble(rangeMinB, rangeMaxB, rangeBytesB), Is.EqualTo(rangeMaxB));
+            Assert.That(Math.Abs(randDoubleValueB - inNetworkReaderB.ReadRangedDouble(rangeMinB, rangeMaxB, rangeBytesB)), Is.LessThan(0.4f));
+            Assert.That(Math.Abs(rangeMinB - inNetworkReaderB.ReadRangedDouble(rangeMinB, rangeMaxB, rangeBytesB)), Is.LessThan(0.4f));
+            Assert.That(Math.Abs(rangeMaxB - inNetworkReaderB.ReadRangedDouble(rangeMinB, rangeMaxB, rangeBytesB)), Is.LessThan(0.4f));
         }
 
         [Test]

--- a/com.unity.multiplayer.mlapi/Tests/Editor/NetworkBufferTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/NetworkBufferTests.cs
@@ -384,6 +384,51 @@ namespace MLAPI.EditorTests
         [Test]
         public void TestRangedDouble()
         {
+            const double rangeMinA = -180;
+            const double rangeMaxA = 180;
+            const int rangeBytesA = 2;
+
+            double randDoubleValueA = new Random().NextDouble() * (rangeMaxA - rangeMinA) + rangeMinA;
+
+            var outNetworkBufferA = new NetworkBuffer();
+            var outNetworkWriterA = new NetworkWriter(outNetworkBufferA);
+
+            outNetworkWriterA.WriteRangedDouble(randDoubleValueA, rangeMinA, rangeMaxA, rangeBytesA);
+            outNetworkWriterA.WriteRangedDouble(rangeMinA, rangeMinA, rangeMaxA, rangeBytesA);
+            outNetworkWriterA.WriteRangedDouble(rangeMaxA, rangeMinA, rangeMaxA, rangeBytesA);
+
+            var rawBufferBytesA = outNetworkBufferA.GetBuffer();
+
+            var inNetworkBufferA = new NetworkBuffer(rawBufferBytesA);
+            var inNetworkReaderA = new NetworkReader(inNetworkBufferA);
+
+            Assert.That(inNetworkReaderA.ReadRangedDouble(rangeMinA, rangeMaxA, rangeBytesA), Is.EqualTo(randDoubleValueA));
+            Assert.That(inNetworkReaderA.ReadRangedDouble(rangeMinA, rangeMaxA, rangeBytesA), Is.EqualTo(rangeMinA));
+            Assert.That(inNetworkReaderA.ReadRangedDouble(rangeMinA, rangeMaxA, rangeBytesA), Is.EqualTo(rangeMaxA));
+
+
+
+            const double rangeMinB = 0;
+            const double rangeMaxB = 360;
+            const int rangeBytesB = 4;
+
+            double randDoubleValueB = new Random().NextDouble() * (rangeMaxB - rangeMinB) + rangeMinB;
+
+            var outNetworkBufferB = new NetworkBuffer();
+            var outNetworkWriterB = new NetworkWriter(outNetworkBufferB);
+
+            outNetworkWriterB.WriteRangedDouble(randDoubleValueB, rangeMinB, rangeMaxB, rangeBytesB);
+            outNetworkWriterB.WriteRangedDouble(rangeMinB, rangeMinB, rangeMaxB, rangeBytesB);
+            outNetworkWriterB.WriteRangedDouble(rangeMaxB, rangeMinB, rangeMaxB, rangeBytesB);
+
+            var rawBufferBytesB = outNetworkBufferB.GetBuffer();
+
+            var inNetworkBufferB = new NetworkBuffer(rawBufferBytesB);
+            var inNetworkReaderB = new NetworkReader(inNetworkBufferB);
+
+            Assert.That(inNetworkReaderB.ReadRangedDouble(rangeMinB, rangeMaxB, rangeBytesB), Is.EqualTo(randDoubleValueB));
+            Assert.That(inNetworkReaderB.ReadRangedDouble(rangeMinB, rangeMaxB, rangeBytesB), Is.EqualTo(rangeMinB));
+            Assert.That(inNetworkReaderB.ReadRangedDouble(rangeMinB, rangeMaxB, rangeBytesB), Is.EqualTo(rangeMaxB));
         }
 
         [Test]

--- a/com.unity.multiplayer.mlapi/Tests/Editor/NetworkBufferTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/NetworkBufferTests.cs
@@ -334,6 +334,51 @@ namespace MLAPI.EditorTests
         [Test]
         public void TestRangedSingle()
         {
+            const float rangeMinA = -180;
+            const float rangeMaxA = 180;
+            const int rangeBytesA = 2;
+
+            float randFloatValueA = UnityEngine.Random.Range(rangeMinA, rangeMaxA);
+
+            var outNetworkBufferA = new NetworkBuffer();
+            var outNetworkWriterA = new NetworkWriter(outNetworkBufferA);
+
+            outNetworkWriterA.WriteRangedSingle(randFloatValueA, rangeMinA, rangeMaxA, rangeBytesA);
+            outNetworkWriterA.WriteRangedSingle(rangeMinA, rangeMinA, rangeMaxA, rangeBytesA);
+            outNetworkWriterA.WriteRangedSingle(rangeMaxA, rangeMinA, rangeMaxA, rangeBytesA);
+
+            var rawBufferBytesA = outNetworkBufferA.GetBuffer();
+
+            var inNetworkBufferA = new NetworkBuffer(rawBufferBytesA);
+            var inNetworkReaderA = new NetworkReader(inNetworkBufferA);
+
+            Assert.That(inNetworkReaderA.ReadRangedSingle(rangeMinA, rangeMaxA, rangeBytesA), Is.EqualTo(randFloatValueA));
+            Assert.That(inNetworkReaderA.ReadRangedSingle(rangeMinA, rangeMaxA, rangeBytesA), Is.EqualTo(rangeMinA));
+            Assert.That(inNetworkReaderA.ReadRangedSingle(rangeMinA, rangeMaxA, rangeBytesA), Is.EqualTo(rangeMaxA));
+
+
+
+            const float rangeMinB = 0;
+            const float rangeMaxB = 360;
+            const int rangeBytesB = 4;
+
+            float randFloatValueB = UnityEngine.Random.Range(rangeMinB, rangeMaxB);
+
+            var outNetworkBufferB = new NetworkBuffer();
+            var outNetworkWriterB = new NetworkWriter(outNetworkBufferB);
+
+            outNetworkWriterB.WriteRangedSingle(randFloatValueB, rangeMinB, rangeMaxB, rangeBytesB);
+            outNetworkWriterB.WriteRangedSingle(rangeMinB, rangeMinB, rangeMaxB, rangeBytesB);
+            outNetworkWriterB.WriteRangedSingle(rangeMaxB, rangeMinB, rangeMaxB, rangeBytesB);
+
+            var rawBufferBytesB = outNetworkBufferB.GetBuffer();
+
+            var inNetworkBufferB = new NetworkBuffer(rawBufferBytesB);
+            var inNetworkReaderB = new NetworkReader(inNetworkBufferB);
+
+            Assert.That(inNetworkReaderB.ReadRangedSingle(rangeMinB, rangeMaxB, rangeBytesB), Is.EqualTo(randFloatValueB));
+            Assert.That(inNetworkReaderB.ReadRangedSingle(rangeMinB, rangeMaxB, rangeBytesB), Is.EqualTo(rangeMinB));
+            Assert.That(inNetworkReaderB.ReadRangedSingle(rangeMinB, rangeMaxB, rangeBytesB), Is.EqualTo(rangeMaxB));
         }
 
         [Test]

--- a/com.unity.multiplayer.mlapi/Tests/Editor/NetworkBufferTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/NetworkBufferTests.cs
@@ -332,6 +332,16 @@ namespace MLAPI.EditorTests
         }
 
         [Test]
+        public void TestRangedSingle()
+        {
+        }
+
+        [Test]
+        public void TestRangedDouble()
+        {
+        }
+
+        [Test]
         public void TestWritePackedSingle()
         {
             float somenumber = (float)Math.PI;


### PR DESCRIPTION
fixes #734

also implements `TestRangedSingle` and `TestRangedDouble` EditorTest in `NetworkBufferTests`.