### PR TITLE
fix: make manualtests asmdef a normal runtime asmdef

### DIFF
--- a/testproject/Assets/Tests/Manual/testproject.manualtests.asmdef
+++ b/testproject/Assets/Tests/Manual/testproject.manualtests.asmdef
@@ -4,10 +4,5 @@
         "TestProject",
         "Unity.Multiplayer.MLAPI.Runtime",
         "Unity.Multiplayer.MLAPI.Editor"
-    ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
-    ],
-    "includePlatforms": [],
-    "excludePlatforms": []
+    ]
 }


### PR DESCRIPTION
`TestProject.ManualTests` asmdef should NOT be a tests asmdef because it'd make it being stripped out from standalone builds.
this PR makes it a standard runtime asmdef.