### PR TITLE
fix: Update package patch version to allow package registry re-publish

### DIFF
--- a/com.unity.multiplayer.mlapi/CHANGELOG.md
+++ b/com.unity.multiplayer.mlapi/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 This file documents all notable changes to this package. Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
-## [0.1.0] - 2021-06-01
+## [0.1.1] - 2021-06-01
 
 This is hotfix v0.1.1 for the initial experimental Unity MLAPI Package.
 

--- a/com.unity.multiplayer.mlapi/CHANGELOG.md
+++ b/com.unity.multiplayer.mlapi/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 This file documents all notable changes to this package. Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
+## [0.1.0] - 2021-06-01
+
+This is hotfix v0.1.1 for the initial experimental Unity MLAPI Package.
+
+### Changes
+
+* Fixed issue with the Unity Registry package version missing some fixes from the v0.1.0 release.
+
 ## [0.1.0] - 2021-03-23
 
 This is the initial experimental Unity MLAPI Package, v0.1.0.

--- a/com.unity.multiplayer.mlapi/Documentation~/Manual.md
+++ b/com.unity.multiplayer.mlapi/Documentation~/Manual.md
@@ -4,10 +4,15 @@ Unity MLAPI is a high level networking library built for the Unity game engine t
 
 ##  Unity MLAPI 
 
- See this guide to install Unity MLAPI, set up your project, and get started with your first networked game.
- [First Steps with Unity MLAPI](https://docs-multiplayer.unity3d.com/docs/tutorials/helloworldintro)
+See this guide to install Unity MLAPI, set up your project, and get started with your first networked game.
+
+* [MLAPI Documentation](https://docs-multiplayer.unity3d.com/docs/getting-started/about-mlapi)
+* [Install MLAPI](https://docs-multiplayer.unity3d.com/docs/migration/install)
+* [First Steps with Unity MLAPI](https://docs-multiplayer.unity3d.com/docs/tutorials/helloworldintro)
+* [MLAPI API Reference](https://docs-multiplayer.unity3d.com/docs/mlapi-api/introduction)
 
 # Technical details
+
 ## Requirements
 
 This version of MLAPI is compatible with the following versions of the Unity Editor:
@@ -20,3 +25,4 @@ This version of MLAPI is compatible with the following versions of the Unity Edi
 |Date|Reason|
 |---|---|
 |March 10, 2021|Document created. Matches package version 0.1.0|
+|June 1, 2021| Updated and added links for additional content. Matches patch version 0.1.0 and hotfixes.|

--- a/com.unity.multiplayer.mlapi/package.json
+++ b/com.unity.multiplayer.mlapi/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.unity.multiplayer.mlapi",
     "displayName": "MLAPI Networking Library",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "unity": "2019.4",
     "unityRelease": "8f1",
     "description": "This the Core Unity Mid-level API that provides core SDK for multiplayer games within unity",


### PR DESCRIPTION
Updates the package version to 0.1.1 so we can publish it to Unity Package Registry.

Version 0.1.0 in the Unity Registry was published against an old commit and is missing several changes for that release. In order to publish a corrected version with all relevant changes, we have to bump the version number.