### PR TITLE
refactor: Removing dead code for NETWORK_VARIABLE_UPDATE

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConstants.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Configuration/NetworkConstants.cs
@@ -17,7 +17,6 @@ namespace MLAPI.Configuration
         internal const byte ADD_OBJECTS = 10;
         internal const byte TIME_SYNC = 11;
         internal const byte NETWORK_VARIABLE_DELTA = 12;
-        internal const byte NETWORK_VARIABLE_UPDATE = 13;
         internal const byte ALL_CLIENTS_LOADED_SCENE = 14;
         internal const byte UNNAMED_MESSAGE = 20;
         internal const byte DESTROY_OBJECTS = 21;
@@ -43,7 +42,7 @@ namespace MLAPI.Configuration
             "ADD_OBJECTS",
             "TIME_SYNC",
             "NETWORK_VARIABLE_DELTA",
-            "NETWORK_VARIABLE_UPDATE",
+            "",
             "ALL_CLIENTS_SWITCH_SCENE_COMPLETED",
             "",
             "", // 16

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -1264,17 +1264,6 @@ namespace MLAPI
                             ReceiveTime = receiveTime
                         });
                         break;
-                    case NetworkConstants.NETWORK_VARIABLE_UPDATE:
-                        MessageHandler.HandleNetworkVariableUpdate(clientId, messageStream, BufferCallback, new PreBufferPreset()
-                        {
-                            AllowBuffer = allowBuffer,
-                            NetworkChannel = networkChannel,
-                            ClientId = clientId,
-                            Data = data,
-                            MessageType = messageType,
-                            ReceiveTime = receiveTime
-                        });
-                        break;
                     case NetworkConstants.UNNAMED_MESSAGE:
                         MessageHandler.HandleUnnamedMessage(clientId, messageStream);
                         break;

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/IInternalMessageHandler.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/IInternalMessageHandler.cs
@@ -18,7 +18,6 @@ namespace MLAPI.Messaging
         void HandleDestroyObjects(ulong clientId, Stream stream);
         void HandleTimeSync(ulong clientId, Stream stream, float receiveTime);
         void HandleNetworkVariableDelta(ulong clientId, Stream stream, Action<ulong, PreBufferPreset> bufferCallback, PreBufferPreset bufferPreset);
-        void HandleNetworkVariableUpdate(ulong clientId, Stream stream, Action<ulong, PreBufferPreset> bufferCallback, PreBufferPreset bufferPreset);
         void RpcReceiveQueueItem(ulong clientId, Stream stream, float receiveTime, RpcQueueContainer.QueueItemType queueItemType);
         void HandleUnnamedMessage(ulong clientId, Stream stream);
         void HandleNamedMessage(ulong clientId, Stream stream);

--- a/com.unity.multiplayer.mlapi/Tests/Editor/NetworkManagerMessageHandlerTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/NetworkManagerMessageHandlerTests.cs
@@ -112,13 +112,6 @@ namespace MLAPI.EditorTests
                 }
 
                 // Should cause log (server and client)
-                LogAssert.Expect(LogType.Log, nameof(MessageHandlerReceivedMessageServerClient) + " " + nameof(DummyMessageHandler.HandleNetworkVariableUpdate));
-                using (var messageStream = MessagePacker.WrapMessage(NetworkConstants.NETWORK_VARIABLE_UPDATE, inputBuffer))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0, true);
-                }
-
-                // Should cause log (server and client)
                 LogAssert.Expect(LogType.Log, nameof(MessageHandlerReceivedMessageServerClient) + " " + nameof(DummyMessageHandler.HandleUnnamedMessage));
                 using (var messageStream = MessagePacker.WrapMessage(NetworkConstants.UNNAMED_MESSAGE, inputBuffer))
                 {
@@ -237,13 +230,6 @@ namespace MLAPI.EditorTests
                 // Should cause log (server and client)
                 LogAssert.Expect(LogType.Log, nameof(MessageHandlerReceivedMessageServerClient) + " " + nameof(DummyMessageHandler.HandleNetworkVariableDelta));
                 using (var messageStream = MessagePacker.WrapMessage(NetworkConstants.NETWORK_VARIABLE_DELTA, inputBuffer))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0, true);
-                }
-
-                // Should cause log (server and client)
-                LogAssert.Expect(LogType.Log, nameof(MessageHandlerReceivedMessageServerClient) + " " + nameof(DummyMessageHandler.HandleNetworkVariableUpdate));
-                using (var messageStream = MessagePacker.WrapMessage(NetworkConstants.NETWORK_VARIABLE_UPDATE, inputBuffer))
                 {
                     networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0, true);
                 }


### PR DESCRIPTION
As far as I could see, the non-delta update of Network Variables is unused at the moment. It seems to be dead code.

It also makes it harder to discuss and reason about the code and future changes. This came up with a team member that wanted to instrument/profile the code.

Can we remove it ?