### PR TITLE
fix: Update package version to 0.2.0 because of unity minversion change

### DIFF
--- a/com.unity.multiplayer.mlapi/CHANGELOG.md
+++ b/com.unity.multiplayer.mlapi/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 This file documents all notable changes to this package. Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
+## [0.2.0] 2021-06-03
+
+WIP version increment to pass package validation checks. Changelog & final version number TBD.
+
 ## [0.1.1] - 2021-06-01
 
 This is hotfix v0.1.1 for the initial experimental Unity MLAPI Package.

--- a/com.unity.multiplayer.mlapi/CHANGELOG.md
+++ b/com.unity.multiplayer.mlapi/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 This file documents all notable changes to this package. Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
-## [0.2.0] 2021-06-03
+## [0.2.0] - 2021-06-03
 
 WIP version increment to pass package validation checks. Changelog & final version number TBD.
 

--- a/com.unity.multiplayer.mlapi/Documentation~/Manual.md
+++ b/com.unity.multiplayer.mlapi/Documentation~/Manual.md
@@ -17,7 +17,7 @@ See this guide to install Unity MLAPI, set up your project, and get started with
 
 This version of MLAPI is compatible with the following versions of the Unity Editor:
 
-* 2019.4 and later (recommended)
+* 2020.3 and later
 * Windows, Mac, Linux platforms are supported by MLAPI
 
 ## Document revision history
@@ -26,3 +26,4 @@ This version of MLAPI is compatible with the following versions of the Unity Edi
 |---|---|
 |March 10, 2021|Document created. Matches package version 0.1.0|
 |June 1, 2021| Updated and added links for additional content. Matches patch version 0.1.0 and hotfixes.|
+|June 3, 2021| Update document to acknowledge Unity min version change. Matches package version 0.2.0|

--- a/com.unity.multiplayer.mlapi/package.json
+++ b/com.unity.multiplayer.mlapi/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.unity.multiplayer.mlapi",
     "displayName": "MLAPI Networking Library",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "unity": "2020.3",
     "unityRelease": "0f1",
     "description": "This the Core Unity Mid-level API that provides core SDK for multiplayer games within unity",


### PR DESCRIPTION
We changed the package's Unity minversion a while ago to drop support for 2019.4. We then updated the package version for a hotfix. This triggered a failure in package validation CI because it noticed we updated the patch version, but it requires a semver Minor increment when Unity minversion changes. So, here we are, with the temporary "0.2.0" version of the package.