### PR TITLE
fix: remove OnClientConnectedCallback registration from StatsDisplay

### DIFF
--- a/testproject/Assets/Tests/Manual/Scripts/StatsDisplay.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/StatsDisplay.cs
@@ -73,6 +73,14 @@ namespace TestProject.ManualTests
         }
 
         /// <summary>
+        /// Remove our OnClientConnectedCallback registration when we are destroyed
+        /// </summary>
+        private void OnDestroy()
+        {
+            NetworkManager.OnClientConnectedCallback -= OnClientConnectedCallback;
+        }
+
+        /// <summary>
         /// Used by UI Button click event
         /// </summary>
         public void ToggleClientSever()

--- a/testproject/Assets/Tests/Manual/Scripts/StatsDisplay.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/StatsDisplay.cs
@@ -18,7 +18,6 @@ namespace TestProject.ManualTests
         private Text m_ClientServerToggleText;
         private List<ulong> m_ClientsToUpdate = new List<ulong>();
 
-
         private bool m_IsServer;
 
         private void Start()


### PR DESCRIPTION
This change is within the test project's manual tests area and this PR is to just fix this minor bug in the StatsDisplay code used in the manual scene transitioning test.

**Background:**
I ran into a bug that can cause late joining players to not get registered with the rest of the players if you have a NetworkBehaviour that has registered for the OnClientConnectedCallback event but never removes the registration when destroyed.  This will cause, on the server side, the HandleApproval method to throw an exception before notifying the rest of the players that a new player has joined and as such the notification is never sent.

**Up for Debate:**
If you are interested in a potential way to fix this "break in the approval process" while also having the ability to notify the user that they failed to remove their OnClientConnectedCallback registration [you can find that in this experimental branch.
](https://github.com/Unity-Technologies/com.unity.multiplayer.mlapi/tree/experimental/OnClientConnectedFails)
_The above experimental branch does not include a unique warning message but that can be easily added_

