### PR TITLE
refactor: isKinematic set to true for rigid bodies of non-authorized instances

### DIFF
--- a/testproject/Assets/Tests/Manual/Scripts/RandomMovement.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/RandomMovement.cs
@@ -11,6 +11,7 @@ namespace TestProject.ManualTests
         private Vector3 m_Direction;
         private Rigidbody m_Rigidbody;
 
+
         public override void NetworkStart()
         {
             m_Rigidbody = GetComponent<Rigidbody>();

--- a/testproject/Assets/Tests/Manual/Scripts/RandomMovement.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/RandomMovement.cs
@@ -15,16 +15,10 @@ namespace TestProject.ManualTests
         public override void NetworkStart()
         {
             m_Rigidbody = GetComponent<Rigidbody>();
-            if (NetworkObject != null)
+            if (NetworkObject != null && m_Rigidbody != null)
             {
-                if (!NetworkObject.IsOwner)
-                {
-                    if (m_Rigidbody != null)
-                    {
-                        m_Rigidbody.isKinematic = true;
-                    }
-                }
-                else
+                m_Rigidbody.isKinematic = !NetworkObject.IsOwner;
+                if (!m_Rigidbody.isKinematic)
                 {
                     ChangeDirection(true, true);
                 }

--- a/testproject/Assets/Tests/Manual/Scripts/RandomMovement.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/RandomMovement.cs
@@ -1,19 +1,33 @@
 using UnityEngine;
+using MLAPI;
 
 namespace TestProject.ManualTests
 {
     /// <summary>
     /// Used with GenericObjects to randomly move them around
     /// </summary>
-    public class RandomMovement : MonoBehaviour, IPlayerMovement
+    public class RandomMovement : NetworkBehaviour, IPlayerMovement
     {
         private Vector3 m_Direction;
         private Rigidbody m_Rigidbody;
 
-        public void Start()
+        public override void NetworkStart()
         {
             m_Rigidbody = GetComponent<Rigidbody>();
-            ChangeDirection(true, true);
+            if (NetworkObject != null)
+            {
+                if (!NetworkObject.IsOwner)
+                {
+                    if (m_Rigidbody != null)
+                    {
+                        m_Rigidbody.isKinematic = true;
+                    }
+                }
+                else
+                {
+                    ChangeDirection(true, true);
+                }
+            }
         }
 
         public void Move(int speed)


### PR DESCRIPTION
Assure non-authorized player instances' rigid body is set to be kinematic in order to avoid micro-motion that causes error spamming.