### PR TITLE
feat: MultiInstanceHelpers to use fixed FrameRate by default

### DIFF
--- a/com.unity.multiplayer.mlapi/Tests/Runtime/MultiInstance/MultiInstanceHelpers.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/MultiInstance/MultiInstanceHelpers.cs
@@ -25,7 +25,7 @@ namespace MLAPI.RuntimeTests
         /// <param name="clientCount">The amount of clients</param>
         /// <param name="server">The server NetworkManager</param>
         /// <param name="clients">The clients NetworkManagers</param>
-        public static bool Create(int clientCount, out NetworkManager server, out NetworkManager[] clients, int targetFrameRate = 50)
+        public static bool Create(int clientCount, out NetworkManager server, out NetworkManager[] clients, int targetFrameRate = 60)
         {
             NetworkManagerInstances = new List<NetworkManager>();
 

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/MultiInstance/MultiInstanceHelpers.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/MultiInstance/MultiInstanceHelpers.cs
@@ -15,8 +15,9 @@ namespace MLAPI.RuntimeTests
     /// </summary>
     public static class MultiInstanceHelpers
     {
-
         public static List<NetworkManager> NetworkManagerInstances = new List<NetworkManager>();
+
+        private static int s_OriginalTargetFrameRate = -1;
 
         /// <summary>
         /// Creates NetworkingManagers and configures them for use in a multi instance setting.
@@ -24,7 +25,7 @@ namespace MLAPI.RuntimeTests
         /// <param name="clientCount">The amount of clients</param>
         /// <param name="server">The server NetworkManager</param>
         /// <param name="clients">The clients NetworkManagers</param>
-        public static bool Create(int clientCount, out NetworkManager server, out NetworkManager[] clients)
+        public static bool Create(int clientCount, out NetworkManager server, out NetworkManager[] clients, int targetFrameRate = 50)
         {
             NetworkManagerInstances = new List<NetworkManager>();
 
@@ -47,6 +48,9 @@ namespace MLAPI.RuntimeTests
                     NetworkTransport = go.AddComponent<SIPTransport>()
                 };
             }
+
+            s_OriginalTargetFrameRate = Application.targetFrameRate;
+            Application.targetFrameRate = targetFrameRate;
 
             return true;
         }
@@ -121,6 +125,8 @@ namespace MLAPI.RuntimeTests
             {
                 Object.Destroy(s_CoroutineRunner);
             }
+
+            Application.targetFrameRate = s_OriginalTargetFrameRate;
         }
 
         /// <summary>

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/MultiInstance/RPCTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/MultiInstance/RPCTests.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Collections;
-using System.Diagnostics;
-using System.Linq;
 using MLAPI.Messaging;
 using NUnit.Framework;
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.TestTools;
 using Debug = UnityEngine.Debug;
@@ -34,10 +31,6 @@ namespace MLAPI.RuntimeTests
         [UnityTest]
         public IEnumerator TestRPCs()
         {
-            // Set target frameRate to work around ubuntu timings
-            int targetFrameRate = Application.targetFrameRate;
-            Application.targetFrameRate = 120;
-
             // Create multiple NetworkManager instances
             if (!MultiInstanceHelpers.Create(1, out NetworkManager server, out NetworkManager[] clients))
             {
@@ -133,9 +126,6 @@ namespace MLAPI.RuntimeTests
             Assert.True(hasReceivedServerRPC, "ServerRPC was not received");
             Assert.True(hasReceivedClientRPCLocally, "ClientRPC was not locally received on the server");
             Assert.True(hasReceivedClientRPCRemotely, "ClientRPC was not remotely received on the client");
-
-            // Release frame rate
-            Application.targetFrameRate = targetFrameRate;
 
             // Cleanup
             MultiInstanceHelpers.Destroy();

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkSpawnManagerTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkSpawnManagerTests.cs
@@ -1,10 +1,8 @@
-using System;
 using System.Collections;
 using MLAPI.Exceptions;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
-using Object = System.Object;
 
 namespace MLAPI.RuntimeTests
 {
@@ -13,7 +11,6 @@ namespace MLAPI.RuntimeTests
         private NetworkManager m_ServerNetworkManager;
         private NetworkManager[] m_ClientNetworkManagers;
         private GameObject m_PlayerPrefab;
-        private int m_OriginalTargetFrameRate;
 
         private ulong serverSideClientId => m_ServerNetworkManager.ServerClientId;
         private ulong clientSideClientId => m_ClientNetworkManagers[0].LocalClientId;
@@ -22,16 +19,6 @@ namespace MLAPI.RuntimeTests
         [UnitySetUp]
         public IEnumerator Setup()
         {
-            // Just always track the current target frame rate (will be re-applied upon TearDown)
-            m_OriginalTargetFrameRate = Application.targetFrameRate;
-
-            // Since we use frame count as a metric, we need to assure it runs at a "common update rate"
-            // between platforms (i.e. Ubuntu seems to run at much higher FPS when set to -1)
-            if (Application.targetFrameRate < 0 || Application.targetFrameRate > 120)
-            {
-                Application.targetFrameRate = 120;
-            }
-
             // Create multiple NetworkManager instances
             if (!MultiInstanceHelpers.Create(2, out NetworkManager server, out NetworkManager[] clients))
             {
@@ -191,11 +178,11 @@ namespace MLAPI.RuntimeTests
         {
             // Shutdown and clean up both of our NetworkManager instances
             MultiInstanceHelpers.Destroy();
-            UnityEngine.Object.Destroy(m_PlayerPrefab);
+            Object.Destroy(m_PlayerPrefab);
 
-            // Set the application's target frame rate back to its original value
-            Application.targetFrameRate = m_OriginalTargetFrameRate;
-            yield return new WaitForSeconds(0); // wait for next frame so everything is destroyed, so following tests can execute from clean environment
+            // wait for next frame so everything is destroyed, so following tests can execute from clean environment
+            int nextFrameNumber = Time.frameCount + 1;
+            yield return new WaitUntil(() => Time.frameCount >= nextFrameNumber);
         }
     }
 }

--- a/testproject/Assets/Tests/Runtime/MultiClientConnectionApproval.cs
+++ b/testproject/Assets/Tests/Runtime/MultiClientConnectionApproval.cs
@@ -20,22 +20,6 @@ namespace TestProject.RuntimeTests
         private GameObject m_PlayerPrefab;
         private GameObject m_PlayerPrefabOverride;
 
-        private int m_OriginalTargetFrameRate;
-
-        [SetUp]
-        public void SetUp()
-        {
-            // Just always track the current target frame rate (will be re-applied upon TearDown)
-            m_OriginalTargetFrameRate = Application.targetFrameRate;
-
-            // Since we use frame count as a metric, we need to assure it runs at a "common update rate"
-            // between platforms (i.e. Ubuntu seems to run at much higher FPS when set to -1)
-            if (Application.targetFrameRate < 0 || Application.targetFrameRate > 120)
-            {
-                Application.targetFrameRate = 120;
-            }
-        }
-
         /// <summary>
         /// Tests connection approval and connection approval failure
         /// </summary>
@@ -44,7 +28,7 @@ namespace TestProject.RuntimeTests
         public IEnumerator ConnectionApproval()
         {
             m_ConnectionToken = "ThisIsTheRightPassword";
-            return ConnectionApprovalHandler(3,1);
+            return ConnectionApprovalHandler(3, 1);
         }
 
         /// <summary>
@@ -60,7 +44,7 @@ namespace TestProject.RuntimeTests
 
 
         /// <summary>
-        /// Allows for several connection approval related configurations 
+        /// Allows for several connection approval related configurations
         /// </summary>
         /// <param name="numClients">total number of clients (excluding the host)</param>
         /// <param name="failureTestCount">how many clients are expected to fail</param>
@@ -68,20 +52,14 @@ namespace TestProject.RuntimeTests
         /// <returns></returns>
         private IEnumerator ConnectionApprovalHandler(int numClients, int failureTestCount = 1, bool prefabOverride = false)
         {
-            Debug.Log($"Application.targetFrameRate = {Application.targetFrameRate}");
-            if (Application.targetFrameRate == -1 || Application.targetFrameRate > 120)
-            {
-                Application.targetFrameRate = 120;
-            }
-
             var startFrameCount = Time.frameCount;
             var startTime = Time.realtimeSinceStartup;
 
             m_SuccessfulConnections = 0;
             m_FailedConnections = 0;
             Assert.IsTrue(numClients >= failureTestCount);
-            
-            // Create Host and (numClients) clients 
+
+            // Create Host and (numClients) clients
             Assert.True(MultiInstanceHelpers.Create(numClients, out NetworkManager server, out NetworkManager[] clients));
 
             // Create a default player GameObject to use
@@ -131,7 +109,7 @@ namespace TestProject.RuntimeTests
                     client.NetworkConfig.ConnectionData = Encoding.ASCII.GetBytes(m_ConnectionToken);
                     clientsAdjustedList.Add(client);
                 }
-                
+
             }
 
             // Start the instances
@@ -141,7 +119,7 @@ namespace TestProject.RuntimeTests
                 Assert.Fail("Failed to start instances");
             }
 
-            // [Client-Side] Wait for a connection to the server 
+            // [Client-Side] Wait for a connection to the server
             yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(clientsAdjustedList.ToArray(), null, 512));
 
             // [Host-Side] Check to make sure all clients are connected
@@ -156,7 +134,7 @@ namespace TestProject.RuntimeTests
             // If we are doing player prefab overrides, then check all of the players to make sure they spawned the appropriate NetworkObject
             if (prefabOverride)
             {
-                foreach(var networkClient in server.ConnectedClientsList)
+                foreach (var networkClient in server.ConnectedClientsList)
                 {
                     Assert.IsNotNull(networkClient.PlayerObject);
                     Assert.AreEqual(networkClient.PlayerObject.GlobalObjectIdHash, m_PrefabOverrideGlobalObjectIdHash);
@@ -171,7 +149,6 @@ namespace TestProject.RuntimeTests
             server.ConnectionApprovalCallback -= ConnectionApprovalCallback;
             server.StopHost();
 
-            Debug.Log($"Application.targetFrameRate = {Application.targetFrameRate}.");
             Debug.Log($"Total frames updated = {Time.frameCount - startFrameCount} within {Time.realtimeSinceStartup - startTime} seconds.");
         }
 
@@ -186,7 +163,7 @@ namespace TestProject.RuntimeTests
             string approvalToken = Encoding.ASCII.GetString(connectionData);
             var isApproved = approvalToken == m_ConnectionToken;
 
-            if(isApproved)
+            if (isApproved)
             {
                 m_SuccessfulConnections++;
             }
@@ -222,9 +199,6 @@ namespace TestProject.RuntimeTests
 
             // Shutdown and clean up both of our NetworkManager instances
             MultiInstanceHelpers.Destroy();
-
-            // Set the application's target frame rate back to its original value
-            Application.targetFrameRate = m_OriginalTargetFrameRate;
         }
     }
 }

--- a/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs
+++ b/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs
@@ -15,8 +15,6 @@ namespace TestProject.RuntimeTests
     {
         private GameObject m_PlayerPrefab;
 
-        private int m_OriginalTargetFrameRate;
-
         private UserSerializableClass m_UserSerializableClass;
         private List<UserSerializableClass> m_UserSerializableClassArray;
 
@@ -24,20 +22,6 @@ namespace TestProject.RuntimeTests
 
         private bool m_IsSendingNull;
         private bool m_IsArrayEmpty;
-
-        [SetUp]
-        public void SetUp()
-        {
-            // Just always track the current target frame rate (will be re-applied upon TearDown)
-            m_OriginalTargetFrameRate = Application.targetFrameRate;
-
-            // Since we use frame count as a metric, we need to assure it runs at a "common update rate"
-            // between platforms (i.e. Ubuntu seems to run at much higher FPS when set to -1)
-            if (Application.targetFrameRate < 0 || Application.targetFrameRate > 120)
-            {
-                Application.targetFrameRate = 120;
-            }
-        }
 
         /// <summary>
         /// Tests that INetworkSerializable can be used through RPCs by a user
@@ -50,7 +34,7 @@ namespace TestProject.RuntimeTests
             var numClients = 1;
             var startTime = Time.realtimeSinceStartup;
 
-            // Create Host and (numClients) clients 
+            // Create Host and (numClients) clients
             Assert.True(MultiInstanceHelpers.Create(numClients, out NetworkManager server, out NetworkManager[] clients));
 
             // Create a default player GameObject to use
@@ -76,7 +60,7 @@ namespace TestProject.RuntimeTests
                 Assert.Fail("Failed to start instances");
             }
 
-            // [Client-Side] Wait for a connection to the server 
+            // [Client-Side] Wait for a connection to the server
             yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(clients, null, 512));
 
             // [Host-Side] Check to make sure all clients are connected
@@ -174,7 +158,7 @@ namespace TestProject.RuntimeTests
         [UnityTest]
         public IEnumerator NetworkSerializableNULLArrayTest()
         {
-            return NetworkSerializableArrayTestHandler(0,true);
+            return NetworkSerializableArrayTestHandler(0, true);
         }
 
         /// <summary>
@@ -197,7 +181,7 @@ namespace TestProject.RuntimeTests
             var numClients = 1;
             var startTime = Time.realtimeSinceStartup;
 
-            // Create Host and (numClients) clients 
+            // Create Host and (numClients) clients
             Assert.True(MultiInstanceHelpers.Create(numClients, out NetworkManager server, out NetworkManager[] clients));
 
             // Create a default player GameObject to use
@@ -223,7 +207,7 @@ namespace TestProject.RuntimeTests
                 Assert.Fail("Failed to start instances");
             }
 
-            // [Client-Side] Wait for a connection to the server 
+            // [Client-Side] Wait for a connection to the server
             yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(clients, null, 512));
 
             // [Host-Side] Check to make sure all clients are connected
@@ -245,7 +229,7 @@ namespace TestProject.RuntimeTests
 
             if (!m_IsSendingNull)
             {
-                // Create an array of userSerializableClass instances 
+                // Create an array of userSerializableClass instances
                 for (int i = 0; i < arraySize; i++)
                 {
                     var userSerializableClass = new UserSerializableClass();
@@ -297,7 +281,7 @@ namespace TestProject.RuntimeTests
             }
             else if (m_IsArrayEmpty)
             {
-                Assert.AreEqual(userSerializableClass.Length,0);
+                Assert.AreEqual(userSerializableClass.Length, 0);
             }
             else
             {
@@ -343,9 +327,6 @@ namespace TestProject.RuntimeTests
 
             // Shutdown and clean up both of our NetworkManager instances
             MultiInstanceHelpers.Destroy();
-
-            // Set the application's target frame rate back to its original value
-            Application.targetFrameRate = m_OriginalTargetFrameRate;
         }
     }
 
@@ -458,7 +439,7 @@ namespace TestProject.RuntimeTests
     }
 
     /// <summary>
-    /// The test version of a custom user-defined class that implements INetworkSerializable 
+    /// The test version of a custom user-defined class that implements INetworkSerializable
     /// </summary>
     public class UserSerializableClass : INetworkSerializable
     {

--- a/testproject/Assets/Tests/Runtime/RpcTestsAutomated.cs
+++ b/testproject/Assets/Tests/Runtime/RpcTestsAutomated.cs
@@ -13,26 +13,8 @@ namespace TestProject.RuntimeTests
     public class RPCTestsAutomated
     {
         private bool m_TimedOut;
-
         private int m_MaxFrames;
-
         private GameObject m_PlayerPrefab;
-
-        private int m_OriginalTargetFrameRate;
-
-        [SetUp]
-        public void SetUp()
-        {
-            // Just always track the current target frame rate (will be re-applied upon TearDown)
-            m_OriginalTargetFrameRate = Application.targetFrameRate;
-
-            // Since we use frame count as a metric, we need to assure it runs at a "common update rate"
-            // between platforms (i.e. Ubuntu seems to run at much higher FPS when set to -1)
-            if (Application.targetFrameRate < 0 || Application.targetFrameRate > 120)
-            {
-                Application.targetFrameRate = 120;
-            }
-        }
 
         /// <summary>
         /// Default Mode (Batched RPCs Enabled)
@@ -57,7 +39,7 @@ namespace TestProject.RuntimeTests
         /// <summary>
         /// This just helps to simplify any further tests that can leverage from
         /// the RpcQueueManualTests' wide array of RPC testing under different
-        /// conditions.  
+        /// conditions.
         /// Currently this allows for the adjustment of client count and whether
         /// RPC Batching is enabled or not.
         /// </summary>
@@ -72,7 +54,7 @@ namespace TestProject.RuntimeTests
             // Set RpcQueueManualTests into unit testing mode
             RpcQueueManualTests.UnitTesting = true;
 
-            // Create Host and (numClients) clients 
+            // Create Host and (numClients) clients
             Assert.True(MultiInstanceHelpers.Create(numClients, out NetworkManager server, out NetworkManager[] clients));
 
             // Create a default player GameObject to use
@@ -110,7 +92,7 @@ namespace TestProject.RuntimeTests
                 clients[i].RpcQueueContainer.EnableBatchedRpcs(useBatching);
             }
 
-            // [Client-Side] Wait for a connection to the server 
+            // [Client-Side] Wait for a connection to the server
             yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(clients, null, 512));
 
             // [Host-Side] Check to make sure all clients are connected
@@ -197,11 +179,9 @@ namespace TestProject.RuntimeTests
                 Object.Destroy(m_PlayerPrefab);
                 m_PlayerPrefab = null;
             }
+
             // Shutdown and clean up both of our NetworkManager instances
             MultiInstanceHelpers.Destroy();
-
-            // Set the application's target frame rate back to its original value
-            Application.targetFrameRate = m_OriginalTargetFrameRate;
         }
     }
 }


### PR DESCRIPTION
having an unlocked framerate sometimes costs us time to figure out why our automated tests were running just fine locally but suddenly fails over Yamato runs on macOS, Ubuntu.
apparently, macOS and Ubuntu platforms are running frames very fast, sometimes crunching thousands of frames per second.
fixing framerate to a specific value solves those unintuitive issues, so I believe we should have a default fixed framerate and still offer configurability off of the API.

note: part of this PR also includes removing/reverting `Application.targetFrameRate` fixes/tricks in some tests already implemented — reducing duplicate code and even saving developer time spent on debugging what the issue was, in the future.