### PR TITLE
fix: do not access/render runtime info if not playing in the editor

### DIFF
--- a/com.unity.multiplayer.mlapi/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.multiplayer.mlapi/Editor/NetworkBehaviourEditor.cs
@@ -174,9 +174,12 @@ namespace UnityEditor
             EditorGUI.BeginChangeCheck();
             serializedObject.Update();
 
-            for (int i = 0; i < m_NetworkVariableNames.Count; i++)
+            if (EditorApplication.isPlaying)
             {
-                RenderNetworkVariable(i);
+                for (int i = 0; i < m_NetworkVariableNames.Count; i++)
+                {
+                    RenderNetworkVariable(i);
+                }
             }
 
             var property = serializedObject.GetIterator();

--- a/com.unity.multiplayer.mlapi/Editor/NetworkObjectEditor.cs
+++ b/com.unity.multiplayer.mlapi/Editor/NetworkObjectEditor.cs
@@ -27,7 +27,7 @@ namespace MLAPI.Editor
         {
             Initialize();
 
-            if (!m_NetworkObject.IsSpawned && m_NetworkObject.NetworkManager != null && m_NetworkObject.NetworkManager.IsServer)
+            if (EditorApplication.isPlaying && !m_NetworkObject.IsSpawned && m_NetworkObject.NetworkManager != null && m_NetworkObject.NetworkManager.IsServer)
             {
                 EditorGUILayout.BeginHorizontal();
                 EditorGUILayout.LabelField(new GUIContent("Spawn", "Spawns the object across the network"));
@@ -39,7 +39,7 @@ namespace MLAPI.Editor
 
                 EditorGUILayout.EndHorizontal();
             }
-            else if (m_NetworkObject.IsSpawned)
+            else if (EditorApplication.isPlaying && m_NetworkObject.IsSpawned)
             {
                 var guiEnabled = GUI.enabled;
                 GUI.enabled = false;


### PR DESCRIPTION
we're probably not supposed to try rendering runtime network values while not playing in the editor :)