### PR TITLE
fix: NetworkPrefabs container's elements invalidated in the NetworkManager after relaunching Unity Project

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -261,54 +261,58 @@ namespace MLAPI
                 };
             }
 
-            // During OnValidate we will always clear out NetworkPrefabOverrideLinks and rebuild it
-            NetworkConfig.NetworkPrefabOverrideLinks.Clear();
-
-            // Check network prefabs and assign to dictionary for quick look up
-            for (int i = 0; i < NetworkConfig.NetworkPrefabs.Count; i++)
+            // If the scene is dirty and the asset database is not updating then we update NetworkPrefab information
+            if (activeScene.isDirty && !UnityEditor.EditorApplication.isUpdating)
             {
-                if (NetworkConfig.NetworkPrefabs[i] != null && NetworkConfig.NetworkPrefabs[i].Prefab != null)
+                // During OnValidate we will always clear out NetworkPrefabOverrideLinks and rebuild it
+                NetworkConfig.NetworkPrefabOverrideLinks.Clear();
+
+                // Check network prefabs and assign to dictionary for quick look up
+                for (int i = 0; i < NetworkConfig.NetworkPrefabs.Count; i++)
                 {
-                    var networkObject = NetworkConfig.NetworkPrefabs[i].Prefab.GetComponent<NetworkObject>();
-                    if (networkObject == null)
+                    if (NetworkConfig.NetworkPrefabs[i] != null && NetworkConfig.NetworkPrefabs[i].Prefab != null)
                     {
-                        if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
+                        var networkObject = NetworkConfig.NetworkPrefabs[i].Prefab.GetComponent<NetworkObject>();
+                        if (networkObject == null)
                         {
-                            NetworkLog.LogWarning($"{nameof(NetworkPrefab)} [{i}] does not have a {nameof(NetworkObject)} component");
-                        }
-                    }
-                    else
-                    {
-                        // Default to the standard NetworkPrefab.Prefab's NetworkObject first
-                        var globalObjectIdHash = networkObject.GlobalObjectIdHash;
-
-                        // Now check to see if it has an override
-                        switch (NetworkConfig.NetworkPrefabs[i].Override)
-                        {
-                            case NetworkPrefabOverride.Prefab:
-                                {
-                                    if (NetworkConfig.NetworkPrefabs[i].SourcePrefabToOverride == null && NetworkConfig.NetworkPrefabs[i].Prefab != null)
-                                    {
-                                        NetworkConfig.NetworkPrefabs[i].SourcePrefabToOverride = NetworkConfig.NetworkPrefabs[i].Prefab;
-                                    }
-                                    globalObjectIdHash = NetworkConfig.NetworkPrefabs[i].SourcePrefabToOverride.GetComponent<NetworkObject>().GlobalObjectIdHash;
-                                }
-                                break;
-                            case NetworkPrefabOverride.Hash:
-                                globalObjectIdHash = NetworkConfig.NetworkPrefabs[i].SourceHashToOverride;
-                                break;
-                        }
-
-                        // Add to the NetworkPrefabOverrideLinks or handle a new (blank) entries
-                        if (!NetworkConfig.NetworkPrefabOverrideLinks.ContainsKey(globalObjectIdHash))
-                        {
-                            NetworkConfig.NetworkPrefabOverrideLinks.Add(globalObjectIdHash, NetworkConfig.NetworkPrefabs[i]);
+                            if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
+                            {
+                                NetworkLog.LogWarning($"{nameof(NetworkPrefab)} [{i}] does not have a {nameof(NetworkObject)} component");
+                            }
                         }
                         else
                         {
-                            // Duplicate entries can happen when adding a new entry into a list of existing entries
-                            // Either this is user error or a new entry, either case we replace it with a new, blank, NetworkPrefab under this condition
-                            NetworkConfig.NetworkPrefabs[i] = new NetworkPrefab();
+                            // Default to the standard NetworkPrefab.Prefab's NetworkObject first
+                            var globalObjectIdHash = networkObject.GlobalObjectIdHash;
+
+                            // Now check to see if it has an override
+                            switch (NetworkConfig.NetworkPrefabs[i].Override)
+                            {
+                                case NetworkPrefabOverride.Prefab:
+                                    {
+                                        if (NetworkConfig.NetworkPrefabs[i].SourcePrefabToOverride == null && NetworkConfig.NetworkPrefabs[i].Prefab != null)
+                                        {
+                                            NetworkConfig.NetworkPrefabs[i].SourcePrefabToOverride = NetworkConfig.NetworkPrefabs[i].Prefab;
+                                        }
+                                        globalObjectIdHash = NetworkConfig.NetworkPrefabs[i].SourcePrefabToOverride.GetComponent<NetworkObject>().GlobalObjectIdHash;
+                                    }
+                                    break;
+                                case NetworkPrefabOverride.Hash:
+                                    globalObjectIdHash = NetworkConfig.NetworkPrefabs[i].SourceHashToOverride;
+                                    break;
+                            }
+
+                            // Add to the NetworkPrefabOverrideLinks or handle a new (blank) entries
+                            if (!NetworkConfig.NetworkPrefabOverrideLinks.ContainsKey(globalObjectIdHash))
+                            {
+                                NetworkConfig.NetworkPrefabOverrideLinks.Add(globalObjectIdHash, NetworkConfig.NetworkPrefabs[i]);
+                            }
+                            else
+                            {
+                                // Duplicate entries can happen when adding a new entry into a list of existing entries
+                                // Either this is user error or a new entry, either case we replace it with a new, blank, NetworkPrefab under this condition
+                                NetworkConfig.NetworkPrefabs[i] = new NetworkPrefab();
+                            }
                         }
                     }
                 }

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -261,7 +261,7 @@ namespace MLAPI
                 };
             }
 
-            // If the scene is dirty and the asset database is not updating then we update NetworkPrefab information
+            // If the scene is dirty and the asset database is not currently updating then we can update NetworkPrefab information
             if (activeScene.isDirty && !UnityEditor.EditorApplication.isUpdating)
             {
                 // During OnValidate we will always clear out NetworkPrefabOverrideLinks and rebuild it


### PR DESCRIPTION
**This resolves the following issue:**
Whilst upgrading Boss Room to MLAPI develop, we encountered an issue with the Network Manager and its NetworkPrefabs container, where if we delete any of the prefabs or variants that were added to the NetworkPrefabs list, then save (apply changes to) the NetworkingManager prefab, then shut down Unity and load it up again, the NetworkPrefabs list will be invalidated, most of the elements will have a null value.
[Github Issue 904](https://github.com/Unity-Technologies/com.unity.multiplayer.mlapi/issues/904)

**Additional Notes:**
This issue only arises if you make changes to a prefab instance and then apply those changes to the source prefab using Overrides->Apply All.  This only applies to the NetworkPrefabs list generation while in the editor as this list is rebuilt during runtime and the only time you would want to generate the list while in the editor is if the currently opened scene is dirty and the asset database is not being updated.