### PR TITLE
test: add utils for multi instance tests

### DIFF
--- a/com.unity.multiplayer.mlapi/Tests/Runtime/BaseMultiInstanceTest.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/BaseMultiInstanceTest.cs
@@ -9,14 +9,11 @@ namespace MLAPI.RuntimeTests
 {
     public abstract class BaseMultiInstanceTest
     {
-        private int m_OriginalTargetFrameRate;
-
         protected GameObject m_PlayerPrefab;
-
         protected NetworkManager m_ServerNetworkManager;
         protected NetworkManager[] m_ClientNetworkManagers;
 
-        public abstract int NbClients { get; }
+        protected abstract int NbClients { get; }
 
         [UnitySetUp]
         public virtual IEnumerator Setup()

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/BaseMultiInstanceTest.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/BaseMultiInstanceTest.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace MLAPI.RuntimeTests
+{
+    public abstract class BaseMultiInstanceTest
+    {
+        private int m_OriginalTargetFrameRate;
+
+        protected GameObject m_PlayerPrefab;
+
+        protected NetworkManager m_ServerNetworkManager;
+        protected NetworkManager[] m_ClientNetworkManagers;
+
+        public virtual IEnumerator Teardown()
+        {
+            // Shutdown and clean up both of our NetworkManager instances
+            MultiInstanceHelpers.Destroy();
+
+            yield return new WaitForSeconds(0); // wait for next frame so everything is destroyed, so following tests can execute from clean environment
+        }
+
+        /// <summary>
+        /// Utility to spawn some clients and a server and set them up
+        /// </summary>
+        /// <param name="nbClients"></param>
+        /// <param name="updatePlayerPrefab">Update the prefab with whatever is needed before players spawn</param>
+        /// <returns></returns>
+        public IEnumerator StartSomeClientsAndServer(bool useHost, int nbClients, Action<GameObject> updatePlayerPrefab)
+        {
+            // Create multiple NetworkManager instances
+            if (!MultiInstanceHelpers.Create(nbClients, out NetworkManager server, out NetworkManager[] clients))
+            {
+                Debug.LogError("Failed to create instances");
+                Assert.Fail("Failed to create instances");
+            }
+
+            m_ClientNetworkManagers = clients;
+            m_ServerNetworkManager = server;
+
+            // Create playerPrefab
+            m_PlayerPrefab = new GameObject("Player");
+            NetworkObject networkObject = m_PlayerPrefab.AddComponent<NetworkObject>();
+
+            // Make it a prefab
+            MultiInstanceHelpers.MakeNetworkedObjectTestPrefab(networkObject);
+
+            updatePlayerPrefab(m_PlayerPrefab); // update player prefab with whatever is needed before players are spawned
+
+            // Set the player prefab
+            server.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
+
+            for (int i = 0; i < clients.Length; i++)
+            {
+                clients[i].NetworkConfig.PlayerPrefab = m_PlayerPrefab;
+            }
+
+            // Start the instances
+            if (!MultiInstanceHelpers.Start(useHost, server, clients))
+            {
+                Debug.LogError("Failed to start instances");
+                Assert.Fail("Failed to start instances");
+            }
+
+            // Wait for connection on client side
+            for (int i = 0; i < clients.Length; i++)
+            {
+                yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientConnected(clients[i]));
+            }
+
+            // Wait for connection on server side
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnectedToServer(server, clientCount: useHost ? nbClients + 1 : nbClients));
+        }
+    }
+}

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/BaseMultiInstanceTest.cs.meta
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/BaseMultiInstanceTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 789a3189410645aca48f11a51c823418
+timeCreated: 1621620979

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkObject/NetworkObjectOnSpawnTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkObject/NetworkObjectOnSpawnTests.cs
@@ -8,9 +8,10 @@ using UnityEngine.TestTools;
 
 namespace MLAPI.RuntimeTests
 {
-    public class NetworkObjectOnSpawnTests
+    public class NetworkObjectOnSpawnTests : BaseMultiInstanceTest
     {
-        private GameObject m_Prefab;
+        public override int NbClients => 2;
+
 
         /// <summary>
         /// Tests that instantiating a <see cref="NetworkObject"/> and destroying without spawning it
@@ -48,6 +49,16 @@ namespace MLAPI.RuntimeTests
             }
         }
 
+        [UnitySetUp]
+        public override IEnumerator Setup()
+        {
+            yield return StartSomeClientsAndServerWithPlayers(true, NbClients, playerPrefab =>
+            {
+                // add test component
+                playerPrefab.AddComponent<TrackOnSpawnFunctions>();
+            });
+        }
+
         /// <summary>
         /// Test that callbacks are run for playerobject spawn, despawn, regular spawn, destroy on server.
         /// </summary>
@@ -55,51 +66,17 @@ namespace MLAPI.RuntimeTests
         [UnityTest]
         public IEnumerator TestOnNetworkSpawnCallbacks()
         {
-            // Create Host and (numClients) clients
-            Assert.True(MultiInstanceHelpers.Create(2, out NetworkManager server, out NetworkManager[] clients));
-
-            // Create a default player GameObject to use
-            m_Prefab = new GameObject("TestObject");
-            var networkObject = m_Prefab.AddComponent<NetworkObject>();
-
-            // add test component
-            m_Prefab.AddComponent<TrackOnSpawnFunctions>();
-
-            // Make it a prefab
-            MultiInstanceHelpers.MakeNetworkedObjectTestPrefab(networkObject);
-
-            // Set the player prefab
-            server.NetworkConfig.PlayerPrefab = m_Prefab;
-
-            // Set all of the client's player prefab
-            for (int i = 0; i < clients.Length; i++)
-            {
-                clients[i].NetworkConfig.PlayerPrefab = m_Prefab;
-            }
-
-            // Start the instances
-            if (!MultiInstanceHelpers.Start(true, server, clients))
-            {
-                Assert.Fail("Failed to start instances");
-            }
-
-            // [Client-Side] Wait for a connection to the server
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(clients, null, 512));
-
-            // [Host-Side] Check to make sure all clients are connected
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnectedToServer(server, clients.Length + 1, null, 512));
-
             // [Host-Side] Get the Host owned instance
             var serverClientPlayerResult = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == clients[0].LocalClientId), server, serverClientPlayerResult));
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId), m_ServerNetworkManager, serverClientPlayerResult));
 
             var serverInstance = serverClientPlayerResult.Result.GetComponent<TrackOnSpawnFunctions>();
 
             var clientInstances = new List<TrackOnSpawnFunctions>();
-            foreach (var client in clients)
+            foreach (var client in m_ClientNetworkManagers)
             {
                 var clientClientPlayerResult = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
-                yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == clients[0].LocalClientId), client, clientClientPlayerResult));
+                yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId), client, clientClientPlayerResult));
                 var clientRpcTests = clientClientPlayerResult.Result.GetComponent<TrackOnSpawnFunctions>();
                 Assert.IsNotNull(clientRpcTests);
                 clientInstances.Add(clientRpcTests);
@@ -174,9 +151,6 @@ namespace MLAPI.RuntimeTests
             {
                 Assert.AreEqual(1, clientInstance.OnNetworkDespawnCalledCount);
             }
-
-            // Shutdown and clean up both of our NetworkManager instances
-            MultiInstanceHelpers.Destroy();
         }
 
         private class TrackOnSpawnFunctions : NetworkBehaviour
@@ -192,16 +166,6 @@ namespace MLAPI.RuntimeTests
             public override void OnNetworkDespawn()
             {
                 OnNetworkDespawnCalledCount++;
-            }
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            if (m_Prefab != null)
-            {
-                Object.Destroy(m_Prefab);
-                m_Prefab = null;
             }
         }
     }

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkObject/NetworkObjectOnSpawnTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkObject/NetworkObjectOnSpawnTests.cs
@@ -10,7 +10,7 @@ namespace MLAPI.RuntimeTests
 {
     public class NetworkObjectOnSpawnTests : BaseMultiInstanceTest
     {
-        public override int NbClients => 2;
+        protected override int NbClients => 2;
 
 
         /// <summary>

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkSpawnManagerTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkSpawnManagerTests.cs
@@ -12,7 +12,7 @@ namespace MLAPI.RuntimeTests
         private ulong clientSideClientId => m_ClientNetworkManagers[0].LocalClientId;
         private ulong otherClientSideClientId => m_ClientNetworkManagers[1].LocalClientId;
 
-        public override int NbClients => 2;
+        protected override int NbClients => 2;
 
         [Test]
         public void TestServerCanAccessItsOwnPlayer()

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkSpawnManagerTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkSpawnManagerTests.cs
@@ -6,59 +6,13 @@ using UnityEngine.TestTools;
 
 namespace MLAPI.RuntimeTests
 {
-    public class NetworkSpawnManagerTests
+    public class NetworkSpawnManagerTests : BaseMultiInstanceTest
     {
-        private NetworkManager m_ServerNetworkManager;
-        private NetworkManager[] m_ClientNetworkManagers;
-        private GameObject m_PlayerPrefab;
-
         private ulong serverSideClientId => m_ServerNetworkManager.ServerClientId;
         private ulong clientSideClientId => m_ClientNetworkManagers[0].LocalClientId;
         private ulong otherClientSideClientId => m_ClientNetworkManagers[1].LocalClientId;
 
-        [UnitySetUp]
-        public IEnumerator Setup()
-        {
-            // Create multiple NetworkManager instances
-            if (!MultiInstanceHelpers.Create(2, out NetworkManager server, out NetworkManager[] clients))
-            {
-                Debug.LogError("Failed to create instances");
-                Assert.Fail("Failed to create instances");
-            }
-
-            m_ServerNetworkManager = server;
-            m_ClientNetworkManagers = clients;
-
-            // Create playerPrefab
-            m_PlayerPrefab = new GameObject("Player");
-            NetworkObject networkObject = m_PlayerPrefab.AddComponent<NetworkObject>();
-
-            // Make it a prefab
-            MultiInstanceHelpers.MakeNetworkedObjectTestPrefab(networkObject);
-
-            // Set the player prefab
-            server.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
-
-            for (int i = 0; i < clients.Length; i++)
-            {
-                clients[i].NetworkConfig.PlayerPrefab = m_PlayerPrefab;
-            }
-
-            // Start the instances
-            if (!MultiInstanceHelpers.Start(true, server, clients))
-            {
-                Assert.Fail("Failed to start instances");
-            }
-
-            // Wait for connection on client side
-            for (int i = 0; i < clients.Length; i++)
-            {
-                yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientConnected(clients[i]));
-            }
-
-            // Wait for connection on server side
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnectedToServer(server, clientCount: 3));
-        }
+        public override int NbClients => 2;
 
         [Test]
         public void TestServerCanAccessItsOwnPlayer()
@@ -168,20 +122,9 @@ namespace MLAPI.RuntimeTests
             var nbConnectedClients = m_ServerNetworkManager.ConnectedClients.Count;
             MultiInstanceHelpers.StopOneClient(newClientNetworkManager);
             yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForCondition(() => m_ServerNetworkManager.ConnectedClients.Count == nbConnectedClients - 1));
+
             serverSideNewClientPlayer = m_ServerNetworkManager.SpawnManager.GetPlayerNetworkObject(newClientLocalClientId);
             Assert.Null(serverSideNewClientPlayer);
-        }
-
-        [UnityTearDown]
-        public IEnumerator Teardown()
-        {
-            // Shutdown and clean up both of our NetworkManager instances
-            MultiInstanceHelpers.Destroy();
-            Object.Destroy(m_PlayerPrefab);
-
-            // wait for next frame so everything is destroyed, so following tests can execute from clean environment
-            int nextFrameNumber = Time.frameCount + 1;
-            yield return new WaitUntil(() => Time.frameCount >= nextFrameNumber);
         }
     }
 }

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/RpcTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/RpcTests.cs
@@ -8,7 +8,7 @@ using Debug = UnityEngine.Debug;
 
 namespace MLAPI.RuntimeTests
 {
-    public class RpcTests
+    public class RpcTests : BaseMultiInstanceTest
     {
         public class RpcTestNB : NetworkBehaviour
         {
@@ -28,60 +28,27 @@ namespace MLAPI.RuntimeTests
             }
         }
 
+        public override int NbClients => 1;
+
+        [UnitySetUp]
+        public override IEnumerator Setup()
+        {
+            yield return StartSomeClientsAndServerWithPlayers(true, NbClients, playerPrefab =>
+            {
+                playerPrefab.AddComponent<RpcTestNB>();
+            });
+        }
+
         [UnityTest]
         public IEnumerator TestRpcs()
         {
-            // Create multiple NetworkManager instances
-            if (!MultiInstanceHelpers.Create(1, out NetworkManager server, out NetworkManager[] clients))
-            {
-                Debug.LogError("Failed to create instances");
-                Assert.Fail("Failed to create instances");
-            }
-
-            /*
-             * Normally we would only allow player prefabs to be set to a prefab. Not runtime created objects.
-             * In order to prevent having a Resource folder full of a TON of prefabs that we have to maintain,
-             * MultiInstanceHelper has a helper function that lets you mark a runtime created object to be
-             * treated as a prefab by the MLAPI. That's how we can get away with creating the player prefab
-             * at runtime without it being treated as a SceneObject or causing other conflicts with the MLAPI.
-             */
-
-            // Create playerPrefab
-            var playerPrefab = new GameObject("Player");
-            NetworkObject networkObject = playerPrefab.AddComponent<NetworkObject>();
-            playerPrefab.AddComponent<RpcTestNB>();
-
-            // Make it a prefab
-            MultiInstanceHelpers.MakeNetworkedObjectTestPrefab(networkObject);
-
-            // Set the player prefab
-            server.NetworkConfig.PlayerPrefab = playerPrefab;
-
-            for (int i = 0; i < clients.Length; i++)
-            {
-                clients[i].NetworkConfig.PlayerPrefab = playerPrefab;
-            }
-
-            // Start the instances
-            if (!MultiInstanceHelpers.Start(true, server, clients))
-            {
-                Assert.Fail("Failed to start instances");
-            }
-
-
-            // Wait for connection on client side
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(clients));
-
-            // Wait for connection on server side
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientConnectedToServer(server));
-
             // This is the *SERVER VERSION* of the *CLIENT PLAYER*
             var serverClientPlayerResult = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == clients[0].LocalClientId), server, serverClientPlayerResult));
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId), m_ServerNetworkManager, serverClientPlayerResult));
 
             // This is the *CLIENT VERSION* of the *CLIENT PLAYER*
             var clientClientPlayerResult = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == clients[0].LocalClientId), clients[0], clientClientPlayerResult));
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId), m_ClientNetworkManagers[0], clientClientPlayerResult));
 
             // Setup state
             bool hasReceivedServerRpc = false;
@@ -125,9 +92,6 @@ namespace MLAPI.RuntimeTests
             Assert.True(hasReceivedServerRpc, "ServerRpc was not received");
             Assert.True(hasReceivedClientRpcLocally, "ClientRpc was not locally received on the server");
             Assert.True(hasReceivedClientRpcRemotely, "ClientRpc was not remotely received on the client");
-
-            // Cleanup
-            MultiInstanceHelpers.Destroy();
         }
     }
 }

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/RpcTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/RpcTests.cs
@@ -28,7 +28,7 @@ namespace MLAPI.RuntimeTests
             }
         }
 
-        public override int NbClients => 1;
+        protected override int NbClients => 1;
 
         [UnitySetUp]
         public override IEnumerator Setup()

--- a/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs
+++ b/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs
@@ -22,7 +22,7 @@ namespace TestProject.RuntimeTests
         private bool m_IsSendingNull;
         private bool m_IsArrayEmpty;
 
-        public override int NbClients => 1;
+        protected override int NbClients => 1;
 
         [UnitySetUp]
         public override IEnumerator Setup()

--- a/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs
+++ b/testproject/Assets/Tests/Runtime/RpcINetworkSerializable.cs
@@ -7,14 +7,13 @@ using MLAPI;
 using MLAPI.RuntimeTests;
 using MLAPI.Serialization;
 using MLAPI.Messaging;
+using UnityEditorInternal;
 using Debug = UnityEngine.Debug;
 
 namespace TestProject.RuntimeTests
 {
-    public class RpcINetworkSerializable
+    public class RpcINetworkSerializable : BaseMultiInstanceTest
     {
-        private GameObject m_PlayerPrefab;
-
         private UserSerializableClass m_UserSerializableClass;
         private List<UserSerializableClass> m_UserSerializableClassArray;
 
@@ -22,6 +21,14 @@ namespace TestProject.RuntimeTests
 
         private bool m_IsSendingNull;
         private bool m_IsArrayEmpty;
+
+        public override int NbClients => 1;
+
+        [UnitySetUp]
+        public override IEnumerator Setup()
+        {
+            yield break; // ignore
+        }
 
         /// <summary>
         /// Tests that INetworkSerializable can be used through RPCs by a user
@@ -31,43 +38,16 @@ namespace TestProject.RuntimeTests
         public IEnumerator NetworkSerializableTest()
         {
             m_FinishedTest = false;
-            var numClients = 1;
             var startTime = Time.realtimeSinceStartup;
 
-            // Create Host and (numClients) clients
-            Assert.True(MultiInstanceHelpers.Create(numClients, out NetworkManager server, out NetworkManager[] clients));
-
-            // Create a default player GameObject to use
-            m_PlayerPrefab = new GameObject("Player");
-            var networkObject = m_PlayerPrefab.AddComponent<NetworkObject>();
-            m_PlayerPrefab.AddComponent<TestSerializationComponent>();
-
-            // Make it a prefab
-            MultiInstanceHelpers.MakeNetworkedObjectTestPrefab(networkObject);
-
-            // [Host-Side] Set the player prefab
-            server.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
-
-            foreach (var client in clients)
+            yield return StartSomeClientsAndServerWithPlayers(true, NbClients, playerPrefab =>
             {
-                client.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
-            }
-
-            // Start the instances
-            if (!MultiInstanceHelpers.Start(true, server, clients))
-            {
-                Assert.Fail("Failed to start instances");
-            }
-
-            // [Client-Side] Wait for a connection to the server
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(clients, null, 512));
-
-            // [Host-Side] Check to make sure all clients are connected
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnectedToServer(server, clients.Length + 1, null, 512));
+                playerPrefab.AddComponent<TestSerializationComponent>();
+            });
 
             // [Client-Side] We only need to get the client side Player's NetworkObject so we can grab that instance of the TestSerializationComponent
             var clientClientPlayerResult = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == clients[0].LocalClientId), clients[0], clientClientPlayerResult));
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId), m_ClientNetworkManagers[0], clientClientPlayerResult));
             var clientSideNetworkBehaviourClass = clientClientPlayerResult.Result.gameObject.GetComponent<TestSerializationComponent>();
             clientSideNetworkBehaviourClass.OnSerializableClassUpdated = OnClientReceivedUserSerializableClassUpdated;
 
@@ -111,9 +91,8 @@ namespace TestProject.RuntimeTests
             }
 
             // End of test
-            clients[0].StopClient();
-            server.StopHost();
-
+            m_ClientNetworkManagers[0].StopClient();
+            m_ServerNetworkManager.StopHost();
         }
 
         /// <summary>
@@ -177,49 +156,22 @@ namespace TestProject.RuntimeTests
                 m_IsArrayEmpty = true;
             }
 
-            var numClients = 1;
             var startTime = Time.realtimeSinceStartup;
 
-            // Create Host and (numClients) clients
-            Assert.True(MultiInstanceHelpers.Create(numClients, out NetworkManager server, out NetworkManager[] clients));
-
-            // Create a default player GameObject to use
-            m_PlayerPrefab = new GameObject("Player");
-            var networkObject = m_PlayerPrefab.AddComponent<NetworkObject>();
-            m_PlayerPrefab.AddComponent<TestCustomTypesArrayComponent>();
-
-            // Make it a prefab
-            MultiInstanceHelpers.MakeNetworkedObjectTestPrefab(networkObject);
-
-            // [Host-Side] Set the player prefab
-            server.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
-
-            foreach (var client in clients)
+            yield return StartSomeClientsAndServerWithPlayers(true, NbClients, playerPrefab =>
             {
-                client.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
-            }
-
-            // Start the instances
-            if (!MultiInstanceHelpers.Start(true, server, clients))
-            {
-                Assert.Fail("Failed to start instances");
-            }
-
-            // [Client-Side] Wait for a connection to the server
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(clients, null, 512));
-
-            // [Host-Side] Check to make sure all clients are connected
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnectedToServer(server, clients.Length + 1, null, 512));
+                playerPrefab.AddComponent<TestCustomTypesArrayComponent>();
+            });
 
             // [Host-Side] Get the host-server side Player's NetworkObject so we can grab that instance of the TestCustomTypesArrayComponent
             var serverClientPlayerResult = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == clients[0].LocalClientId), server, serverClientPlayerResult));
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId), m_ServerNetworkManager, serverClientPlayerResult));
             var serverSideNetworkBehaviourClass = serverClientPlayerResult.Result.gameObject.GetComponent<TestCustomTypesArrayComponent>();
             serverSideNetworkBehaviourClass.OnSerializableClassesUpdatedServerRpc = OnServerReceivedUserSerializableClassesUpdated;
 
             // [Client-Side] Get the client side Player's NetworkObject so we can grab that instance of the TestCustomTypesArrayComponent
             var clientClientPlayerResult = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == clients[0].LocalClientId), clients[0], clientClientPlayerResult));
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId), m_ClientNetworkManagers[0], clientClientPlayerResult));
             var clientSideNetworkBehaviourClass = clientClientPlayerResult.Result.gameObject.GetComponent<TestCustomTypesArrayComponent>();
             clientSideNetworkBehaviourClass.OnSerializableClassesUpdatedClientRpc = OnClientReceivedUserSerializableClassesUpdated;
 
@@ -261,8 +213,8 @@ namespace TestProject.RuntimeTests
             Assert.False(timedOut);
 
             // End of test
-            clients[0].StopClient();
-            server.StopHost();
+            m_ClientNetworkManagers[0].StopClient();
+            m_ServerNetworkManager.StopHost();
 
         }
 
@@ -314,18 +266,6 @@ namespace TestProject.RuntimeTests
             ValidateUserSerializableClasses(userSerializableClass);
         }
 
-        [TearDown]
-        public void TearDown()
-        {
-            if (m_PlayerPrefab != null)
-            {
-                Object.Destroy(m_PlayerPrefab);
-                m_PlayerPrefab = null;
-            }
-
-            // Shutdown and clean up both of our NetworkManager instances
-            MultiInstanceHelpers.Destroy();
-        }
     }
 
     /// <summary>

--- a/testproject/Assets/Tests/Runtime/RpcTestsAutomated.cs
+++ b/testproject/Assets/Tests/Runtime/RpcTestsAutomated.cs
@@ -17,7 +17,7 @@ namespace TestProject.RuntimeTests
         private bool m_TimedOut;
         private int m_MaxFrames;
 
-        public override int NbClients => throw new NotSupportedException("Not implemented on purpose, setup is implementing this itself");
+        protected override int NbClients => throw new NotSupportedException("Not implemented on purpose, setup is implementing this itself");
 
         [UnitySetUp]
         public override IEnumerator Setup()


### PR DESCRIPTION
Moving boiler plate code to base class. This way, each tests will have a common setup and teardown following multi instance tests.
Didn't touch reparenting tests, since they didn't require a player prefab and didn't seem to suffer from that boilerplate code issue.