### PR TITLE
refactor: move NetworkBehaviour update to a separate non-static class

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviourUpdater.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviourUpdater.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using Unity.Profiling;
+
+namespace MLAPI
+{
+    public class NetworkBehaviourUpdater
+    {
+        private HashSet<NetworkObject> m_Touched = new HashSet<NetworkObject>();
+
+        /// <summary>
+        /// Stores the network tick at the NetworkBehaviourUpdate time
+        /// This allows sending NetworkVariables not more often than once per network tick, regardless of the update rate
+        /// </summary>
+        public ushort CurrentTick { get; set; }
+
+#if DEVELOPMENT_BUILD || UNITY_EDITOR
+        private ProfilerMarker m_NetworkBehaviourUpdate = new ProfilerMarker($"{nameof(NetworkBehaviour)}.{nameof(NetworkBehaviourUpdate)}");
+#endif
+
+        internal void NetworkBehaviourUpdate(NetworkManager networkManager)
+        {
+            // Do not execute NetworkBehaviourUpdate more than once per network tick
+            ushort tick = networkManager.NetworkTickSystem.GetTick();
+            if (tick == CurrentTick)
+            {
+                return;
+            }
+
+            CurrentTick = tick;
+
+#if DEVELOPMENT_BUILD || UNITY_EDITOR
+            m_NetworkBehaviourUpdate.Begin();
+#endif
+            try
+            {
+                if (networkManager.IsServer)
+                {
+                    m_Touched.Clear();
+                    for (int i = 0; i < networkManager.ConnectedClientsList.Count; i++)
+                    {
+                        var client = networkManager.ConnectedClientsList[i];
+                        var spawnedObjs = networkManager.SpawnManager.SpawnedObjectsList;
+                        m_Touched.UnionWith(spawnedObjs);
+                        foreach (var sobj in spawnedObjs)
+                        {
+                            // Sync just the variables for just the objects this client sees
+                            for (int k = 0; k < sobj.ChildNetworkBehaviours.Count; k++)
+                            {
+                                sobj.ChildNetworkBehaviours[k].VariableUpdate(client.ClientId);
+                            }
+                        }
+                    }
+
+                    // Now, reset all the no-longer-dirty variables
+                    foreach (var sobj in m_Touched)
+                    {
+                        for (int k = 0; k < sobj.ChildNetworkBehaviours.Count; k++)
+                        {
+                            sobj.ChildNetworkBehaviours[k].PostNetworkVariableWrite();
+                        }
+                    }
+                }
+                else
+                {
+                    // when client updates the server, it tells it about all its objects
+                    foreach (var sobj in networkManager.SpawnManager.SpawnedObjectsList)
+                    {
+                        for (int k = 0; k < sobj.ChildNetworkBehaviours.Count; k++)
+                        {
+                            sobj.ChildNetworkBehaviours[k].VariableUpdate(networkManager.ServerClientId);
+                        }
+                    }
+
+                    // Now, reset all the no-longer-dirty variables
+                    foreach (var sobj in networkManager.SpawnManager.SpawnedObjectsList)
+                    {
+                        for (int k = 0; k < sobj.ChildNetworkBehaviours.Count; k++)
+                        {
+                            sobj.ChildNetworkBehaviours[k].PostNetworkVariableWrite();
+                        }
+                    }
+                }
+            }
+            finally
+            {
+#if DEVELOPMENT_BUILD || UNITY_EDITOR
+                m_NetworkBehaviourUpdate.End();
+#endif
+            }
+        }
+
+    }
+}

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviourUpdater.cs.meta
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviourUpdater.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d084c01093b446878bcb76e5d7f3221e
+timeCreated: 1622225163

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -59,6 +59,7 @@ namespace MLAPI
         internal NetworkTickSystem NetworkTickSystem { get; private set; }
 
         internal SnapshotSystem SnapshotSystem { get; private set; }
+        internal NetworkBehaviourUpdater BehaviourUpdater { get; private set; }
 
         private NetworkPrefabHandler m_PrefabHandler;
         public NetworkPrefabHandler PrefabHandler
@@ -347,6 +348,8 @@ namespace MLAPI
             BufferManager = new BufferManager(this);
 
             SceneManager = new NetworkSceneManager(this);
+
+            BehaviourUpdater = new NetworkBehaviourUpdater();
 
             // Only create this if it's not already set (like in test cases)
             MessageHandler ??= CreateMessageHandler();
@@ -844,6 +847,11 @@ namespace MLAPI
                 CustomMessagingManager = null;
             }
 
+            if (BehaviourUpdater != null)
+            {
+                BehaviourUpdater = null;
+            }
+
             //The Transport is set during Init time, thus it is possible for the Transport to be null
             NetworkConfig?.NetworkTransport?.Shutdown();
         }
@@ -931,7 +939,7 @@ namespace MLAPI
                     if (NetworkConfig.EnableNetworkVariable)
                     {
                         // Do NetworkVariable updates
-                        NetworkBehaviour.NetworkBehaviourUpdate(this);
+                        BehaviourUpdater.NetworkBehaviourUpdate(this);
                     }
 
                     if (!IsServer && NetworkConfig.EnableMessageBuffering)

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkBehaviourUpdaterTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkBehaviourUpdaterTests.cs
@@ -97,7 +97,7 @@ namespace MLAPI.RuntimeTests
                 int nbBehaviours = 0;
                 foreach (var networkBehaviour in spawnedObject.GetComponents<NetworkBehaviour>())
                 {
-                    serverNetVarsToUpdate.AddRange(((INetVarInfo)networkBehaviour).allNetVars);
+                    serverNetVarsToUpdate.AddRange(((INetVarInfo)networkBehaviour).AllNetVars);
                     nbBehaviours++;
                 }
                 Assert.That(nbBehaviours, Is.EqualTo((firstNetworkBehaviour == null ? 0 : 1) + (secondNetworkBehaviour == null ? 0 : 1)));
@@ -168,24 +168,24 @@ namespace MLAPI.RuntimeTests
 
     public interface INetVarInfo
     {
-        public List<NetworkVariableInt> allNetVars { get; }
+        public List<NetworkVariableInt> AllNetVars { get; }
     }
 
     public class ZeroNetVar : NetworkBehaviour, INetVarInfo
     {
-        public List<NetworkVariableInt> allNetVars => new List<NetworkVariableInt>(); // Needed to be independant from NetworkBehaviour's list of fields. This way, if that changes, we can still do this validation in this test
+        public List<NetworkVariableInt> AllNetVars => new List<NetworkVariableInt>(); // Needed to be independant from NetworkBehaviour's list of fields. This way, if that changes, we can still do this validation in this test
     }
 
     public class OneNetVar : NetworkBehaviour, INetVarInfo
     {
         private NetworkVariableInt m_SomeValue = new NetworkVariableInt();
-        public List<NetworkVariableInt> allNetVars => new List<NetworkVariableInt>() { m_SomeValue };
+        public List<NetworkVariableInt> AllNetVars => new List<NetworkVariableInt>() { m_SomeValue };
     }
 
     public class TwoNetVar : NetworkBehaviour, INetVarInfo
     {
         private NetworkVariableInt m_SomeValue = new NetworkVariableInt();
         private NetworkVariableInt m_SomeOtherValue = new NetworkVariableInt();
-        public List<NetworkVariableInt> allNetVars => new List<NetworkVariableInt>() { m_SomeValue, m_SomeOtherValue };
+        public List<NetworkVariableInt> AllNetVars => new List<NetworkVariableInt>() { m_SomeValue, m_SomeOtherValue };
     }
 }

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkBehaviourUpdaterTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkBehaviourUpdaterTests.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using MLAPI.NetworkVariable;
+using MLAPI.RuntimeTests;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Object = UnityEngine.Object;
+
+namespace MLAPI.RuntimeTests
+{
+    public class NetworkBehaviourUpdaterTests : BaseMultiInstanceTest
+    {
+        protected override int NbClients => throw new NotSupportedException("handled per test");
+
+        private static Type[] s_TypesToTest = new[] { null, typeof(ZeroNetVar), typeof(OneNetVar), typeof(TwoNetVar) };
+
+        [UnitySetUp]
+        public override IEnumerator Setup()
+        {
+            yield break;
+        }
+
+        [UnityTest]
+        public IEnumerator BehaviourUpdaterAllTests([Values(0, 1, 2)] int nbClients, [Values] bool useHost, [Values(0, 1, 2)] int nbSpawnedObjects,
+            [ValueSource(nameof(s_TypesToTest)) ] Type firstNetworkBehaviour, [ValueSource(nameof(s_TypesToTest)) ] Type secondNetworkBehaviour, [ValueSource(nameof(s_TypesToTest)) ] Type thirdNetworkBehaviour)
+        // public IEnumerator BehaviourUpdaterAllTests([Values(1)] int nbClients, [Values(true)] bool useHost, [Values(1)] int nbSpawnedObjects,
+        // [Values(typeof(OneNetVar)) ] Type firstNetworkBehaviour, [Values(typeof(OneNetVar)) ] Type secondNetworkBehaviour, [Values(typeof(OneNetVar)) ] Type thirdNetworkBehaviour)
+        {
+            // Create multiple NetworkManager instances
+            if (!MultiInstanceHelpers.Create(nbClients, out NetworkManager server, out NetworkManager[] clients))
+            {
+                Debug.LogError("Failed to create instances");
+                Assert.Fail("Failed to create instances");
+            }
+
+            m_ClientNetworkManagers = clients;
+            m_ServerNetworkManager = server;
+
+            void AddNetworkBehaviour(Type type, GameObject prefab)
+            {
+                if (type != null)
+                {
+                    var info = prefab.AddComponent(type) as INetVarInfo;
+                    // return info.allNetVars;
+                }
+                // return new List<NetworkVariableInt>();
+            }
+            var prefabsToSpawn = new List<GameObject>();
+
+            for (int i = 0; i < nbSpawnedObjects; i++)
+            {
+                var prefabToSpawn = new GameObject();
+                var networkObjectPrefab = prefabToSpawn.AddComponent<NetworkObject>();
+                AddNetworkBehaviour(firstNetworkBehaviour, prefabToSpawn);
+                AddNetworkBehaviour(secondNetworkBehaviour, prefabToSpawn);
+                AddNetworkBehaviour(thirdNetworkBehaviour, prefabToSpawn);
+                MultiInstanceHelpers.MakeNetworkedObjectTestPrefab(networkObjectPrefab);
+                m_ServerNetworkManager.NetworkConfig.NetworkPrefabs.Add(new Configuration.NetworkPrefab() { Prefab = prefabToSpawn });
+                foreach (var clientNetworkManager in m_ClientNetworkManagers)
+                {
+                    clientNetworkManager.NetworkConfig.NetworkPrefabs.Add(new Configuration.NetworkPrefab() { Prefab = prefabToSpawn });
+                }
+                // networkObjectPrefab.NetworkManagerOwner = m_ServerNetworkManager;
+                prefabsToSpawn.Add(prefabToSpawn);
+            }
+
+            // Tests with a varying number of network behaviours, each with a varying number of network variables
+            // yield return StartSomeClientsAndServerWithPlayers(useHost: useHost, nbClients: nbClients, playerPrefab => { }, hasPlayer: false);
+            // Start the instances
+            if (!MultiInstanceHelpers.Start(useHost, server, clients))
+            {
+                Debug.LogError("Failed to start instances");
+                Assert.Fail("Failed to start instances");
+            }
+
+            // Wait for connection on client side
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(clients));
+
+            // Wait for connection on server side
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnectedToServer(server, clientCount: useHost ? nbClients + 1 : nbClients));
+
+            var serverNetVarsToUpdate = new List<NetworkVariableInt>();
+            foreach (var prefab in prefabsToSpawn)
+            {
+                var spawnedObject = Object.Instantiate(prefab);
+                var networkSpawnedObject = spawnedObject.GetComponent<NetworkObject>();
+                networkSpawnedObject.NetworkManagerOwner = m_ServerNetworkManager;
+                networkSpawnedObject.Spawn();
+                foreach (var networkBehaviour in spawnedObject.GetComponents<NetworkBehaviour>())
+                {
+                    serverNetVarsToUpdate.AddRange(((INetVarInfo)networkBehaviour).allNetVars);
+                }
+            }
+
+            var serverNetVarCount = serverNetVarsToUpdate.Count;
+
+            yield return new WaitForSeconds(0); // wait a frame
+
+            foreach (var netVar in serverNetVarsToUpdate)
+            {
+                Assert.That(netVar.Value, Is.EqualTo(0)); // sanity check
+            }
+
+            foreach (var netVar in serverNetVarsToUpdate)
+            {
+                netVar.Value = 1;
+                Assert.That(netVar.IsDirty, Is.True);
+            }
+
+            m_ServerNetworkManager.BehaviourUpdater.CurrentTick = 0; // reset to zero so we can call it here, else need to do a wait for update
+
+            m_ServerNetworkManager.BehaviourUpdater.NetworkBehaviourUpdate(m_ServerNetworkManager);
+
+            // yield return new WaitForSeconds(0); // wait a frame so NetworkBehaviourUpdater has time to update values
+
+            foreach (var netVar in serverNetVarsToUpdate)
+            {
+                Assert.That(netVar.IsDirty, Is.Not.True);
+            }
+
+
+
+
+            // yield return new WaitForSeconds(1); // wait for clients to update
+
+            var nbVarsCheckedClientSide = 0;
+            foreach (var client in m_ClientNetworkManagers)
+            {
+                foreach (var spawnedObject in client.SpawnManager.SpawnedObjects)
+                {
+                    foreach (var behaviour in spawnedObject.Value.GetComponentsInChildren<NetworkBehaviour>())
+                    {
+                        foreach (var networkVariable in behaviour.NetworkVariableFields)
+                        {
+
+                            var varInt = networkVariable as NetworkVariableInt;
+                            yield return MultiInstanceHelpers.WaitForCondition(() => varInt.Value == 1);
+                            nbVarsCheckedClientSide++;
+                            Assert.That(varInt.Value, Is.EqualTo(1));
+                        }
+                    }
+                }
+            }
+
+            Assert.That(nbVarsCheckedClientSide, Is.EqualTo(m_ClientNetworkManagers.Length > 0 ? serverNetVarCount : 0));
+
+            if (serverNetVarCount > 0)
+            {
+                m_ServerNetworkManager.BehaviourUpdater.NetworkBehaviourUpdate(m_ServerNetworkManager);
+                serverNetVarsToUpdate[0].Value = -1;
+                m_ServerNetworkManager.BehaviourUpdater.NetworkBehaviourUpdate(m_ServerNetworkManager);
+                Assert.That(serverNetVarsToUpdate[0].IsDirty, Is.True); // check that network behaviour updater can only be called once per frame
+            }
+
+            // test with 0, 1, 2 clients
+            // test with host and server
+            // test with 0, 1, 2 spawned objects
+            // test with 0, 1, 2 network behaviour per object
+            // test with 0, 1, 2 network variable per network behaviour
+            // for each, update netvar
+            // for each check value changed
+            // check that all network variables are no longer dirty after update
+            // test execute network behaviour more than once per tick (should fail)
+        }
+    }
+
+    public interface INetVarInfo
+    {
+        public List<NetworkVariableInt> allNetVars { get; }
+    }
+
+    public class ZeroNetVar : NetworkBehaviour, INetVarInfo
+    {
+        public List<NetworkVariableInt> allNetVars => new List<NetworkVariableInt>();
+    }
+
+    public class OneNetVar : NetworkBehaviour, INetVarInfo
+    {
+        private NetworkVariableInt m_SomeValue = new NetworkVariableInt();
+        public List<NetworkVariableInt> allNetVars => new List<NetworkVariableInt>() { m_SomeValue };
+    }
+
+    public class TwoNetVar : NetworkBehaviour, INetVarInfo
+    {
+        private NetworkVariableInt m_SomeValue = new NetworkVariableInt();
+        private NetworkVariableInt m_SomeOtherValue = new NetworkVariableInt();
+        public List<NetworkVariableInt> allNetVars => new List<NetworkVariableInt>() { m_SomeValue, m_SomeOtherValue };
+    }
+}

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkBehaviourUpdaterTests.cs.meta
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkBehaviourUpdaterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef76141a46cb34c44a8ca73bc15d2bd6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Behaviour update was static and made multiinstance tests flaky. Moving this to its own separate component on NetworkManager solves this.
This PR also adds a first pass at tests for NetworkBehaviourUpdater.