### PR TITLE
test: downgrading testproject to 2020LTS

### DIFF
--- a/testproject/Packages/manifest.json
+++ b/testproject/Packages/manifest.json
@@ -1,14 +1,14 @@
 {
   "dependencies": {
-    "com.unity.collab-proxy": "1.3.9",
+    "com.unity.collab-proxy": "1.5.7",
     "com.unity.ide.rider": "3.0.5",
-    "com.unity.ide.visualstudio": "2.0.7",
+    "com.unity.ide.visualstudio": "2.0.8",
     "com.unity.ide.vscode": "1.2.3",
     "com.unity.multiplayer.mlapi": "file:../../com.unity.multiplayer.mlapi",
     "com.unity.multiplayer.transport.utp": "file:../../com.unity.multiplayer.transport.utp",
     "com.unity.package-validation-suite": "0.19.2-preview",
     "com.unity.test-framework": "1.1.24",
-    "com.unity.textmeshpro": "3.0.4",
+    "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.5.2",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.ai": "1.0.0",

--- a/testproject/Packages/packages-lock.json
+++ b/testproject/Packages/packages-lock.json
@@ -1,19 +1,21 @@
 {
   "dependencies": {
     "com.unity.burst": {
-      "version": "1.4.1",
-      "depth": 2,
+      "version": "1.3.2",
+      "depth": 3,
       "source": "registry",
       "dependencies": {
-        "com.unity.mathematics": "1.2.1"
+        "com.unity.mathematics": "1.1.0"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.collab-proxy": {
-      "version": "1.3.9",
+      "version": "1.5.7",
       "depth": 0,
       "source": "registry",
-      "dependencies": {},
+      "dependencies": {
+        "com.unity.nuget.newtonsoft-json": "2.0.0"
+      },
       "url": "https://packages.unity.com"
     },
     "com.unity.collections": {
@@ -41,7 +43,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.7",
+      "version": "2.0.8",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -67,7 +69,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.mathematics": {
-      "version": "1.2.1",
+      "version": "1.1.0",
       "depth": 2,
       "source": "registry",
       "dependencies": {},
@@ -102,7 +104,7 @@
     },
     "com.unity.nuget.newtonsoft-json": {
       "version": "2.0.0",
-      "depth": 4,
+      "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
@@ -138,7 +140,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.textmeshpro": {
-      "version": "3.0.4",
+      "version": "3.0.6",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/testproject/ProjectSettings/ProjectSettings.asset
+++ b/testproject/ProjectSettings/ProjectSettings.asset
@@ -156,7 +156,7 @@ PlayerSettings:
   AndroidMinSdkVersion: 19
   AndroidTargetSdkVersion: 0
   AndroidPreferredInstallLocation: 1
-  aotOptions: 
+  aotOptions: nimt-trampolines=1024
   stripEngineCode: 1
   iPhoneStrippingLevel: 0
   iPhoneScriptCallOptimization: 0
@@ -354,7 +354,6 @@ PlayerSettings:
   switchScreenResolutionBehavior: 2
   switchUseCPUProfiler: 0
   switchUseGOLDLinker: 0
-  switchLTOSetting: 0
   switchApplicationID: 0x01004b9000490000
   switchNSODependencies: 
   switchTitleNames_0: 
@@ -484,6 +483,8 @@ PlayerSettings:
   switchNetworkInterfaceManagerInitializeEnabled: 1
   switchPlayerConnectionEnabled: 1
   switchUseNewStyleFilepaths: 0
+  switchUseMicroSleepForYield: 1
+  switchMicroSleepForYieldTime: 25
   ps4NPAgeRating: 12
   ps4NPTitleSecret: 
   ps4NPTrophyPackPath: 
@@ -588,6 +589,7 @@ PlayerSettings:
   suppressCommonWarnings: 1
   allowUnsafeCode: 0
   useDeterministicCompilation: 1
+  useReferenceAssemblies: 1
   enableRoslynAnalyzers: 1
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 1

--- a/testproject/ProjectSettings/ProjectVersion.txt
+++ b/testproject/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.1.1f1
-m_EditorVersionWithRevision: 2021.1.1f1 (6fdc41dfa55a)
+m_EditorVersion: 2020.3.12f1
+m_EditorVersionWithRevision: 2020.3.12f1 (b3b2c6512326)


### PR DESCRIPTION
The project should be at min version by default and tested with higher versions.
It should be easier to upgrade than downgrade in the future when testing higher versions.