### PR TITLE
feat: log warning if detected child NetworkObjects under a NetworkPrefab

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -274,42 +274,55 @@ namespace MLAPI
             // Check network prefabs and assign to dictionary for quick look up
             for (int i = 0; i < NetworkConfig.NetworkPrefabs.Count; i++)
             {
-                if (NetworkConfig.NetworkPrefabs[i] != null && NetworkConfig.NetworkPrefabs[i].Prefab != null)
+                var networkPrefab = NetworkConfig.NetworkPrefabs[i];
+                if (networkPrefab != null && networkPrefab.Prefab != null)
                 {
-                    var networkObject = NetworkConfig.NetworkPrefabs[i].Prefab.GetComponent<NetworkObject>();
+                    var networkObject = networkPrefab.Prefab.GetComponent<NetworkObject>();
                     if (networkObject == null)
                     {
                         if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
                         {
-                            NetworkLog.LogWarning($"{nameof(NetworkPrefab)} [{i}] does not have a {nameof(NetworkObject)} component");
+                            NetworkLog.LogError($"Cannot register {nameof(NetworkPrefab)}[{i}], it does not have a {nameof(NetworkObject)} component at its root");
                         }
                     }
                     else
                     {
+                        {
+                            var childNetworkObjects = new List<NetworkObject>();
+                            networkPrefab.Prefab.GetComponentsInChildren(/* includeInactive = */ true, childNetworkObjects);
+                            if (childNetworkObjects.Count > 1) // total count = 1 root NetworkObject + n child NetworkObjects
+                            {
+                                if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
+                                {
+                                    NetworkLog.LogWarning($"{nameof(NetworkPrefab)}[{i}] has child {nameof(NetworkObject)}(s) but they will not be spawned across the network (unsupported {nameof(NetworkPrefab)} setup)");
+                                }
+                            }
+                        }
+
                         // Default to the standard NetworkPrefab.Prefab's NetworkObject first
                         var globalObjectIdHash = networkObject.GlobalObjectIdHash;
 
                         // Now check to see if it has an override
-                        switch (NetworkConfig.NetworkPrefabs[i].Override)
+                        switch (networkPrefab.Override)
                         {
                             case NetworkPrefabOverride.Prefab:
                                 {
-                                    if (NetworkConfig.NetworkPrefabs[i].SourcePrefabToOverride == null && NetworkConfig.NetworkPrefabs[i].Prefab != null)
+                                    if (networkPrefab.SourcePrefabToOverride == null && networkPrefab.Prefab != null)
                                     {
-                                        NetworkConfig.NetworkPrefabs[i].SourcePrefabToOverride = NetworkConfig.NetworkPrefabs[i].Prefab;
+                                        networkPrefab.SourcePrefabToOverride = networkPrefab.Prefab;
                                     }
-                                    globalObjectIdHash = NetworkConfig.NetworkPrefabs[i].SourcePrefabToOverride.GetComponent<NetworkObject>().GlobalObjectIdHash;
+                                    globalObjectIdHash = networkPrefab.SourcePrefabToOverride.GetComponent<NetworkObject>().GlobalObjectIdHash;
                                 }
                                 break;
                             case NetworkPrefabOverride.Hash:
-                                globalObjectIdHash = NetworkConfig.NetworkPrefabs[i].SourceHashToOverride;
+                                globalObjectIdHash = networkPrefab.SourceHashToOverride;
                                 break;
                         }
 
                         // Add to the NetworkPrefabOverrideLinks or handle a new (blank) entries
                         if (!NetworkConfig.NetworkPrefabOverrideLinks.ContainsKey(globalObjectIdHash))
                         {
-                            NetworkConfig.NetworkPrefabOverrideLinks.Add(globalObjectIdHash, NetworkConfig.NetworkPrefabs[i]);
+                            NetworkConfig.NetworkPrefabOverrideLinks.Add(globalObjectIdHash, networkPrefab);
                         }
                         else
                         {
@@ -500,7 +513,7 @@ namespace MLAPI
 
             // Clear out anything that is invalid or not used (for invalid entries we already logged warnings to the user earlier)
             // Iterate backwards so indices don't shift as we remove
-            for (int i = removeEmptyPrefabs.Count-1; i >= 0; i--)
+            for (int i = removeEmptyPrefabs.Count - 1; i >= 0; i--)
             {
                 NetworkConfig.NetworkPrefabs.RemoveAt(removeEmptyPrefabs[i]);
             }


### PR DESCRIPTION
this PR promotes non-NetworkObject NetworkPrefab detection to ErrorLog because that particular problematic NetworkPrefab will not be registered at all.

this PR also introduces a warning log if we detect child NetworkObjects under a NetworkPrefab because spawning child NetworkObjects under NetworkPrefabs is not supported yet.