### PR TITLE
[draft]feat!: Alternate authority implementation

### DIFF
--- a/com.unity.multiplayer.mlapi/Prototyping/AssemblyInfo.cs
+++ b/com.unity.multiplayer.mlapi/Prototyping/AssemblyInfo.cs
@@ -1,0 +1,11 @@
+using System.Runtime.CompilerServices;
+
+#if UNITY_EDITOR
+[assembly: InternalsVisibleTo("Unity.Multiplayer.MLAPI.EditorTests")]
+[assembly: InternalsVisibleTo("Unity.Multiplayer.MLAPI.RuntimeTests")]
+[assembly: InternalsVisibleTo("Unity.Multiplayer.MLAPI.Editor.CodeGen")]
+[assembly: InternalsVisibleTo("Unity.Multiplayer.MLAPI.Editor")]
+[assembly: InternalsVisibleTo("TestProject.EditorTests")]
+[assembly: InternalsVisibleTo("TestProject.RuntimeTests")]
+[assembly: InternalsVisibleTo("TestProject.ManualTests")]
+#endif

--- a/com.unity.multiplayer.mlapi/Prototyping/AssemblyInfo.cs.meta
+++ b/com.unity.multiplayer.mlapi/Prototyping/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25ffd1b5f4845104e9289fdb0a2289a3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.multiplayer.mlapi/Prototyping/AuthorityUtility.cs
+++ b/com.unity.multiplayer.mlapi/Prototyping/AuthorityUtility.cs
@@ -13,13 +13,30 @@ namespace MLAPI.Prototyping
         Server = 0, // default
         Owner,
     }
+
+    /// <summary>
+    /// Contains utility functions for implementing NetworkBehaviours which support multiple authority modes.
+    /// </summary>
     public static class AuthorityUtility
     {
+        /// <summary>
+        /// Check whether the given <see cref="NetworkBehaviour"/> has authority based on <see cref="NetworkObject"/> ownership.
+        /// </summary>
+        /// <param name="networkBehaviour">The NetworkBehaviour to check for authority.</param>
+        /// <param name="authority">The authority mode.</param>
+        /// <returns>True if the networkBehaviour has authority; Else false.</returns>
         public static bool HasAuthority(this NetworkBehaviour networkBehaviour, Authority authority)
         {
             return (networkBehaviour.IsClient && authority == Authority.Owner && networkBehaviour.IsOwner) || (networkBehaviour.IsServer && authority == Authority.Server);
         }
 
+        /// <summary>
+        /// Updates the read and write permissions of a network variable based on authority.
+        /// </summary>
+        /// <param name="variableToUpdate">The NetworkVariable for which to change the permissions.</param>
+        /// <param name="authority">The new authority mode.</param>
+        /// <typeparam name="T"></typeparam>
+        /// <exception cref="NotImplementedException"></exception>
         public static void UpdateStateVariablePermission<T>(this NetworkVariable<T> variableToUpdate, Authority authority)
         {
             switch (authority)

--- a/com.unity.multiplayer.mlapi/Prototyping/AuthorityUtility.cs
+++ b/com.unity.multiplayer.mlapi/Prototyping/AuthorityUtility.cs
@@ -1,0 +1,40 @@
+using System;
+using MLAPI.NetworkVariable;
+using UnityEngine;
+
+namespace MLAPI.Prototyping
+{
+    /// <summary>
+    /// Server authority only allows the server to update this transform
+    /// Client authority only allows the client owner to update this transform
+    /// </summary>
+    public enum Authority
+    {
+        Server = 0, // default
+        Owner,
+    }
+    public static class AuthorityUtility
+    {
+        public static bool HasAuthority(this NetworkBehaviour networkBehaviour, Authority authority)
+        {
+            return (networkBehaviour.IsClient && authority == Authority.Owner && networkBehaviour.IsOwner) || (networkBehaviour.IsServer && authority == Authority.Server);
+        }
+
+        public static void UpdateStateVariablePermission<T>(this NetworkVariable<T> variableToUpdate, Authority authority)
+        {
+            switch (authority)
+            {
+                case Authority.Owner:
+                    variableToUpdate.Settings.WritePermission = NetworkVariablePermission.OwnerOnly;
+                    variableToUpdate.Settings.ReadPermission = NetworkVariablePermission.Everyone;
+                    break;
+                case Authority.Server:
+                    variableToUpdate.Settings.WritePermission = NetworkVariablePermission.ServerOnly;
+                    variableToUpdate.Settings.ReadPermission = NetworkVariablePermission.Everyone;
+                    break;
+                default:
+                    throw new NotImplementedException($"{authority} is not handled");
+            }
+        }
+    }
+}

--- a/com.unity.multiplayer.mlapi/Prototyping/AuthorityUtility.cs.meta
+++ b/com.unity.multiplayer.mlapi/Prototyping/AuthorityUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f0d0f0e060d617a44b590544bb551f70
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.multiplayer.mlapi/Prototyping/NetworkNavMeshAgent.cs
+++ b/com.unity.multiplayer.mlapi/Prototyping/NetworkNavMeshAgent.cs
@@ -15,6 +15,9 @@ namespace MLAPI.Prototyping
     {
         private NavMeshAgent m_Agent;
 
+        private Vector3 m_LastDestination = Vector3.zero;
+        private float m_LastCorrectionTime = 0f;
+
         /// <summary>
         /// Is proximity enabled
         /// </summary>
@@ -47,12 +50,9 @@ namespace MLAPI.Prototyping
             m_Agent = GetComponent<NavMeshAgent>();
         }
 
-        private Vector3 m_LastDestination = Vector3.zero;
-        private float m_LastCorrectionTime = 0f;
-
         private void Update()
         {
-            if (!IsOwner)
+            if (!IsServer) // TODO This currently only works with server authority because it uses ClientRPCs
             {
                 return;
             }

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviour.cs
@@ -219,17 +219,17 @@ namespace MLAPI
         /// <summary>
         /// Gets if we are executing as server
         /// </summary>
-        protected bool IsServer => IsRunning && NetworkManager.IsServer;
+        public bool IsServer => IsRunning && NetworkManager.IsServer;
 
         /// <summary>
         /// Gets if we are executing as client
         /// </summary>
-        protected bool IsClient => IsRunning && NetworkManager.IsClient;
+        public bool IsClient => IsRunning && NetworkManager.IsClient;
 
         /// <summary>
         /// Gets if we are executing as Host, I.E Server and Client
         /// </summary>
-        protected bool IsHost => IsRunning && NetworkManager.IsHost;
+        public bool IsHost => IsRunning && NetworkManager.IsHost;
 
         private bool IsRunning => NetworkManager != null && NetworkManager.IsListening;
 

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkTransformTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkTransformTests.cs
@@ -46,24 +46,24 @@ namespace MLAPI.RuntimeTests
         }
 
         [UnityTest]
-        [TestCase(true, Authority.Client, ExpectedResult = null)]
+        [TestCase(true, Authority.Owner, ExpectedResult = null)]
         [TestCase(true, Authority.Server, ExpectedResult = null)]
-        [TestCase(false, Authority.Client, ExpectedResult = null)]
+        [TestCase(false, Authority.Owner, ExpectedResult = null)]
         [TestCase(false, Authority.Server, ExpectedResult = null)]
         public IEnumerator TestAuthoritativeTransformChangeOneAtATime(bool testLocalTransform, Authority authorityToTest)
         {
             var waitResult = new MultiInstanceHelpers.CoroutineResultWrapper<bool>();
 
-            var networkTransform = (authorityToTest == Authority.Client ? m_ClientSideClientPlayer : m_ServerSideClientPlayer).GetComponent<NetworkTransform>();
+            var networkTransform = (authorityToTest == Authority.Owner ? m_ClientSideClientPlayer : m_ServerSideClientPlayer).GetComponent<NetworkTransform>();
             networkTransform.SetAuthority(authorityToTest);
 
-            var otherSideNetworkTransform = (authorityToTest == Authority.Client ? m_ServerSideClientPlayer : m_ClientSideClientPlayer).GetComponent<NetworkTransform>();
+            var otherSideNetworkTransform = (authorityToTest == Authority.Owner ? m_ServerSideClientPlayer : m_ClientSideClientPlayer).GetComponent<NetworkTransform>();
             otherSideNetworkTransform.SetAuthority(authorityToTest);
 
             bool HasAuthority(NetworkTransform transform)
             {
                 return transform.NetworkObject.NetworkManager.IsServer && transform.TransformAuthority == Authority.Server ||
-                    transform.NetworkObject.NetworkManager.IsClient && transform.TransformAuthority == Authority.Client;
+                    transform.NetworkObject.NetworkManager.IsClient && transform.TransformAuthority == Authority.Owner;
             }
 
             if (HasAuthority(networkTransform))
@@ -121,15 +121,15 @@ namespace MLAPI.RuntimeTests
         }
 
         [UnityTest]
-        [TestCase(Authority.Client, ExpectedResult = null)]
+        [TestCase(Authority.Owner, ExpectedResult = null)]
         [TestCase(Authority.Server, ExpectedResult = null)]
         public IEnumerator TestCantChangeTransformFromOtherSideAuthority(Authority authorityToTest)
         {
             // test server can't change client authoritative transform
-            var networkTransform = (authorityToTest == Authority.Client ? m_ClientSideClientPlayer : m_ServerSideClientPlayer).GetComponent<NetworkTransform>();
+            var networkTransform = (authorityToTest == Authority.Owner ? m_ClientSideClientPlayer : m_ServerSideClientPlayer).GetComponent<NetworkTransform>();
             networkTransform.SetAuthority(authorityToTest);
 
-            var otherSideNetworkTransform = (authorityToTest == Authority.Client ? m_ServerSideClientPlayer : m_ClientSideClientPlayer).GetComponent<NetworkTransform>();
+            var otherSideNetworkTransform = (authorityToTest == Authority.Owner ? m_ServerSideClientPlayer : m_ClientSideClientPlayer).GetComponent<NetworkTransform>();
             otherSideNetworkTransform.SetAuthority(authorityToTest);
 
             Assert.AreEqual(Vector3.zero, otherSideNetworkTransform.transform.position, "other side pos should be zero at first"); // sanity check


### PR DESCRIPTION
Showcases how we could provide a utility which allows us to better implement authority on our prototyping components without needing a full-blown authority system.

Note: NetworkNavMeshAgent always only supported a mode where the server was the owner else it would throw exceptions. This PR just locks the NetworkNavMeshAgent into a server authority mode for now because fixing it to work with any authority mode would be non trivial.