### PR TITLE
fix: (MLAPI.Serialization) 'specified cast is not valid.' on NetworkW…

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Serialization/NetworkWriter.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Serialization/NetworkWriter.cs
@@ -210,7 +210,7 @@ namespace MLAPI.Serialization
             {
                 if (!((NetworkObject)value).IsSpawned)
                 {
-                    throw new ArgumentException($"{nameof(NetworkWriter)} cannot write {nameof(NetworkObject)} types that are not spawned. {nameof(GameObject)}: {((GameObject)value).name}");
+                    throw new ArgumentException($"{nameof(NetworkWriter)} cannot write {nameof(NetworkObject)} types that are not spawned. {nameof(GameObject)}: {((NetworkObject)value).gameObject.name}");
                 }
 
                 WriteUInt64Packed(((NetworkObject)value).NetworkObjectId);
@@ -220,7 +220,7 @@ namespace MLAPI.Serialization
             {
                 if (!((NetworkBehaviour)value).HasNetworkObject || !((NetworkBehaviour)value).NetworkObject.IsSpawned)
                 {
-                    throw new ArgumentException($"{nameof(NetworkWriter)} cannot write {nameof(NetworkBehaviour)} types that are not spawned. {nameof(GameObject)}: {((GameObject)value).name}");
+                    throw new ArgumentException($"{nameof(NetworkWriter)} cannot write {nameof(NetworkBehaviour)} types that are not spawned. {nameof(GameObject)}: {((NetworkBehaviour)value).gameObject.name}");
                 }
 
                 WriteUInt64Packed(((NetworkBehaviour)value).NetworkObjectId);

--- a/com.unity.multiplayer.mlapi/Tests/Editor/NetworkSerializerTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/NetworkSerializerTests.cs
@@ -25,7 +25,7 @@ namespace MLAPI.EditorTests
                 // we expect the exception below
                 Assert.Fail();
             }
-            catch(System.ArgumentException exception)
+            catch(ArgumentException exception)
             {
                 Assert.True(exception.Message.IndexOf("NetworkWriter cannot write NetworkObject types that are not spawned") != -1);
             }

--- a/com.unity.multiplayer.mlapi/Tests/Editor/NetworkSerializerTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/NetworkSerializerTests.cs
@@ -9,6 +9,29 @@ namespace MLAPI.EditorTests
     public class NetworkSerializerTests
     {
         [Test]
+        public void SerializeUnspawnedNetworkObject()
+        {
+            var gameObject = new GameObject(nameof(SerializeUnspawnedNetworkObject));
+            var networkObject = gameObject.AddComponent<NetworkObject>();
+
+            try
+            {
+                using (var outStream = PooledNetworkBuffer.Get())
+                using (var outWriter = PooledNetworkWriter.Get(outStream))
+                {
+                    outWriter.WriteObjectPacked(networkObject);
+                }
+
+                // we expect the exception below
+                Assert.Fail();
+            }
+            catch(System.ArgumentException exception)
+            {
+                Assert.True(exception.Message.IndexOf("NetworkWriter cannot write NetworkObject types that are not spawned") != -1);
+            }
+        }
+
+        [Test]
         public void SerializeBool()
         {
             using (var outStream = PooledNetworkBuffer.Get())


### PR DESCRIPTION
…riter.

This source code has Illegal cast some network components To GameObject.
So, fix it to get the GameObject from the component.

Contribution from https://github.com/0vjm3wfw9gqm4j