### PR TITLE
feat: snapshot. Adding RTT computation API.

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/SnapshotRTT.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/SnapshotRTT.cs
@@ -5,8 +5,8 @@ namespace MLAPI
 {
     internal class ConnectionRtt
     {
-        private const int k_RttSize = 5; // number of RTT to keep an average of (plus one)
-        private const int k_RingSize = 64; // number of slots to use for RTT computations (max number of in-flight packets)
+        internal const int RttSize = 5; // number of RTT to keep an average of (plus one)
+        internal const int RingSize = 64; // number of slots to use for RTT computations (max number of in-flight packets)
 
         private double[] m_RttSendTimes; // times at which packet were sent for RTT computations
         private int[] m_SendSequence; // tick, or other key, at which packets were sent (to allow matching)
@@ -27,9 +27,9 @@ namespace MLAPI
         }
         public ConnectionRtt()
         {
-            m_RttSendTimes = new double[k_RingSize];
-            m_SendSequence = new int[k_RingSize];
-            m_MeasuredLatencies = new double[k_RingSize];
+            m_RttSendTimes = new double[RingSize];
+            m_SendSequence = new int[RingSize];
+            m_MeasuredLatencies = new double[RingSize];
         }
 
         /// <summary>
@@ -49,14 +49,14 @@ namespace MLAPI
                 ret.SampleCount++;
                 ret.BestSec = Math.Min(ret.BestSec, m_MeasuredLatencies[index]);
                 ret.WorstSec = Math.Max(ret.WorstSec, m_MeasuredLatencies[index]);
-                index = (index + 1) % k_RttSize;
+                index = (index + 1) % RttSize;
             }
 
             if (ret.SampleCount != 0)
             {
                 ret.AverageSec = total / ret.SampleCount;
                 // the latest RTT is one before m_LatenciesEnd
-                ret.LastSec = m_MeasuredLatencies[(m_LatenciesEnd + (k_RingSize - 1)) % k_RingSize];
+                ret.LastSec = m_MeasuredLatencies[(m_LatenciesEnd + (RingSize - 1)) % RingSize];
             }
             else
             {
@@ -72,23 +72,23 @@ namespace MLAPI
 
         internal void NotifySend(int sequence, double timeSec)
         {
-            m_RttSendTimes[sequence % k_RingSize] = timeSec;
-            m_SendSequence[sequence % k_RingSize] = sequence;
+            m_RttSendTimes[sequence % RingSize] = timeSec;
+            m_SendSequence[sequence % RingSize] = sequence;
         }
 
         internal void NotifyAck(int sequence, double timeSec)
         {
             // if the same slot was not used by a later send
-            if (m_SendSequence[sequence % k_RingSize] == sequence)
+            if (m_SendSequence[sequence % RingSize] == sequence)
             {
-                double latency = timeSec - m_RttSendTimes[sequence % k_RingSize];
+                double latency = timeSec - m_RttSendTimes[sequence % RingSize];
 
                 m_MeasuredLatencies[m_LatenciesEnd] = latency;
-                m_LatenciesEnd = (m_LatenciesEnd + 1) % k_RttSize;
+                m_LatenciesEnd = (m_LatenciesEnd + 1) % RttSize;
 
                 if (m_LatenciesEnd == m_LatenciesBegin)
                 {
-                    m_LatenciesBegin = (m_LatenciesBegin + 1) % k_RttSize;
+                    m_LatenciesBegin = (m_LatenciesBegin + 1) % RttSize;
                 }
             }
         }

--- a/com.unity.multiplayer.mlapi/Runtime/Core/SnapshotRTT.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/SnapshotRTT.cs
@@ -1,0 +1,94 @@
+using System;
+using UnityEngine;
+
+namespace MLAPI
+{
+    internal class ClientRtt
+    {
+        /// <summary>
+        /// Round-trip-time data
+        /// </summary>
+        public struct Rtt
+        {
+            public double Best;
+            public double Average;
+            public double Worst;
+            public int SampleCount;
+        }
+        public ClientRtt()
+        {
+            m_RttSendTimes = new double[k_RingSize];
+            m_SendKey = new int[k_RingSize];
+            m_MeasuredLatencies = new double[k_RingSize];
+        }
+
+        /// <summary>
+        /// Returns the Round-trip-time computation for this client
+        /// </summary>
+        public Rtt GetRtt()
+        {
+            var ret = new Rtt(); // is this a memory alloc ? How do I get a stack alloc ?
+            var index = m_LatenciesBegin;
+            double total = 0.0;
+            ret.Best = m_MeasuredLatencies[m_LatenciesBegin];
+            ret.Worst = m_MeasuredLatencies[m_LatenciesBegin];
+
+            while (index != m_LatenciesEnd)
+            {
+                total += m_MeasuredLatencies[index];
+                ret.SampleCount++;
+                ret.Best = Math.Min(ret.Best, m_MeasuredLatencies[index]);
+                ret.Worst = Math.Max(ret.Worst, m_MeasuredLatencies[index]);
+                index = (index + 1) % k_RttSize;
+            }
+
+            if (ret.SampleCount != 0)
+            {
+                ret.Average = total / ret.SampleCount;
+            }
+            else
+            {
+                ret.Average = 0;
+                ret.Best = 0;
+                ret.Worst = 0;
+                ret.SampleCount = 0;
+            }
+
+            return ret;
+        }
+
+        internal void NotifySend(int key, double when)
+        {
+            m_RttSendTimes[key % k_RingSize] = when;
+            m_SendKey[key % k_RingSize] = key;
+        }
+
+        internal void NotifyAck(int key, double when)
+        {
+            // if the same slot was not used by a later send
+            if (m_SendKey[key % k_RingSize] == key)
+            {
+                double latency = when - m_RttSendTimes[key % k_RingSize];
+                Debug.Log(string.Format("Measured latency of {0}", latency));
+                m_MeasuredLatencies[m_LatenciesEnd] = latency;
+                m_LatenciesEnd = (m_LatenciesEnd + 1) % k_RttSize;
+
+                if (m_LatenciesEnd == m_LatenciesBegin)
+                {
+                    m_LatenciesBegin = (m_LatenciesBegin + 1) % k_RttSize;
+                }
+            }
+        }
+
+        private const int k_RttSize = 5; // number of RTT to keep an average of (plus one)
+
+        private const int
+            k_RingSize = 64; // number of slots to use for RTT computations (max number of in-flight packets)
+
+        private double[] m_RttSendTimes; // times at which packet were sent for RTT computations
+        private int[] m_SendKey; // tick (or other key) at which packets were sent (to allow matching)
+        private double[] m_MeasuredLatencies; // measured latencies (ring buffer)
+        private int m_LatenciesBegin = 0; // ring buffer begin
+        private int m_LatenciesEnd = 0; // ring buffer end
+    }
+}

--- a/com.unity.multiplayer.mlapi/Runtime/Core/SnapshotRTT.cs.meta
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/SnapshotRTT.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 69c3c1c5a885d4aed99ee2e1fa40f763
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.multiplayer.mlapi/Runtime/Core/SnapshotSystem.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/SnapshotSystem.cs
@@ -273,15 +273,15 @@ namespace MLAPI
         private NetworkManager m_NetworkManager = NetworkManager.Singleton;
         private Snapshot m_Snapshot = new Snapshot(NetworkManager.Singleton, false);
         private Dictionary<ulong, Snapshot> m_ClientReceivedSnapshot = new Dictionary<ulong, Snapshot>();
-        private Dictionary<ulong, ClientRtt> m_ClientRtts = new Dictionary<ulong, ClientRtt>();
+        private Dictionary<ulong, ConnectionRtt> m_ClientRtts = new Dictionary<ulong, ConnectionRtt>();
 
         private ushort m_CurrentTick = 0;
 
-        internal ClientRtt Rtt(ulong clientId)
+        internal ConnectionRtt Rtt(ulong clientId)
         {
             if (!m_ClientRtts.ContainsKey(clientId))
             {
-                m_ClientRtts.Add(clientId, new ClientRtt());
+                m_ClientRtts.Add(clientId, new ConnectionRtt());
             }
 
             return m_ClientRtts[clientId];

--- a/com.unity.multiplayer.mlapi/Runtime/Core/SnapshotSystem.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/SnapshotSystem.cs
@@ -277,7 +277,7 @@ namespace MLAPI
 
         private ushort m_CurrentTick = 0;
 
-        internal ConnectionRtt Rtt(ulong clientId)
+        internal ConnectionRtt GetConnectionRtt(ulong clientId)
         {
             if (!m_ClientRtts.ContainsKey(clientId))
             {

--- a/com.unity.multiplayer.mlapi/Runtime/Core/SnapshotSystem.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/SnapshotSystem.cs
@@ -2,13 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using MLAPI.Configuration;
-using MLAPI.Messaging;
 using MLAPI.NetworkVariable;
 using MLAPI.Serialization;
 using MLAPI.Serialization.Pooled;
 using MLAPI.Transports;
 using UnityEngine;
-using UnityEngine.UIElements;
 
 namespace MLAPI
 {
@@ -275,8 +273,19 @@ namespace MLAPI
         private NetworkManager m_NetworkManager = NetworkManager.Singleton;
         private Snapshot m_Snapshot = new Snapshot(NetworkManager.Singleton, false);
         private Dictionary<ulong, Snapshot> m_ClientReceivedSnapshot = new Dictionary<ulong, Snapshot>();
+        private Dictionary<ulong, ClientRtt> m_ClientRtts = new Dictionary<ulong, ClientRtt>();
 
         private ushort m_CurrentTick = 0;
+
+        internal ClientRtt Rtt(ulong clientId)
+        {
+            if (!m_ClientRtts.ContainsKey(clientId))
+            {
+                m_ClientRtts.Add(clientId, new ClientRtt());
+            }
+
+            return m_ClientRtts[clientId];
+        }
 
         /// <summary>
         /// Constructor

--- a/com.unity.multiplayer.mlapi/Tests/Editor/SnapshotRttTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/SnapshotRttTests.cs
@@ -6,6 +6,8 @@ namespace MLAPI.EditorTests
 {
     public class SnapshotRttTests
     {
+        private const double k_Epsilon = 0.0001;
+
         [Test]
         public void TestBasicRtt()
         {
@@ -24,19 +26,17 @@ namespace MLAPI.EditorTests
             client1.NotifyAck(4, 38.0);
             client1.NotifyAck(3, 40.0);
 
-            double epsilon = 0.0001;
-
             ConnectionRtt.Rtt ret = client1.GetRtt();
-            Assert.True(ret.AverageSec < 7.0 + epsilon);
-            Assert.True(ret.AverageSec > 7.0 - epsilon);
-            Assert.True(ret.WorstSec < 10.0 + epsilon);
-            Assert.True(ret.WorstSec > 10.0 - epsilon);
-            Assert.True(ret.BestSec < 5.0 + epsilon);
-            Assert.True(ret.BestSec > 5.0 - epsilon);
+            Assert.True(ret.AverageSec < 7.0 + k_Epsilon);
+            Assert.True(ret.AverageSec > 7.0 - k_Epsilon);
+            Assert.True(ret.WorstSec < 10.0 + k_Epsilon);
+            Assert.True(ret.WorstSec > 10.0 - k_Epsilon);
+            Assert.True(ret.BestSec < 5.0 + k_Epsilon);
+            Assert.True(ret.BestSec > 5.0 - k_Epsilon);
 
             // note: `last` latency is latest received Ack, not latest sent sequence.
-            Assert.True(ret.LastSec < 10.0 + epsilon);
-            Assert.True(ret.LastSec > 10.0 - epsilon);
+            Assert.True(ret.LastSec < 10.0 + k_Epsilon);
+            Assert.True(ret.LastSec > 10.0 - k_Epsilon);
         }
 
         [Test]
@@ -63,15 +63,13 @@ namespace MLAPI.EditorTests
                 client1.NotifyAck(iteration, 42.0);
             }
 
-            double epsilon = 0.0001;
-
             ConnectionRtt.Rtt ret = client1.GetRtt();
-            Assert.True(ret.AverageSec < 7.0 + epsilon);
-            Assert.True(ret.AverageSec > 7.0 - epsilon);
-            Assert.True(ret.WorstSec < 7.0 + epsilon);
-            Assert.True(ret.WorstSec > 7.0 - epsilon);
-            Assert.True(ret.BestSec < 7.0 + epsilon);
-            Assert.True(ret.BestSec > 7.0 - epsilon);
+            Assert.True(ret.AverageSec < 7.0 + k_Epsilon);
+            Assert.True(ret.AverageSec > 7.0 - k_Epsilon);
+            Assert.True(ret.WorstSec < 7.0 + k_Epsilon);
+            Assert.True(ret.WorstSec > 7.0 - k_Epsilon);
+            Assert.True(ret.BestSec < 7.0 + k_Epsilon);
+            Assert.True(ret.BestSec > 7.0 - k_Epsilon);
         }
     }
 }

--- a/com.unity.multiplayer.mlapi/Tests/Editor/SnapshotRttTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/SnapshotRttTests.cs
@@ -12,7 +12,7 @@ namespace MLAPI.EditorTests
         public void TestBasicRtt()
         {
             var snapshot = new SnapshotSystem();
-            var client1 = snapshot.Rtt(0);
+            var client1 = snapshot.GetConnectionRtt(0);
 
             client1.NotifySend(0, 0.0);
             client1.NotifySend(1, 10.0);
@@ -43,9 +43,9 @@ namespace MLAPI.EditorTests
         public void TestEdgeCasesRtt()
         {
             var snapshot = new SnapshotSystem();
-            var client1 = snapshot.Rtt(0);
-            var iterationCount = 200;
-            var extraCount = 100;
+            var client1 = snapshot.GetConnectionRtt(0);
+            var iterationCount = ConnectionRtt.RingSize * 3;
+            var extraCount = ConnectionRtt.RingSize * 2;
 
             // feed in some messages
             for (var iteration = 0; iteration < iterationCount; iteration++)

--- a/com.unity.multiplayer.mlapi/Tests/Editor/SnapshotRttTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/SnapshotRttTests.cs
@@ -1,33 +1,77 @@
 using MLAPI;
 using NUnit.Framework;
+using UnityEngine;
 
 namespace MLAPI.EditorTests
 {
     public class SnapshotRttTests
     {
         [Test]
-        public void TestRtt()
+        public void TestBasicRtt()
         {
             var snapshot = new SnapshotSystem();
             var client1 = snapshot.Rtt(0);
 
             client1.NotifySend(0, 0.0);
             client1.NotifySend(1, 10.0);
-            client1.NotifySend(2, 20.0);
-            client1.NotifySend(3, 30.0);
 
             client1.NotifyAck(1, 15.0);
+
+            client1.NotifySend(2, 20.0);
+            client1.NotifySend(3, 30.0);
+            client1.NotifySend(4, 32.0);
+
+            client1.NotifyAck(4, 38.0);
             client1.NotifyAck(3, 40.0);
 
             double epsilon = 0.0001;
 
-            ClientRtt.Rtt ret = client1.GetRtt();
-            Assert.True(ret.Average < 7.5 + epsilon);
-            Assert.True(ret.Average > 7.5 - epsilon);
-            Assert.True(ret.Worst < 10.0 + epsilon);
-            Assert.True(ret.Worst > 10.0 - epsilon);
-            Assert.True(ret.Best < 5.0 + epsilon);
-            Assert.True(ret.Best > 5.0 - epsilon);
+            ConnectionRtt.Rtt ret = client1.GetRtt();
+            Assert.True(ret.AverageSec < 7.0 + epsilon);
+            Assert.True(ret.AverageSec > 7.0 - epsilon);
+            Assert.True(ret.WorstSec < 10.0 + epsilon);
+            Assert.True(ret.WorstSec > 10.0 - epsilon);
+            Assert.True(ret.BestSec < 5.0 + epsilon);
+            Assert.True(ret.BestSec > 5.0 - epsilon);
+
+            // note: `last` latency is latest received Ack, not latest sent sequence.
+            Assert.True(ret.LastSec < 10.0 + epsilon);
+            Assert.True(ret.LastSec > 10.0 - epsilon);
+        }
+
+        [Test]
+        public void TestEdgeCasesRtt()
+        {
+            var snapshot = new SnapshotSystem();
+            var client1 = snapshot.Rtt(0);
+            var iterationCount = 200;
+            var extraCount = 100;
+
+            // feed in some messages
+            for (var iteration = 0; iteration < iterationCount; iteration++)
+            {
+                client1.NotifySend(iteration, 25.0 * iteration);
+            }
+            // ack some random ones in there (1 out of each 9), always 7.0 later
+            for (var iteration = 0; iteration < iterationCount; iteration += 9)
+            {
+                client1.NotifyAck(iteration, 25.0 * iteration + 7.0);
+            }
+            // ack some unused key, to check it doesn't throw off the values
+            for (var iteration = iterationCount; iteration < iterationCount + extraCount; iteration++)
+            {
+                client1.NotifyAck(iteration, 42.0);
+            }
+
+            double epsilon = 0.0001;
+
+            ConnectionRtt.Rtt ret = client1.GetRtt();
+            Assert.True(ret.AverageSec < 7.0 + epsilon);
+            Assert.True(ret.AverageSec > 7.0 - epsilon);
+            Assert.True(ret.WorstSec < 7.0 + epsilon);
+            Assert.True(ret.WorstSec > 7.0 - epsilon);
+            Assert.True(ret.BestSec < 7.0 + epsilon);
+            Assert.True(ret.BestSec > 7.0 - epsilon);
         }
     }
 }

--- a/com.unity.multiplayer.mlapi/Tests/Editor/SnapshotRttTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/SnapshotRttTests.cs
@@ -1,0 +1,33 @@
+using MLAPI;
+using NUnit.Framework;
+
+namespace MLAPI.EditorTests
+{
+    public class SnapshotRttTests
+    {
+        [Test]
+        public void TestRtt()
+        {
+            var snapshot = new SnapshotSystem();
+            var client1 = snapshot.Rtt(0);
+
+            client1.NotifySend(0, 0.0);
+            client1.NotifySend(1, 10.0);
+            client1.NotifySend(2, 20.0);
+            client1.NotifySend(3, 30.0);
+
+            client1.NotifyAck(1, 15.0);
+            client1.NotifyAck(3, 40.0);
+
+            double epsilon = 0.0001;
+
+            ClientRtt.Rtt ret = client1.GetRtt();
+            Assert.True(ret.Average < 7.5 + epsilon);
+            Assert.True(ret.Average > 7.5 - epsilon);
+            Assert.True(ret.Worst < 10.0 + epsilon);
+            Assert.True(ret.Worst > 10.0 - epsilon);
+            Assert.True(ret.Best < 5.0 + epsilon);
+            Assert.True(ret.Best > 5.0 - epsilon);
+        }
+    }
+}

--- a/com.unity.multiplayer.mlapi/Tests/Editor/SnapshotRttTests.cs.meta
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/SnapshotRttTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a05afab7f08d44c07b2c5e144ba0b45a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This adds the API exposed by the Snapshot System for round-trip times. For now, those values are not filled, they will be in a future PR. But it should allow other development to proceed as it sets the API they will use.