### PR TITLE
fix: remove time assert

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
@@ -264,9 +264,6 @@ namespace MLAPI.Messaging
 
         public void HandleTimeSync(ulong clientId, Stream stream)
         {
-
-            Assert.IsTrue(clientId == NetworkManager.ServerClientId);
-
             using (var reader = PooledNetworkReader.Get(stream))
             {
                 int tick = reader.ReadInt32Packed();


### PR DESCRIPTION
This assert gets currently constantly triggered when using UNetTransport but not with SIPTransport. We have inconsistencies with ServerClientId. This assert is correct and should never get triggered.

Will remove this for now to make develop work as this is a larger issue / feature which needs to be addressed.