### PR TITLE
fix: NetworkWriter.WriteObjectPacked to throw exception with full type name

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Serialization/NetworkWriter.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Serialization/NetworkWriter.cs
@@ -234,7 +234,7 @@ namespace MLAPI.Serialization
             }
 
 
-            throw new ArgumentException($"{nameof(NetworkWriter)} cannot write type {value.GetType().Namespace}");
+            throw new ArgumentException($"{nameof(NetworkWriter)} cannot write type {value.GetType()}");
         }
 
         /// <summary>


### PR DESCRIPTION
fixes #974