### PR TITLE
chore: standards check to run over all projects

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviour.cs
@@ -32,7 +32,7 @@ namespace MLAPI
             Client = 2
         }
 
-        private static void SetUpdateStage<T>(ref T param) where T: IHasUpdateStage
+        private static void SetUpdateStage<T>(ref T param) where T : IHasUpdateStage
         {
             if (param.UpdateStage == NetworkUpdateStage.Unset)
             {
@@ -584,7 +584,7 @@ namespace MLAPI
                             {
                                 var context = NetworkManager.MessageQueueContainer.EnterInternalCommandContext(
                                     MessageQueueContainer.MessageType.NetworkVariableDelta, m_ChannelsForNetworkVariableGroups[j],
-                                    new[] {clientId}, NetworkUpdateLoop.UpdateStage);
+                                    new[] { clientId }, NetworkUpdateLoop.UpdateStage);
                                 if (context != null)
                                 {
                                     using (var nonNullContext = (InternalCommandContext)context)

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -346,20 +346,20 @@ namespace MLAPI
                         switch (networkPrefab.Override)
                         {
                             case NetworkPrefabOverride.Prefab:
-                            {
-                                if (NetworkConfig.NetworkPrefabs[i].SourcePrefabToOverride == null &&
-                                    NetworkConfig.NetworkPrefabs[i].Prefab != null)
                                 {
-                                    if (networkPrefab.SourcePrefabToOverride == null && networkPrefab.Prefab != null)
+                                    if (NetworkConfig.NetworkPrefabs[i].SourcePrefabToOverride == null &&
+                                        NetworkConfig.NetworkPrefabs[i].Prefab != null)
                                     {
-                                        networkPrefab.SourcePrefabToOverride = networkPrefab.Prefab;
+                                        if (networkPrefab.SourcePrefabToOverride == null && networkPrefab.Prefab != null)
+                                        {
+                                            networkPrefab.SourcePrefabToOverride = networkPrefab.Prefab;
+                                        }
+
+                                        globalObjectIdHash = networkPrefab.SourcePrefabToOverride.GetComponent<NetworkObject>().GlobalObjectIdHash;
                                     }
 
-                                    globalObjectIdHash = networkPrefab.SourcePrefabToOverride.GetComponent<NetworkObject>().GlobalObjectIdHash;
+                                    break;
                                 }
-
-                                break;
-                            }
                             case NetworkPrefabOverride.Hash:
                                 globalObjectIdHash = networkPrefab.SourceHashToOverride;
                                 break;
@@ -467,8 +467,8 @@ namespace MLAPI
                 for (int i = 0; i < NetworkConfig.RegisteredScenes.Count; i++)
                 {
                     SceneManager.RegisteredSceneNames.Add(NetworkConfig.RegisteredScenes[i]);
-                    SceneManager.SceneIndexToString.Add((uint) i, NetworkConfig.RegisteredScenes[i]);
-                    SceneManager.SceneNameToIndex.Add(NetworkConfig.RegisteredScenes[i], (uint) i);
+                    SceneManager.SceneIndexToString.Add((uint)i, NetworkConfig.RegisteredScenes[i]);
+                    SceneManager.SceneNameToIndex.Add(NetworkConfig.RegisteredScenes[i], (uint)i);
                 }
 
                 SceneManager.SetCurrentSceneIndex();
@@ -1029,13 +1029,13 @@ namespace MLAPI
 
         private void SendConnectionRequest()
         {
-            var clientIds = new[] {ServerClientId};
+            var clientIds = new[] { ServerClientId };
             var context = MessageQueueContainer.EnterInternalCommandContext(
                 MessageQueueContainer.MessageType.ConnectionRequest, NetworkChannel.Internal,
                 clientIds, NetworkUpdateStage.EarlyUpdate);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext) context)
+                using (var nonNullContext = (InternalCommandContext)context)
                 {
                     nonNullContext.NetworkWriter.WriteUInt64Packed(NetworkConfig.GetConfig());
 
@@ -1124,15 +1124,15 @@ namespace MLAPI
 #endif
                     break;
                 case NetworkEvent.Data:
-                {
-                    if (NetworkLog.CurrentLogLevel <= LogLevel.Developer)
                     {
-                        NetworkLog.LogInfo($"Incoming Data From {clientId}: {payload.Count} bytes");
-                    }
+                        if (NetworkLog.CurrentLogLevel <= LogLevel.Developer)
+                        {
+                            NetworkLog.LogInfo($"Incoming Data From {clientId}: {payload.Count} bytes");
+                        }
 
-                    HandleIncomingData(clientId, networkChannel, payload, receiveTime);
-                    break;
-                }
+                        HandleIncomingData(clientId, networkChannel, payload, receiveTime);
+                        break;
+                    }
                 case NetworkEvent.Disconnect:
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
                     s_TransportDisconnect.Begin();
@@ -1254,7 +1254,7 @@ namespace MLAPI
                             {
                                 Receive = new ServerRpcReceiveParams
                                 {
-                                    UpdateStage = (NetworkUpdateStage) networkUpdateStage,
+                                    UpdateStage = (NetworkUpdateStage)networkUpdateStage,
                                     SenderClientId = item.NetworkId
                                 }
                             };
@@ -1264,7 +1264,7 @@ namespace MLAPI
                             {
                                 Receive = new ClientRpcReceiveParams
                                 {
-                                    UpdateStage = (NetworkUpdateStage) networkUpdateStage
+                                    UpdateStage = (NetworkUpdateStage)networkUpdateStage
                                 }
                             };
                             break;
@@ -1386,7 +1386,7 @@ namespace MLAPI
                 clientIds, NetworkUpdateStage.EarlyUpdate);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext) context)
+                using (var nonNullContext = (InternalCommandContext)context)
                 {
                     nonNullContext.NetworkWriter.WriteInt32Packed(NetworkTickSystem.ServerTime.Tick);
                 }
@@ -1434,7 +1434,7 @@ namespace MLAPI
                 if (ownerClientId != ServerClientId)
                 {
                     // Don't send any data over the wire if the host "connected"
-                    ulong[] clientIds = {ownerClientId};
+                    ulong[] clientIds = { ownerClientId };
 
                     var context = MessageQueueContainer.EnterInternalCommandContext(
                         MessageQueueContainer.MessageType.ConnectionApproved, NetworkChannel.Internal,
@@ -1442,7 +1442,7 @@ namespace MLAPI
 
                     if (context != null)
                     {
-                        using (var nonNullContext = (InternalCommandContext) context)
+                        using (var nonNullContext = (InternalCommandContext)context)
                         {
                             nonNullContext.NetworkWriter.WriteUInt64Packed(ownerClientId);
 
@@ -1454,7 +1454,7 @@ namespace MLAPI
                             }
 
                             nonNullContext.NetworkWriter.WriteInt32Packed(LocalTime.Tick);
-                            nonNullContext.NetworkWriter.WriteUInt32Packed((uint) m_ObservedObjects.Count);
+                            nonNullContext.NetworkWriter.WriteUInt32Packed((uint)m_ObservedObjects.Count);
 
                             for (int i = 0; i < m_ObservedObjects.Count; i++)
                             {
@@ -1484,7 +1484,7 @@ namespace MLAPI
 
                     var context = MessageQueueContainer.EnterInternalCommandContext(
                         MessageQueueContainer.MessageType.CreateObject, NetworkChannel.Internal,
-                        new[] {clientPair.Key}, NetworkUpdateLoop.UpdateStage);
+                        new[] { clientPair.Key }, NetworkUpdateLoop.UpdateStage);
                     if (context != null)
                     {
                         using (var nonNullContext = (InternalCommandContext)context)

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
@@ -291,13 +291,13 @@ namespace MLAPI
 
             var context = networkManager.MessageQueueContainer.EnterInternalCommandContext(
                 MessageQueueContainer.MessageType.CreateObjects, NetworkChannel.Internal,
-                new[] {clientId}, NetworkUpdateLoop.UpdateStage);
+                new[] { clientId }, NetworkUpdateLoop.UpdateStage);
 
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext) context)
+                using (var nonNullContext = (InternalCommandContext)context)
                 {
-                    nonNullContext.NetworkWriter.WriteUInt16Packed((ushort) networkObjects.Count);
+                    nonNullContext.NetworkWriter.WriteUInt16Packed((ushort)networkObjects.Count);
 
                     for (int i = 0; i < networkObjects.Count; i++)
                     {
@@ -342,10 +342,10 @@ namespace MLAPI
 
             var context = NetworkManager.MessageQueueContainer.EnterInternalCommandContext(
                 MessageQueueContainer.MessageType.DestroyObject, NetworkChannel.Internal,
-                new[] {clientId}, NetworkUpdateStage.PostLateUpdate);
+                new[] { clientId }, NetworkUpdateStage.PostLateUpdate);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext) context)
+                using (var nonNullContext = (InternalCommandContext)context)
                 {
                     nonNullContext.NetworkWriter.WriteUInt64Packed(NetworkObjectId);
                 }
@@ -397,12 +397,12 @@ namespace MLAPI
 
             var context = networkManager.MessageQueueContainer.EnterInternalCommandContext(
                 MessageQueueContainer.MessageType.DestroyObjects, NetworkChannel.Internal,
-                new[] {clientId}, NetworkUpdateStage.PostLateUpdate);
+                new[] { clientId }, NetworkUpdateStage.PostLateUpdate);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext) context)
+                using (var nonNullContext = (InternalCommandContext)context)
                 {
-                    nonNullContext.NetworkWriter.WriteUInt16Packed((ushort) networkObjects.Count);
+                    nonNullContext.NetworkWriter.WriteUInt16Packed((ushort)networkObjects.Count);
 
                     for (int i = 0; i < networkObjects.Count; i++)
                     {
@@ -695,7 +695,7 @@ namespace MLAPI
 
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext) context)
+                using (var nonNullContext = (InternalCommandContext)context)
                 {
                     nonNullContext.NetworkWriter.WriteUInt64Packed(NetworkObjectId);
                     WriteNetworkParenting(nonNullContext.NetworkWriter, m_IsReparented, m_LatestParent);

--- a/com.unity.multiplayer.mlapi/Runtime/Core/SnapshotSystem.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/SnapshotSystem.cs
@@ -360,18 +360,18 @@ namespace MLAPI
         private void SendSnapshot(ulong clientId)
         {
             // Send the entry index and the buffer where the variables are serialized
-            
+
             var context = m_NetworkManager.MessageQueueContainer.EnterInternalCommandContext(
                 MessageQueueContainer.MessageType.SnapshotData, NetworkChannel.SnapshotExchange,
-                new[] {clientId}, NetworkUpdateLoop.UpdateStage);
-            
+                new[] { clientId }, NetworkUpdateLoop.UpdateStage);
+
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext) context)
+                using (var nonNullContext = (InternalCommandContext)context)
                 {
                     nonNullContext.NetworkWriter.WriteInt32Packed(m_CurrentTick);
 
-                    var buffer = (NetworkBuffer) nonNullContext.NetworkWriter.GetStream();
+                    var buffer = (NetworkBuffer)nonNullContext.NetworkWriter.GetStream();
                     WriteIndex(buffer);
                     WriteBuffer(buffer);
                 }
@@ -496,11 +496,11 @@ namespace MLAPI
         {
             var context = m_NetworkManager.MessageQueueContainer.EnterInternalCommandContext(
                 MessageQueueContainer.MessageType.SnapshotAck, NetworkChannel.SnapshotExchange,
-                new[] {clientId}, NetworkUpdateLoop.UpdateStage);
-            
+                new[] { clientId }, NetworkUpdateLoop.UpdateStage);
+
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext) context)
+                using (var nonNullContext = (InternalCommandContext)context)
                 {
                     nonNullContext.NetworkWriter.WriteInt32Packed(tick);
                 }

--- a/com.unity.multiplayer.mlapi/Runtime/Logging/NetworkLog.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Logging/NetworkLog.cs
@@ -62,12 +62,12 @@ namespace MLAPI.Logging
             {
                 var context = NetworkManager.Singleton.MessageQueueContainer.EnterInternalCommandContext(
                     MessageQueueContainer.MessageType.ServerLog, NetworkChannel.Internal,
-                    new[] {NetworkManager.Singleton.ServerClientId}, NetworkUpdateLoop.UpdateStage);
+                    new[] { NetworkManager.Singleton.ServerClientId }, NetworkUpdateLoop.UpdateStage);
                 if (context != null)
                 {
-                    using (var nonNullContext = (InternalCommandContext) context)
+                    using (var nonNullContext = (InternalCommandContext)context)
                     {
-                        nonNullContext.NetworkWriter.WriteByte((byte) logType);
+                        nonNullContext.NetworkWriter.WriteByte((byte)logType);
                         nonNullContext.NetworkWriter.WriteStringPacked(message);
                     }
                 }

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/CustomMessageManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/CustomMessageManager.cs
@@ -56,7 +56,7 @@ namespace MLAPI.Messaging
                 clientIds.ToArray(), NetworkUpdateLoop.UpdateStage);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext) context)
+                using (var nonNullContext = (InternalCommandContext)context)
                 {
                     buffer.Position = 0;
                     buffer.CopyTo(nonNullContext.NetworkWriter.GetStream());
@@ -76,10 +76,10 @@ namespace MLAPI.Messaging
         {
             var context = m_NetworkManager.MessageQueueContainer.EnterInternalCommandContext(
                 MessageQueueContainer.MessageType.UnnamedMessage, networkChannel,
-                new[] {clientId}, NetworkUpdateLoop.UpdateStage);
+                new[] { clientId }, NetworkUpdateLoop.UpdateStage);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext) context)
+                using (var nonNullContext = (InternalCommandContext)context)
                 {
                     buffer.Position = 0;
                     buffer.CopyTo(nonNullContext.NetworkWriter.GetStream());
@@ -175,10 +175,10 @@ namespace MLAPI.Messaging
 
             var context = m_NetworkManager.MessageQueueContainer.EnterInternalCommandContext(
                 MessageQueueContainer.MessageType.NamedMessage, networkChannel,
-                new[] {clientId}, NetworkUpdateLoop.UpdateStage);
+                new[] { clientId }, NetworkUpdateLoop.UpdateStage);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext) context)
+                using (var nonNullContext = (InternalCommandContext)context)
                 {
                     nonNullContext.NetworkWriter.WriteUInt64Packed(hash);
 
@@ -219,7 +219,7 @@ namespace MLAPI.Messaging
                 clientIds.ToArray(), NetworkUpdateLoop.UpdateStage);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext) context)
+                using (var nonNullContext = (InternalCommandContext)context)
                 {
                     nonNullContext.NetworkWriter.WriteUInt64Packed(hash);
 

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalCommandContext.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalCommandContext.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using MLAPI.Serialization.Pooled;
 using System.Linq;
 

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/MessageQueue/MessageQueueContainer.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/MessageQueue/MessageQueueContainer.cs
@@ -68,7 +68,7 @@ namespace MLAPI.Messaging
         private bool m_IsTestingEnabled;
         private bool m_ProcessUpdateStagesExternally;
         private bool m_IsNotUsingBatching;
-        
+
         // TODO hack: Fixed update can run multiple times in a frame and the queue history frame doesn't get cleared
         // until the end of the frame. This results in messages executing at FixedUpdate being invoked multiple times.
         // This is used to prevent it being called more than once per frame.

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/MessageQueue/MessageQueueProcessor.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/MessageQueue/MessageQueueProcessor.cs
@@ -317,7 +317,7 @@ namespace MLAPI.Messaging
             var length = (int)sendStream.Buffer.Length;
             var bytes = sendStream.Buffer.GetBuffer();
             var sendBuffer = new ArraySegment<byte>(bytes, 0, length);
-            
+
             var channel = sendStream.NetworkChannel;
             // If the length is greater than the fragmented threshold, switch to a fragmented channel.
             // This is kind of a hack to get around issues with certain usages patterns on fragmentation with UNet.

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/RpcParams.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/RpcParams.cs
@@ -9,7 +9,7 @@ namespace MLAPI.Messaging
         }
     }
 
-    public struct ServerRpcSendParams: IHasUpdateStage
+    public struct ServerRpcSendParams : IHasUpdateStage
     {
         private NetworkUpdateStage m_UpdateStage;
 
@@ -20,7 +20,7 @@ namespace MLAPI.Messaging
         }
     }
 
-    public struct ServerRpcReceiveParams: IHasUpdateStage
+    public struct ServerRpcReceiveParams : IHasUpdateStage
     {
         private NetworkUpdateStage m_UpdateStage;
 
@@ -38,7 +38,7 @@ namespace MLAPI.Messaging
         public ServerRpcReceiveParams Receive;
     }
 
-    public struct ClientRpcSendParams: IHasUpdateStage
+    public struct ClientRpcSendParams : IHasUpdateStage
     {
         private NetworkUpdateStage m_UpdateStage;
 
@@ -50,7 +50,7 @@ namespace MLAPI.Messaging
         public ulong[] TargetClientIds;
     }
 
-    public struct ClientRpcReceiveParams: IHasUpdateStage
+    public struct ClientRpcReceiveParams : IHasUpdateStage
     {
         private NetworkUpdateStage m_UpdateStage;
 

--- a/com.unity.multiplayer.mlapi/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -182,10 +182,10 @@ namespace MLAPI.SceneManagement
 
                 var context = m_NetworkManager.MessageQueueContainer.EnterInternalCommandContext(
                     MessageQueueContainer.MessageType.AllClientsLoadedScene, NetworkChannel.Internal,
-                    new[] {NetworkManager.Singleton.ServerClientId}, NetworkUpdateLoop.UpdateStage);
+                    new[] { NetworkManager.Singleton.ServerClientId }, NetworkUpdateLoop.UpdateStage);
                 if (context != null)
                 {
-                    using (var nonNullContext = (InternalCommandContext) context)
+                    using (var nonNullContext = (InternalCommandContext)context)
                     {
                         var doneClientIds = switchSceneProgress.DoneClients.ToArray();
                         var timedOutClientIds = m_NetworkManager.ConnectedClients.Keys.Except(doneClientIds).ToArray();
@@ -267,10 +267,10 @@ namespace MLAPI.SceneManagement
 
             var context = m_NetworkManager.MessageQueueContainer.EnterInternalCommandContext(
                 MessageQueueContainer.MessageType.ClientSwitchSceneCompleted, NetworkChannel.Internal,
-                new[] {m_NetworkManager.ServerClientId}, NetworkUpdateLoop.UpdateStage);
+                new[] { m_NetworkManager.ServerClientId }, NetworkUpdateLoop.UpdateStage);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext) context)
+                using (var nonNullContext = (InternalCommandContext)context)
                 {
                     nonNullContext.NetworkWriter.WriteByteArray(switchSceneGuid.ToByteArray());
                 }
@@ -356,7 +356,7 @@ namespace MLAPI.SceneManagement
                 {
                     var context = m_NetworkManager.MessageQueueContainer.EnterInternalCommandContext(
                         MessageQueueContainer.MessageType.SwitchScene, NetworkChannel.Internal,
-                        new[] {m_NetworkManager.ConnectedClientsList[j].ClientId}, NetworkUpdateLoop.UpdateStage);
+                        new[] { m_NetworkManager.ConnectedClientsList[j].ClientId }, NetworkUpdateLoop.UpdateStage);
                     if (context != null)
                     {
                         using (var nonNullContext = (InternalCommandContext)context)
@@ -415,10 +415,10 @@ namespace MLAPI.SceneManagement
 
             var context = m_NetworkManager.MessageQueueContainer.EnterInternalCommandContext(
                 MessageQueueContainer.MessageType.ClientSwitchSceneCompleted, NetworkChannel.Internal,
-                new[] {m_NetworkManager.ServerClientId}, NetworkUpdateLoop.UpdateStage);
+                new[] { m_NetworkManager.ServerClientId }, NetworkUpdateLoop.UpdateStage);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext) context)
+                using (var nonNullContext = (InternalCommandContext)context)
                 {
                     nonNullContext.NetworkWriter.WriteByteArray(switchSceneGuid.ToByteArray());
                 }

--- a/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkPrefabHandler.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkPrefabHandler.cs
@@ -108,7 +108,7 @@ namespace MLAPI.Spawning
         /// <param name="networkPrefabOverrides">one or more NetworkPrefabs could be used to override the source NetworkPrefab</param>
         public void RegisterHostGlobalObjectIdHashValues(GameObject sourceNetworkPrefab, List<GameObject> networkPrefabOverrides)
         {
-            if(NetworkManager.Singleton.IsListening)
+            if (NetworkManager.Singleton.IsListening)
             {
                 if (NetworkManager.Singleton.IsHost)
                 {
@@ -120,7 +120,7 @@ namespace MLAPI.Spawning
                         foreach (var gameObject in networkPrefabOverrides)
                         {
                             var targetNetworkObject = gameObject.GetComponent<NetworkObject>();
-                            if(targetNetworkObject != null)
+                            if (targetNetworkObject != null)
                             {
                                 if (!m_PrefabInstanceToPrefabAsset.ContainsKey(targetNetworkObject.GlobalObjectIdHash))
                                 {
@@ -234,11 +234,11 @@ namespace MLAPI.Spawning
         /// <returns></returns>
         internal uint GetSourceGlobalObjectIdHash(uint networkPrefabHash)
         {
-            if(m_PrefabAssetToPrefabHandler.ContainsKey(networkPrefabHash))
+            if (m_PrefabAssetToPrefabHandler.ContainsKey(networkPrefabHash))
             {
                 return networkPrefabHash;
             }
-            else if(m_PrefabInstanceToPrefabAsset.ContainsKey(networkPrefabHash))
+            else if (m_PrefabInstanceToPrefabAsset.ContainsKey(networkPrefabHash))
             {
                 return m_PrefabInstanceToPrefabAsset[networkPrefabHash];
             }

--- a/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Spawning/NetworkSpawnManager.cs
@@ -115,7 +115,7 @@ namespace MLAPI.Spawning
                 NetworkManager.ConnectedClientsIds, NetworkUpdateLoop.UpdateStage);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext) context)
+                using (var nonNullContext = (InternalCommandContext)context)
                 {
                     nonNullContext.NetworkWriter.WriteUInt64Packed(networkObject.NetworkObjectId);
                     nonNullContext.NetworkWriter.WriteUInt64Packed(networkObject.OwnerClientId);
@@ -157,7 +157,7 @@ namespace MLAPI.Spawning
                 clientIds, NetworkUpdateLoop.UpdateStage);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext) context)
+                using (var nonNullContext = (InternalCommandContext)context)
                 {
                     nonNullContext.NetworkWriter.WriteUInt64Packed(networkObject.NetworkObjectId);
                     nonNullContext.NetworkWriter.WriteUInt64Packed(clientId);
@@ -384,7 +384,7 @@ namespace MLAPI.Spawning
                 new ulong[] { clientId }, NetworkUpdateLoop.UpdateStage);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext) context)
+                using (var nonNullContext = (InternalCommandContext)context)
                 {
                     WriteSpawnCallForObject(nonNullContext.NetworkWriter, ownerClientId, networkObject, payload);
                 }
@@ -666,7 +666,7 @@ namespace MLAPI.Spawning
                                 clientIds, NetworkUpdateStage.PostLateUpdate);
                             if (context != null)
                             {
-                                using (var nonNullContext = (InternalCommandContext) context)
+                                using (var nonNullContext = (InternalCommandContext)context)
                                 {
                                     nonNullContext.NetworkWriter.WriteUInt64Packed(networkObject.NetworkObjectId);
                                 }

--- a/com.unity.multiplayer.mlapi/Runtime/Transports/NetworkTransport.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Transports/NetworkTransport.cs
@@ -108,7 +108,7 @@ namespace MLAPI.Transports
             new TransportChannel(NetworkChannel.SnapshotExchange, NetworkDelivery.ReliableSequenced), // todo: temporary until we separate snapshots in chunks
  
             new TransportChannel(NetworkChannel.Fragmented, NetworkDelivery.ReliableFragmentedSequenced),
-            
+
         };
 
         /// <summary>

--- a/com.unity.multiplayer.mlapi/Tests/Editor/DummyMessageHandler.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/DummyMessageHandler.cs
@@ -50,7 +50,7 @@ namespace MLAPI.EditorTests
                 // That's what will then call back into this for the others.
                 var messageQueueContainer = NetworkManager.MessageQueueContainer;
                 messageQueueContainer.AddQueueItemToInboundFrame(messageType, receiveTime, clientId,
-                    (NetworkBuffer) stream, receiveChannel);
+                    (NetworkBuffer)stream, receiveChannel);
                 messageQueueContainer.ProcessAndFlushMessageQueue(
                     MessageQueueContainer.MessageQueueProcessingTypes.Receive, NetworkUpdateLoop.UpdateStage);
                 messageQueueContainer.AdvanceFrameHistory(MessageQueueHistoryFrame.QueueFrameType.Inbound);

--- a/com.unity.multiplayer.mlapi/Tests/Editor/Timing/ClientNetworkTimeSystemTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/Timing/ClientNetworkTimeSystemTests.cs
@@ -91,8 +91,8 @@ namespace MLAPI.EditorTests.Timing
             double unscaledServerTime = timeSystem.ServerTime;
             TimingTestHelper.ApplySteps(timeSystem, tickSystem, steps, delegate (int step)
              {
-                // sync network stats
-                unscaledLocalTime += steps[step];
+                 // sync network stats
+                 unscaledLocalTime += steps[step];
                  unscaledServerTime += steps[step];
                  receivedServerTime += steps[step];
                  timeSystem.Sync(receivedServerTime, rttSteps2[step]);

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/Messaging/NamedMessageTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/Messaging/NamedMessageTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -72,7 +72,7 @@ namespace MLAPI.RuntimeTests.Messaging
                     stream.CopyTo(memoryStream);
                     firstReceivedMessageContent = Encoding.UTF8.GetString(memoryStream.ToArray());
                 });
-            
+
             ulong secondReceivedMessageSender = 0;
             string secondReceivedMessageContent = null;
             SecondClient.CustomMessagingManager.RegisterNamedMessageHandler(

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/Messaging/UnnamedMessageTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/Messaging/UnnamedMessageTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -13,7 +13,7 @@ namespace MLAPI.RuntimeTests.Messaging
     public class UnnamedMessageTests : BaseMultiInstanceTest
     {
         protected override int NbClients => 2;
-        
+
         private NetworkManager FirstClient => m_ClientNetworkManagers[0];
         private NetworkManager SecondClient => m_ClientNetworkManagers[1];
 
@@ -42,7 +42,7 @@ namespace MLAPI.RuntimeTests.Messaging
             Assert.AreEqual(messageContent, receivedMessageContent);
             Assert.AreEqual(m_ServerNetworkManager.LocalClientId, receivedMessageSender);
         }
-        
+
         [UnityTest]
         public IEnumerator UnnamedMessageIsReceivedOnMultipleClientsWithContent()
         {
@@ -61,7 +61,7 @@ namespace MLAPI.RuntimeTests.Messaging
                 stream.CopyTo(memoryStream);
                 firstReceivedMessageContent = Encoding.UTF8.GetString(memoryStream.ToArray());
             };
-            
+
             ulong secondReceivedMessageSender = 0;
             string secondReceivedMessageContent = null;
             SecondClient.CustomMessagingManager.OnUnnamedMessage += (sender, stream) =>

--- a/com.unity.multiplayer.mlapi/Tests/Runtime/MultiInstanceHelpers.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/MultiInstanceHelpers.cs
@@ -318,7 +318,7 @@ namespace MLAPI.RuntimeTests
                     var client = clients[i];
                     // Logging i+1 because that's the local client ID they'll get (0 is server)
                     // Can't use client.LocalClientId because that doesn't get assigned until IsConnectedClient == true,
-                    Assert.True(client.IsConnectedClient, $"Client {i+1} never connected");
+                    Assert.True(client.IsConnectedClient, $"Client {i + 1} never connected");
                 }
             }
         }

--- a/standards.py
+++ b/standards.py
@@ -18,7 +18,7 @@ parser.add_argument("--yamato", action="store_true")
 
 parser.add_argument("--tool-path", default="dotnet-format")
 parser.add_argument("--project-path", default="testproject")
-parser.add_argument("--project-glob", default="Unity.Multiplayer*.csproj")
+parser.add_argument("--project-glob", default="*.csproj")
 
 if len(sys.argv) == 1:
     parser.print_help(sys.stderr)

--- a/testproject/Assets/Samples/EnableDisableNetworkObject/EnableDisableSceneNetworkObjectComponent.cs
+++ b/testproject/Assets/Samples/EnableDisableNetworkObject/EnableDisableSceneNetworkObjectComponent.cs
@@ -30,7 +30,7 @@ public class EnableDisableSceneNetworkObjectComponent : NetworkBehaviour
     public override void OnNetworkSpawn()
     {
         //For this example, the server controls whether the mesh is visible and can collide or not
-        if(IsServer && IsHost)
+        if (IsServer && IsHost)
         {
             if (m_ActivateObjectButton)
             {

--- a/testproject/Assets/Scripts/CommandLineHandler.cs
+++ b/testproject/Assets/Scripts/CommandLineHandler.cs
@@ -26,14 +26,14 @@ public class CommandLineProcessor
     public CommandLineProcessor(string[] args)
     {
         try
-        {        
-            if(s_Singleton != null)
+        {
+            if (s_Singleton != null)
             {
                 Debug.LogError($"More than one {nameof(CommandLineProcessor)} has been instantiated!");
                 throw new Exception();
             }
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
             Debug.LogError($"Stack Trace: {ex.StackTrace}");
         }
@@ -62,13 +62,13 @@ public class CommandLineProcessor
         {
             switch (mlapiValue)
             {
-                case "server":                   
+                case "server":
                 case "host":
                 case "client":
-                {
+                    {
 
-                    return true;
-                }
+                        return true;
+                    }
             }
         }
         return false;
@@ -129,7 +129,7 @@ public class CommandLineProcessor
 
     private void StartSceneSwitch()
     {
-        if(m_SceneToLoad != string.Empty)
+        if (m_SceneToLoad != string.Empty)
         {
             SceneManager.sceneLoaded += SceneManager_sceneLoaded;
             SceneManager.LoadSceneAsync(m_SceneToLoad, LoadSceneMode.Single);
@@ -149,7 +149,7 @@ public class CommandLineProcessor
                 if (m_ConnectionModeScript)
                 {
                     m_ConnectionModeScript.SetCommandLineHandler(this);
-         
+
                     return;
                 }
             }
@@ -192,7 +192,7 @@ public class CommandLineProcessor
         else
         {
             NetworkManager.Singleton.StartClient();
-        }       
+        }
     }
 
     private void SetTransportAddress(string address)
@@ -228,10 +228,10 @@ public class CommandLineHandler : MonoBehaviour
     private static CommandLineProcessor s_CommandLineProcessorInstance;
     private void Start()
     {
-        if(s_CommandLineProcessorInstance == null)
+        if (s_CommandLineProcessorInstance == null)
         {
             s_CommandLineProcessorInstance = new CommandLineProcessor(Environment.GetCommandLineArgs());
         }
-        
+
     }
 }

--- a/testproject/Assets/Scripts/ConnectionModeScript.cs
+++ b/testproject/Assets/Scripts/ConnectionModeScript.cs
@@ -15,7 +15,7 @@ public class ConnectionModeScript : MonoBehaviour
     internal void SetCommandLineHandler(CommandLineProcessor commandLineProcessor)
     {
         m_CommandLineProcessor = commandLineProcessor;
-        if(m_CommandLineProcessor.AutoConnectEnabled())
+        if (m_CommandLineProcessor.AutoConnectEnabled())
         {
             StartCoroutine(WaitForNetworkManager());
         }
@@ -30,7 +30,7 @@ public class ConnectionModeScript : MonoBehaviour
 
     private IEnumerator WaitForNetworkManager()
     {
-        while(true)
+        while (true)
         {
             yield return new WaitForSeconds(0.5f);
             try

--- a/testproject/Assets/Scripts/ExitButtonScript.cs
+++ b/testproject/Assets/Scripts/ExitButtonScript.cs
@@ -30,13 +30,13 @@ public class ExitButtonScript : MonoBehaviour
         }
 
         if (m_SceneMenuToLoad != null && m_SceneMenuToLoad.GetReferencedScenes()[0] != string.Empty)
-        {           
+        {
             SceneManager.LoadSceneAsync(m_SceneMenuToLoad.GetReferencedScenes()[0], LoadSceneMode.Single);
         }
         else
         {
             SceneManager.LoadSceneAsync(0, LoadSceneMode.Single);
         }
-        
+
     }
 }

--- a/testproject/Assets/Scripts/MenuManagement/MainMenuManager.cs
+++ b/testproject/Assets/Scripts/MenuManagement/MainMenuManager.cs
@@ -16,7 +16,7 @@ public class MainMenuManager : MenuManager<MenuReference>
 /// Used for to construct a menu that accepts a specific type of ISceneReference
 /// </summary>
 /// <typeparam name="T"></typeparam>
-public class MenuManager<T>: MonoBehaviour where T : ISceneReference
+public class MenuManager<T> : MonoBehaviour where T : ISceneReference
 {
     [SerializeField]
     protected List<T> m_SceneMenus;
@@ -49,7 +49,7 @@ public class MenuManager<T>: MonoBehaviour where T : ISceneReference
         {
             if (!m_SceneMenuReferencesByDisplayName.ContainsKey(menuReference.GetReferencedScenes()[0]))
             {
-                m_SceneMenuReferencesByDisplayName.Add(menuReference.GetDisplayName(), menuReference );
+                m_SceneMenuReferencesByDisplayName.Add(menuReference.GetDisplayName(), menuReference);
 
                 var optionData = new Dropdown.OptionData();
                 optionData.text = menuReference.GetDisplayName();

--- a/testproject/Assets/Scripts/MenuManagement/MenuReference.cs
+++ b/testproject/Assets/Scripts/MenuManagement/MenuReference.cs
@@ -7,7 +7,7 @@ using UnityEditor;
 
 
 [CreateAssetMenu(fileName = "MenuReference", menuName = "MLAPI/MenuReference")]
-public class MenuReference: ScriptableObject, ISceneReference
+public class MenuReference : ScriptableObject, ISceneReference
 {
 #if UNITY_EDITOR    
     public SceneAsset MenuScene;

--- a/testproject/Assets/Scripts/MenuManagement/SceneReference.cs
+++ b/testproject/Assets/Scripts/MenuManagement/SceneReference.cs
@@ -7,7 +7,7 @@ using UnityEditor;
 
 [CreateAssetMenu(fileName = "SceneReference", menuName = "MLAPI/SceneReference")]
 [Serializable]
-public class SceneReference : ScriptableObject,ISceneReference
+public class SceneReference : ScriptableObject, ISceneReference
 {
 #if UNITY_EDITOR    
     public SceneAsset SceneToReference;
@@ -63,7 +63,7 @@ public class SceneReference : ScriptableObject,ISceneReference
 
 
 public interface ISceneReference
-{ 
+{
     string GetDisplayName();
     List<string> GetReferencedScenes();
 }

--- a/testproject/Assets/Tests/Manual/NetworkAnimatorTests/AnimatedCubeController.cs
+++ b/testproject/Assets/Tests/Manual/NetworkAnimatorTests/AnimatedCubeController.cs
@@ -11,7 +11,7 @@ namespace Tests.Manual.NetworkAnimatorTests
         private Animator m_Animator;
         private bool m_Rotate;
         private NetworkAnimator m_NetworkAnimator;
-        
+
         private void Awake()
         {
             m_Animator = GetComponent<Animator>();
@@ -26,30 +26,30 @@ namespace Tests.Manual.NetworkAnimatorTests
                 enabled = false;
             }
         }
-        
+
         private void Update()
         {
             if (m_NetworkAnimator.IsAuthorityOverAnimator)
             {
-                if(Input.GetKeyDown(KeyCode.C))
+                if (Input.GetKeyDown(KeyCode.C))
                 {
                     ToggleRotateAnimation();
-                }  
-                if(Input.GetKeyDown(KeyCode.Space))
+                }
+                if (Input.GetKeyDown(KeyCode.Space))
                 {
                     PlayPulseAnimation();
-                }  
+                }
             }
-            else 
+            else
             {
-                if(Input.GetKeyDown(KeyCode.C))
+                if (Input.GetKeyDown(KeyCode.C))
                 {
                     ToggleRotateAnimationServerRpc();
-                }  
-                if(Input.GetKeyDown(KeyCode.Space))
+                }
+                if (Input.GetKeyDown(KeyCode.Space))
                 {
                     PlayPulseAnimationServerRpc();
-                }  
+                }
             }
         }
 
@@ -63,7 +63,7 @@ namespace Tests.Manual.NetworkAnimatorTests
         {
             m_Animator.SetTrigger("Pulse");
         }
-        
+
         [ServerRpc]
         public void ToggleRotateAnimationServerRpc()
         {
@@ -73,7 +73,7 @@ namespace Tests.Manual.NetworkAnimatorTests
         [ServerRpc]
         public void PlayPulseAnimationServerRpc()
         {
-           PlayPulseAnimation();
+            PlayPulseAnimation();
         }
     }
 }

--- a/testproject/Assets/Tests/Manual/Scripts/GenericNetworkObjectBehaviour.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/GenericNetworkObjectBehaviour.cs
@@ -60,7 +60,7 @@ namespace TestProject.ManualTests
                 }
                 m_MeshRenderer.enabled = false;
                 m_VisibilitySpawn = Time.realtimeSinceStartup + 0.12f;
-                if(NetworkObject.NetworkObjectId == 0)
+                if (NetworkObject.NetworkObjectId == 0)
                 {
                     Debug.Log("Spawning NetworkObjectId 0!");
                 }
@@ -118,7 +118,7 @@ namespace TestProject.ManualTests
 
         private void Update()
         {
-            if(IsOwner && m_ShouldDespawn && NetworkObject != null)
+            if (IsOwner && m_ShouldDespawn && NetworkObject != null)
             {
                 m_ShouldDespawn = false;
 

--- a/testproject/Assets/Tests/Manual/Scripts/IPlayerMovement.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/IPlayerMovement.cs
@@ -1,4 +1,4 @@
-﻿namespace TestProject.ManualTests
+namespace TestProject.ManualTests
 {
     public interface IPlayerMovement
     {

--- a/testproject/Assets/Tests/Manual/Scripts/NetworkManagerHud.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/NetworkManagerHud.cs
@@ -9,27 +9,25 @@ namespace TestProject.ManualTests
     [DisallowMultipleComponent]
     public class NetworkManagerHud : MonoBehaviour
     {
-        NetworkManager m_NetworkManager;
-
-        UNetTransport m_Transport;
-
-        GUIStyle m_LabelTextStyle;
+        private NetworkManager m_NetworkManager;
+        private UNetTransport m_Transport;
+        private GUIStyle m_LabelTextStyle;
 
         // This is needed to make the port field more convenient. GUILayout.TextField is very limited and we want to be able to clear the field entirely so we can't cache this as ushort.
-        string m_PortString;
+        private string m_PortString;
 
         public Vector2 DrawOffset = new Vector2(10, 10);
 
         public Color LabelColor = Color.black;
 
-        void Awake()
+        private void Awake()
         {
             // Only cache networking manager but not transport here because transport could change anytime.
             m_NetworkManager = GetComponent<NetworkManager>();
             m_LabelTextStyle = new GUIStyle(GUIStyle.none);
         }
 
-        void OnGUI()
+        private void OnGUI()
         {
             m_LabelTextStyle.normal.textColor = LabelColor;
 
@@ -54,7 +52,7 @@ namespace TestProject.ManualTests
             GUILayout.EndArea();
         }
 
-        void DrawConnectGUI()
+        private void DrawConnectGUI()
         {
             GUILayout.BeginHorizontal();
             GUILayout.Space(10);
@@ -94,7 +92,7 @@ namespace TestProject.ManualTests
             GUILayout.EndHorizontal();
         }
 
-        void DrawStatusGUI()
+        private void DrawStatusGUI()
         {
             if (m_NetworkManager.IsServer)
             {
@@ -115,7 +113,7 @@ namespace TestProject.ManualTests
                 {
                     m_NetworkManager.StopHost();
                 }
-                else if(m_NetworkManager.IsServer)
+                else if (m_NetworkManager.IsServer)
                 {
                     m_NetworkManager.StopServer();
                 }
@@ -125,8 +123,8 @@ namespace TestProject.ManualTests
                 }
             }
         }
-        
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        bool IsRunning(NetworkManager networkManager) => networkManager.IsServer || networkManager.IsClient;
+        private bool IsRunning(NetworkManager networkManager) => networkManager.IsServer || networkManager.IsClient;
     }
 }

--- a/testproject/Assets/Tests/Manual/Scripts/PlayerMovementManager.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/PlayerMovementManager.cs
@@ -23,7 +23,7 @@ namespace TestProject.ManualTests
         {
             m_NetworkedObject = GetComponent<NetworkObject>();
             m_RandomMovement = GetComponent<RandomMovement>();
-         
+
         }
 
         public override void OnNetworkSpawn()

--- a/testproject/Assets/Tests/Runtime/FixedUpdateMessagesAreOnlyProcessedOnceTest.cs
+++ b/testproject/Assets/Tests/Runtime/FixedUpdateMessagesAreOnlyProcessedOnceTest.cs
@@ -1,4 +1,3 @@
-﻿using System;
 using System.Collections;
 using MLAPI;
 using MLAPI.Configuration;
@@ -13,7 +12,7 @@ namespace TestProject.RuntimeTests
     public class FixedUpdateMessagesAreOnlyProcessedOnceTest
     {
         private GameObject m_Prefab;
-        private int m_originalFrameRate;
+        private int m_OriginalFrameRate;
 
 
         [UnityTearDown]
@@ -23,19 +22,19 @@ namespace TestProject.RuntimeTests
             if (m_Prefab)
             {
                 MultiInstanceHelpers.Destroy();
-                UnityEngine.Object.Destroy(m_Prefab);
+                Object.Destroy(m_Prefab);
                 m_Prefab = null;
-                Support.SpawnRpcDespawn.ClientUpdateCount = 0;
-                Support.SpawnRpcDespawn.ServerUpdateCount = 0;
-                Application.targetFrameRate = m_originalFrameRate;
+                SpawnRpcDespawn.ClientUpdateCount = 0;
+                SpawnRpcDespawn.ServerUpdateCount = 0;
+                Application.targetFrameRate = m_OriginalFrameRate;
             }
             yield break;
         }
-        
+
         [UnitySetUp]
         public IEnumerator Setup()
         {
-            m_originalFrameRate = Application.targetFrameRate;
+            m_OriginalFrameRate = Application.targetFrameRate;
             yield break;
         }
 
@@ -43,13 +42,13 @@ namespace TestProject.RuntimeTests
         public IEnumerator TestFixedUpdateMessagesAreOnlyProcessedOnce()
         {
             NetworkUpdateStage testStage = NetworkUpdateStage.FixedUpdate;
-            
+
             // Must be 1 for this test.
             const int numClients = 1;
             Assert.True(MultiInstanceHelpers.Create(numClients, out NetworkManager server, out NetworkManager[] clients));
             m_Prefab = new GameObject("Object");
             m_Prefab.AddComponent<SpawnRpcDespawn>();
-            Support.SpawnRpcDespawn.TestStage = testStage;
+            SpawnRpcDespawn.TestStage = testStage;
             var networkObject = m_Prefab.AddComponent<NetworkObject>();
 
             // Make it a prefab
@@ -85,17 +84,17 @@ namespace TestProject.RuntimeTests
             // Setting targetFrameRate to 1 will cause FixedUpdate to get called multiple times.
             // We should only see ClientUpdateCount increment once because only one RPC is being sent.
             Application.targetFrameRate = 1;
-            GameObject serverObject = GameObject.Instantiate(m_Prefab, Vector3.zero, Quaternion.identity);
+            var serverObject = Object.Instantiate(m_Prefab, Vector3.zero, Quaternion.identity);
             NetworkObject serverNetworkObject = serverObject.GetComponent<NetworkObject>();
             serverNetworkObject.NetworkManagerOwner = server;
             SpawnRpcDespawn srdComponent = serverObject.GetComponent<SpawnRpcDespawn>();
             srdComponent.Activate();
 
             // Wait until all objects have spawned.
-            int expectedCount = Support.SpawnRpcDespawn.ClientUpdateCount + 1;
+            int expectedCount = SpawnRpcDespawn.ClientUpdateCount + 1;
             const int maxFrames = 240;
             var doubleCheckTime = Time.realtimeSinceStartup + 1.0f;
-            while (Support.SpawnRpcDespawn.ClientUpdateCount < expectedCount)
+            while (SpawnRpcDespawn.ClientUpdateCount < expectedCount)
             {
                 if (Time.frameCount > maxFrames)
                 {
@@ -111,8 +110,8 @@ namespace TestProject.RuntimeTests
                 yield return new WaitUntil(() => Time.frameCount >= nextFrameNumber);
             }
 
-            Assert.AreEqual(testStage, Support.SpawnRpcDespawn.StageExecutedByReceiver);
-            Assert.AreEqual(Support.SpawnRpcDespawn.ServerUpdateCount, Support.SpawnRpcDespawn.ClientUpdateCount);
+            Assert.AreEqual(testStage, SpawnRpcDespawn.StageExecutedByReceiver);
+            Assert.AreEqual(SpawnRpcDespawn.ServerUpdateCount, SpawnRpcDespawn.ClientUpdateCount);
             Assert.True(handler.WasSpawned);
             var lastFrameNumber = Time.frameCount + 1;
             yield return new WaitUntil(() => Time.frameCount >= lastFrameNumber);

--- a/testproject/Assets/Tests/Runtime/MessageOrdering.cs
+++ b/testproject/Assets/Tests/Runtime/MessageOrdering.cs
@@ -1,4 +1,3 @@
-﻿using System;
 using System.Collections;
 using MLAPI;
 using MLAPI.Configuration;
@@ -22,7 +21,7 @@ namespace TestProject.RuntimeTests
             if (m_Prefab)
             {
                 MultiInstanceHelpers.Destroy();
-                UnityEngine.Object.Destroy(m_Prefab);
+                Object.Destroy(m_Prefab);
                 m_Prefab = null;
                 Support.SpawnRpcDespawn.ClientUpdateCount = 0;
                 Support.SpawnRpcDespawn.ServerUpdateCount = 0;
@@ -63,7 +62,7 @@ namespace TestProject.RuntimeTests
             yield return MultiInstanceHelpers.Run(
                 MultiInstanceHelpers.WaitForClientsConnectedToServer(server, clients.Length + 1, null, 512));
 
-            GameObject serverObject = GameObject.Instantiate(m_Prefab, Vector3.zero, Quaternion.identity);
+            var serverObject = Object.Instantiate(m_Prefab, Vector3.zero, Quaternion.identity);
             NetworkObject serverNetworkObject = serverObject.GetComponent<NetworkObject>();
             serverNetworkObject.NetworkManagerOwner = server;
             serverNetworkObject.Spawn();
@@ -73,7 +72,7 @@ namespace TestProject.RuntimeTests
             const int expectedNetworkObjects = numClients + 2; // +2 = one for prefab, one for server.
             const int maxFrames = 240;
             var doubleCheckTime = Time.realtimeSinceStartup + 10.0f;
-            while (GameObject.FindObjectsOfType<NetworkObject>().Length != expectedNetworkObjects)
+            while (Object.FindObjectsOfType<NetworkObject>().Length != expectedNetworkObjects)
             {
                 if (Time.frameCount > maxFrames)
                 {
@@ -91,7 +90,7 @@ namespace TestProject.RuntimeTests
         }
 
         [UnityTest]
-        public IEnumerator SpawnRpcDespawn([Values]NetworkUpdateStage testStage)
+        public IEnumerator SpawnRpcDespawn([Values] NetworkUpdateStage testStage)
         {
             // Neither of these is supported for sending RPCs.
             if (testStage == NetworkUpdateStage.Unset || testStage == NetworkUpdateStage.Initialization)
@@ -136,7 +135,7 @@ namespace TestProject.RuntimeTests
             yield return MultiInstanceHelpers.Run(
                 MultiInstanceHelpers.WaitForClientsConnectedToServer(server, clients.Length + 1, null, 512));
 
-            GameObject serverObject = GameObject.Instantiate(m_Prefab, Vector3.zero, Quaternion.identity);
+            var serverObject = Object.Instantiate(m_Prefab, Vector3.zero, Quaternion.identity);
             NetworkObject serverNetworkObject = serverObject.GetComponent<NetworkObject>();
             serverNetworkObject.NetworkManagerOwner = server;
             SpawnRpcDespawn srdComponent = serverObject.GetComponent<SpawnRpcDespawn>();

--- a/testproject/Assets/Tests/Runtime/RpcTestsAutomated.cs
+++ b/testproject/Assets/Tests/Runtime/RpcTestsAutomated.cs
@@ -63,11 +63,11 @@ namespace TestProject.RuntimeTests
             // Set RpcQueueManualTests into unit testing mode
             RpcQueueManualTests.UnitTesting = true;
 
-            yield return StartSomeClientsAndServerWithPlayers(useHost:true, numClients, playerPrefab =>
-            {
-                // Add our RpcQueueManualTests component
-                playerPrefab.AddComponent<RpcQueueManualTests>();
-            });
+            yield return StartSomeClientsAndServerWithPlayers(useHost: true, numClients, playerPrefab =>
+             {
+                 // Add our RpcQueueManualTests component
+                 playerPrefab.AddComponent<RpcQueueManualTests>();
+             });
 
             // Set the RPC Batch sending mode
             m_ServerNetworkManager.MessageQueueContainer.EnableBatchedMessages(useBatching);

--- a/testproject/Assets/Tests/Runtime/Support/SpawnRpcDespawn.cs
+++ b/testproject/Assets/Tests/Runtime/Support/SpawnRpcDespawn.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using MLAPI;

--- a/testproject/Assets/Tests/Runtime/Support/SpawnRpcDespawnInstanceHandler.cs
+++ b/testproject/Assets/Tests/Runtime/Support/SpawnRpcDespawnInstanceHandler.cs
@@ -53,7 +53,7 @@ namespace TestProject.RuntimeTests.Support
             }
 
             // Otherwise, instantiate an instance of the NetworkPrefab linked to the prefabHash
-            var networkObject =  Object.Instantiate(networkPrefabReference, position, rotation).GetComponent<NetworkObject>();
+            var networkObject = Object.Instantiate(networkPrefabReference, position, rotation).GetComponent<NetworkObject>();
 
             return networkObject;
         }


### PR DESCRIPTION
Let's run standards check over all C# projects including TestProject and asmdefs under TestProject as well.
All the file changes are either done by standards script or fixed after standards check complaints.