### PR TITLE
refactor!: remove spawn payload technical debt

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviour.cs
@@ -316,21 +316,12 @@ namespace MLAPI
         public ulong OwnerClientId => NetworkObject.OwnerClientId;
 
         /// <summary>
-        /// Gets called when message handlers are ready to be registered and the network is setup
+        /// Gets called when the <see cref="MLAPI.NetworkObject"/> gets spawned, message handlers are ready to be registered and the network is setup.
         /// </summary>
         public virtual void OnNetworkSpawn() { }
 
         /// <summary>
-        /// Gets called when the <see cref="NetworkObject"/> gets spawned, message handlers are ready to be registered and the network is setup. Provides a Payload if it was provided
-        /// </summary>
-        /// <param name="stream">The stream containing the spawn payload</param>
-        internal void NetworkSpawn()
-        {
-            OnNetworkSpawn();
-        }
-
-        /// <summary>
-        /// Gets called when the <see cref="NetworkObject"/> gets de-spawned. Is called both on the server and clients.
+        /// Gets called when the <see cref="MLAPI.NetworkObject"/> gets despawned. Is called both on the server and clients.
         /// </summary>
         public virtual void OnNetworkDespawn() { }
 

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkBehaviour.cs
@@ -324,7 +324,7 @@ namespace MLAPI
         /// Gets called when the <see cref="NetworkObject"/> gets spawned, message handlers are ready to be registered and the network is setup. Provides a Payload if it was provided
         /// </summary>
         /// <param name="stream">The stream containing the spawn payload</param>
-        public virtual void OnNetworkSpawn(Stream stream)
+        internal void NetworkSpawn()
         {
             OnNetworkSpawn();
         }

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkManager.cs
@@ -1415,7 +1415,7 @@ namespace MLAPI
                 if (createPlayerObject)
                 {
                     var networkObject = SpawnManager.CreateLocalNetworkObject(false, playerPrefabHash ?? NetworkConfig.PlayerPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash, ownerClientId, null, position, rotation);
-                    SpawnManager.SpawnNetworkObjectLocally(networkObject, SpawnManager.GetNetworkObjectId(), false, true, ownerClientId, null, false, 0, false, false);
+                    SpawnManager.SpawnNetworkObjectLocally(networkObject, SpawnManager.GetNetworkObjectId(), false, true, ownerClientId, null, false, false);
 
                     ConnectedClients[ownerClientId].PlayerObject = networkObject;
                 }

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
@@ -3,12 +3,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using MLAPI.Configuration;
 using MLAPI.Exceptions;
 using MLAPI.Hashing;
 using MLAPI.Logging;
 using MLAPI.Messaging;
-using MLAPI.Serialization.Pooled;
 using MLAPI.Transports;
 using MLAPI.Serialization;
 using UnityEngine;
@@ -222,10 +220,9 @@ namespace MLAPI
         }
 
         /// <summary>
-        /// Shows a previously hidden object to a client
+        /// Shows a previously hidden <see cref="NetworkObject"/> to a client
         /// </summary>
-        /// <param name="clientId">The client to show the object to</param>
-        /// <param name="payload">An optional payload to send as part of the spawn</param>
+        /// <param name="clientId">The client to show the <see cref="NetworkObject"/> to</param>
         public void NetworkShow(ulong clientId)
         {
             if (!IsSpawned)
@@ -249,11 +246,10 @@ namespace MLAPI
         }
 
         /// <summary>
-        /// Shows a list of previously hidden objects to a client
+        /// Shows a list of previously hidden <see cref="NetworkObject"/>s to a client
         /// </summary>
-        /// <param name="networkObjects">The objects to show</param>
+        /// <param name="networkObjects">The <see cref="NetworkObject"/>s to show</param>
         /// <param name="clientId">The client to show the objects to</param>
-        /// <param name="payload">An optional payload to send as part of the spawns</param>
         public static void NetworkShow(List<NetworkObject> networkObjects, ulong clientId)
         {
             if (networkObjects == null || networkObjects.Count == 0)
@@ -453,9 +449,8 @@ namespace MLAPI
         }
 
         /// <summary>
-        /// Spawns this GameObject across the network. Can only be called from the Server
+        /// Spawns this <see cref="NetworkObject"/> across the network. Can only be called from the Server
         /// </summary>
-        /// <param name="spawnPayload">The writer containing the spawn payload</param>
         /// <param name="destroyWithScene">Should the object be destroyed when the scene is changed</param>
         public void Spawn(bool destroyWithScene = false)
         {
@@ -463,21 +458,19 @@ namespace MLAPI
         }
 
         /// <summary>
-        /// Spawns an object across the network with a given owner. Can only be called from server
+        /// Spawns a <see cref="NetworkObject"/> across the network with a given owner. Can only be called from server
         /// </summary>
         /// <param name="clientId">The clientId to own the object</param>
-        /// <param name="spawnPayload">The writer containing the spawn payload</param>
-        /// <param name="destroyWithScene">Should the object be destroyd when the scene is changed</param>
+        /// <param name="destroyWithScene">Should the object be destroyed when the scene is changed</param>
         public void SpawnWithOwnership(ulong clientId, bool destroyWithScene = false)
         {
             SpawnInternal(destroyWithScene, clientId, false);
         }
 
         /// <summary>
-        /// Spawns an object across the network and makes it the player object for the given client
+        /// Spawns a <see cref="NetworkObject"/> across the network and makes it the player object for the given client
         /// </summary>
         /// <param name="clientId">The clientId whos player object this is</param>
-        /// <param name="spawnPayload">The writer containing the spawn payload</param>
         /// <param name="destroyWithScene">Should the object be destroyd when the scene is changed</param>
         public void SpawnAsPlayerObject(ulong clientId, bool destroyWithScene = false)
         {
@@ -781,7 +774,7 @@ namespace MLAPI
             for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
             {
                 ChildNetworkBehaviours[i].InternalOnNetworkSpawn();
-                ChildNetworkBehaviours[i].NetworkSpawn();
+                ChildNetworkBehaviours[i].OnNetworkSpawn();
             }
         }
 

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
@@ -164,9 +164,6 @@ namespace MLAPI.Messaging
 
                 var (isReparented, latestParent) = NetworkObject.ReadNetworkParenting(reader);
 
-                var hasPayload = reader.ReadBool();
-                var payLoadLength = hasPayload ? reader.ReadInt32Packed() : 0;
-
                 var networkObject = NetworkManager.SpawnManager.CreateLocalNetworkObject(softSync, prefabHash, ownerClientId, parentNetworkId, pos, rot, isReparented);
                 networkObject.SetNetworkParenting(isReparented, latestParent);
                 NetworkManager.SpawnManager.SpawnNetworkObjectLocally(networkObject, networkId, softSync, isPlayerObject, ownerClientId, stream, true, false);

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
@@ -169,7 +169,7 @@ namespace MLAPI.Messaging
 
                 var networkObject = NetworkManager.SpawnManager.CreateLocalNetworkObject(softSync, prefabHash, ownerClientId, parentNetworkId, pos, rot, isReparented);
                 networkObject.SetNetworkParenting(isReparented, latestParent);
-                NetworkManager.SpawnManager.SpawnNetworkObjectLocally(networkObject, networkId, softSync, isPlayerObject, ownerClientId, stream, hasPayload, payLoadLength, true, false);
+                NetworkManager.SpawnManager.SpawnNetworkObjectLocally(networkObject, networkId, softSync, isPlayerObject, ownerClientId, stream, true, false);
             }
         }
 

--- a/com.unity.multiplayer.mlapi/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -346,7 +346,7 @@ namespace MLAPI.SceneManagement
             {
                 if (!keyValuePair.Value.IsPlayerObject)
                 {
-                    m_NetworkManager.SpawnManager.SpawnNetworkObjectLocally(keyValuePair.Value, m_NetworkManager.SpawnManager.GetNetworkObjectId(), true, false, null, null, false, 0, false, true);
+                    m_NetworkManager.SpawnManager.SpawnNetworkObjectLocally(keyValuePair.Value, m_NetworkManager.SpawnManager.GetNetworkObjectId(), true, false, null, null, false, true);
                 }
             }
 

--- a/testproject/Assets/Tests/Manual/Scripts/NetworkPrefabPool.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/NetworkPrefabPool.cs
@@ -350,7 +350,7 @@ namespace TestProject.ManualTests
                                 var no = go.GetComponent<NetworkObject>();
                                 if (!no.IsSpawned)
                                 {
-                                    no.Spawn(null, true);
+                                    no.Spawn(true);
                                 }
                             }
                         }

--- a/testproject/Assets/Tests/Manual/Scripts/StatsDisplay.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/StatsDisplay.cs
@@ -66,7 +66,7 @@ namespace TestProject.ManualTests
                 var networkObject = GetComponent<NetworkObject>();
                 if (networkObject != null)
                 {
-                    networkObject.SpawnWithOwnership(clientId, null, true);
+                    networkObject.SpawnWithOwnership(clientId, true);
                 }
             }
         }


### PR DESCRIPTION
This PR remove the option to send a payload when spawning an object.
The primary reason for this is that we do not save the payload data on a per NetworkObject instance basis and if a user were to use the spawn payload parameter that included data that was required to set any specific states of a NetworkObject or associated components then late joining players would not receive the payload information and would become out of sych with the game.

Associated Jira Technical Debt Ticket: [MTT-982](https://jira.unity3d.com/browse/MTT-982)

