### PR TITLE
fix: rename Finalize to Cleanup on InternalCommandContext due to CS0465 compiler warning

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalCommandContext.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalCommandContext.cs
@@ -25,10 +25,10 @@ namespace Unity.Multiplayer.Netcode.Messaging
 
         public void Dispose()
         {
-            Finalize();
+            Cleanup();
         }
 
-        public void Finalize()
+        public void Cleanup()
         {
             if (m_Owner.NetworkManager.IsHost)
             {


### PR DESCRIPTION
a simple fix, please see [CS0465](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0465) here (non-virtual method also makes compiler throw the same warning).