### PR TITLE
fix: do not expose Runtime internals to TestProject.ManualTests asmdef

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/AssemblyInfo.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/AssemblyInfo.cs
@@ -7,5 +7,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Unity.Multiplayer.MLAPI.Editor")]
 [assembly: InternalsVisibleTo("TestProject.EditorTests")]
 [assembly: InternalsVisibleTo("TestProject.RuntimeTests")]
-[assembly: InternalsVisibleTo("TestProject.ManualTests")]
 #endif

--- a/testproject/Assets/Tests/Manual/Scripts/StatsDisplay.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/StatsDisplay.cs
@@ -110,11 +110,11 @@ namespace TestProject.ManualTests
         /// </summary>
         /// <param name="statsinfo"></param>
         [ClientRpc]
-        private void ReceiveStatsClientRPC(StatsInfoContainer statsinfo)
+        private void ReceiveStatsClientRpc(StatsInfoContainer statsinfo)
         {
             m_LastStatsDump = "Server Stats";
             m_LastStatsDump += "\ndeltaTime: [" + Time.deltaTime.ToString() + "]";
-            if (ProfilerStatManager.AllStats.Count != statsinfo.StatValues.Count)
+            /* if (ProfilerStatManager.AllStats.Count != statsinfo.StatValues.Count)
             {
                 Debug.LogError("[StatsDisplay-Error][Mismatch] Recieved " + statsinfo.StatValues.Count.ToString() + " values and have " + ProfilerStatManager.AllStats.Count.ToString() + " profiler stats entries!");
             }
@@ -130,7 +130,7 @@ namespace TestProject.ManualTests
                     m_LastStatsDump += p.PrettyPrintName + ": " + statsinfo.StatValues[statsCounter].ToString(("0.0"));
                     statsCounter++;
                 }
-            }
+            } */
         }
 
         /// <summary>
@@ -164,24 +164,24 @@ namespace TestProject.ManualTests
                     {
                         m_LastStatsDump = m_IsServer ? "Server Stats" : "Client Stats";
                         m_LastStatsDump += "\ndeltaTime: [" + Time.deltaTime.ToString() + "]";
-                        foreach (ProfilerStat p in ProfilerStatManager.AllStats)
+                        /* foreach (ProfilerStat p in ProfilerStatManager.AllStats)
                         {
                             if (m_LastStatsDump != string.Empty)
                             {
                                 m_LastStatsDump += "\n";
                             }
                             m_LastStatsDump += p.PrettyPrintName + ": " + p.SampleRate().ToString("0.0");
-                        }
+                        } */
                     }
                     if (NetworkManager.Singleton.IsServer && m_ClientsToUpdate.Count > 0)
                     {
                         var statsInfoContainer = new StatsInfoContainer();
                         statsInfoContainer.StatValues = new List<float>();
-                        foreach (ProfilerStat p in ProfilerStatManager.AllStats)
+                        /* foreach (ProfilerStat p in ProfilerStatManager.AllStats)
                         {
                             statsInfoContainer.StatValues.Add(p.SampleRate());
-                        }
-                        ReceiveStatsClientRPC(statsInfoContainer);
+                        } */
+                        ReceiveStatsClientRpc(statsInfoContainer);
                     }
                 }
                 yield return new WaitForSeconds(0.5f);


### PR DESCRIPTION
let's not expose runtime internals to TestProject.ManualTests because we'll not be able to use them targeting standalone builds.