### PR TITLE
chore: run standards check over solution files

### DIFF
--- a/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Runtime/NetworkVariableTests.cs
@@ -31,15 +31,15 @@ public class TestClass : INetworkSerializable
 public class NetworkVariableTest : NetworkBehaviour
 {
     public readonly NetworkList<int> TheList = new NetworkList<int>(
-        new NetworkVariableSettings {WritePermission = NetworkVariablePermission.ServerOnly}
+        new NetworkVariableSettings { WritePermission = NetworkVariablePermission.ServerOnly }
     );
 
     public readonly NetworkSet<int> TheSet = new NetworkSet<int>(
-        new NetworkVariableSettings {WritePermission = NetworkVariablePermission.ServerOnly}
+        new NetworkVariableSettings { WritePermission = NetworkVariablePermission.ServerOnly }
     );
 
     public readonly NetworkDictionary<int, int> TheDictionary = new NetworkDictionary<int, int>(
-        new NetworkVariableSettings {WritePermission = NetworkVariablePermission.ServerOnly}
+        new NetworkVariableSettings { WritePermission = NetworkVariablePermission.ServerOnly }
     );
 
     private void ListChanged(NetworkListEvent<int> e)
@@ -425,7 +425,7 @@ namespace Unity.Netcode.RuntimeTests
                 () =>
                 {
                     m_ServerComp.TheStruct.Value =
-                        new TestStruct() {SomeInt = k_TestUInt, SomeBool = false};
+                        new TestStruct() { SomeInt = k_TestUInt, SomeBool = false };
                     m_ServerComp.TheStruct.SetDirty(true);
                 },
                 () =>

--- a/standards.py
+++ b/standards.py
@@ -18,7 +18,7 @@ parser.add_argument("--yamato", action="store_true")
 
 parser.add_argument("--tool-path", default="dotnet-format")
 parser.add_argument("--project-path", default="testproject")
-parser.add_argument("--project-glob", default="*.csproj")
+parser.add_argument("--project-glob", default="*.sln")
 
 if len(sys.argv) == 1:
     parser.print_help(sys.stderr)


### PR DESCRIPTION
we're already running standards check over all `*.csproj` files.
running it over `*.sln` (`testproject.sln` for now) makes it faster and more error resilient.