### PR TITLE
refactor: calling networkShow(NetworkObject) code in networkshow(List<NetworkObject>)

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
@@ -278,7 +278,7 @@ namespace Unity.Netcode
                 }
             }
 
-            foreach(var networkObject in networkObjects)
+            foreach (var networkObject in networkObjects)
             {
                 networkObject.NetworkShow(clientId);
             }

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
@@ -278,25 +278,9 @@ namespace Unity.Netcode
                 }
             }
 
-
-            var context = networkManager.MessageQueueContainer.EnterInternalCommandContext(
-                MessageQueueContainer.MessageType.CreateObjects, NetworkChannel.Internal,
-                new[] { clientId }, NetworkUpdateLoop.UpdateStage);
-
-            if (context != null)
+            foreach(var networkObject in networkObjects)
             {
-                using (var nonNullContext = (InternalCommandContext)context)
-                {
-                    nonNullContext.NetworkWriter.WriteUInt16Packed((ushort)networkObjects.Count);
-
-                    for (int i = 0; i < networkObjects.Count; i++)
-                    {
-                        networkObjects[i].Observers.Add(clientId);
-
-                        networkManager.SpawnManager.WriteSpawnCallForObject(nonNullContext.NetworkWriter, clientId,
-                            networkObjects[i]);
-                    }
-                }
+                networkObject.NetworkShow(clientId);
             }
         }
 

--- a/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Core/NetworkObject.cs
@@ -369,23 +369,9 @@ namespace Unity.Netcode
                 }
             }
 
-            var context = networkManager.MessageQueueContainer.EnterInternalCommandContext(
-                MessageQueueContainer.MessageType.DestroyObjects, NetworkChannel.Internal,
-                new[] { clientId }, NetworkUpdateStage.PostLateUpdate);
-            if (context != null)
+            foreach (var networkObject in networkObjects)
             {
-                using (var nonNullContext = (InternalCommandContext)context)
-                {
-                    nonNullContext.NetworkWriter.WriteUInt16Packed((ushort)networkObjects.Count);
-
-                    for (int i = 0; i < networkObjects.Count; i++)
-                    {
-                        // Send destroy call
-                        networkObjects[i].Observers.Remove(clientId);
-
-                        nonNullContext.NetworkWriter.WriteUInt64Packed(networkObjects[i].NetworkObjectId);
-                    }
-                }
+                networkObject.NetworkHide(clientId);
             }
         }
 


### PR DESCRIPTION
instead of calling a deeper-nested function. Make the code more uniform and prepares for incoming snapshot changes