### PR TITLE
feat: Adding channels for those that just want to know what they do.

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Transports/NetworkTransport.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Transports/NetworkTransport.cs
@@ -19,6 +19,11 @@ namespace Unity.Netcode
         NetworkVariable, //todo: this channel will be used for snapshotting and should then go from reliable to unreliable
         SnapshotExchange,
         Fragmented,
+        ReliableSequenced,
+        ReliableUnsequenced,
+        ReliableFragmentedSequenced,
+        UnreliableSequenced,
+        UnreliableUnsequenced,
         ChannelUnused, // <<-- must be present, and must be last
     };
 
@@ -108,6 +113,12 @@ namespace Unity.Netcode
 
             new TransportChannel(NetworkChannel.Fragmented, NetworkDelivery.ReliableFragmentedSequenced),
 
+            // Channels for those that just want to know exactly what it is
+            new TransportChannel(NetworkChannel.UnreliableSequenced, NetworkDelivery.UnreliableSequenced),
+            new TransportChannel(NetworkChannel.UnreliableUnsequenced, NetworkDelivery.Unreliable),
+            new TransportChannel(NetworkChannel.ReliableSequenced, NetworkDelivery.ReliableSequenced),
+            new TransportChannel(NetworkChannel.ReliableUnsequenced, NetworkDelivery.Reliable),
+            new TransportChannel(NetworkChannel.ReliableFragmentedSequenced, NetworkDelivery.ReliableFragmentedSequenced),
         };
 
         /// <summary>


### PR DESCRIPTION
I didn't want to create an RFC for this, but I was looking for this since the beginning of me using MLAPI and I figured I'd add this. I'm open to discussion.
I always wanted to directly set my channel type without having to rely on some names I didn't know what they did.
I feel this would help those setting up their custom netvar channels for example into not having to always reverse lookup what that channel actually does.