### PR TITLE
refactor: Snapshot prep. createObjects and destroyObjects dead code

### DIFF
--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/IInternalMessageHandler.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/IInternalMessageHandler.cs
@@ -12,7 +12,6 @@ namespace Unity.Netcode
         void HandleSwitchScene(ulong clientId, Stream stream);
         void HandleClientSwitchSceneCompleted(ulong clientId, Stream stream);
         void HandleChangeOwner(ulong clientId, Stream stream);
-        void HandleAddObjects(ulong clientId, Stream stream);
         void HandleDestroyObjects(ulong clientId, Stream stream);
         void HandleTimeSync(ulong clientId, Stream stream);
         void HandleNetworkVariableDelta(ulong clientId, Stream stream);

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/IInternalMessageHandler.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/IInternalMessageHandler.cs
@@ -12,7 +12,6 @@ namespace Unity.Netcode
         void HandleSwitchScene(ulong clientId, Stream stream);
         void HandleClientSwitchSceneCompleted(ulong clientId, Stream stream);
         void HandleChangeOwner(ulong clientId, Stream stream);
-        void HandleDestroyObjects(ulong clientId, Stream stream);
         void HandleTimeSync(ulong clientId, Stream stream);
         void HandleNetworkVariableDelta(ulong clientId, Stream stream);
         void MessageReceiveQueueItem(ulong clientId, Stream stream, float receiveTime, MessageQueueContainer.MessageType messageType, NetworkChannel receiveChannel);

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
@@ -223,19 +223,6 @@ namespace Unity.Netcode
             }
         }
 
-        public void HandleAddObjects(ulong clientId, Stream stream)
-        {
-            using (var reader = PooledNetworkReader.Get(stream))
-            {
-                ushort objectCount = reader.ReadUInt16Packed();
-
-                for (int i = 0; i < objectCount; i++)
-                {
-                    HandleAddObject(clientId, stream);
-                }
-            }
-        }
-
         public void HandleDestroyObjects(ulong clientId, Stream stream)
         {
             using (var reader = PooledNetworkReader.Get(stream))

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/InternalMessageHandler.cs
@@ -223,19 +223,6 @@ namespace Unity.Netcode
             }
         }
 
-        public void HandleDestroyObjects(ulong clientId, Stream stream)
-        {
-            using (var reader = PooledNetworkReader.Get(stream))
-            {
-                ushort objectCount = reader.ReadUInt16Packed();
-
-                for (int i = 0; i < objectCount; i++)
-                {
-                    HandleDestroyObject(clientId, stream);
-                }
-            }
-        }
-
         public void HandleTimeSync(ulong clientId, Stream stream)
         {
             using (var reader = PooledNetworkReader.Get(stream))

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/MessageQueue/MessageQueueContainer.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/MessageQueue/MessageQueueContainer.cs
@@ -25,7 +25,6 @@ namespace Unity.Netcode
             ServerRpc,
             CreateObject,
             DestroyObject,
-            DestroyObjects,
             ChangeOwner,
             TimeSync,
             UnnamedMessage,

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/MessageQueue/MessageQueueContainer.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/MessageQueue/MessageQueueContainer.cs
@@ -24,7 +24,6 @@ namespace Unity.Netcode
             ClientRpc,
             ServerRpc,
             CreateObject,
-            CreateObjects,
             DestroyObject,
             DestroyObjects,
             ChangeOwner,

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/MessageQueue/MessageQueueProcessor.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/MessageQueue/MessageQueueProcessor.cs
@@ -68,13 +68,6 @@ namespace Unity.Netcode
                         }
 
                         break;
-                    case MessageQueueContainer.MessageType.CreateObjects:
-                        if (m_NetworkManager.IsClient)
-                        {
-                            m_NetworkManager.MessageHandler.HandleAddObjects(item.NetworkId, item.NetworkBuffer);
-                        }
-
-                        break;
                     case MessageQueueContainer.MessageType.DestroyObject:
                         if (m_NetworkManager.IsClient)
                         {

--- a/com.unity.multiplayer.mlapi/Runtime/Messaging/MessageQueue/MessageQueueProcessor.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Messaging/MessageQueue/MessageQueueProcessor.cs
@@ -75,13 +75,6 @@ namespace Unity.Netcode
                         }
 
                         break;
-                    case MessageQueueContainer.MessageType.DestroyObjects:
-                        if (m_NetworkManager.IsClient)
-                        {
-                            m_NetworkManager.MessageHandler.HandleDestroyObjects(item.NetworkId, item.NetworkBuffer);
-                        }
-
-                        break;
                     case MessageQueueContainer.MessageType.ChangeOwner:
                         if (m_NetworkManager.IsClient)
                         {

--- a/com.unity.multiplayer.mlapi/Runtime/Profiling/InternalMessageHandlerProfilingDecorator.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Profiling/InternalMessageHandlerProfilingDecorator.cs
@@ -12,7 +12,6 @@ namespace Unity.Netcode
         private readonly ProfilerMarker m_HandleSwitchScene = new ProfilerMarker($"{nameof(InternalMessageHandler)}.{nameof(HandleSwitchScene)}");
         private readonly ProfilerMarker m_HandleClientSwitchSceneCompleted = new ProfilerMarker($"{nameof(InternalMessageHandler)}.{nameof(HandleClientSwitchSceneCompleted)}");
         private readonly ProfilerMarker m_HandleChangeOwner = new ProfilerMarker($"{nameof(InternalMessageHandler)}.{nameof(HandleChangeOwner)}");
-        private readonly ProfilerMarker m_HandleDestroyObjects = new ProfilerMarker($"{nameof(InternalMessageHandler)}.{nameof(HandleDestroyObjects)}");
         private readonly ProfilerMarker m_HandleTimeSync = new ProfilerMarker($"{nameof(InternalMessageHandler)}.{nameof(HandleTimeSync)}");
         private readonly ProfilerMarker m_HandleNetworkVariableDelta = new ProfilerMarker($"{nameof(InternalMessageHandler)}.{nameof(HandleNetworkVariableDelta)}");
         private readonly ProfilerMarker m_HandleUnnamedMessage = new ProfilerMarker($"{nameof(InternalMessageHandler)}.{nameof(HandleUnnamedMessage)}");
@@ -93,15 +92,6 @@ namespace Unity.Netcode
             m_MessageHandler.HandleChangeOwner(clientId, stream);
 
             m_HandleChangeOwner.End();
-        }
-
-        public void HandleDestroyObjects(ulong clientId, Stream stream)
-        {
-            m_HandleDestroyObjects.Begin();
-
-            m_MessageHandler.HandleDestroyObjects(clientId, stream);
-
-            m_HandleDestroyObjects.End();
         }
 
         public void HandleTimeSync(ulong clientId, Stream stream)

--- a/com.unity.multiplayer.mlapi/Runtime/Profiling/InternalMessageHandlerProfilingDecorator.cs
+++ b/com.unity.multiplayer.mlapi/Runtime/Profiling/InternalMessageHandlerProfilingDecorator.cs
@@ -12,7 +12,6 @@ namespace Unity.Netcode
         private readonly ProfilerMarker m_HandleSwitchScene = new ProfilerMarker($"{nameof(InternalMessageHandler)}.{nameof(HandleSwitchScene)}");
         private readonly ProfilerMarker m_HandleClientSwitchSceneCompleted = new ProfilerMarker($"{nameof(InternalMessageHandler)}.{nameof(HandleClientSwitchSceneCompleted)}");
         private readonly ProfilerMarker m_HandleChangeOwner = new ProfilerMarker($"{nameof(InternalMessageHandler)}.{nameof(HandleChangeOwner)}");
-        private readonly ProfilerMarker m_HandleAddObjects = new ProfilerMarker($"{nameof(InternalMessageHandler)}.{nameof(HandleAddObjects)}");
         private readonly ProfilerMarker m_HandleDestroyObjects = new ProfilerMarker($"{nameof(InternalMessageHandler)}.{nameof(HandleDestroyObjects)}");
         private readonly ProfilerMarker m_HandleTimeSync = new ProfilerMarker($"{nameof(InternalMessageHandler)}.{nameof(HandleTimeSync)}");
         private readonly ProfilerMarker m_HandleNetworkVariableDelta = new ProfilerMarker($"{nameof(InternalMessageHandler)}.{nameof(HandleNetworkVariableDelta)}");
@@ -94,15 +93,6 @@ namespace Unity.Netcode
             m_MessageHandler.HandleChangeOwner(clientId, stream);
 
             m_HandleChangeOwner.End();
-        }
-
-        public void HandleAddObjects(ulong clientId, Stream stream)
-        {
-            m_HandleAddObjects.Begin();
-
-            m_MessageHandler.HandleAddObjects(clientId, stream);
-
-            m_HandleAddObjects.End();
         }
 
         public void HandleDestroyObjects(ulong clientId, Stream stream)

--- a/com.unity.multiplayer.mlapi/Tests/Editor/DummyMessageHandler.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/DummyMessageHandler.cs
@@ -26,8 +26,6 @@ namespace Unity.Netcode.EditorTests
 
         public void HandleChangeOwner(ulong clientId, Stream stream) => VerifyCalled(nameof(HandleChangeOwner));
 
-        public void HandleAddObjects(ulong clientId, Stream stream) => VerifyCalled(nameof(HandleAddObjects));
-
         public void HandleDestroyObjects(ulong clientId, Stream stream) => VerifyCalled(nameof(HandleDestroyObjects));
 
         public void HandleTimeSync(ulong clientId, Stream stream) => VerifyCalled(nameof(HandleTimeSync));

--- a/com.unity.multiplayer.mlapi/Tests/Editor/DummyMessageHandler.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/DummyMessageHandler.cs
@@ -26,8 +26,6 @@ namespace Unity.Netcode.EditorTests
 
         public void HandleChangeOwner(ulong clientId, Stream stream) => VerifyCalled(nameof(HandleChangeOwner));
 
-        public void HandleDestroyObjects(ulong clientId, Stream stream) => VerifyCalled(nameof(HandleDestroyObjects));
-
         public void HandleTimeSync(ulong clientId, Stream stream) => VerifyCalled(nameof(HandleTimeSync));
 
         public void HandleNetworkVariableDelta(ulong clientId, Stream stream) => VerifyCalled(nameof(HandleNetworkVariableDelta));

--- a/com.unity.multiplayer.mlapi/Tests/Editor/NetworkManagerMessageHandlerTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/NetworkManagerMessageHandlerTests.cs
@@ -96,14 +96,6 @@ namespace Unity.Netcode.EditorTests
                 // Should not cause log (client only)
                 // Everything should log MessageReceiveQueueItem even if ignored
                 LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.CreateObjects, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
-
-                // Should not cause log (client only)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
                 using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.DestroyObjects, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
                 {
                     networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
@@ -224,15 +216,6 @@ namespace Unity.Netcode.EditorTests
                 LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
                 LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleChangeOwner));
                 using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.ChangeOwner, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
-
-                // Should cause log (client only)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleAddObjects));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.CreateObjects, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
                 {
                     networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
                 }

--- a/com.unity.multiplayer.mlapi/Tests/Editor/NetworkManagerMessageHandlerTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/NetworkManagerMessageHandlerTests.cs
@@ -96,14 +96,6 @@ namespace Unity.Netcode.EditorTests
                 // Should not cause log (client only)
                 // Everything should log MessageReceiveQueueItem even if ignored
                 LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.DestroyObjects, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
-
-                // Should not cause log (client only)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
                 using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.TimeSync, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
                 {
                     networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
@@ -216,15 +208,6 @@ namespace Unity.Netcode.EditorTests
                 LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
                 LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleChangeOwner));
                 using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.ChangeOwner, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
-
-                // Should cause log (client only)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleDestroyObjects));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.DestroyObjects, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
                 {
                     networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
                 }

--- a/com.unity.multiplayer.mlapi/Tests/Editor/Profiling/InternalMessageHandlerProfilingDecoratorTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/Profiling/InternalMessageHandlerProfilingDecoratorTests.cs
@@ -71,14 +71,6 @@ namespace Unity.Netcode.EditorTests
         }
 
         [Test]
-        public void HandleAddObjectsCallsUnderlyingHandler()
-        {
-            m_Decorator.HandleAddObjects(0, null);
-
-            LogAssert.Expect(LogType.Log, nameof(m_Decorator.HandleAddObjects));
-        }
-
-        [Test]
         public void HandleDestroyObjectsCallsUnderlyingHandler()
         {
             m_Decorator.HandleDestroyObjects(0, null);

--- a/com.unity.multiplayer.mlapi/Tests/Editor/Profiling/InternalMessageHandlerProfilingDecoratorTests.cs
+++ b/com.unity.multiplayer.mlapi/Tests/Editor/Profiling/InternalMessageHandlerProfilingDecoratorTests.cs
@@ -71,14 +71,6 @@ namespace Unity.Netcode.EditorTests
         }
 
         [Test]
-        public void HandleDestroyObjectsCallsUnderlyingHandler()
-        {
-            m_Decorator.HandleDestroyObjects(0, null);
-
-            LogAssert.Expect(LogType.Log, nameof(m_Decorator.HandleDestroyObjects));
-        }
-
-        [Test]
         public void HandleNetworkVariableDeltaCallsUnderlyingHandler()
         {
             m_Decorator.HandleNetworkVariableDelta(0, null);


### PR DESCRIPTION
Following networkShow and Hide refactor, the plural version of CreateObjects and DestroyObjects became dead code. I think. Objections to this 96 lines removal ?

All tests still pass.
+ Noel, because discussion on spawns and snapshots
+ Jaedyn, because you touched some of that in message queueing
+ Fatih, well, because I think you like code removal :-)

And most importantly, this simplifies the snapshot task.