### PR TITLE
fix: pull request trigger name does not match the one configured in github branch protections

### DIFF
--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -12,12 +12,18 @@ develop_nightly_trigger:
     - .yamato/code-coverage.yml#code_coverage_win_{{ project.name }}
 {% endfor -%}
     
+# Legacy job that matches the name with branch protections as of 8/11
+# Can be removed once branch protections are updated to the new name
+pull_request_trigger_legacy:
+  name: Pull Request Trigger on 2021.1 (master, develop, & release branches)
+  dependencies:
+    - .yamato/_triggers.yml#pull_request_trigger
 
 # Run all relevant tasks when a pull request targeting the develop
 # branch is created or updated. Currently only mlapi package tests are
 # enabled, since the others are missing test coverage and will fail CI.
 pull_request_trigger:
-  name: Pull Request Trigger on 2021.1 (master, develop, & release branches)
+  name: Pull Request Trigger (master, develop, & release branches)
   dependencies:
     - .yamato/project-standards.yml#standards_{{ projects.first.name }}
 {% for project in projects -%}

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -17,7 +17,7 @@ develop_nightly_trigger:
 # branch is created or updated. Currently only mlapi package tests are
 # enabled, since the others are missing test coverage and will fail CI.
 pull_request_trigger:
-  name: Pull Request Trigger (master, develop, & release branches)
+  name: Pull Request Trigger on 2021.1 (master, develop, & release branches)
   dependencies:
     - .yamato/project-standards.yml#standards_{{ projects.first.name }}
 {% for project in projects -%}


### PR DESCRIPTION
This job name will be slightly inaccurate, but it's better than having to reconfigure github branch protections