### PR TITLE
test: adding parrelSync to testproject to help out when debugging our features

### DIFF
--- a/testproject/Packages/manifest.json
+++ b/testproject/Packages/manifest.json
@@ -5,6 +5,7 @@
     "com.unity.ide.visualstudio": "2.0.8",
     "com.unity.ide.vscode": "1.2.3",
     "com.unity.multiplayer.mlapi": "file:../../com.unity.multiplayer.mlapi",
+    "com.veriorpies.parrelsync": "https://github.com/VeriorPies/ParrelSync.git?path=/ParrelSync#bb3d5067e49e403d8b8ba15c036d313b4dd2c696",
     "com.unity.multiplayer.transport.utp": "file:../../com.unity.multiplayer.transport.utp",
     "com.unity.package-validation-suite": "0.19.2-preview",
     "com.unity.test-framework": "1.1.27",

--- a/testproject/Packages/packages-lock.json
+++ b/testproject/Packages/packages-lock.json
@@ -180,6 +180,13 @@
         "com.unity.modules.imgui": "1.0.0"
       }
     },
+    "com.veriorpies.parrelsync": {
+      "version": "https://github.com/VeriorPies/ParrelSync.git?path=/ParrelSync#bb3d5067e49e403d8b8ba15c036d313b4dd2c696",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {},
+      "hash": "bb3d5067e49e403d8b8ba15c036d313b4dd2c696"
+    },
     "com.unity.modules.ai": {
       "version": "1.0.0",
       "depth": 0,


### PR DESCRIPTION
ParrelSync has been great help while working on NetworkTransform interpolation, it'd be great to add it to our testproject so we don't have to keep it locally.