### PR TITLE
feat: snapshot mtt-1086: use unreliable packets

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Transports/NetworkTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/NetworkTransport.cs
@@ -104,8 +104,7 @@ namespace Unity.Netcode
             // todo: Currently, fragmentation support needed to deal with oversize packets encounterable with current pre-snapshot code".
             // todo: once we have snapshotting able to deal with missing frame, this should be unreliable
             new TransportChannel(NetworkChannel.NetworkVariable, NetworkDelivery.ReliableSequenced),
-            new TransportChannel(NetworkChannel.SnapshotExchange, NetworkDelivery.ReliableSequenced), // todo: temporary until we separate snapshots in chunks
-
+            new TransportChannel(NetworkChannel.SnapshotExchange, NetworkDelivery.Unreliable),
             new TransportChannel(NetworkChannel.Fragmented, NetworkDelivery.ReliableFragmentedSequenced),
 
         };


### PR DESCRIPTION
using unreliable packets, now that the underlying foundation supports it. 

**Only merge after** https://github.com/Unity-Technologies/com.unity.multiplayer.mlapi/pull/1062