### PR TITLE
fix: 2+ inheritance from network behaviour causes compilation exception (#1078)

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -595,8 +595,8 @@ namespace Unity.Netcode.Editor.CodeGen
 
             // override NetworkBehaviour.__getTypeName() method to return concrete type
             {
-                var baseType = typeDefinition.BaseType.Resolve();
-                var baseGetTypeNameMethod = baseType.Methods.First(p => p.Name.Equals(nameof(NetworkBehaviour.__getTypeName)));
+                var networkBehaviourType = m_NetworkBehaviour_TypeRef.Resolve();
+                var baseGetTypeNameMethod = networkBehaviourType.Methods.First(p => p.Name.Equals(nameof(NetworkBehaviour.__getTypeName)));
 
                 var newGetTypeNameMethod = new MethodDefinition(
                     nameof(NetworkBehaviour.__getTypeName),

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -595,8 +595,8 @@ namespace Unity.Netcode.Editor.CodeGen
 
             // override NetworkBehaviour.__getTypeName() method to return concrete type
             {
-                var networkBehaviourType = m_NetworkBehaviour_TypeRef.Resolve();
-                var baseGetTypeNameMethod = networkBehaviourType.Methods.First(p => p.Name.Equals(nameof(NetworkBehaviour.__getTypeName)));
+                var networkBehaviour_TypeDef = m_NetworkBehaviour_TypeRef.Resolve();
+                var baseGetTypeNameMethod = networkBehaviour_TypeDef.Methods.First(p => p.Name.Equals(nameof(NetworkBehaviour.__getTypeName)));
 
                 var newGetTypeNameMethod = new MethodDefinition(
                     nameof(NetworkBehaviour.__getTypeName),

--- a/com.unity.netcode.gameobjects/Tests/Editor/NetworkBehaviourTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/NetworkBehaviourTests.cs
@@ -47,12 +47,28 @@ namespace Unity.Netcode.EditorTests
         }
 
         [Test]
-        public void GetNetworkBehaviourNameTest()
+        public void GivenClassDerivesFromNetworkBehaviour_GetTypeNameReturnsCorrectValue()
         {
-            var gameObject = new GameObject(nameof(GetNetworkBehaviourNameTest));
+            var gameObject = new GameObject(nameof(GivenClassDerivesFromNetworkBehaviour_GetTypeNameReturnsCorrectValue));
             var networkBehaviour = gameObject.AddComponent<EmptyNetworkBehaviour>();
 
             Assert.AreEqual(nameof(EmptyNetworkBehaviour), networkBehaviour.__getTypeName());
+        }
+
+        [Test]
+        public void GivenClassDerivesFromNetworkBehaviourDerivedClass_GetTypeNameReturnsCorrectValue()
+        {
+            var gameObject = new GameObject(nameof(GivenClassDerivesFromNetworkBehaviourDerivedClass_GetTypeNameReturnsCorrectValue));
+            var networkBehaviour = gameObject.AddComponent<DerivedNetworkBehaviour>();
+
+            Assert.AreEqual(nameof(DerivedNetworkBehaviour), networkBehaviour.__getTypeName());
+        }
+
+        // Note: in order to repro https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/1078
+        // this class must be defined first in the file so that the most-derived definition is processed first by ILPP
+        public class DerivedNetworkBehaviour : EmptyNetworkBehaviour
+        {
+
         }
 
         public class EmptyNetworkBehaviour : NetworkBehaviour

--- a/com.unity.netcode.gameobjects/Tests/Editor/NetworkBehaviourTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/NetworkBehaviourTests.cs
@@ -65,7 +65,7 @@ namespace Unity.Netcode.EditorTests
         }
 
         // Note: in order to repro https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/1078
-        // this class must be defined first in the file so that the most-derived definition is processed first by ILPP
+        // this child class must be defined before its parent to assure it is processed first by ILPP
         public class DerivedNetworkBehaviour : EmptyNetworkBehaviour
         {
 


### PR DESCRIPTION
the original implementation assumed that a network behaviour's immediate ancestor was NetworkBehaviour. depending on ILPP processing order, a derived class may fail to compile because it cannot find the base class method that is used as a template for the override.

github issue:  https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/1078