### PR TITLE
test: NetworkTransformStateTests no longer uses ReplNetworkState

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformStateTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformStateTests.cs
@@ -15,7 +15,6 @@ namespace Unity.Netcode.RuntimeTests
         {
             var gameObject = new GameObject($"Test-{nameof(NetworkTransformStateTests)}.{nameof(TestSyncAxes)}");
             var networkObject = gameObject.AddComponent<NetworkObject>();
-            networkObject.GlobalObjectIdHash = (uint)Time.realtimeSinceStartup;
             var networkTransform = gameObject.AddComponent<NetworkTransform>();
             networkTransform.enabled = false; // do not tick `FixedUpdate()` or `Update()`
 
@@ -37,7 +36,7 @@ namespace Unity.Netcode.RuntimeTests
             networkTransform.SyncScaleZ = syncScaZ;
             networkTransform.InLocalSpace = inLocalSpace;
 
-            networkTransform.ReplNetworkState.Value = new NetworkTransform.NetworkState
+            var networkTransformState = new NetworkTransform.NetworkState
             {
                 PositionX = initialPosition.x,
                 PositionY = initialPosition.y,
@@ -62,25 +61,17 @@ namespace Unity.Netcode.RuntimeTests
 
             // Step 1: change properties, expect state to be dirty
             {
-                networkTransform.InLocalSpace = !inLocalSpace;
                 networkTransform.transform.position = new Vector3(3, 4, 5);
                 networkTransform.transform.eulerAngles = new Vector3(30, 45, 90);
                 networkTransform.transform.localScale = new Vector3(1.1f, 0.5f, 2.5f);
 
-                bool isDirty = networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef);
-                networkTransform.ReplNetworkState.SetDirty(isDirty);
-                Assert.IsTrue(isDirty);
+                if (syncPosX || syncPosY || syncPosZ || syncRotX || syncRotY || syncRotZ || syncScaX || syncScaY || syncScaZ)
+                {
+                    Assert.IsTrue(networkTransform.UpdateNetworkState(ref networkTransformState));
+                }
             }
 
-            // Step 2: apply current state locally, expect state to be not dirty/different
-            {
-                networkTransform.ApplyNetworkState(networkTransform.ReplNetworkState.Value);
-
-                bool isDirty = networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef);
-                Assert.IsFalse(isDirty);
-            }
-
-            // Step 3: disable a particular sync flag, expect state to be not dirty
+            // Step 2: disable a particular sync flag, expect state to be not dirty
             {
                 var position = networkTransform.transform.position;
                 var rotAngles = networkTransform.transform.eulerAngles;
@@ -93,7 +84,7 @@ namespace Unity.Netcode.RuntimeTests
                     position.x++;
                     networkTransform.transform.position = position;
 
-                    Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                    Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransformState));
                 }
                 // SyncPositionY
                 {
@@ -102,7 +93,7 @@ namespace Unity.Netcode.RuntimeTests
                     position.y++;
                     networkTransform.transform.position = position;
 
-                    Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                    Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransformState));
                 }
                 // SyncPositionZ
                 {
@@ -111,7 +102,7 @@ namespace Unity.Netcode.RuntimeTests
                     position.z++;
                     networkTransform.transform.position = position;
 
-                    Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                    Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransformState));
                 }
 
                 // SyncRotAngleX
@@ -121,7 +112,7 @@ namespace Unity.Netcode.RuntimeTests
                     rotAngles.x++;
                     networkTransform.transform.eulerAngles = rotAngles;
 
-                    Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                    Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransformState));
                 }
                 // SyncRotAngleY
                 {
@@ -130,7 +121,7 @@ namespace Unity.Netcode.RuntimeTests
                     rotAngles.y++;
                     networkTransform.transform.eulerAngles = rotAngles;
 
-                    Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                    Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransformState));
                 }
                 // SyncRotAngleZ
                 {
@@ -139,7 +130,7 @@ namespace Unity.Netcode.RuntimeTests
                     rotAngles.z++;
                     networkTransform.transform.eulerAngles = rotAngles;
 
-                    Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                    Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransformState));
                 }
 
                 // SyncScaleX
@@ -149,7 +140,7 @@ namespace Unity.Netcode.RuntimeTests
                     scale.x++;
                     networkTransform.transform.localScale = scale;
 
-                    Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                    Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransformState));
                 }
                 // SyncScaleY
                 {
@@ -158,7 +149,7 @@ namespace Unity.Netcode.RuntimeTests
                     scale.y++;
                     networkTransform.transform.localScale = scale;
 
-                    Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                    Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransformState));
                 }
                 // SyncScaleZ
                 {
@@ -167,7 +158,7 @@ namespace Unity.Netcode.RuntimeTests
                     scale.z++;
                     networkTransform.transform.localScale = scale;
 
-                    Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                    Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransformState));
                 }
             }
 
@@ -207,7 +198,7 @@ namespace Unity.Netcode.RuntimeTests
             networkTransform.RotAngleThreshold = rotAngleThreshold;
             networkTransform.ScaleThreshold = scaleThreshold;
 
-            networkTransform.ReplNetworkState.Value = new NetworkTransform.NetworkState
+            var networkTransformState = new NetworkTransform.NetworkState
             {
                 PositionX = initialPosition.x,
                 PositionY = initialPosition.y,
@@ -223,25 +214,14 @@ namespace Unity.Netcode.RuntimeTests
 
             // Step 1: change properties, expect state to be dirty
             {
-                networkTransform.InLocalSpace = !inLocalSpace;
                 networkTransform.transform.position = new Vector3(3, 4, 5);
                 networkTransform.transform.eulerAngles = new Vector3(30, 45, 90);
                 networkTransform.transform.localScale = new Vector3(1.1f, 0.5f, 2.5f);
 
-                bool isDirty = networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef);
-                networkTransform.ReplNetworkState.SetDirty(isDirty);
-                Assert.IsTrue(isDirty);
+                Assert.IsTrue(networkTransform.UpdateNetworkState(ref networkTransformState));
             }
 
-            // Step 2: apply current state locally, expect state to be not dirty/different
-            {
-                networkTransform.ApplyNetworkState(networkTransform.ReplNetworkState.Value);
-
-                bool isDirty = networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef);
-                Assert.IsFalse(isDirty);
-            }
-
-            // Step 3: make changes below and above thresholds
+            // Step 2: make changes below and above thresholds
             // changes below the threshold should not make `NetworkState` dirty
             // changes above the threshold should make `NetworkState` dirty
             {
@@ -254,42 +234,33 @@ namespace Unity.Netcode.RuntimeTests
                     {
                         position.x += positionThreshold / 2;
                         networkTransform.transform.position = position;
-                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransformState));
 
                         position.x += positionThreshold * 2;
                         networkTransform.transform.position = position;
-                        Assert.IsTrue(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
-
-                        networkTransform.ApplyNetworkState(networkTransform.ReplNetworkState.Value);
-                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                        Assert.IsTrue(networkTransform.UpdateNetworkState(ref networkTransformState));
                     }
 
                     // PositionY
                     {
                         position.y += positionThreshold / 2;
                         networkTransform.transform.position = position;
-                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransformState));
 
                         position.y += positionThreshold * 2;
                         networkTransform.transform.position = position;
-                        Assert.IsTrue(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
-
-                        networkTransform.ApplyNetworkState(networkTransform.ReplNetworkState.Value);
-                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                        Assert.IsTrue(networkTransform.UpdateNetworkState(ref networkTransformState));
                     }
 
                     // PositionZ
                     {
                         position.z += positionThreshold / 2;
                         networkTransform.transform.position = position;
-                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransformState));
 
                         position.z += positionThreshold * 2;
                         networkTransform.transform.position = position;
-                        Assert.IsTrue(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
-
-                        networkTransform.ApplyNetworkState(networkTransform.ReplNetworkState.Value);
-                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                        Assert.IsTrue(networkTransform.UpdateNetworkState(ref networkTransformState));
                     }
                 }
 
@@ -302,42 +273,33 @@ namespace Unity.Netcode.RuntimeTests
                     {
                         rotAngles.x += rotAngleThreshold / 2;
                         networkTransform.transform.eulerAngles = rotAngles;
-                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransformState));
 
                         rotAngles.x += rotAngleThreshold * 2;
                         networkTransform.transform.eulerAngles = rotAngles;
-                        Assert.IsTrue(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
-
-                        networkTransform.ApplyNetworkState(networkTransform.ReplNetworkState.Value);
-                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                        Assert.IsTrue(networkTransform.UpdateNetworkState(ref networkTransformState));
                     }
 
                     // RotAngleY
                     {
                         rotAngles.y += rotAngleThreshold / 2;
                         networkTransform.transform.eulerAngles = rotAngles;
-                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransformState));
 
                         rotAngles.y += rotAngleThreshold * 2;
                         networkTransform.transform.eulerAngles = rotAngles;
-                        Assert.IsTrue(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
-
-                        networkTransform.ApplyNetworkState(networkTransform.ReplNetworkState.Value);
-                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                        Assert.IsTrue(networkTransform.UpdateNetworkState(ref networkTransformState));
                     }
 
                     // RotAngleZ
                     {
                         rotAngles.z += rotAngleThreshold / 2;
                         networkTransform.transform.eulerAngles = rotAngles;
-                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransformState));
 
                         rotAngles.z += rotAngleThreshold * 2;
                         networkTransform.transform.eulerAngles = rotAngles;
-                        Assert.IsTrue(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
-
-                        networkTransform.ApplyNetworkState(networkTransform.ReplNetworkState.Value);
-                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                        Assert.IsTrue(networkTransform.UpdateNetworkState(ref networkTransformState));
                     }
                 }
 
@@ -350,47 +312,38 @@ namespace Unity.Netcode.RuntimeTests
                     {
                         scale.x += scaleThreshold / 2;
                         networkTransform.transform.localScale = scale;
-                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransformState));
 
                         scale.x += scaleThreshold * 2;
                         networkTransform.transform.localScale = scale;
-                        Assert.IsTrue(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
-
-                        networkTransform.ApplyNetworkState(networkTransform.ReplNetworkState.Value);
-                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                        Assert.IsTrue(networkTransform.UpdateNetworkState(ref networkTransformState));
                     }
 
                     // ScaleY
                     {
                         scale.y += scaleThreshold / 2;
                         networkTransform.transform.localScale = scale;
-                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransformState));
 
                         scale.y += scaleThreshold * 2;
                         networkTransform.transform.localScale = scale;
-                        Assert.IsTrue(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
-
-                        networkTransform.ApplyNetworkState(networkTransform.ReplNetworkState.Value);
-                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                        Assert.IsTrue(networkTransform.UpdateNetworkState(ref networkTransformState));
                     }
 
                     // ScaleZ
                     {
                         scale.z += scaleThreshold / 2;
                         networkTransform.transform.localScale = scale;
-                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransformState));
 
                         scale.z += scaleThreshold * 2;
                         networkTransform.transform.localScale = scale;
-                        Assert.IsTrue(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
-
-                        networkTransform.ApplyNetworkState(networkTransform.ReplNetworkState.Value);
-                        Assert.IsFalse(networkTransform.UpdateNetworkState(ref networkTransform.ReplNetworkState.ValueRef));
+                        Assert.IsTrue(networkTransform.UpdateNetworkState(ref networkTransformState));
                     }
                 }
             }
 
-            Object.DestroyImmediate(gameObject);
+            Object.DestroyImmediate(networkTransform);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformStateTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformStateTests.cs
@@ -162,7 +162,7 @@ namespace Unity.Netcode.RuntimeTests
                 }
             }
 
-            Object.DestroyImmediate(networkTransform);
+            Object.DestroyImmediate(gameObject);
         }
 
         [Test]
@@ -343,7 +343,7 @@ namespace Unity.Netcode.RuntimeTests
                 }
             }
 
-            Object.DestroyImmediate(networkTransform);
+            Object.DestroyImmediate(gameObject);
         }
     }
 }


### PR DESCRIPTION
It will be helpful later in PR #1060 and #1074
(I will merge this back into those PRs when it lands into the `develop` branch)