### PR TITLE
refactor: convert using var statements to using var declarations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,7 @@ indent_size = 4
 dotnet_diagnostic.IDE0001.severity = error # Simplify name
 dotnet_diagnostic.IDE0002.severity = error # Simplify member access
 dotnet_diagnostic.IDE0005.severity = error # Remove unnecessary import
+dotnet_diagnostic.IDE0063.severity = error # Use simple 'using' statement
 dotnet_style_qualification_for_field = false:error
 dotnet_style_qualification_for_property = false:error
 dotnet_style_qualification_for_method = false:error

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/PostProcessorAssemblyResolver.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/PostProcessorAssemblyResolver.cs
@@ -97,10 +97,10 @@ namespace Unity.Netcode.Editor.CodeGen
             return Retry(10, TimeSpan.FromSeconds(1), () =>
             {
                 byte[] byteArray;
-                var fs = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                byteArray = new byte[fs.Length];
-                var readLength = fs.Read(byteArray, 0, (int)fs.Length);
-                if (readLength != fs.Length)
+                using var fileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                byteArray = new byte[fileStream.Length];
+                var readLength = fileStream.Read(byteArray, 0, (int)fileStream.Length);
+                if (readLength != fileStream.Length)
                 {
                     throw new InvalidOperationException("File read length is not full length of file.");
                 }

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/PostProcessorAssemblyResolver.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/PostProcessorAssemblyResolver.cs
@@ -97,14 +97,12 @@ namespace Unity.Netcode.Editor.CodeGen
             return Retry(10, TimeSpan.FromSeconds(1), () =>
             {
                 byte[] byteArray;
-                using (var fs = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                var fs = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                byteArray = new byte[fs.Length];
+                var readLength = fs.Read(byteArray, 0, (int)fs.Length);
+                if (readLength != fs.Length)
                 {
-                    byteArray = new byte[fs.Length];
-                    var readLength = fs.Read(byteArray, 0, (int)fs.Length);
-                    if (readLength != fs.Length)
-                    {
-                        throw new InvalidOperationException("File read length is not full length of file.");
-                    }
+                    throw new InvalidOperationException("File read length is not full length of file.");
                 }
 
                 return new MemoryStream(byteArray);

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -510,100 +510,92 @@ namespace Unity.Netcode
             {
                 for (int j = 0; j < m_ChannelMappedNetworkVariableIndexes.Count; j++)
                 {
-                    using (var buffer = PooledNetworkBuffer.Get())
+                    using var buffer = PooledNetworkBuffer.Get();
+                    using var writer = PooledNetworkWriter.Get(buffer);
+                    // TODO: could skip this if no variables dirty, though obsolete w/ Snapshot
+                    writer.WriteUInt64Packed(NetworkObjectId);
+                    writer.WriteUInt16Packed(NetworkObject.GetNetworkBehaviourOrderIndex(this));
+
+                    var bufferSizeCapture = new BufferSizeCapture(buffer);
+
+                    var writtenAny = false;
+                    for (int k = 0; k < NetworkVariableFields.Count; k++)
                     {
-                        using (var writer = PooledNetworkWriter.Get(buffer))
+                        if (!m_ChannelMappedNetworkVariableIndexes[j].Contains(k))
                         {
-                            // TODO: could skip this if no variables dirty, though obsolete w/ Snapshot
-                            writer.WriteUInt64Packed(NetworkObjectId);
-                            writer.WriteUInt16Packed(NetworkObject.GetNetworkBehaviourOrderIndex(this));
-
-                            var bufferSizeCapture = new BufferSizeCapture(buffer);
-
-                            var writtenAny = false;
-                            for (int k = 0; k < NetworkVariableFields.Count; k++)
+                            // This var does not belong to the currently iterating channel group.
+                            if (NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
                             {
-                                if (!m_ChannelMappedNetworkVariableIndexes[j].Contains(k))
-                                {
-                                    // This var does not belong to the currently iterating channel group.
-                                    if (NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
-                                    {
-                                        writer.WriteUInt16Packed(0);
-                                    }
-                                    else
-                                    {
-                                        writer.WriteBool(false);
-                                    }
-
-                                    continue;
-                                }
-
-                                //   if I'm dirty AND a client, write (server always has all permissions)
-                                //   if I'm dirty AND the server AND the client can read me, send.
-                                bool shouldWrite = NetworkVariableFields[k].ShouldWrite(clientId, IsServer);
-
-                                if (NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
-                                {
-                                    if (!shouldWrite)
-                                    {
-                                        writer.WriteUInt16Packed(0);
-                                    }
-                                }
-                                else
-                                {
-                                    writer.WriteBool(shouldWrite);
-                                }
-
-                                if (shouldWrite)
-                                {
-                                    writtenAny = true;
-
-                                    if (NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
-                                    {
-                                        using (var varBuffer = PooledNetworkBuffer.Get())
-                                        {
-                                            NetworkVariableFields[k].WriteDelta(varBuffer);
-                                            varBuffer.PadBuffer();
-
-                                            writer.WriteUInt16Packed((ushort)varBuffer.Length);
-                                            buffer.CopyFrom(varBuffer);
-                                        }
-                                    }
-                                    else
-                                    {
-                                        NetworkVariableFields[k].WriteDelta(buffer);
-                                        buffer.PadBuffer();
-                                    }
-
-                                    if (!m_NetworkVariableIndexesToResetSet.Contains(k))
-                                    {
-                                        m_NetworkVariableIndexesToResetSet.Add(k);
-                                        m_NetworkVariableIndexesToReset.Add(k);
-                                    }
-
-                                    NetworkManager.NetworkMetrics.TrackNetworkVariableDeltaSent(
-                                        clientId,
-                                        NetworkObjectId,
-                                        name,
-                                        NetworkVariableFields[k].Name,
-                                        __getTypeName(),
-                                        bufferSizeCapture.Flush());
-                                }
+                                writer.WriteUInt16Packed(0);
+                            }
+                            else
+                            {
+                                writer.WriteBool(false);
                             }
 
-                            if (writtenAny)
+                            continue;
+                        }
+
+                        //   if I'm dirty AND a client, write (server always has all permissions)
+                        //   if I'm dirty AND the server AND the client can read me, send.
+                        bool shouldWrite = NetworkVariableFields[k].ShouldWrite(clientId, IsServer);
+
+                        if (NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
+                        {
+                            if (!shouldWrite)
                             {
-                                var context = NetworkManager.MessageQueueContainer.EnterInternalCommandContext(
-                                    MessageQueueContainer.MessageType.NetworkVariableDelta, m_ChannelsForNetworkVariableGroups[j],
-                                    new[] { clientId }, NetworkUpdateLoop.UpdateStage);
-                                if (context != null)
-                                {
-                                    using (var nonNullContext = (InternalCommandContext)context)
-                                    {
-                                        nonNullContext.NetworkWriter.WriteBytes(buffer.GetBuffer(), buffer.Position);
-                                    }
-                                }
+                                writer.WriteUInt16Packed(0);
                             }
+                        }
+                        else
+                        {
+                            writer.WriteBool(shouldWrite);
+                        }
+
+                        if (shouldWrite)
+                        {
+                            writtenAny = true;
+
+                            if (NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
+                            {
+                                using var varBuffer = PooledNetworkBuffer.Get();
+                                NetworkVariableFields[k].WriteDelta(varBuffer);
+                                varBuffer.PadBuffer();
+
+                                writer.WriteUInt16Packed((ushort)varBuffer.Length);
+                                buffer.CopyFrom(varBuffer);
+                            }
+                            else
+                            {
+                                NetworkVariableFields[k].WriteDelta(buffer);
+                                buffer.PadBuffer();
+                            }
+
+                            if (!m_NetworkVariableIndexesToResetSet.Contains(k))
+                            {
+                                m_NetworkVariableIndexesToResetSet.Add(k);
+                                m_NetworkVariableIndexesToReset.Add(k);
+                            }
+
+                            NetworkManager.NetworkMetrics.TrackNetworkVariableDeltaSent(
+                                clientId,
+                                NetworkObjectId,
+                                name,
+                                NetworkVariableFields[k].Name,
+                                __getTypeName(),
+                                bufferSizeCapture.Flush());
+                        }
+                    }
+
+                    if (writtenAny)
+                    {
+                        var context = NetworkManager.MessageQueueContainer.EnterInternalCommandContext(
+                            MessageQueueContainer.MessageType.NetworkVariableDelta, m_ChannelsForNetworkVariableGroups[j],
+                            new[] { clientId }, NetworkUpdateLoop.UpdateStage);
+                        if (context != null)
+                        {
+                            using var nonNullContext = (InternalCommandContext)context;
+                            nonNullContext.NetworkWriter.WriteBytes(buffer.GetBuffer(), buffer.Position);
                         }
                     }
                 }
@@ -626,94 +618,92 @@ namespace Unity.Netcode
 
         internal void HandleNetworkVariableDeltas(Stream stream, ulong clientId)
         {
-            using (var reader = PooledNetworkReader.Get(stream))
+            using var reader = PooledNetworkReader.Get(stream);
+            for (int i = 0; i < NetworkVariableFields.Count; i++)
             {
-                for (int i = 0; i < NetworkVariableFields.Count; i++)
-                {
-                    ushort varSize = 0;
+                ushort varSize = 0;
 
+                if (NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
+                {
+                    varSize = reader.ReadUInt16Packed();
+
+                    if (varSize == 0)
+                    {
+                        continue;
+                    }
+                }
+                else
+                {
+                    if (!reader.ReadBool())
+                    {
+                        continue;
+                    }
+                }
+
+                if (NetworkManager.IsServer && !NetworkVariableFields[i].CanClientWrite(clientId))
+                {
+                    // we are choosing not to fire an exception here, because otherwise a malicious client could use this to crash the server
                     if (NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
                     {
-                        varSize = reader.ReadUInt16Packed();
-
-                        if (varSize == 0)
+                        if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
                         {
-                            continue;
-                        }
-                    }
-                    else
-                    {
-                        if (!reader.ReadBool())
-                        {
-                            continue;
-                        }
-                    }
-
-                    if (NetworkManager.IsServer && !NetworkVariableFields[i].CanClientWrite(clientId))
-                    {
-                        // we are choosing not to fire an exception here, because otherwise a malicious client could use this to crash the server
-                        if (NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
-                        {
-                            if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
-                            {
-                                NetworkLog.LogWarning($"Client wrote to {typeof(NetworkVariable<>).Name} without permission. => {nameof(NetworkObjectId)}: {NetworkObjectId} - {nameof(NetworkObject.GetNetworkBehaviourOrderIndex)}(): {NetworkObject.GetNetworkBehaviourOrderIndex(this)} - VariableIndex: {i}");
-                                NetworkLog.LogError($"[{NetworkVariableFields[i].GetType().Name}]");
-                            }
-
-                            stream.Position += varSize;
-                            continue;
-                        }
-
-                        //This client wrote somewhere they are not allowed. This is critical
-                        //We can't just skip this field. Because we don't actually know how to dummy read
-                        //That is, we don't know how many bytes to skip. Because the interface doesn't have a
-                        //Read that gives us the value. Only a Read that applies the value straight away
-                        //A dummy read COULD be added to the interface for this situation, but it's just being too nice.
-                        //This is after all a developer fault. A critical error should be fine.
-                        // - TwoTen
-                        if (NetworkLog.CurrentLogLevel <= LogLevel.Error)
-                        {
-                            NetworkLog.LogError($"Client wrote to {typeof(NetworkVariable<>).Name} without permission. No more variables can be read. This is critical. => {nameof(NetworkObjectId)}: {NetworkObjectId} - {nameof(NetworkObject.GetNetworkBehaviourOrderIndex)}(): {NetworkObject.GetNetworkBehaviourOrderIndex(this)} - VariableIndex: {i}");
+                            NetworkLog.LogWarning($"Client wrote to {typeof(NetworkVariable<>).Name} without permission. => {nameof(NetworkObjectId)}: {NetworkObjectId} - {nameof(NetworkObject.GetNetworkBehaviourOrderIndex)}(): {NetworkObject.GetNetworkBehaviourOrderIndex(this)} - VariableIndex: {i}");
                             NetworkLog.LogError($"[{NetworkVariableFields[i].GetType().Name}]");
                         }
 
-                        return;
+                        stream.Position += varSize;
+                        continue;
                     }
-                    long readStartPos = stream.Position;
 
-                    NetworkVariableFields[i].ReadDelta(stream, NetworkManager.IsServer);
-                    NetworkManager.NetworkMetrics.TrackNetworkVariableDeltaReceived(
-                        clientId,
-                        NetworkObjectId,
-                        name,
-                        NetworkVariableFields[i].Name,
-                        __getTypeName(),
-                        stream.Length);
-
-                    (stream as NetworkBuffer).SkipPadBits();
-
-                    if (NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
+                    //This client wrote somewhere they are not allowed. This is critical
+                    //We can't just skip this field. Because we don't actually know how to dummy read
+                    //That is, we don't know how many bytes to skip. Because the interface doesn't have a
+                    //Read that gives us the value. Only a Read that applies the value straight away
+                    //A dummy read COULD be added to the interface for this situation, but it's just being too nice.
+                    //This is after all a developer fault. A critical error should be fine.
+                    // - TwoTen
+                    if (NetworkLog.CurrentLogLevel <= LogLevel.Error)
                     {
-                        if (stream.Position > (readStartPos + varSize))
-                        {
-                            if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
-                            {
-                                NetworkLog.LogWarning(
-                                    $"Var delta read too far. {stream.Position - (readStartPos + varSize)} bytes. => {nameof(NetworkObjectId)}: {NetworkObjectId} - {nameof(NetworkObject.GetNetworkBehaviourOrderIndex)}(): {NetworkObject.GetNetworkBehaviourOrderIndex(this)} - VariableIndex: {i}");
-                            }
+                        NetworkLog.LogError($"Client wrote to {typeof(NetworkVariable<>).Name} without permission. No more variables can be read. This is critical. => {nameof(NetworkObjectId)}: {NetworkObjectId} - {nameof(NetworkObject.GetNetworkBehaviourOrderIndex)}(): {NetworkObject.GetNetworkBehaviourOrderIndex(this)} - VariableIndex: {i}");
+                        NetworkLog.LogError($"[{NetworkVariableFields[i].GetType().Name}]");
+                    }
 
-                            stream.Position = readStartPos + varSize;
-                        }
-                        else if (stream.Position < (readStartPos + varSize))
-                        {
-                            if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
-                            {
-                                NetworkLog.LogWarning(
-                                    $"Var delta read too little. {(readStartPos + varSize) - stream.Position} bytes. => {nameof(NetworkObjectId)}: {NetworkObjectId} - {nameof(NetworkObject.GetNetworkBehaviourOrderIndex)}(): {NetworkObject.GetNetworkBehaviourOrderIndex(this)} - VariableIndex: {i}");
-                            }
+                    return;
+                }
+                long readStartPos = stream.Position;
 
-                            stream.Position = readStartPos + varSize;
+                NetworkVariableFields[i].ReadDelta(stream, NetworkManager.IsServer);
+                NetworkManager.NetworkMetrics.TrackNetworkVariableDeltaReceived(
+                    clientId,
+                    NetworkObjectId,
+                    name,
+                    NetworkVariableFields[i].Name,
+                    __getTypeName(),
+                    stream.Length);
+
+                (stream as NetworkBuffer).SkipPadBits();
+
+                if (NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
+                {
+                    if (stream.Position > (readStartPos + varSize))
+                    {
+                        if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
+                        {
+                            NetworkLog.LogWarning(
+                                $"Var delta read too far. {stream.Position - (readStartPos + varSize)} bytes. => {nameof(NetworkObjectId)}: {NetworkObjectId} - {nameof(NetworkObject.GetNetworkBehaviourOrderIndex)}(): {NetworkObject.GetNetworkBehaviourOrderIndex(this)} - VariableIndex: {i}");
                         }
+
+                        stream.Position = readStartPos + varSize;
+                    }
+                    else if (stream.Position < (readStartPos + varSize))
+                    {
+                        if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
+                        {
+                            NetworkLog.LogWarning(
+                                $"Var delta read too little. {(readStartPos + varSize) - stream.Position} bytes. => {nameof(NetworkObjectId)}: {NetworkObjectId} - {nameof(NetworkObject.GetNetworkBehaviourOrderIndex)}(): {NetworkObject.GetNetworkBehaviourOrderIndex(this)} - VariableIndex: {i}");
+                        }
+
+                        stream.Position = readStartPos + varSize;
                     }
                 }
             }
@@ -726,42 +716,38 @@ namespace Unity.Netcode
                 return;
             }
 
-            using (var writer = PooledNetworkWriter.Get(stream))
+            using var writer = PooledNetworkWriter.Get(stream);
+            for (int j = 0; j < NetworkVariableFields.Count; j++)
             {
-                for (int j = 0; j < NetworkVariableFields.Count; j++)
-                {
-                    bool canClientRead = NetworkVariableFields[j].CanClientRead(clientId);
+                bool canClientRead = NetworkVariableFields[j].CanClientRead(clientId);
 
+                if (NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
+                {
+                    if (!canClientRead)
+                    {
+                        writer.WriteUInt16Packed(0);
+                    }
+                }
+                else
+                {
+                    writer.WriteBool(canClientRead);
+                }
+
+                if (canClientRead)
+                {
                     if (NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
                     {
-                        if (!canClientRead)
-                        {
-                            writer.WriteUInt16Packed(0);
-                        }
+                        using var varBuffer = PooledNetworkBuffer.Get();
+                        NetworkVariableFields[j].WriteField(varBuffer);
+                        varBuffer.PadBuffer();
+
+                        writer.WriteUInt16Packed((ushort)varBuffer.Length);
+                        varBuffer.CopyTo(stream);
                     }
                     else
                     {
-                        writer.WriteBool(canClientRead);
-                    }
-
-                    if (canClientRead)
-                    {
-                        if (NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
-                        {
-                            using (var varBuffer = PooledNetworkBuffer.Get())
-                            {
-                                NetworkVariableFields[j].WriteField(varBuffer);
-                                varBuffer.PadBuffer();
-
-                                writer.WriteUInt16Packed((ushort)varBuffer.Length);
-                                varBuffer.CopyTo(stream);
-                            }
-                        }
-                        else
-                        {
-                            NetworkVariableFields[j].WriteField(stream);
-                            writer.WritePadBits();
-                        }
+                        NetworkVariableFields[j].WriteField(stream);
+                        writer.WritePadBits();
                     }
                 }
             }
@@ -774,59 +760,57 @@ namespace Unity.Netcode
                 return;
             }
 
-            using (var reader = PooledNetworkReader.Get(stream))
+            using var reader = PooledNetworkReader.Get(stream);
+            for (int j = 0; j < NetworkVariableFields.Count; j++)
             {
-                for (int j = 0; j < NetworkVariableFields.Count; j++)
+                ushort varSize = 0;
+
+                if (NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
                 {
-                    ushort varSize = 0;
+                    varSize = reader.ReadUInt16Packed();
 
-                    if (NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
+                    if (varSize == 0)
                     {
-                        varSize = reader.ReadUInt16Packed();
-
-                        if (varSize == 0)
-                        {
-                            continue;
-                        }
+                        continue;
                     }
-                    else
+                }
+                else
+                {
+                    if (!reader.ReadBool())
                     {
-                        if (!reader.ReadBool())
-                        {
-                            continue;
-                        }
+                        continue;
+                    }
+                }
+
+                long readStartPos = stream.Position;
+
+                NetworkVariableFields[j].ReadField(stream);
+                reader.SkipPadBits();
+
+                if (NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
+                {
+                    if (stream is NetworkBuffer networkBuffer)
+                    {
+                        networkBuffer.SkipPadBits();
                     }
 
-                    long readStartPos = stream.Position;
-
-                    NetworkVariableFields[j].ReadField(stream);
-                    reader.SkipPadBits();
-
-                    if (NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
+                    if (stream.Position > (readStartPos + varSize))
                     {
-                        if (stream is NetworkBuffer networkBuffer)
+                        if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
                         {
-                            networkBuffer.SkipPadBits();
+                            NetworkLog.LogWarning($"Var data read too far. {stream.Position - (readStartPos + varSize)} bytes.");
                         }
 
-                        if (stream.Position > (readStartPos + varSize))
+                        stream.Position = readStartPos + varSize;
+                    }
+                    else if (stream.Position < (readStartPos + varSize))
+                    {
+                        if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
                         {
-                            if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
-                            {
-                                NetworkLog.LogWarning($"Var data read too far. {stream.Position - (readStartPos + varSize)} bytes.");
-                            }
-
-                            stream.Position = readStartPos + varSize;
+                            NetworkLog.LogWarning($"Var data read too little. {(readStartPos + varSize) - stream.Position} bytes.");
                         }
-                        else if (stream.Position < (readStartPos + varSize))
-                        {
-                            if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
-                            {
-                                NetworkLog.LogWarning($"Var data read too little. {(readStartPos + varSize) - stream.Position} bytes.");
-                            }
 
-                            stream.Position = readStartPos + varSize;
-                        }
+                        stream.Position = readStartPos + varSize;
                     }
                 }
             }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1126,14 +1126,12 @@ namespace Unity.Netcode
                 clientIds, NetworkUpdateStage.EarlyUpdate);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext)context)
-                {
-                    nonNullContext.NetworkWriter.WriteUInt64Packed(NetworkConfig.GetConfig());
+                using var nonNullContext = (InternalCommandContext)context;
+                nonNullContext.NetworkWriter.WriteUInt64Packed(NetworkConfig.GetConfig());
 
-                    if (NetworkConfig.ConnectionApproval)
-                    {
-                        nonNullContext.NetworkWriter.WriteByteArray(NetworkConfig.ConnectionData);
-                    }
+                if (NetworkConfig.ConnectionApproval)
+                {
+                    nonNullContext.NetworkWriter.WriteByteArray(NetworkConfig.ConnectionData);
                 }
             }
         }
@@ -1255,19 +1253,17 @@ namespace Unity.Netcode
             m_InputBufferWrapper.SetLength(data.Count + data.Offset);
             m_InputBufferWrapper.Position = data.Offset;
 
-            using (var messageStream = m_InputBufferWrapper)
-            {
-                // Client tried to send a network message that was not the connection request before he was accepted.
+            using var messageStream = m_InputBufferWrapper;
+            // Client tried to send a network message that was not the connection request before he was accepted.
 
-                if (MessageQueueContainer.IsUsingBatching())
-                {
-                    m_MessageBatcher.ReceiveItems(messageStream, ReceiveCallback, clientId, receiveTime, networkChannel);
-                }
-                else
-                {
-                    var messageType = (MessageQueueContainer.MessageType)messageStream.ReadByte();
-                    MessageHandler.MessageReceiveQueueItem(clientId, messageStream, receiveTime, messageType, networkChannel);
-                }
+            if (MessageQueueContainer.IsUsingBatching())
+            {
+                m_MessageBatcher.ReceiveItems(messageStream, ReceiveCallback, clientId, receiveTime, networkChannel);
+            }
+            else
+            {
+                var messageType = (MessageQueueContainer.MessageType)messageStream.ReadByte();
+                MessageHandler.MessageReceiveQueueItem(clientId, messageStream, receiveTime, messageType, networkChannel);
             }
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
             s_HandleIncomingData.End();
@@ -1290,65 +1286,63 @@ namespace Unity.Netcode
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
             s_InvokeRpc.Begin();
 #endif
-            using (var reader = PooledNetworkReader.Get(item.NetworkBuffer))
+            using var reader = PooledNetworkReader.Get(item.NetworkBuffer);
+            var networkObjectId = reader.ReadUInt64Packed();
+            var networkBehaviourId = reader.ReadUInt16Packed();
+            var networkMethodId = reader.ReadUInt32Packed();
+
+            if (__rpc_func_table.ContainsKey(networkMethodId))
             {
-                var networkObjectId = reader.ReadUInt64Packed();
-                var networkBehaviourId = reader.ReadUInt16Packed();
-                var networkMethodId = reader.ReadUInt32Packed();
-
-                if (__rpc_func_table.ContainsKey(networkMethodId))
+                if (!SpawnManager.SpawnedObjects.ContainsKey(networkObjectId))
                 {
-                    if (!SpawnManager.SpawnedObjects.ContainsKey(networkObjectId))
-                    {
-                        return;
-                    }
+                    return;
+                }
 
-                    var networkObject = SpawnManager.SpawnedObjects[networkObjectId];
+                var networkObject = SpawnManager.SpawnedObjects[networkObjectId];
 
-                    var networkBehaviour = networkObject.GetNetworkBehaviourAtOrderIndex(networkBehaviourId);
-                    if (networkBehaviour == null)
-                    {
-                        return;
-                    }
+                var networkBehaviour = networkObject.GetNetworkBehaviourAtOrderIndex(networkBehaviourId);
+                if (networkBehaviour == null)
+                {
+                    return;
+                }
 
-                    var rpcParams = new __RpcParams();
-                    switch (item.MessageType)
-                    {
-                        case MessageQueueContainer.MessageType.ServerRpc:
-                            rpcParams.Server = new ServerRpcParams
+                var rpcParams = new __RpcParams();
+                switch (item.MessageType)
+                {
+                    case MessageQueueContainer.MessageType.ServerRpc:
+                        rpcParams.Server = new ServerRpcParams
+                        {
+                            Receive = new ServerRpcReceiveParams
                             {
-                                Receive = new ServerRpcReceiveParams
-                                {
-                                    UpdateStage = (NetworkUpdateStage)networkUpdateStage,
-                                    SenderClientId = item.NetworkId
-                                }
-                            };
-                            break;
-                        case MessageQueueContainer.MessageType.ClientRpc:
-                            rpcParams.Client = new ClientRpcParams
+                                UpdateStage = (NetworkUpdateStage)networkUpdateStage,
+                                SenderClientId = item.NetworkId
+                            }
+                        };
+                        break;
+                    case MessageQueueContainer.MessageType.ClientRpc:
+                        rpcParams.Client = new ClientRpcParams
+                        {
+                            Receive = new ClientRpcReceiveParams
                             {
-                                Receive = new ClientRpcReceiveParams
-                                {
-                                    UpdateStage = (NetworkUpdateStage)networkUpdateStage
-                                }
-                            };
-                            break;
-                    }
+                                UpdateStage = (NetworkUpdateStage)networkUpdateStage
+                            }
+                        };
+                        break;
+                }
 
-                    __rpc_func_table[networkMethodId](networkBehaviour, new NetworkSerializer(item.NetworkReader), rpcParams);
+                __rpc_func_table[networkMethodId](networkBehaviour, new NetworkSerializer(item.NetworkReader), rpcParams);
 
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
-                    if (__rpc_name_table.TryGetValue(networkMethodId, out var rpcMethodName))
-                    {
-                        NetworkMetrics.TrackRpcReceived(
-                            item.NetworkId,
-                            networkObjectId,
-                            rpcMethodName,
-                            networkBehaviour.__getTypeName(),
-                            item.StreamSize);
-                    }
-#endif
+                if (__rpc_name_table.TryGetValue(networkMethodId, out var rpcMethodName))
+                {
+                    NetworkMetrics.TrackRpcReceived(
+                        item.NetworkId,
+                        networkObjectId,
+                        rpcMethodName,
+                        networkBehaviour.__getTypeName(),
+                        item.StreamSize);
                 }
+#endif
             }
         }
 
@@ -1459,10 +1453,8 @@ namespace Unity.Netcode
                 clientIds, NetworkUpdateStage.EarlyUpdate);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext)context)
-                {
-                    nonNullContext.NetworkWriter.WriteInt32Packed(NetworkTickSystem.ServerTime.Tick);
-                }
+                using var nonNullContext = (InternalCommandContext)context;
+                nonNullContext.NetworkWriter.WriteInt32Packed(NetworkTickSystem.ServerTime.Tick);
             }
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
             s_SyncTime.End();
@@ -1505,16 +1497,14 @@ namespace Unity.Netcode
 
                     if (context != null)
                     {
-                        using (var nonNullContext = (InternalCommandContext)context)
-                        {
-                            nonNullContext.NetworkWriter.WriteUInt64Packed(ownerClientId);
-                            nonNullContext.NetworkWriter.WriteInt32Packed(LocalTime.Tick);
+                        using var nonNullContext = (InternalCommandContext)context;
+                        nonNullContext.NetworkWriter.WriteUInt64Packed(ownerClientId);
+                        nonNullContext.NetworkWriter.WriteInt32Packed(LocalTime.Tick);
 
-                            // If scene management is disabled, then just serialize all client relative (observed) NetworkObjects
-                            if (!NetworkConfig.EnableSceneManagement)
-                            {
-                                SpawnManager.SerializeObservedNetworkObjects(ownerClientId, nonNullContext.NetworkWriter);
-                            }
+                        // If scene management is disabled, then just serialize all client relative (observed) NetworkObjects
+                        if (!NetworkConfig.EnableSceneManagement)
+                        {
+                            SpawnManager.SerializeObservedNetworkObjects(ownerClientId, nonNullContext.NetworkWriter);
                         }
                     }
 
@@ -1569,42 +1559,40 @@ namespace Unity.Netcode
                     new[] { clientPair.Key }, NetworkUpdateLoop.UpdateStage);
                 if (context != null)
                 {
-                    using (var nonNullContext = (InternalCommandContext)context)
+                    using var nonNullContext = (InternalCommandContext)context;
+                    nonNullContext.NetworkWriter.WriteBool(true);
+                    nonNullContext.NetworkWriter.WriteUInt64Packed(ConnectedClients[clientId].PlayerObject.NetworkObjectId);
+                    nonNullContext.NetworkWriter.WriteUInt64Packed(clientId);
+
+                    //Does not have a parent
+                    nonNullContext.NetworkWriter.WriteBool(false);
+
+                    // This is not a scene object
+                    nonNullContext.NetworkWriter.WriteBool(false);
+
+                    nonNullContext.NetworkWriter.WriteUInt32Packed(playerPrefabHash);
+
+                    if (ConnectedClients[clientId].PlayerObject.IncludeTransformWhenSpawning == null || ConnectedClients[clientId].PlayerObject.IncludeTransformWhenSpawning(clientId))
                     {
                         nonNullContext.NetworkWriter.WriteBool(true);
-                        nonNullContext.NetworkWriter.WriteUInt64Packed(ConnectedClients[clientId].PlayerObject.NetworkObjectId);
-                        nonNullContext.NetworkWriter.WriteUInt64Packed(clientId);
+                        nonNullContext.NetworkWriter.WriteSinglePacked(ConnectedClients[clientId].PlayerObject.transform.position.x);
+                        nonNullContext.NetworkWriter.WriteSinglePacked(ConnectedClients[clientId].PlayerObject.transform.position.y);
+                        nonNullContext.NetworkWriter.WriteSinglePacked(ConnectedClients[clientId].PlayerObject.transform.position.z);
 
-                        //Does not have a parent
+                        nonNullContext.NetworkWriter.WriteSinglePacked(ConnectedClients[clientId].PlayerObject.transform.rotation.eulerAngles.x);
+                        nonNullContext.NetworkWriter.WriteSinglePacked(ConnectedClients[clientId].PlayerObject.transform.rotation.eulerAngles.y);
+                        nonNullContext.NetworkWriter.WriteSinglePacked(ConnectedClients[clientId].PlayerObject.transform.rotation.eulerAngles.z);
+                    }
+                    else
+                    {
                         nonNullContext.NetworkWriter.WriteBool(false);
+                    }
 
-                        // This is not a scene object
-                        nonNullContext.NetworkWriter.WriteBool(false);
+                    nonNullContext.NetworkWriter.WriteBool(false); //No payload data
 
-                        nonNullContext.NetworkWriter.WriteUInt32Packed(playerPrefabHash);
-
-                        if (ConnectedClients[clientId].PlayerObject.IncludeTransformWhenSpawning == null || ConnectedClients[clientId].PlayerObject.IncludeTransformWhenSpawning(clientId))
-                        {
-                            nonNullContext.NetworkWriter.WriteBool(true);
-                            nonNullContext.NetworkWriter.WriteSinglePacked(ConnectedClients[clientId].PlayerObject.transform.position.x);
-                            nonNullContext.NetworkWriter.WriteSinglePacked(ConnectedClients[clientId].PlayerObject.transform.position.y);
-                            nonNullContext.NetworkWriter.WriteSinglePacked(ConnectedClients[clientId].PlayerObject.transform.position.z);
-
-                            nonNullContext.NetworkWriter.WriteSinglePacked(ConnectedClients[clientId].PlayerObject.transform.rotation.eulerAngles.x);
-                            nonNullContext.NetworkWriter.WriteSinglePacked(ConnectedClients[clientId].PlayerObject.transform.rotation.eulerAngles.y);
-                            nonNullContext.NetworkWriter.WriteSinglePacked(ConnectedClients[clientId].PlayerObject.transform.rotation.eulerAngles.z);
-                        }
-                        else
-                        {
-                            nonNullContext.NetworkWriter.WriteBool(false);
-                        }
-
-                        nonNullContext.NetworkWriter.WriteBool(false); //No payload data
-
-                        if (NetworkConfig.EnableNetworkVariable)
-                        {
-                            ConnectedClients[clientId].PlayerObject.WriteNetworkVariableData(nonNullContext.NetworkWriter.GetStream(), clientPair.Key);
-                        }
+                    if (NetworkConfig.EnableNetworkVariable)
+                    {
+                        ConnectedClients[clientId].PlayerObject.WriteNetworkVariableData(nonNullContext.NetworkWriter.GetStream(), clientPair.Key);
                     }
                 }
             }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -329,16 +329,14 @@ namespace Unity.Netcode
                     new[] { clientId }, NetworkUpdateStage.PostLateUpdate);
                 if (context != null)
                 {
-                    using (var nonNullContext = (InternalCommandContext)context)
-                    {
-                        var bufferSizeCapture = new CommandContextSizeCapture(nonNullContext);
-                        bufferSizeCapture.StartMeasureSegment();
+                    using var nonNullContext = (InternalCommandContext)context;
+                    var bufferSizeCapture = new CommandContextSizeCapture(nonNullContext);
+                    bufferSizeCapture.StartMeasureSegment();
 
-                        nonNullContext.NetworkWriter.WriteUInt64Packed(NetworkObjectId);
+                    nonNullContext.NetworkWriter.WriteUInt64Packed(NetworkObjectId);
 
-                        var size = bufferSizeCapture.StopMeasureSegment();
-                        NetworkManager.NetworkMetrics.TrackObjectDestroySent(clientId, NetworkObjectId, name, size);
-                    }
+                    var size = bufferSizeCapture.StopMeasureSegment();
+                    NetworkManager.NetworkMetrics.TrackObjectDestroySent(clientId, NetworkObjectId, name, size);
                 }
             }
         }
@@ -744,11 +742,9 @@ namespace Unity.Netcode
 
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext)context)
-                {
-                    nonNullContext.NetworkWriter.WriteUInt64Packed(NetworkObjectId);
-                    WriteNetworkParenting(nonNullContext.NetworkWriter, m_IsReparented, m_LatestParent);
-                }
+                using var nonNullContext = (InternalCommandContext)context;
+                nonNullContext.NetworkWriter.WriteUInt64Packed(NetworkObjectId);
+                WriteNetworkParenting(nonNullContext.NetworkWriter, m_IsReparented, m_LatestParent);
             }
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
@@ -714,34 +714,30 @@ namespace Unity.Netcode
 
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext)context)
-                {
-                    var sequence = m_ClientData[clientId].SequenceNumber;
+                using var nonNullContext = (InternalCommandContext)context;
+                var sequence = m_ClientData[clientId].SequenceNumber;
 
-                    // write the tick and sequence header
-                    nonNullContext.NetworkWriter.WriteInt32Packed(m_CurrentTick);
-                    nonNullContext.NetworkWriter.WriteUInt16(sequence);
+                // write the tick and sequence header
+                nonNullContext.NetworkWriter.WriteInt32Packed(m_CurrentTick);
+                nonNullContext.NetworkWriter.WriteUInt16(sequence);
 
-                    var buffer = (NetworkBuffer)nonNullContext.NetworkWriter.GetStream();
+                var buffer = (NetworkBuffer)nonNullContext.NetworkWriter.GetStream();
 
-                    using (var writer = PooledNetworkWriter.Get(buffer))
-                    {
-                        // write the snapshot: buffer, index, spawns, despawns
-                        writer.WriteUInt16(SentinelBefore);
-                        WriteBuffer(buffer);
-                        WriteIndex(buffer);
-                        WriteSpawns(buffer, clientId);
-                        WriteAcks(buffer, clientId);
-                        writer.WriteUInt16(SentinelAfter);
+                using var writer = PooledNetworkWriter.Get(buffer);
+                // write the snapshot: buffer, index, spawns, despawns
+                writer.WriteUInt16(SentinelBefore);
+                WriteBuffer(buffer);
+                WriteIndex(buffer);
+                WriteSpawns(buffer, clientId);
+                WriteAcks(buffer, clientId);
+                writer.WriteUInt16(SentinelAfter);
 
-                        m_ClientData[clientId].LastReceivedSequence = 0;
+                m_ClientData[clientId].LastReceivedSequence = 0;
 
-                        // todo: this is incorrect (well, sub-optimal)
-                        // we should still continue ack'ing past messages, in case this one is dropped
-                        m_ClientData[clientId].ReceivedSequenceMask = 0;
-                        m_ClientData[clientId].SequenceNumber++;
-                    }
-                }
+                // todo: this is incorrect (well, sub-optimal)
+                // we should still continue ack'ing past messages, in case this one is dropped
+                m_ClientData[clientId].ReceivedSequenceMask = 0;
+                m_ClientData[clientId].SequenceNumber++;
             }
         }
 
@@ -772,71 +768,67 @@ namespace Unity.Netcode
                 clientData.NextDespawnIndex = 0;
             }
 
-            using (var writer = PooledNetworkWriter.Get(buffer))
+            using var writer = PooledNetworkWriter.Get(buffer);
+            var positionSpawns = writer.GetStream().Position;
+            writer.WriteInt16((short)m_Snapshot.NumSpawns);
+            var positionDespawns = writer.GetStream().Position;
+            writer.WriteInt16((short)m_Snapshot.NumDespawns);
+
+            for (var j = 0; j < m_Snapshot.NumSpawns && !overSize; j++)
             {
-                var positionSpawns = writer.GetStream().Position;
-                writer.WriteInt16((short)m_Snapshot.NumSpawns);
-                var positionDespawns = writer.GetStream().Position;
-                writer.WriteInt16((short)m_Snapshot.NumDespawns);
+                var index = clientData.NextSpawnIndex;
 
-                for (var j = 0; j < m_Snapshot.NumSpawns && !overSize; j++)
+                if (m_Snapshot.Spawns[index].TargetClientIds.Contains(clientId))
                 {
-                    var index = clientData.NextSpawnIndex;
-
-                    if (m_Snapshot.Spawns[index].TargetClientIds.Contains(clientId))
-                    {
-                        m_Snapshot.WriteSpawn(clientData, writer, in m_Snapshot.Spawns[index]);
-                        spawnWritten++;
-                    }
-
-                    // limit spawn sizes, compare current pos to very first position we wrote to
-                    if (writer.GetStream().Position - positionSpawns > k_MaxSpawnUsage)
-                    {
-                        overSize = true;
-                    }
-                    clientData.NextSpawnIndex = (clientData.NextSpawnIndex + 1) % m_Snapshot.NumSpawns;
+                    m_Snapshot.WriteSpawn(clientData, writer, in m_Snapshot.Spawns[index]);
+                    spawnWritten++;
                 }
 
-
-                for (var j = 0; j < m_Snapshot.NumDespawns && !overSize; j++)
+                // limit spawn sizes, compare current pos to very first position we wrote to
+                if (writer.GetStream().Position - positionSpawns > k_MaxSpawnUsage)
                 {
-                    var index = clientData.NextDespawnIndex;
-
-                    if (m_Snapshot.Despawns[index].TargetClientIds.Contains(clientId))
-                    {
-                        m_Snapshot.WriteDespawn(clientData, writer, in m_Snapshot.Despawns[index]);
-                        despawnWritten++;
-                    }
-                    // limit spawn sizes, compare current pos to very first position we wrote to
-                    if (writer.GetStream().Position - positionSpawns > k_MaxSpawnUsage)
-                    {
-                        overSize = true;
-                    }
-                    clientData.NextDespawnIndex = (clientData.NextDespawnIndex + 1) % m_Snapshot.NumDespawns;
+                    overSize = true;
                 }
-
-                long positionAfter = 0;
-
-                positionAfter = writer.GetStream().Position;
-                writer.GetStream().Position = positionSpawns;
-                writer.WriteInt16((short)spawnWritten);
-                writer.GetStream().Position = positionAfter;
-
-                positionAfter = writer.GetStream().Position;
-                writer.GetStream().Position = positionDespawns;
-                writer.WriteInt16((short)despawnWritten);
-                writer.GetStream().Position = positionAfter;
+                clientData.NextSpawnIndex = (clientData.NextSpawnIndex + 1) % m_Snapshot.NumSpawns;
             }
+
+
+            for (var j = 0; j < m_Snapshot.NumDespawns && !overSize; j++)
+            {
+                var index = clientData.NextDespawnIndex;
+
+                if (m_Snapshot.Despawns[index].TargetClientIds.Contains(clientId))
+                {
+                    m_Snapshot.WriteDespawn(clientData, writer, in m_Snapshot.Despawns[index]);
+                    despawnWritten++;
+                }
+                // limit spawn sizes, compare current pos to very first position we wrote to
+                if (writer.GetStream().Position - positionSpawns > k_MaxSpawnUsage)
+                {
+                    overSize = true;
+                }
+                clientData.NextDespawnIndex = (clientData.NextDespawnIndex + 1) % m_Snapshot.NumDespawns;
+            }
+
+            long positionAfter = 0;
+
+            positionAfter = writer.GetStream().Position;
+            writer.GetStream().Position = positionSpawns;
+            writer.WriteInt16((short)spawnWritten);
+            writer.GetStream().Position = positionAfter;
+
+            positionAfter = writer.GetStream().Position;
+            writer.GetStream().Position = positionDespawns;
+            writer.WriteInt16((short)despawnWritten);
+            writer.GetStream().Position = positionAfter;
         }
 
         private void WriteAcks(NetworkBuffer buffer, ulong clientId)
         {
-            using (var writer = PooledNetworkWriter.Get(buffer))
-            {
-                // todo: revisit whether 16-bit is enough for LastReceivedSequence
-                writer.WriteUInt16(m_ClientData[clientId].LastReceivedSequence);
-                writer.WriteUInt16(m_ClientData[clientId].ReceivedSequenceMask);
-            }
+            using var writer = PooledNetworkWriter.Get(buffer);
+            // todo: revisit whether 16-bit is enough for LastReceivedSequence
+            writer.WriteUInt16(m_ClientData[clientId].LastReceivedSequence);
+            writer.WriteUInt16(m_ClientData[clientId].ReceivedSequenceMask);
         }
 
         /// <summary>
@@ -845,13 +837,11 @@ namespace Unity.Netcode
         /// <param name="buffer">The buffer to write the index to</param>
         private void WriteIndex(NetworkBuffer buffer)
         {
-            using (var writer = PooledNetworkWriter.Get(buffer))
+            using var writer = PooledNetworkWriter.Get(buffer);
+            writer.WriteInt16((short)m_Snapshot.LastEntry);
+            for (var i = 0; i < m_Snapshot.LastEntry; i++)
             {
-                writer.WriteInt16((short)m_Snapshot.LastEntry);
-                for (var i = 0; i < m_Snapshot.LastEntry; i++)
-                {
-                    m_Snapshot.WriteEntry(writer, in m_Snapshot.Entries[i]);
-                }
+                m_Snapshot.WriteEntry(writer, in m_Snapshot.Entries[i]);
             }
         }
 
@@ -862,10 +852,8 @@ namespace Unity.Netcode
         /// <param name="buffer">The NetworkBuffer to write our buffer of variables to</param>
         private void WriteBuffer(NetworkBuffer buffer)
         {
-            using (var writer = PooledNetworkWriter.Get(buffer))
-            {
-                writer.WriteUInt16((ushort)m_Snapshot.Allocator.Range);
-            }
+            using var writer = PooledNetworkWriter.Get(buffer);
+            writer.WriteUInt16((ushort)m_Snapshot.Allocator.Range);
 
             // todo --M1--
             // this sends the whole buffer
@@ -917,18 +905,16 @@ namespace Unity.Netcode
         private void WriteVariableToSnapshot(Snapshot snapshot, NetworkVariableBase networkVariable, int index)
         {
             // write var into buffer, possibly adjusting entry's position and Length
-            using (var varBuffer = PooledNetworkBuffer.Get())
+            using var varBuffer = PooledNetworkBuffer.Get();
+            networkVariable.WriteDelta(varBuffer);
+            if (varBuffer.Length > snapshot.Entries[index].Length)
             {
-                networkVariable.WriteDelta(varBuffer);
-                if (varBuffer.Length > snapshot.Entries[index].Length)
-                {
-                    // allocate this Entry's buffer
-                    snapshot.AllocateEntry(ref snapshot.Entries[index], index, (int)varBuffer.Length);
-                }
-
-                // Copy the serialized NetworkVariable into our buffer
-                Buffer.BlockCopy(varBuffer.GetBuffer(), 0, snapshot.MainBuffer, snapshot.Entries[index].Position, (int)varBuffer.Length);
+                // allocate this Entry's buffer
+                snapshot.AllocateEntry(ref snapshot.Entries[index], index, (int)varBuffer.Length);
             }
+
+            // Copy the serialized NetworkVariable into our buffer
+            Buffer.BlockCopy(varBuffer.GetBuffer(), 0, snapshot.MainBuffer, snapshot.Entries[index].Position, (int)varBuffer.Length);
         }
 
 
@@ -948,72 +934,70 @@ namespace Unity.Netcode
 
             int snapshotTick = default;
 
-            using (var reader = PooledNetworkReader.Get(snapshotStream))
+            using var reader = PooledNetworkReader.Get(snapshotStream);
+            // make sure we have a ClientData entry for each client
+            if (!m_ClientData.ContainsKey(clientId))
             {
-                // make sure we have a ClientData entry for each client
-                if (!m_ClientData.ContainsKey(clientId))
-                {
-                    m_ClientData.Add(clientId, new ClientData());
-                }
+                m_ClientData.Add(clientId, new ClientData());
+            }
 
-                snapshotTick = reader.ReadInt32Packed();
-                var sequence = reader.ReadUInt16();
+            snapshotTick = reader.ReadInt32Packed();
+            var sequence = reader.ReadUInt16();
 
-                if (sequence >= m_ClientData[clientId].LastReceivedSequence)
+            if (sequence >= m_ClientData[clientId].LastReceivedSequence)
+            {
+                if (m_ClientData[clientId].ReceivedSequenceMask != 0)
                 {
-                    if (m_ClientData[clientId].ReceivedSequenceMask != 0)
+                    // since each bit in ReceivedSequenceMask is relative to the last received sequence
+                    // we need to shift all the bits by the difference in sequence
+                    var shift = sequence - m_ClientData[clientId].LastReceivedSequence;
+                    if (shift < sizeof(ushort) * 8)
                     {
-                        // since each bit in ReceivedSequenceMask is relative to the last received sequence
-                        // we need to shift all the bits by the difference in sequence
-                        var shift = sequence - m_ClientData[clientId].LastReceivedSequence;
-                        if (shift < sizeof(ushort) * 8)
-                        {
-                            m_ClientData[clientId].ReceivedSequenceMask <<= shift;
-                        }
-                        else
-                        {
-                            m_ClientData[clientId].ReceivedSequenceMask = 0;
-                        }
+                        m_ClientData[clientId].ReceivedSequenceMask <<= shift;
                     }
-
-                    if (m_ClientData[clientId].LastReceivedSequence != 0)
+                    else
                     {
-                        // because the bit we're adding for the previous ReceivedSequenceMask
-                        // was implicit, it needs to be shift by one less
-                        var shift = sequence - 1 - m_ClientData[clientId].LastReceivedSequence;
-                        if (shift < sizeof(ushort) * 8)
-                        {
-                            m_ClientData[clientId].ReceivedSequenceMask |= (ushort)(1 << shift);
-                        }
+                        m_ClientData[clientId].ReceivedSequenceMask = 0;
                     }
-
-                    m_ClientData[clientId].LastReceivedSequence = sequence;
                 }
-                else
+
+                if (m_ClientData[clientId].LastReceivedSequence != 0)
                 {
-                    // todo: Missing: dealing with out-of-order message acknowledgments
-                    // we should set m_ClientData[clientId].ReceivedSequenceMask accordingly
-                    // testing this will require a way to reorder SnapshotMessages, which we lack at the moment
-                    //
-                    // without this, we incur extra retransmit, not a catastrophic failure
+                    // because the bit we're adding for the previous ReceivedSequenceMask
+                    // was implicit, it needs to be shift by one less
+                    var shift = sequence - 1 - m_ClientData[clientId].LastReceivedSequence;
+                    if (shift < sizeof(ushort) * 8)
+                    {
+                        m_ClientData[clientId].ReceivedSequenceMask |= (ushort)(1 << shift);
+                    }
                 }
 
-                var sentinel = reader.ReadUInt16();
-                if (sentinel != SentinelBefore)
-                {
-                    Debug.Log("Critical : snapshot integrity (before)");
-                }
+                m_ClientData[clientId].LastReceivedSequence = sequence;
+            }
+            else
+            {
+                // todo: Missing: dealing with out-of-order message acknowledgments
+                // we should set m_ClientData[clientId].ReceivedSequenceMask accordingly
+                // testing this will require a way to reorder SnapshotMessages, which we lack at the moment
+                //
+                // without this, we incur extra retransmit, not a catastrophic failure
+            }
 
-                m_Snapshot.ReadBuffer(reader, snapshotStream);
-                m_Snapshot.ReadIndex(reader);
-                m_Snapshot.ReadSpawns(reader);
-                m_Snapshot.ReadAcks(clientId, m_ClientData[clientId], reader, GetConnectionRtt(clientId));
+            var sentinel = reader.ReadUInt16();
+            if (sentinel != SentinelBefore)
+            {
+                Debug.Log("Critical : snapshot integrity (before)");
+            }
 
-                sentinel = reader.ReadUInt16();
-                if (sentinel != SentinelAfter)
-                {
-                    Debug.Log("Critical : snapshot integrity (after)");
-                }
+            m_Snapshot.ReadBuffer(reader, snapshotStream);
+            m_Snapshot.ReadIndex(reader);
+            m_Snapshot.ReadSpawns(reader);
+            m_Snapshot.ReadAcks(clientId, m_ClientData[clientId], reader, GetConnectionRtt(clientId));
+
+            sentinel = reader.ReadUInt16();
+            if (sentinel != SentinelAfter)
+            {
+                Debug.Log("Critical : snapshot integrity (after)");
             }
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Logging/NetworkLog.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Logging/NetworkLog.cs
@@ -61,16 +61,14 @@ namespace Unity.Netcode
                     new[] { NetworkManager.Singleton.ServerClientId }, NetworkUpdateLoop.UpdateStage);
                 if (context != null)
                 {
-                    using (var nonNullContext = (InternalCommandContext)context)
-                    {
-                        var bufferSizeCapture = new CommandContextSizeCapture(nonNullContext);
-                        bufferSizeCapture.StartMeasureSegment();
-                        nonNullContext.NetworkWriter.WriteByte((byte)logType);
-                        nonNullContext.NetworkWriter.WriteStringPacked(message);
-                        var size = bufferSizeCapture.StopMeasureSegment();
+                    using var nonNullContext = (InternalCommandContext)context;
+                    var bufferSizeCapture = new CommandContextSizeCapture(nonNullContext);
+                    bufferSizeCapture.StartMeasureSegment();
+                    nonNullContext.NetworkWriter.WriteByte((byte)logType);
+                    nonNullContext.NetworkWriter.WriteStringPacked(message);
+                    var size = bufferSizeCapture.StopMeasureSegment();
 
-                        NetworkManager.Singleton.NetworkMetrics.TrackServerLogSent(NetworkManager.Singleton.ServerClientId, (uint)logType, size);
-                    }
+                    NetworkManager.Singleton.NetworkMetrics.TrackServerLogSent(NetworkManager.Singleton.ServerClientId, (uint)logType, size);
                 }
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/CustomMessageManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/CustomMessageManager.cs
@@ -53,11 +53,9 @@ namespace Unity.Netcode
                 clientIds.ToArray(), NetworkUpdateLoop.UpdateStage);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext)context)
-                {
-                    buffer.Position = 0;
-                    buffer.CopyTo(nonNullContext.NetworkWriter.GetStream());
-                }
+                using var nonNullContext = (InternalCommandContext)context;
+                buffer.Position = 0;
+                buffer.CopyTo(nonNullContext.NetworkWriter.GetStream());
             }
 
             m_NetworkManager.NetworkMetrics.TrackUnnamedMessageSent(clientIds, buffer.Length);
@@ -76,12 +74,10 @@ namespace Unity.Netcode
                 new[] { clientId }, NetworkUpdateLoop.UpdateStage);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext)context)
-                {
-                    m_NetworkManager.NetworkMetrics.TrackUnnamedMessageSent(clientId, buffer.Position);
-                    buffer.Position = 0;
-                    buffer.CopyTo(nonNullContext.NetworkWriter.GetStream());
-                }
+                using var nonNullContext = (InternalCommandContext)context;
+                m_NetworkManager.NetworkMetrics.TrackUnnamedMessageSent(clientId, buffer.Position);
+                buffer.Position = 0;
+                buffer.CopyTo(nonNullContext.NetworkWriter.GetStream());
             }
         }
 
@@ -196,20 +192,18 @@ namespace Unity.Netcode
                 new[] { clientId }, NetworkUpdateLoop.UpdateStage);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext)context)
-                {
-                    var bufferSizeCapture = new CommandContextSizeCapture(nonNullContext);
-                    bufferSizeCapture.StartMeasureSegment();
+                using var nonNullContext = (InternalCommandContext)context;
+                var bufferSizeCapture = new CommandContextSizeCapture(nonNullContext);
+                bufferSizeCapture.StartMeasureSegment();
 
-                    nonNullContext.NetworkWriter.WriteUInt64Packed(hash);
+                nonNullContext.NetworkWriter.WriteUInt64Packed(hash);
 
-                    stream.Position = 0;
-                    stream.CopyTo(nonNullContext.NetworkWriter.GetStream());
+                stream.Position = 0;
+                stream.CopyTo(nonNullContext.NetworkWriter.GetStream());
 
-                    var size = bufferSizeCapture.StopMeasureSegment();
+                var size = bufferSizeCapture.StopMeasureSegment();
 
-                    m_NetworkManager.NetworkMetrics.TrackNamedMessageSent(clientId, name, size);
-                }
+                m_NetworkManager.NetworkMetrics.TrackNamedMessageSent(clientId, name, size);
             }
         }
 
@@ -243,19 +237,17 @@ namespace Unity.Netcode
                 clientIds.ToArray(), NetworkUpdateLoop.UpdateStage);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext)context)
-                {
-                    var bufferSizeCapture = new CommandContextSizeCapture(nonNullContext);
-                    bufferSizeCapture.StartMeasureSegment();
+                using var nonNullContext = (InternalCommandContext)context;
+                var bufferSizeCapture = new CommandContextSizeCapture(nonNullContext);
+                bufferSizeCapture.StartMeasureSegment();
 
-                    nonNullContext.NetworkWriter.WriteUInt64Packed(hash);
+                nonNullContext.NetworkWriter.WriteUInt64Packed(hash);
 
-                    stream.Position = 0;
-                    stream.CopyTo(nonNullContext.NetworkWriter.GetStream());
+                stream.Position = 0;
+                stream.CopyTo(nonNullContext.NetworkWriter.GetStream());
 
-                    var size = bufferSizeCapture.StopMeasureSegment();
-                    m_NetworkManager.NetworkMetrics.TrackNamedMessageSent(clientIds, name, size);
-                }
+                var size = bufferSizeCapture.StopMeasureSegment();
+                m_NetworkManager.NetworkMetrics.TrackNamedMessageSent(clientIds, name, size);
             }
         }
     }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/InternalMessageHandler.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/InternalMessageHandler.cs
@@ -22,31 +22,29 @@ namespace Unity.Netcode
                 client.ConnectionState = PendingClient.State.PendingApproval;
             }
 
-            using (var reader = PooledNetworkReader.Get(stream))
+            using var reader = PooledNetworkReader.Get(stream);
+            ulong configHash = reader.ReadUInt64Packed();
+            if (!NetworkManager.NetworkConfig.CompareConfig(configHash))
             {
-                ulong configHash = reader.ReadUInt64Packed();
-                if (!NetworkManager.NetworkConfig.CompareConfig(configHash))
+                if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
                 {
-                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
-                    {
-                        NetworkLog.LogWarning($"{nameof(NetworkConfig)} mismatch. The configuration between the server and client does not match");
-                    }
-
-                    NetworkManager.DisconnectClient(clientId);
-                    return;
+                    NetworkLog.LogWarning($"{nameof(NetworkConfig)} mismatch. The configuration between the server and client does not match");
                 }
 
-                if (NetworkManager.NetworkConfig.ConnectionApproval)
-                {
-                    byte[] connectionBuffer = reader.ReadByteArray();
-                    NetworkManager.InvokeConnectionApproval(connectionBuffer, clientId,
-                        (createPlayerObject, playerPrefabHash, approved, position, rotation) =>
-                            NetworkManager.HandleApproval(clientId, createPlayerObject, playerPrefabHash, approved, position, rotation));
-                }
-                else
-                {
-                    NetworkManager.HandleApproval(clientId, NetworkManager.NetworkConfig.PlayerPrefab != null, null, true, null, null);
-                }
+                NetworkManager.DisconnectClient(clientId);
+                return;
+            }
+
+            if (NetworkManager.NetworkConfig.ConnectionApproval)
+            {
+                byte[] connectionBuffer = reader.ReadByteArray();
+                NetworkManager.InvokeConnectionApproval(connectionBuffer, clientId,
+                    (createPlayerObject, playerPrefabHash, approved, position, rotation) =>
+                        NetworkManager.HandleApproval(clientId, createPlayerObject, playerPrefabHash, approved, position, rotation));
+            }
+            else
+            {
+                NetworkManager.HandleApproval(clientId, NetworkManager.NetworkConfig.PlayerPrefab != null, null, true, null, null);
             }
         }
 
@@ -58,64 +56,60 @@ namespace Unity.Netcode
         /// <param name="receiveTime">time this message was received (currently not used)</param>
         public void HandleConnectionApproved(ulong clientId, Stream stream, float receiveTime)
         {
-            using (var reader = PooledNetworkReader.Get(stream))
+            using var reader = PooledNetworkReader.Get(stream);
+            NetworkManager.LocalClientId = reader.ReadUInt64Packed();
+
+            int tick = reader.ReadInt32Packed();
+            var time = new NetworkTime(NetworkManager.NetworkTickSystem.TickRate, tick);
+            NetworkManager.NetworkTimeSystem.Reset(time.Time, 0.15f); // Start with a constant RTT of 150 until we receive values from the transport.
+
+            NetworkManager.ConnectedClients.Add(NetworkManager.LocalClientId, new NetworkClient { ClientId = NetworkManager.LocalClientId });
+
+            // Only if scene management is disabled do we handle NetworkObject synchronization at this point
+            if (!NetworkManager.NetworkConfig.EnableSceneManagement)
             {
-                NetworkManager.LocalClientId = reader.ReadUInt64Packed();
+                NetworkManager.SpawnManager.DestroySceneObjects();
 
-                int tick = reader.ReadInt32Packed();
-                var time = new NetworkTime(NetworkManager.NetworkTickSystem.TickRate, tick);
-                NetworkManager.NetworkTimeSystem.Reset(time.Time, 0.15f); // Start with a constant RTT of 150 until we receive values from the transport.
-
-                NetworkManager.ConnectedClients.Add(NetworkManager.LocalClientId, new NetworkClient { ClientId = NetworkManager.LocalClientId });
-
-                // Only if scene management is disabled do we handle NetworkObject synchronization at this point
-                if (!NetworkManager.NetworkConfig.EnableSceneManagement)
+                // is not packed!
+                var objectCount = reader.ReadUInt16();
+                for (ushort i = 0; i < objectCount; i++)
                 {
-                    NetworkManager.SpawnManager.DestroySceneObjects();
-
-                    // is not packed!
-                    var objectCount = reader.ReadUInt16();
-                    for (ushort i = 0; i < objectCount; i++)
-                    {
-                        NetworkObject.DeserializeSceneObject(reader.GetStream() as NetworkBuffer, reader, m_NetworkManager);
-                    }
+                    NetworkObject.DeserializeSceneObject(reader.GetStream() as NetworkBuffer, reader, m_NetworkManager);
                 }
             }
         }
 
         public void HandleAddObject(ulong clientId, Stream stream)
         {
-            using (var reader = PooledNetworkReader.Get(stream))
+            using var reader = PooledNetworkReader.Get(stream);
+            var isPlayerObject = reader.ReadBool();
+            var networkId = reader.ReadUInt64Packed();
+            var ownerClientId = reader.ReadUInt64Packed();
+            var hasParent = reader.ReadBool();
+            ulong? parentNetworkId = null;
+
+            if (hasParent)
             {
-                var isPlayerObject = reader.ReadBool();
-                var networkId = reader.ReadUInt64Packed();
-                var ownerClientId = reader.ReadUInt64Packed();
-                var hasParent = reader.ReadBool();
-                ulong? parentNetworkId = null;
-
-                if (hasParent)
-                {
-                    parentNetworkId = reader.ReadUInt64Packed();
-                }
-
-                var softSync = reader.ReadBool();
-                var prefabHash = reader.ReadUInt32Packed();
-
-                Vector3? pos = null;
-                Quaternion? rot = null;
-                if (reader.ReadBool())
-                {
-                    pos = new Vector3(reader.ReadSinglePacked(), reader.ReadSinglePacked(), reader.ReadSinglePacked());
-                    rot = Quaternion.Euler(reader.ReadSinglePacked(), reader.ReadSinglePacked(), reader.ReadSinglePacked());
-                }
-
-                var (isReparented, latestParent) = NetworkObject.ReadNetworkParenting(reader);
-
-                var networkObject = NetworkManager.SpawnManager.CreateLocalNetworkObject(softSync, prefabHash, ownerClientId, parentNetworkId, pos, rot, isReparented);
-                networkObject.SetNetworkParenting(isReparented, latestParent);
-                NetworkManager.SpawnManager.SpawnNetworkObjectLocally(networkObject, networkId, softSync, isPlayerObject, ownerClientId, stream, true, false);
-                m_NetworkManager.NetworkMetrics.TrackObjectSpawnReceived(clientId, networkObject.NetworkObjectId, networkObject.name, stream.Length);
+                parentNetworkId = reader.ReadUInt64Packed();
             }
+
+            var softSync = reader.ReadBool();
+            var prefabHash = reader.ReadUInt32Packed();
+
+            Vector3? pos = null;
+            Quaternion? rot = null;
+            if (reader.ReadBool())
+            {
+                pos = new Vector3(reader.ReadSinglePacked(), reader.ReadSinglePacked(), reader.ReadSinglePacked());
+                rot = Quaternion.Euler(reader.ReadSinglePacked(), reader.ReadSinglePacked(), reader.ReadSinglePacked());
+            }
+
+            var (isReparented, latestParent) = NetworkObject.ReadNetworkParenting(reader);
+
+            var networkObject = NetworkManager.SpawnManager.CreateLocalNetworkObject(softSync, prefabHash, ownerClientId, parentNetworkId, pos, rot, isReparented);
+            networkObject.SetNetworkParenting(isReparented, latestParent);
+            NetworkManager.SpawnManager.SpawnNetworkObjectLocally(networkObject, networkId, softSync, isPlayerObject, ownerClientId, stream, true, false);
+            m_NetworkManager.NetworkMetrics.TrackObjectSpawnReceived(clientId, networkObject.NetworkObjectId, networkObject.name, stream.Length);
         }
 
         public void HandleDestroyObject(ulong clientId, Stream stream)
@@ -184,12 +178,10 @@ namespace Unity.Netcode
 
         public void HandleTimeSync(ulong clientId, Stream stream)
         {
-            using (var reader = PooledNetworkReader.Get(stream))
-            {
-                int tick = reader.ReadInt32Packed();
-                var time = new NetworkTime(NetworkManager.NetworkTickSystem.TickRate, tick);
-                NetworkManager.NetworkTimeSystem.Sync(time.Time, NetworkManager.NetworkConfig.NetworkTransport.GetCurrentRtt(clientId) / 1000d);
-            }
+            using var reader = PooledNetworkReader.Get(stream);
+            int tick = reader.ReadInt32Packed();
+            var time = new NetworkTime(NetworkManager.NetworkTickSystem.TickRate, tick);
+            NetworkManager.NetworkTimeSystem.Sync(time.Time, NetworkManager.NetworkConfig.NetworkTransport.GetCurrentRtt(clientId) / 1000d);
         }
 
         public void HandleNetworkVariableDelta(ulong clientId, Stream stream)
@@ -204,33 +196,31 @@ namespace Unity.Netcode
                 return;
             }
 
-            using (var reader = PooledNetworkReader.Get(stream))
+            using var reader = PooledNetworkReader.Get(stream);
+            ulong networkObjectId = reader.ReadUInt64Packed();
+            ushort networkBehaviourIndex = reader.ReadUInt16Packed();
+
+            if (NetworkManager.SpawnManager.SpawnedObjects.TryGetValue(networkObjectId, out NetworkObject networkObject))
             {
-                ulong networkObjectId = reader.ReadUInt64Packed();
-                ushort networkBehaviourIndex = reader.ReadUInt16Packed();
+                NetworkBehaviour behaviour = networkObject.GetNetworkBehaviourAtOrderIndex(networkBehaviourIndex);
 
-                if (NetworkManager.SpawnManager.SpawnedObjects.TryGetValue(networkObjectId, out NetworkObject networkObject))
-                {
-                    NetworkBehaviour behaviour = networkObject.GetNetworkBehaviourAtOrderIndex(networkBehaviourIndex);
-
-                    if (behaviour == null)
-                    {
-                        if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
-                        {
-                            NetworkLog.LogWarning($"Network variable delta message received for a non-existent behaviour. {nameof(networkObjectId)}: {networkObjectId}, {nameof(networkBehaviourIndex)}: {networkBehaviourIndex}");
-                        }
-                    }
-                    else
-                    {
-                        behaviour.HandleNetworkVariableDeltas(stream, clientId);
-                    }
-                }
-                else if (NetworkManager.IsServer)
+                if (behaviour == null)
                 {
                     if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
                     {
-                        NetworkLog.LogWarning($"Network variable delta message received for a non-existent object with {nameof(networkObjectId)}: {networkObjectId}. This delta was lost.");
+                        NetworkLog.LogWarning($"Network variable delta message received for a non-existent behaviour. {nameof(networkObjectId)}: {networkObjectId}, {nameof(networkBehaviourIndex)}: {networkBehaviourIndex}");
                     }
+                }
+                else
+                {
+                    behaviour.HandleNetworkVariableDeltas(stream, clientId);
+                }
+            }
+            else if (NetworkManager.IsServer)
+            {
+                if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
+                {
+                    NetworkLog.LogWarning($"Network variable delta message received for a non-existent object with {nameof(networkObjectId)}: {networkObjectId}. This delta was lost.");
                 }
             }
         }
@@ -284,35 +274,31 @@ namespace Unity.Netcode
 
         public void HandleNamedMessage(ulong clientId, Stream stream)
         {
-            using (var reader = PooledNetworkReader.Get(stream))
-            {
-                ulong hash = reader.ReadUInt64Packed();
+            using var reader = PooledNetworkReader.Get(stream);
+            ulong hash = reader.ReadUInt64Packed();
 
-                NetworkManager.CustomMessagingManager.InvokeNamedMessage(hash, clientId, stream);
-            }
+            NetworkManager.CustomMessagingManager.InvokeNamedMessage(hash, clientId, stream);
         }
 
         public void HandleNetworkLog(ulong clientId, Stream stream)
         {
-            using (var reader = PooledNetworkReader.Get(stream))
-            {
-                var length = stream.Length;
-                var logType = (NetworkLog.LogType)reader.ReadByte();
-                m_NetworkManager.NetworkMetrics.TrackServerLogReceived(clientId, (uint)logType, length);
-                string message = reader.ReadStringPacked();
+            using var reader = PooledNetworkReader.Get(stream);
+            var length = stream.Length;
+            var logType = (NetworkLog.LogType)reader.ReadByte();
+            m_NetworkManager.NetworkMetrics.TrackServerLogReceived(clientId, (uint)logType, length);
+            string message = reader.ReadStringPacked();
 
-                switch (logType)
-                {
-                    case NetworkLog.LogType.Info:
-                        NetworkLog.LogInfoServerLocal(message, clientId);
-                        break;
-                    case NetworkLog.LogType.Warning:
-                        NetworkLog.LogWarningServerLocal(message, clientId);
-                        break;
-                    case NetworkLog.LogType.Error:
-                        NetworkLog.LogErrorServerLocal(message, clientId);
-                        break;
-                }
+            switch (logType)
+            {
+                case NetworkLog.LogType.Info:
+                    NetworkLog.LogInfoServerLocal(message, clientId);
+                    break;
+                case NetworkLog.LogType.Warning:
+                    NetworkLog.LogWarningServerLocal(message, clientId);
+                    break;
+                case NetworkLog.LogType.Error:
+                    NetworkLog.LogErrorServerLocal(message, clientId);
+                    break;
             }
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -294,10 +294,8 @@ namespace Unity.Netcode
 
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext)context)
-                {
-                    SceneEventData.OnWrite(nonNullContext.NetworkWriter);
-                }
+                using var nonNullContext = (InternalCommandContext)context;
+                SceneEventData.OnWrite(nonNullContext.NetworkWriter);
                 return;
             }
 
@@ -428,15 +426,13 @@ namespace Unity.Netcode
             var context = m_NetworkManager.MessageQueueContainer.EnterInternalCommandContext(k_MessageType, k_ChannelType, m_NetworkManager.ConnectedClientsIds, k_NetworkUpdateStage);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext)context)
-                {
-                    ClientSynchEventData.SceneEventGuid = sceneEventProgress.Guid;
-                    ClientSynchEventData.SceneIndex = SceneNameToIndex[sceneEventProgress.SceneName];
-                    ClientSynchEventData.SceneEventType = sceneEventProgress.SceneEventType;
-                    ClientSynchEventData.ClientsCompleted = sceneEventProgress.DoneClients;
-                    ClientSynchEventData.ClientsTimedOut = m_NetworkManager.ConnectedClients.Keys.Except(sceneEventProgress.DoneClients).ToList();
-                    ClientSynchEventData.OnWrite(nonNullContext.NetworkWriter);
-                }
+                using var nonNullContext = (InternalCommandContext)context;
+                ClientSynchEventData.SceneEventGuid = sceneEventProgress.Guid;
+                ClientSynchEventData.SceneIndex = SceneNameToIndex[sceneEventProgress.SceneName];
+                ClientSynchEventData.SceneEventType = sceneEventProgress.SceneEventType;
+                ClientSynchEventData.ClientsCompleted = sceneEventProgress.DoneClients;
+                ClientSynchEventData.ClientsTimedOut = m_NetworkManager.ConnectedClients.Keys.Except(sceneEventProgress.DoneClients).ToList();
+                ClientSynchEventData.OnWrite(nonNullContext.NetworkWriter);
             }
 
             // Send a local notification to the server that all clients are done loading or unloading
@@ -873,10 +869,8 @@ namespace Unity.Netcode
                         // Set the target client id that will be used during in scene NetworkObject serialization
                         SceneEventData.TargetClientId = clientId;
 
-                        using (var nonNullContext = (InternalCommandContext)context)
-                        {
-                            SceneEventData.OnWrite(nonNullContext.NetworkWriter);
-                        }
+                        using var nonNullContext = (InternalCommandContext)context;
+                        SceneEventData.OnWrite(nonNullContext.NetworkWriter);
                     }
                     else
                     {
@@ -973,10 +967,8 @@ namespace Unity.Netcode
             var context = m_NetworkManager.MessageQueueContainer.EnterInternalCommandContext(k_MessageType, k_ChannelType, new ulong[] { clientId }, k_NetworkUpdateStage);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext)context)
-                {
-                    ClientSynchEventData.OnWrite(nonNullContext.NetworkWriter);
-                }
+                using var nonNullContext = (InternalCommandContext)context;
+                ClientSynchEventData.OnWrite(nonNullContext.NetworkWriter);
             }
 
             // Notify the local server that the client has been sent the SceneEventData.SceneEventTypes.S2C_Event_Sync event
@@ -1111,10 +1103,8 @@ namespace Unity.Netcode
                 new ulong[] { m_NetworkManager.ServerClientId }, k_NetworkUpdateStage);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext)context)
-                {
-                    ClientSynchEventData.OnWrite(nonNullContext.NetworkWriter);
-                }
+                using var nonNullContext = (InternalCommandContext)context;
+                ClientSynchEventData.OnWrite(nonNullContext.NetworkWriter);
             }
 
             // Send notification to local client that the scene has finished loading

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -104,20 +104,18 @@ namespace Unity.Netcode
                 NetworkManager.ConnectedClientsIds, NetworkUpdateLoop.UpdateStage);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext)context)
+                using var nonNullContext = (InternalCommandContext)context;
+                var bufferSizeCapture = new CommandContextSizeCapture(nonNullContext);
+                bufferSizeCapture.StartMeasureSegment();
+
+                nonNullContext.NetworkWriter.WriteUInt64Packed(networkObject.NetworkObjectId);
+                nonNullContext.NetworkWriter.WriteUInt64Packed(networkObject.OwnerClientId);
+
+                var size = bufferSizeCapture.StopMeasureSegment();
+
+                foreach (var client in NetworkManager.ConnectedClients)
                 {
-                    var bufferSizeCapture = new CommandContextSizeCapture(nonNullContext);
-                    bufferSizeCapture.StartMeasureSegment();
-
-                    nonNullContext.NetworkWriter.WriteUInt64Packed(networkObject.NetworkObjectId);
-                    nonNullContext.NetworkWriter.WriteUInt64Packed(networkObject.OwnerClientId);
-
-                    var size = bufferSizeCapture.StopMeasureSegment();
-
-                    foreach (var client in NetworkManager.ConnectedClients)
-                    {
-                        NetworkManager.NetworkMetrics.TrackOwnershipChangeSent(client.Key, networkObject.NetworkObjectId, networkObject.name, size);
-                    }
+                    NetworkManager.NetworkMetrics.TrackOwnershipChangeSent(client.Key, networkObject.NetworkObjectId, networkObject.name, size);
                 }
             }
         }
@@ -156,19 +154,17 @@ namespace Unity.Netcode
                 clientIds, NetworkUpdateLoop.UpdateStage);
             if (context != null)
             {
-                using (var nonNullContext = (InternalCommandContext)context)
+                using var nonNullContext = (InternalCommandContext)context;
+                var bufferSizeCapture = new CommandContextSizeCapture(nonNullContext);
+                bufferSizeCapture.StartMeasureSegment();
+
+                nonNullContext.NetworkWriter.WriteUInt64Packed(networkObject.NetworkObjectId);
+                nonNullContext.NetworkWriter.WriteUInt64Packed(clientId);
+
+                var size = bufferSizeCapture.StopMeasureSegment();
+                foreach (var client in NetworkManager.ConnectedClients)
                 {
-                    var bufferSizeCapture = new CommandContextSizeCapture(nonNullContext);
-                    bufferSizeCapture.StartMeasureSegment();
-
-                    nonNullContext.NetworkWriter.WriteUInt64Packed(networkObject.NetworkObjectId);
-                    nonNullContext.NetworkWriter.WriteUInt64Packed(clientId);
-
-                    var size = bufferSizeCapture.StopMeasureSegment();
-                    foreach (var client in NetworkManager.ConnectedClients)
-                    {
-                        NetworkManager.NetworkMetrics.TrackOwnershipChangeSent(client.Key, networkObject.NetworkObjectId, networkObject.name, size);
-                    }
+                    NetworkManager.NetworkMetrics.TrackOwnershipChangeSent(client.Key, networkObject.NetworkObjectId, networkObject.name, size);
                 }
             }
         }
@@ -389,16 +385,14 @@ namespace Unity.Netcode
                     new ulong[] { clientId }, NetworkUpdateLoop.UpdateStage);
                 if (context != null)
                 {
-                    using (var nonNullContext = (InternalCommandContext)context)
-                    {
-                        var bufferSizeCapture = new CommandContextSizeCapture(nonNullContext);
-                        bufferSizeCapture.StartMeasureSegment();
+                    using var nonNullContext = (InternalCommandContext)context;
+                    var bufferSizeCapture = new CommandContextSizeCapture(nonNullContext);
+                    bufferSizeCapture.StartMeasureSegment();
 
-                        WriteSpawnCallForObject(nonNullContext.NetworkWriter, clientId, networkObject);
+                    WriteSpawnCallForObject(nonNullContext.NetworkWriter, clientId, networkObject);
 
-                        var size = bufferSizeCapture.StopMeasureSegment();
-                        NetworkManager.NetworkMetrics.TrackObjectSpawnSent(clientId, networkObject.NetworkObjectId, networkObject.name, size);
-                    }
+                    var size = bufferSizeCapture.StopMeasureSegment();
+                    NetworkManager.NetworkMetrics.TrackObjectSpawnSent(clientId, networkObject.NetworkObjectId, networkObject.name, size);
                 }
             }
         }
@@ -666,16 +660,14 @@ namespace Unity.Netcode
                                     clientIds, NetworkUpdateStage.PostLateUpdate);
                                 if (context != null)
                                 {
-                                    using (var nonNullContext = (InternalCommandContext)context)
-                                    {
-                                        var bufferSizeCapture = new CommandContextSizeCapture(nonNullContext);
-                                        bufferSizeCapture.StartMeasureSegment();
+                                    using var nonNullContext = (InternalCommandContext)context;
+                                    var bufferSizeCapture = new CommandContextSizeCapture(nonNullContext);
+                                    bufferSizeCapture.StartMeasureSegment();
 
-                                        nonNullContext.NetworkWriter.WriteUInt64Packed(networkObject.NetworkObjectId);
+                                    nonNullContext.NetworkWriter.WriteUInt64Packed(networkObject.NetworkObjectId);
 
-                                        var size = bufferSizeCapture.StopMeasureSegment();
-                                        NetworkManager.NetworkMetrics.TrackObjectDestroySent(clientIds, networkObject.NetworkObjectId, networkObject.name, size);
-                                    }
+                                    var size = bufferSizeCapture.StopMeasureSegment();
+                                    NetworkManager.NetworkMetrics.TrackObjectDestroySent(clientIds, networkObject.NetworkObjectId, networkObject.name, size);
                                 }
                             }
                         }

--- a/com.unity.netcode.gameobjects/Tests/Editor/NetworkManagerMessageHandlerTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/NetworkManagerMessageHandlerTests.cs
@@ -35,222 +35,176 @@ namespace Unity.Netcode.EditorTests
             // Have to force the update stage to something valid. It starts at Unset.
             NetworkUpdateLoop.UpdateStage = NetworkUpdateStage.Update;
 
-            using (var inputBuffer = new NetworkBuffer())
-            {
-                // Start server since pre-message-handler passes IsServer & IsClient checks
-                networkManager.StartServer();
+            using var inputBuffer = new NetworkBuffer();
+            // Start server since pre-message-handler passes IsServer & IsClient checks
+            networkManager.StartServer();
 
-                // Disable batching to make the RPCs come straight through
-                // This has to be done post start
-                networkManager.MessageQueueContainer.EnableBatchedMessages(false);
+            // Disable batching to make the RPCs come straight through
+            // This has to be done post start
+            networkManager.MessageQueueContainer.EnableBatchedMessages(false);
 
-                // Should cause log (server only)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleConnectionRequest));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.ConnectionRequest, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
+            // Should cause log (server only)
+            // Everything should log MessageReceiveQueueItem even if ignored
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleConnectionRequest));
+            using var messageStream0 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.ConnectionRequest, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
+            networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream0.GetBuffer(), 0, (int)messageStream0.Length), 0);
 
-                // Should not cause log (client only)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.ConnectionApproved, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
+            // Should not cause log (client only)
+            // Everything should log MessageReceiveQueueItem even if ignored
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
+            using var messageStream1 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.ConnectionApproved, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
+            networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream1.GetBuffer(), 0, (int)messageStream1.Length), 0);
 
-                // Should not cause log (client only)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.CreateObject, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
+            // Should not cause log (client only)
+            // Everything should log MessageReceiveQueueItem even if ignored
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
+            using var messageStream2 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.CreateObject, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
+            networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream2.GetBuffer(), 0, (int)messageStream2.Length), 0);
 
-                // Should not cause log (client only)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.DestroyObject, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
+            // Should not cause log (client only)
+            // Everything should log MessageReceiveQueueItem even if ignored
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
+            using var messageStream3 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.DestroyObject, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
+            networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream3.GetBuffer(), 0, (int)messageStream3.Length), 0);
 
-                // Should not cause log (client only)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleSceneEvent));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.SceneEvent, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
+            // Should not cause log (client only)
+            // Everything should log MessageReceiveQueueItem even if ignored
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleSceneEvent));
+            using var messageStream4 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.SceneEvent, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
+            networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream4.GetBuffer(), 0, (int)messageStream4.Length), 0);
 
-                // Should not cause log (client only)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.ChangeOwner, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
+            // Should not cause log (client only)
+            // Everything should log MessageReceiveQueueItem even if ignored
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
+            using var messageStream5 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.ChangeOwner, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
+            networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream5.GetBuffer(), 0, (int)messageStream5.Length), 0);
 
-                // Should not cause log (client only)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.TimeSync, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
+            // Should not cause log (client only)
+            // Everything should log MessageReceiveQueueItem even if ignored
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
+            using var messageStream6 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.TimeSync, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
+            networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream6.GetBuffer(), 0, (int)messageStream6.Length), 0);
 
-                // Should cause log (server and client)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleNetworkVariableDelta));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.NetworkVariableDelta, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
+            // Should cause log (server and client)
+            // Everything should log MessageReceiveQueueItem even if ignored
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleNetworkVariableDelta));
+            using var messageStream7 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.NetworkVariableDelta, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
+            networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream7.GetBuffer(), 0, (int)messageStream7.Length), 0);
 
-                // Should cause log (server and client)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleUnnamedMessage));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.UnnamedMessage, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
+            // Should cause log (server and client)
+            // Everything should log MessageReceiveQueueItem even if ignored
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleUnnamedMessage));
+            using var messageStream8 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.UnnamedMessage, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
+            networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream8.GetBuffer(), 0, (int)messageStream8.Length), 0);
 
-                // Should cause log (server and client)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleNamedMessage));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.NamedMessage, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
+            // Should cause log (server and client)
+            // Everything should log MessageReceiveQueueItem even if ignored
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleNamedMessage));
+            using var messageStream9 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.NamedMessage, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
+            networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream9.GetBuffer(), 0, (int)messageStream9.Length), 0);
 
-                // Should cause log (server only)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleNetworkLog));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.ServerLog, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
+            // Should cause log (server only)
+            // Everything should log MessageReceiveQueueItem even if ignored
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleNetworkLog));
+            using var messageStream10 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.ServerLog, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
+            networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream10.GetBuffer(), 0, (int)messageStream10.Length), 0);
 
-                // Stop server to trigger full shutdown
-                networkManager.StopServer();
+            // Stop server to trigger full shutdown
+            networkManager.StopServer();
 
-                // Replace the real message handler with a dummy one that just prints a result
-                networkManager.MessageHandler = new DummyMessageHandler(networkManager);
+            // Replace the real message handler with a dummy one that just prints a result
+            networkManager.MessageHandler = new DummyMessageHandler(networkManager);
 
-                // Start client since pre-message-handler passes IsServer & IsClient checks
-                networkManager.StartClient();
+            // Start client since pre-message-handler passes IsServer & IsClient checks
+            networkManager.StartClient();
 
-                // Disable batching to make the RPCs come straight through
-                // This has to be done post start (and post restart since the queue container is reset)
-                networkManager.MessageQueueContainer.EnableBatchedMessages(false);
+            // Disable batching to make the RPCs come straight through
+            // This has to be done post start (and post restart since the queue container is reset)
+            networkManager.MessageQueueContainer.EnableBatchedMessages(false);
 
-                // Should not cause log (server only)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.ConnectionRequest, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
+            // Should not cause log (server only)
+            // Everything should log MessageReceiveQueueItem even if ignored
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
+            using var messageStream11 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.ConnectionRequest, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
+            networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream11.GetBuffer(), 0, (int)messageStream11.Length), 0);
 
-                // Should cause log (client only)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleConnectionApproved));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.ConnectionApproved, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
+            // Should cause log (client only)
+            // Everything should log MessageReceiveQueueItem even if ignored
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleConnectionApproved));
+            using var messageStream12 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.ConnectionApproved, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
+            networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream12.GetBuffer(), 0, (int)messageStream12.Length), 0);
 
-                // Should cause log (client only)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleAddObject));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.CreateObject, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
+            // Should cause log (client only)
+            // Everything should log MessageReceiveQueueItem even if ignored
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleAddObject));
+            using var messageStream13 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.CreateObject, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
+            networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream13.GetBuffer(), 0, (int)messageStream13.Length), 0);
 
-                // Should cause log (client only)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleDestroyObject));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.DestroyObject, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
+            // Should cause log (client only)
+            // Everything should log MessageReceiveQueueItem even if ignored
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleDestroyObject));
+            using var messageStream14 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.DestroyObject, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
+            networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream14.GetBuffer(), 0, (int)messageStream14.Length), 0);
 
-                // Should cause log (client only)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleSceneEvent));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.SceneEvent, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
+            // Should cause log (client only)
+            // Everything should log MessageReceiveQueueItem even if ignored
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleSceneEvent));
+            using var messageStream15 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.SceneEvent, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
+            networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream15.GetBuffer(), 0, (int)messageStream15.Length), 0);
 
-                // Should cause log (client only)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleChangeOwner));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.ChangeOwner, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
+            // Should cause log (client only)
+            // Everything should log MessageReceiveQueueItem even if ignored
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleChangeOwner));
+            using var messageStream16 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.ChangeOwner, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
+            networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream16.GetBuffer(), 0, (int)messageStream16.Length), 0);
 
-                // Should cause log (client only)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleTimeSync));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.TimeSync, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
+            // Should cause log (client only)
+            // Everything should log MessageReceiveQueueItem even if ignored
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleTimeSync));
+            using var messageStream17 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.TimeSync, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
+            networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream17.GetBuffer(), 0, (int)messageStream17.Length), 0);
 
-                // Should cause log (server and client)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleNetworkVariableDelta));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.NetworkVariableDelta, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
+            // Should cause log (server and client)
+            // Everything should log MessageReceiveQueueItem even if ignored
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleNetworkVariableDelta));
+            using var messageStream18 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.NetworkVariableDelta, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
+            networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream18.GetBuffer(), 0, (int)messageStream18.Length), 0);
 
-                // Should cause log (server and client)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleUnnamedMessage));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.UnnamedMessage, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
+            // Should cause log (server and client)
+            // Everything should log MessageReceiveQueueItem even if ignored
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleUnnamedMessage));
+            using var messageStream19 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.UnnamedMessage, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
+            networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream19.GetBuffer(), 0, (int)messageStream19.Length), 0);
 
-                // Should cause log (server and client)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleNamedMessage));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.NamedMessage, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
+            // Should cause log (server and client)
+            // Everything should log MessageReceiveQueueItem even if ignored
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.HandleNamedMessage));
+            using var messageStream20 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.NamedMessage, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
+            networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream20.GetBuffer(), 0, (int)messageStream20.Length), 0);
 
-                // Should not cause log (server only)
-                // Everything should log MessageReceiveQueueItem even if ignored
-                LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
-                using (var messageStream = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.ServerLog, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching()))
-                {
-                    networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream.GetBuffer(), 0, (int)messageStream.Length), 0);
-                }
+            // Should not cause log (server only)
+            // Everything should log MessageReceiveQueueItem even if ignored
+            LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));
+            using var messageStream21 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.ServerLog, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
+            networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream21.GetBuffer(), 0, (int)messageStream21.Length), 0);
 
-                // Full cleanup
-                networkManager.StopClient();
-            }
+            // Full cleanup
+            networkManager.StopClient();
 
             // Ensure no missmatches with expectations
             LogAssert.NoUnexpectedReceived();

--- a/com.unity.netcode.gameobjects/Tests/Editor/NetworkSerializerTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/NetworkSerializerTests.cs
@@ -14,11 +14,9 @@ namespace Unity.Netcode.EditorTests
 
             try
             {
-                using (var outStream = PooledNetworkBuffer.Get())
-                using (var outWriter = PooledNetworkWriter.Get(outStream))
-                {
-                    outWriter.WriteObjectPacked(networkObject);
-                }
+                using var outStream = PooledNetworkBuffer.Get();
+                using var outWriter = PooledNetworkWriter.Get(outStream);
+                outWriter.WriteObjectPacked(networkObject);
 
                 // we expect the exception below
                 Assert.Fail();
@@ -32,731 +30,689 @@ namespace Unity.Netcode.EditorTests
         [Test]
         public void SerializeBool()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                bool outValueA = true;
-                bool outValueB = false;
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outValueA);
-                outSerializer.Serialize(ref outValueB);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            bool outValueA = true;
+            bool outValueB = false;
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outValueA);
+            outSerializer.Serialize(ref outValueB);
 
-                // deserialize
-                bool inValueA = default;
-                bool inValueB = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inValueA);
-                inSerializer.Serialize(ref inValueB);
+            // deserialize
+            bool inValueA = default;
+            bool inValueB = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inValueA);
+            inSerializer.Serialize(ref inValueB);
 
-                // validate
-                Assert.AreEqual(inValueA, outValueA);
-                Assert.AreEqual(inValueB, outValueB);
-            }
+            // validate
+            Assert.AreEqual(inValueA, outValueA);
+            Assert.AreEqual(inValueB, outValueB);
         }
 
         [Test]
         public void SerializeChar()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                char outValueA = 'U';
-                char outValueB = char.MinValue;
-                char outValueC = char.MaxValue;
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outValueA);
-                outSerializer.Serialize(ref outValueB);
-                outSerializer.Serialize(ref outValueC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            char outValueA = 'U';
+            char outValueB = char.MinValue;
+            char outValueC = char.MaxValue;
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outValueA);
+            outSerializer.Serialize(ref outValueB);
+            outSerializer.Serialize(ref outValueC);
 
-                // deserialize
-                char inValueA = default;
-                char inValueB = default;
-                char inValueC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inValueA);
-                inSerializer.Serialize(ref inValueB);
-                inSerializer.Serialize(ref inValueC);
+            // deserialize
+            char inValueA = default;
+            char inValueB = default;
+            char inValueC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inValueA);
+            inSerializer.Serialize(ref inValueB);
+            inSerializer.Serialize(ref inValueC);
 
-                // validate
-                Assert.AreEqual(inValueA, outValueA);
-                Assert.AreEqual(inValueB, outValueB);
-                Assert.AreEqual(inValueC, outValueC);
-            }
+            // validate
+            Assert.AreEqual(inValueA, outValueA);
+            Assert.AreEqual(inValueB, outValueB);
+            Assert.AreEqual(inValueC, outValueC);
         }
 
         [Test]
         public void SerializeSbyte()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                sbyte outValueA = -123;
-                sbyte outValueB = sbyte.MinValue;
-                sbyte outValueC = sbyte.MaxValue;
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outValueA);
-                outSerializer.Serialize(ref outValueB);
-                outSerializer.Serialize(ref outValueC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            sbyte outValueA = -123;
+            sbyte outValueB = sbyte.MinValue;
+            sbyte outValueC = sbyte.MaxValue;
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outValueA);
+            outSerializer.Serialize(ref outValueB);
+            outSerializer.Serialize(ref outValueC);
 
-                // deserialize
-                sbyte inValueA = default;
-                sbyte inValueB = default;
-                sbyte inValueC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inValueA);
-                inSerializer.Serialize(ref inValueB);
-                inSerializer.Serialize(ref inValueC);
+            // deserialize
+            sbyte inValueA = default;
+            sbyte inValueB = default;
+            sbyte inValueC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inValueA);
+            inSerializer.Serialize(ref inValueB);
+            inSerializer.Serialize(ref inValueC);
 
-                // validate
-                Assert.AreEqual(inValueA, outValueA);
-                Assert.AreEqual(inValueB, outValueB);
-                Assert.AreEqual(inValueC, outValueC);
-            }
+            // validate
+            Assert.AreEqual(inValueA, outValueA);
+            Assert.AreEqual(inValueB, outValueB);
+            Assert.AreEqual(inValueC, outValueC);
         }
 
         [Test]
         public void SerializeByte()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                byte outValueA = 123;
-                byte outValueB = byte.MinValue;
-                byte outValueC = byte.MaxValue;
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outValueA);
-                outSerializer.Serialize(ref outValueB);
-                outSerializer.Serialize(ref outValueC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            byte outValueA = 123;
+            byte outValueB = byte.MinValue;
+            byte outValueC = byte.MaxValue;
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outValueA);
+            outSerializer.Serialize(ref outValueB);
+            outSerializer.Serialize(ref outValueC);
 
-                // deserialize
-                byte inValueA = default;
-                byte inValueB = default;
-                byte inValueC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inValueA);
-                inSerializer.Serialize(ref inValueB);
-                inSerializer.Serialize(ref inValueC);
+            // deserialize
+            byte inValueA = default;
+            byte inValueB = default;
+            byte inValueC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inValueA);
+            inSerializer.Serialize(ref inValueB);
+            inSerializer.Serialize(ref inValueC);
 
-                // validate
-                Assert.AreEqual(inValueA, outValueA);
-                Assert.AreEqual(inValueB, outValueB);
-                Assert.AreEqual(inValueC, outValueC);
-            }
+            // validate
+            Assert.AreEqual(inValueA, outValueA);
+            Assert.AreEqual(inValueB, outValueB);
+            Assert.AreEqual(inValueC, outValueC);
         }
 
         [Test]
         public void SerializeShort()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                short outValueA = 12345;
-                short outValueB = short.MinValue;
-                short outValueC = short.MaxValue;
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outValueA);
-                outSerializer.Serialize(ref outValueB);
-                outSerializer.Serialize(ref outValueC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            short outValueA = 12345;
+            short outValueB = short.MinValue;
+            short outValueC = short.MaxValue;
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outValueA);
+            outSerializer.Serialize(ref outValueB);
+            outSerializer.Serialize(ref outValueC);
 
-                // deserialize
-                short inValueA = default;
-                short inValueB = default;
-                short inValueC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inValueA);
-                inSerializer.Serialize(ref inValueB);
-                inSerializer.Serialize(ref inValueC);
+            // deserialize
+            short inValueA = default;
+            short inValueB = default;
+            short inValueC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inValueA);
+            inSerializer.Serialize(ref inValueB);
+            inSerializer.Serialize(ref inValueC);
 
-                // validate
-                Assert.AreEqual(inValueA, outValueA);
-                Assert.AreEqual(inValueB, outValueB);
-                Assert.AreEqual(inValueC, outValueC);
-            }
+            // validate
+            Assert.AreEqual(inValueA, outValueA);
+            Assert.AreEqual(inValueB, outValueB);
+            Assert.AreEqual(inValueC, outValueC);
         }
 
         [Test]
         public void SerializeUshort()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                ushort outValueA = 12345;
-                ushort outValueB = ushort.MinValue;
-                ushort outValueC = ushort.MaxValue;
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outValueA);
-                outSerializer.Serialize(ref outValueB);
-                outSerializer.Serialize(ref outValueC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            ushort outValueA = 12345;
+            ushort outValueB = ushort.MinValue;
+            ushort outValueC = ushort.MaxValue;
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outValueA);
+            outSerializer.Serialize(ref outValueB);
+            outSerializer.Serialize(ref outValueC);
 
-                // deserialize
-                ushort inValueA = default;
-                ushort inValueB = default;
-                ushort inValueC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inValueA);
-                inSerializer.Serialize(ref inValueB);
-                inSerializer.Serialize(ref inValueC);
+            // deserialize
+            ushort inValueA = default;
+            ushort inValueB = default;
+            ushort inValueC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inValueA);
+            inSerializer.Serialize(ref inValueB);
+            inSerializer.Serialize(ref inValueC);
 
-                // validate
-                Assert.AreEqual(inValueA, outValueA);
-                Assert.AreEqual(inValueB, outValueB);
-                Assert.AreEqual(inValueC, outValueC);
-            }
+            // validate
+            Assert.AreEqual(inValueA, outValueA);
+            Assert.AreEqual(inValueB, outValueB);
+            Assert.AreEqual(inValueC, outValueC);
         }
 
         [Test]
         public void SerializeInt()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                int outValueA = 1234567890;
-                int outValueB = int.MinValue;
-                int outValueC = int.MaxValue;
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outValueA);
-                outSerializer.Serialize(ref outValueB);
-                outSerializer.Serialize(ref outValueC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            int outValueA = 1234567890;
+            int outValueB = int.MinValue;
+            int outValueC = int.MaxValue;
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outValueA);
+            outSerializer.Serialize(ref outValueB);
+            outSerializer.Serialize(ref outValueC);
 
-                // deserialize
-                int inValueA = default;
-                int inValueB = default;
-                int inValueC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inValueA);
-                inSerializer.Serialize(ref inValueB);
-                inSerializer.Serialize(ref inValueC);
+            // deserialize
+            int inValueA = default;
+            int inValueB = default;
+            int inValueC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inValueA);
+            inSerializer.Serialize(ref inValueB);
+            inSerializer.Serialize(ref inValueC);
 
-                // validate
-                Assert.AreEqual(inValueA, outValueA);
-                Assert.AreEqual(inValueB, outValueB);
-                Assert.AreEqual(inValueC, outValueC);
-            }
+            // validate
+            Assert.AreEqual(inValueA, outValueA);
+            Assert.AreEqual(inValueB, outValueB);
+            Assert.AreEqual(inValueC, outValueC);
         }
 
         [Test]
         public void SerializeUint()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                uint outValueA = 1234567890;
-                uint outValueB = uint.MinValue;
-                uint outValueC = uint.MaxValue;
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outValueA);
-                outSerializer.Serialize(ref outValueB);
-                outSerializer.Serialize(ref outValueC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            uint outValueA = 1234567890;
+            uint outValueB = uint.MinValue;
+            uint outValueC = uint.MaxValue;
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outValueA);
+            outSerializer.Serialize(ref outValueB);
+            outSerializer.Serialize(ref outValueC);
 
-                // deserialize
-                uint inValueA = default;
-                uint inValueB = default;
-                uint inValueC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inValueA);
-                inSerializer.Serialize(ref inValueB);
-                inSerializer.Serialize(ref inValueC);
+            // deserialize
+            uint inValueA = default;
+            uint inValueB = default;
+            uint inValueC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inValueA);
+            inSerializer.Serialize(ref inValueB);
+            inSerializer.Serialize(ref inValueC);
 
-                // validate
-                Assert.AreEqual(inValueA, outValueA);
-                Assert.AreEqual(inValueB, outValueB);
-                Assert.AreEqual(inValueC, outValueC);
-            }
+            // validate
+            Assert.AreEqual(inValueA, outValueA);
+            Assert.AreEqual(inValueB, outValueB);
+            Assert.AreEqual(inValueC, outValueC);
         }
 
         [Test]
         public void SerializeLong()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                long outValueA = 9876543210;
-                long outValueB = long.MinValue;
-                long outValueC = long.MaxValue;
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outValueA);
-                outSerializer.Serialize(ref outValueB);
-                outSerializer.Serialize(ref outValueC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            long outValueA = 9876543210;
+            long outValueB = long.MinValue;
+            long outValueC = long.MaxValue;
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outValueA);
+            outSerializer.Serialize(ref outValueB);
+            outSerializer.Serialize(ref outValueC);
 
-                // deserialize
-                long inValueA = default;
-                long inValueB = default;
-                long inValueC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inValueA);
-                inSerializer.Serialize(ref inValueB);
-                inSerializer.Serialize(ref inValueC);
+            // deserialize
+            long inValueA = default;
+            long inValueB = default;
+            long inValueC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inValueA);
+            inSerializer.Serialize(ref inValueB);
+            inSerializer.Serialize(ref inValueC);
 
-                // validate
-                Assert.AreEqual(inValueA, outValueA);
-                Assert.AreEqual(inValueB, outValueB);
-                Assert.AreEqual(inValueC, outValueC);
-            }
+            // validate
+            Assert.AreEqual(inValueA, outValueA);
+            Assert.AreEqual(inValueB, outValueB);
+            Assert.AreEqual(inValueC, outValueC);
         }
 
         [Test]
         public void SerializeUlong()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                ulong outValueA = 9876543210;
-                ulong outValueB = ulong.MinValue;
-                ulong outValueC = ulong.MaxValue;
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outValueA);
-                outSerializer.Serialize(ref outValueB);
-                outSerializer.Serialize(ref outValueC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            ulong outValueA = 9876543210;
+            ulong outValueB = ulong.MinValue;
+            ulong outValueC = ulong.MaxValue;
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outValueA);
+            outSerializer.Serialize(ref outValueB);
+            outSerializer.Serialize(ref outValueC);
 
-                // deserialize
-                ulong inValueA = default;
-                ulong inValueB = default;
-                ulong inValueC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inValueA);
-                inSerializer.Serialize(ref inValueB);
-                inSerializer.Serialize(ref inValueC);
+            // deserialize
+            ulong inValueA = default;
+            ulong inValueB = default;
+            ulong inValueC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inValueA);
+            inSerializer.Serialize(ref inValueB);
+            inSerializer.Serialize(ref inValueC);
 
-                // validate
-                Assert.AreEqual(inValueA, outValueA);
-                Assert.AreEqual(inValueB, outValueB);
-                Assert.AreEqual(inValueC, outValueC);
-            }
+            // validate
+            Assert.AreEqual(inValueA, outValueA);
+            Assert.AreEqual(inValueB, outValueB);
+            Assert.AreEqual(inValueC, outValueC);
         }
 
         [Test]
         public void SerializeFloat()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                float outValueA = 12345.6789f;
-                float outValueB = float.MinValue;
-                float outValueC = float.MaxValue;
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outValueA);
-                outSerializer.Serialize(ref outValueB);
-                outSerializer.Serialize(ref outValueC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            float outValueA = 12345.6789f;
+            float outValueB = float.MinValue;
+            float outValueC = float.MaxValue;
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outValueA);
+            outSerializer.Serialize(ref outValueB);
+            outSerializer.Serialize(ref outValueC);
 
-                // deserialize
-                float inValueA = default;
-                float inValueB = default;
-                float inValueC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inValueA);
-                inSerializer.Serialize(ref inValueB);
-                inSerializer.Serialize(ref inValueC);
+            // deserialize
+            float inValueA = default;
+            float inValueB = default;
+            float inValueC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inValueA);
+            inSerializer.Serialize(ref inValueB);
+            inSerializer.Serialize(ref inValueC);
 
-                // validate
-                Assert.AreEqual(inValueA, outValueA);
-                Assert.AreEqual(inValueB, outValueB);
-                Assert.AreEqual(inValueC, outValueC);
-            }
+            // validate
+            Assert.AreEqual(inValueA, outValueA);
+            Assert.AreEqual(inValueB, outValueB);
+            Assert.AreEqual(inValueC, outValueC);
         }
 
         [Test]
         public void SerializeDouble()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                double outValueA = 12345.6789;
-                double outValueB = double.MinValue;
-                double outValueC = double.MaxValue;
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outValueA);
-                outSerializer.Serialize(ref outValueB);
-                outSerializer.Serialize(ref outValueC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            double outValueA = 12345.6789;
+            double outValueB = double.MinValue;
+            double outValueC = double.MaxValue;
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outValueA);
+            outSerializer.Serialize(ref outValueB);
+            outSerializer.Serialize(ref outValueC);
 
-                // deserialize
-                double inValueA = default;
-                double inValueB = default;
-                double inValueC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inValueA);
-                inSerializer.Serialize(ref inValueB);
-                inSerializer.Serialize(ref inValueC);
+            // deserialize
+            double inValueA = default;
+            double inValueB = default;
+            double inValueC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inValueA);
+            inSerializer.Serialize(ref inValueB);
+            inSerializer.Serialize(ref inValueC);
 
-                // validate
-                Assert.AreEqual(inValueA, outValueA);
-                Assert.AreEqual(inValueB, outValueB);
-                Assert.AreEqual(inValueC, outValueC);
-            }
+            // validate
+            Assert.AreEqual(inValueA, outValueA);
+            Assert.AreEqual(inValueB, outValueB);
+            Assert.AreEqual(inValueC, outValueC);
         }
 
         [Test]
         public void SerializeString()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                string outValueA = Guid.NewGuid().ToString("N");
-                string outValueB = string.Empty;
-                string outValueC = null;
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outValueA);
-                outSerializer.Serialize(ref outValueB);
-                outSerializer.Serialize(ref outValueC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            string outValueA = Guid.NewGuid().ToString("N");
+            string outValueB = string.Empty;
+            string outValueC = null;
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outValueA);
+            outSerializer.Serialize(ref outValueB);
+            outSerializer.Serialize(ref outValueC);
 
-                // deserialize
-                string inValueA = default;
-                string inValueB = default;
-                string inValueC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inValueA);
-                inSerializer.Serialize(ref inValueB);
-                inSerializer.Serialize(ref inValueC);
+            // deserialize
+            string inValueA = default;
+            string inValueB = default;
+            string inValueC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inValueA);
+            inSerializer.Serialize(ref inValueB);
+            inSerializer.Serialize(ref inValueC);
 
-                // validate
-                Assert.AreEqual(inValueA, outValueA);
-                Assert.AreEqual(inValueB, outValueB);
-                Assert.AreEqual(inValueC, outValueC);
-            }
+            // validate
+            Assert.AreEqual(inValueA, outValueA);
+            Assert.AreEqual(inValueB, outValueB);
+            Assert.AreEqual(inValueC, outValueC);
         }
 
         [Test]
         public void SerializeColor()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                Color outValueA = Color.black;
-                Color outValueB = Color.white;
-                Color outValueC = Color.red;
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outValueA);
-                outSerializer.Serialize(ref outValueB);
-                outSerializer.Serialize(ref outValueC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            Color outValueA = Color.black;
+            Color outValueB = Color.white;
+            Color outValueC = Color.red;
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outValueA);
+            outSerializer.Serialize(ref outValueB);
+            outSerializer.Serialize(ref outValueC);
 
-                // deserialize
-                Color inValueA = default;
-                Color inValueB = default;
-                Color inValueC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inValueA);
-                inSerializer.Serialize(ref inValueB);
-                inSerializer.Serialize(ref inValueC);
+            // deserialize
+            Color inValueA = default;
+            Color inValueB = default;
+            Color inValueC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inValueA);
+            inSerializer.Serialize(ref inValueB);
+            inSerializer.Serialize(ref inValueC);
 
-                // validate
-                Assert.AreEqual(inValueA, outValueA);
-                Assert.AreEqual(inValueB, outValueB);
-                Assert.AreEqual(inValueC, outValueC);
-            }
+            // validate
+            Assert.AreEqual(inValueA, outValueA);
+            Assert.AreEqual(inValueB, outValueB);
+            Assert.AreEqual(inValueC, outValueC);
         }
 
         [Test]
         public void SerializeColor32()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                var outValueA = new Color32(0, 0, 0, byte.MaxValue);
-                var outValueB = new Color32(byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue);
-                var outValueC = new Color32(byte.MaxValue, 0, 0, byte.MaxValue);
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outValueA);
-                outSerializer.Serialize(ref outValueB);
-                outSerializer.Serialize(ref outValueC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            var outValueA = new Color32(0, 0, 0, byte.MaxValue);
+            var outValueB = new Color32(byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue);
+            var outValueC = new Color32(byte.MaxValue, 0, 0, byte.MaxValue);
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outValueA);
+            outSerializer.Serialize(ref outValueB);
+            outSerializer.Serialize(ref outValueC);
 
-                // deserialize
-                Color32 inValueA = default;
-                Color32 inValueB = default;
-                Color32 inValueC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inValueA);
-                inSerializer.Serialize(ref inValueB);
-                inSerializer.Serialize(ref inValueC);
+            // deserialize
+            Color32 inValueA = default;
+            Color32 inValueB = default;
+            Color32 inValueC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inValueA);
+            inSerializer.Serialize(ref inValueB);
+            inSerializer.Serialize(ref inValueC);
 
-                // validate
-                Assert.AreEqual(inValueA, outValueA);
-                Assert.AreEqual(inValueB, outValueB);
-                Assert.AreEqual(inValueC, outValueC);
-            }
+            // validate
+            Assert.AreEqual(inValueA, outValueA);
+            Assert.AreEqual(inValueB, outValueB);
+            Assert.AreEqual(inValueC, outValueC);
         }
 
         [Test]
         public void SerializeVector2()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                Vector2 outValueA = Vector2.up;
-                Vector2 outValueB = Vector2.negativeInfinity;
-                Vector2 outValueC = Vector2.positiveInfinity;
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outValueA);
-                outSerializer.Serialize(ref outValueB);
-                outSerializer.Serialize(ref outValueC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            Vector2 outValueA = Vector2.up;
+            Vector2 outValueB = Vector2.negativeInfinity;
+            Vector2 outValueC = Vector2.positiveInfinity;
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outValueA);
+            outSerializer.Serialize(ref outValueB);
+            outSerializer.Serialize(ref outValueC);
 
-                // deserialize
-                Vector2 inValueA = default;
-                Vector2 inValueB = default;
-                Vector2 inValueC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inValueA);
-                inSerializer.Serialize(ref inValueB);
-                inSerializer.Serialize(ref inValueC);
+            // deserialize
+            Vector2 inValueA = default;
+            Vector2 inValueB = default;
+            Vector2 inValueC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inValueA);
+            inSerializer.Serialize(ref inValueB);
+            inSerializer.Serialize(ref inValueC);
 
-                // validate
-                Assert.AreEqual(inValueA, outValueA);
-                Assert.AreEqual(inValueB, outValueB);
-                Assert.AreEqual(inValueC, outValueC);
-            }
+            // validate
+            Assert.AreEqual(inValueA, outValueA);
+            Assert.AreEqual(inValueB, outValueB);
+            Assert.AreEqual(inValueC, outValueC);
         }
 
         [Test]
         public void SerializeVector3()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                Vector3 outValueA = Vector3.forward;
-                Vector3 outValueB = Vector3.negativeInfinity;
-                Vector3 outValueC = Vector3.positiveInfinity;
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outValueA);
-                outSerializer.Serialize(ref outValueB);
-                outSerializer.Serialize(ref outValueC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            Vector3 outValueA = Vector3.forward;
+            Vector3 outValueB = Vector3.negativeInfinity;
+            Vector3 outValueC = Vector3.positiveInfinity;
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outValueA);
+            outSerializer.Serialize(ref outValueB);
+            outSerializer.Serialize(ref outValueC);
 
-                // deserialize
-                Vector3 inValueA = default;
-                Vector3 inValueB = default;
-                Vector3 inValueC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inValueA);
-                inSerializer.Serialize(ref inValueB);
-                inSerializer.Serialize(ref inValueC);
+            // deserialize
+            Vector3 inValueA = default;
+            Vector3 inValueB = default;
+            Vector3 inValueC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inValueA);
+            inSerializer.Serialize(ref inValueB);
+            inSerializer.Serialize(ref inValueC);
 
-                // validate
-                Assert.AreEqual(inValueA, outValueA);
-                Assert.AreEqual(inValueB, outValueB);
-                Assert.AreEqual(inValueC, outValueC);
-            }
+            // validate
+            Assert.AreEqual(inValueA, outValueA);
+            Assert.AreEqual(inValueB, outValueB);
+            Assert.AreEqual(inValueC, outValueC);
         }
 
         [Test]
         public void SerializeVector4()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                Vector4 outValueA = Vector4.one;
-                Vector4 outValueB = Vector4.negativeInfinity;
-                Vector4 outValueC = Vector4.positiveInfinity;
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outValueA);
-                outSerializer.Serialize(ref outValueB);
-                outSerializer.Serialize(ref outValueC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            Vector4 outValueA = Vector4.one;
+            Vector4 outValueB = Vector4.negativeInfinity;
+            Vector4 outValueC = Vector4.positiveInfinity;
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outValueA);
+            outSerializer.Serialize(ref outValueB);
+            outSerializer.Serialize(ref outValueC);
 
-                // deserialize
-                Vector4 inValueA = default;
-                Vector4 inValueB = default;
-                Vector4 inValueC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inValueA);
-                inSerializer.Serialize(ref inValueB);
-                inSerializer.Serialize(ref inValueC);
+            // deserialize
+            Vector4 inValueA = default;
+            Vector4 inValueB = default;
+            Vector4 inValueC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inValueA);
+            inSerializer.Serialize(ref inValueB);
+            inSerializer.Serialize(ref inValueC);
 
-                // validate
-                Assert.AreEqual(inValueA, outValueA);
-                Assert.AreEqual(inValueB, outValueB);
-                Assert.AreEqual(inValueC, outValueC);
-            }
+            // validate
+            Assert.AreEqual(inValueA, outValueA);
+            Assert.AreEqual(inValueB, outValueB);
+            Assert.AreEqual(inValueC, outValueC);
         }
 
         [Test]
         public void SerializeQuaternion()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                Quaternion outValueA = Quaternion.identity;
-                var outValueB = Quaternion.Euler(new Vector3(30, 45, -60));
-                var outValueC = Quaternion.Euler(new Vector3(90, -90, 180));
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outValueA);
-                outSerializer.Serialize(ref outValueB);
-                outSerializer.Serialize(ref outValueC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            Quaternion outValueA = Quaternion.identity;
+            var outValueB = Quaternion.Euler(new Vector3(30, 45, -60));
+            var outValueC = Quaternion.Euler(new Vector3(90, -90, 180));
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outValueA);
+            outSerializer.Serialize(ref outValueB);
+            outSerializer.Serialize(ref outValueC);
 
-                // deserialize
-                Quaternion inValueA = default;
-                Quaternion inValueB = default;
-                Quaternion inValueC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inValueA);
-                inSerializer.Serialize(ref inValueB);
-                inSerializer.Serialize(ref inValueC);
+            // deserialize
+            Quaternion inValueA = default;
+            Quaternion inValueB = default;
+            Quaternion inValueC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inValueA);
+            inSerializer.Serialize(ref inValueB);
+            inSerializer.Serialize(ref inValueC);
 
-                // validate
-                Assert.Greater(Mathf.Abs(Quaternion.Dot(inValueA, outValueA)), 0.999f);
-                Assert.Greater(Mathf.Abs(Quaternion.Dot(inValueB, outValueB)), 0.999f);
-                Assert.Greater(Mathf.Abs(Quaternion.Dot(inValueC, outValueC)), 0.999f);
-            }
+            // validate
+            Assert.Greater(Mathf.Abs(Quaternion.Dot(inValueA, outValueA)), 0.999f);
+            Assert.Greater(Mathf.Abs(Quaternion.Dot(inValueB, outValueB)), 0.999f);
+            Assert.Greater(Mathf.Abs(Quaternion.Dot(inValueC, outValueC)), 0.999f);
         }
 
         [Test]
         public void SerializeRay()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                var outValueA = new Ray(Vector3.zero, Vector3.forward);
-                var outValueB = new Ray(Vector3.zero, Vector3.left);
-                var outValueC = new Ray(Vector3.zero, Vector3.up);
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outValueA);
-                outSerializer.Serialize(ref outValueB);
-                outSerializer.Serialize(ref outValueC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            var outValueA = new Ray(Vector3.zero, Vector3.forward);
+            var outValueB = new Ray(Vector3.zero, Vector3.left);
+            var outValueC = new Ray(Vector3.zero, Vector3.up);
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outValueA);
+            outSerializer.Serialize(ref outValueB);
+            outSerializer.Serialize(ref outValueC);
 
-                // deserialize
-                Ray inValueA = default;
-                Ray inValueB = default;
-                Ray inValueC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inValueA);
-                inSerializer.Serialize(ref inValueB);
-                inSerializer.Serialize(ref inValueC);
+            // deserialize
+            Ray inValueA = default;
+            Ray inValueB = default;
+            Ray inValueC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inValueA);
+            inSerializer.Serialize(ref inValueB);
+            inSerializer.Serialize(ref inValueC);
 
-                // validate
-                Assert.AreEqual(inValueA, outValueA);
-                Assert.AreEqual(inValueB, outValueB);
-                Assert.AreEqual(inValueC, outValueC);
-            }
+            // validate
+            Assert.AreEqual(inValueA, outValueA);
+            Assert.AreEqual(inValueB, outValueB);
+            Assert.AreEqual(inValueC, outValueC);
         }
 
         [Test]
         public void SerializeRay2D()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                var outValueA = new Ray2D(Vector2.zero, Vector2.up);
-                var outValueB = new Ray2D(Vector2.zero, Vector2.left);
-                var outValueC = new Ray2D(Vector2.zero, Vector2.right);
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outValueA);
-                outSerializer.Serialize(ref outValueB);
-                outSerializer.Serialize(ref outValueC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            var outValueA = new Ray2D(Vector2.zero, Vector2.up);
+            var outValueB = new Ray2D(Vector2.zero, Vector2.left);
+            var outValueC = new Ray2D(Vector2.zero, Vector2.right);
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outValueA);
+            outSerializer.Serialize(ref outValueB);
+            outSerializer.Serialize(ref outValueC);
 
-                // deserialize
-                Ray2D inValueA = default;
-                Ray2D inValueB = default;
-                Ray2D inValueC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inValueA);
-                inSerializer.Serialize(ref inValueB);
-                inSerializer.Serialize(ref inValueC);
+            // deserialize
+            Ray2D inValueA = default;
+            Ray2D inValueB = default;
+            Ray2D inValueC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inValueA);
+            inSerializer.Serialize(ref inValueB);
+            inSerializer.Serialize(ref inValueC);
 
-                // validate
-                Assert.AreEqual(inValueA, outValueA);
-                Assert.AreEqual(inValueB, outValueB);
-                Assert.AreEqual(inValueC, outValueC);
-            }
+            // validate
+            Assert.AreEqual(inValueA, outValueA);
+            Assert.AreEqual(inValueB, outValueB);
+            Assert.AreEqual(inValueC, outValueC);
         }
 
         private enum EnumA // int
@@ -792,834 +748,788 @@ namespace Unity.Netcode.EditorTests
         [Test]
         public void SerializeEnum()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                EnumA outValueA = EnumA.C;
-                EnumB outValueB = EnumB.X;
-                EnumC outValueC = EnumC.N;
-                EnumD outValueD = EnumD.T;
-                var outValueX = (EnumD)123;
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outValueA);
-                outSerializer.Serialize(ref outValueB);
-                outSerializer.Serialize(ref outValueC);
-                outSerializer.Serialize(ref outValueD);
-                outSerializer.Serialize(ref outValueX);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            EnumA outValueA = EnumA.C;
+            EnumB outValueB = EnumB.X;
+            EnumC outValueC = EnumC.N;
+            EnumD outValueD = EnumD.T;
+            var outValueX = (EnumD)123;
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outValueA);
+            outSerializer.Serialize(ref outValueB);
+            outSerializer.Serialize(ref outValueC);
+            outSerializer.Serialize(ref outValueD);
+            outSerializer.Serialize(ref outValueX);
 
-                // deserialize
-                EnumA inValueA = default;
-                EnumB inValueB = default;
-                EnumC inValueC = default;
-                EnumD inValueD = default;
-                EnumD inValueX = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inValueA);
-                inSerializer.Serialize(ref inValueB);
-                inSerializer.Serialize(ref inValueC);
-                inSerializer.Serialize(ref inValueD);
-                inSerializer.Serialize(ref inValueX);
+            // deserialize
+            EnumA inValueA = default;
+            EnumB inValueB = default;
+            EnumC inValueC = default;
+            EnumD inValueD = default;
+            EnumD inValueX = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inValueA);
+            inSerializer.Serialize(ref inValueB);
+            inSerializer.Serialize(ref inValueC);
+            inSerializer.Serialize(ref inValueD);
+            inSerializer.Serialize(ref inValueX);
 
-                // validate
-                Assert.AreEqual(inValueA, outValueA);
-                Assert.AreEqual(inValueB, outValueB);
-                Assert.AreEqual(inValueC, outValueC);
-                Assert.AreEqual(inValueD, outValueD);
-                Assert.AreEqual(inValueX, outValueX);
-            }
+            // validate
+            Assert.AreEqual(inValueA, outValueA);
+            Assert.AreEqual(inValueB, outValueB);
+            Assert.AreEqual(inValueC, outValueC);
+            Assert.AreEqual(inValueD, outValueD);
+            Assert.AreEqual(inValueX, outValueX);
         }
 
         [Test]
         public void SerializeBoolArray()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                bool[] outArrayA = null;
-                bool[] outArrayB = new bool[0];
-                bool[] outArrayC = { true, false, true };
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outArrayA);
-                outSerializer.Serialize(ref outArrayB);
-                outSerializer.Serialize(ref outArrayC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            bool[] outArrayA = null;
+            bool[] outArrayB = new bool[0];
+            bool[] outArrayC = { true, false, true };
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outArrayA);
+            outSerializer.Serialize(ref outArrayB);
+            outSerializer.Serialize(ref outArrayC);
 
-                // deserialize
-                bool[] inArrayA = default;
-                bool[] inArrayB = default;
-                bool[] inArrayC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inArrayA);
-                inSerializer.Serialize(ref inArrayB);
-                inSerializer.Serialize(ref inArrayC);
+            // deserialize
+            bool[] inArrayA = default;
+            bool[] inArrayB = default;
+            bool[] inArrayC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inArrayA);
+            inSerializer.Serialize(ref inArrayB);
+            inSerializer.Serialize(ref inArrayC);
 
-                // validate
-                Assert.AreEqual(inArrayA, outArrayA);
-                Assert.AreEqual(inArrayB, outArrayB);
-                Assert.AreEqual(inArrayC, outArrayC);
-            }
+            // validate
+            Assert.AreEqual(inArrayA, outArrayA);
+            Assert.AreEqual(inArrayB, outArrayB);
+            Assert.AreEqual(inArrayC, outArrayC);
         }
 
         [Test]
         public void SerializeCharArray()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                char[] outArrayA = null;
-                char[] outArrayB = new char[0];
-                char[] outArrayC = { 'U', 'N', 'I', 'T', 'Y', '\0' };
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outArrayA);
-                outSerializer.Serialize(ref outArrayB);
-                outSerializer.Serialize(ref outArrayC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            char[] outArrayA = null;
+            char[] outArrayB = new char[0];
+            char[] outArrayC = { 'U', 'N', 'I', 'T', 'Y', '\0' };
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outArrayA);
+            outSerializer.Serialize(ref outArrayB);
+            outSerializer.Serialize(ref outArrayC);
 
-                // deserialize
-                char[] inArrayA = default;
-                char[] inArrayB = default;
-                char[] inArrayC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inArrayA);
-                inSerializer.Serialize(ref inArrayB);
-                inSerializer.Serialize(ref inArrayC);
+            // deserialize
+            char[] inArrayA = default;
+            char[] inArrayB = default;
+            char[] inArrayC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inArrayA);
+            inSerializer.Serialize(ref inArrayB);
+            inSerializer.Serialize(ref inArrayC);
 
-                // validate
-                Assert.AreEqual(inArrayA, outArrayA);
-                Assert.AreEqual(inArrayB, outArrayB);
-                Assert.AreEqual(inArrayC, outArrayC);
-            }
+            // validate
+            Assert.AreEqual(inArrayA, outArrayA);
+            Assert.AreEqual(inArrayB, outArrayB);
+            Assert.AreEqual(inArrayC, outArrayC);
         }
 
         [Test]
         public void SerializeSbyteArray()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                sbyte[] outArrayA = null;
-                sbyte[] outArrayB = new sbyte[0];
-                sbyte[] outArrayC = { -123, sbyte.MinValue, sbyte.MaxValue };
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outArrayA);
-                outSerializer.Serialize(ref outArrayB);
-                outSerializer.Serialize(ref outArrayC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            sbyte[] outArrayA = null;
+            sbyte[] outArrayB = new sbyte[0];
+            sbyte[] outArrayC = { -123, sbyte.MinValue, sbyte.MaxValue };
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outArrayA);
+            outSerializer.Serialize(ref outArrayB);
+            outSerializer.Serialize(ref outArrayC);
 
-                // deserialize
-                sbyte[] inArrayA = default;
-                sbyte[] inArrayB = default;
-                sbyte[] inArrayC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inArrayA);
-                inSerializer.Serialize(ref inArrayB);
-                inSerializer.Serialize(ref inArrayC);
+            // deserialize
+            sbyte[] inArrayA = default;
+            sbyte[] inArrayB = default;
+            sbyte[] inArrayC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inArrayA);
+            inSerializer.Serialize(ref inArrayB);
+            inSerializer.Serialize(ref inArrayC);
 
-                // validate
-                Assert.AreEqual(inArrayA, outArrayA);
-                Assert.AreEqual(inArrayB, outArrayB);
-                Assert.AreEqual(inArrayC, outArrayC);
-            }
+            // validate
+            Assert.AreEqual(inArrayA, outArrayA);
+            Assert.AreEqual(inArrayB, outArrayB);
+            Assert.AreEqual(inArrayC, outArrayC);
         }
 
         [Test]
         public void SerializeByteArray()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                byte[] outArrayA = null;
-                byte[] outArrayB = new byte[0];
-                byte[] outArrayC = { 123, byte.MinValue, byte.MaxValue };
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outArrayA);
-                outSerializer.Serialize(ref outArrayB);
-                outSerializer.Serialize(ref outArrayC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            byte[] outArrayA = null;
+            byte[] outArrayB = new byte[0];
+            byte[] outArrayC = { 123, byte.MinValue, byte.MaxValue };
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outArrayA);
+            outSerializer.Serialize(ref outArrayB);
+            outSerializer.Serialize(ref outArrayC);
 
-                // deserialize
-                byte[] inArrayA = default;
-                byte[] inArrayB = default;
-                byte[] inArrayC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inArrayA);
-                inSerializer.Serialize(ref inArrayB);
-                inSerializer.Serialize(ref inArrayC);
+            // deserialize
+            byte[] inArrayA = default;
+            byte[] inArrayB = default;
+            byte[] inArrayC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inArrayA);
+            inSerializer.Serialize(ref inArrayB);
+            inSerializer.Serialize(ref inArrayC);
 
-                // validate
-                Assert.AreEqual(inArrayA, outArrayA);
-                Assert.AreEqual(inArrayB, outArrayB);
-                Assert.AreEqual(inArrayC, outArrayC);
-            }
+            // validate
+            Assert.AreEqual(inArrayA, outArrayA);
+            Assert.AreEqual(inArrayB, outArrayB);
+            Assert.AreEqual(inArrayC, outArrayC);
         }
 
         [Test]
         public void SerializeShortArray()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                short[] outArrayA = null;
-                short[] outArrayB = new short[0];
-                short[] outArrayC = { 12345, short.MinValue, short.MaxValue };
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outArrayA);
-                outSerializer.Serialize(ref outArrayB);
-                outSerializer.Serialize(ref outArrayC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            short[] outArrayA = null;
+            short[] outArrayB = new short[0];
+            short[] outArrayC = { 12345, short.MinValue, short.MaxValue };
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outArrayA);
+            outSerializer.Serialize(ref outArrayB);
+            outSerializer.Serialize(ref outArrayC);
 
-                // deserialize
-                short[] inArrayA = default;
-                short[] inArrayB = default;
-                short[] inArrayC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inArrayA);
-                inSerializer.Serialize(ref inArrayB);
-                inSerializer.Serialize(ref inArrayC);
+            // deserialize
+            short[] inArrayA = default;
+            short[] inArrayB = default;
+            short[] inArrayC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inArrayA);
+            inSerializer.Serialize(ref inArrayB);
+            inSerializer.Serialize(ref inArrayC);
 
-                // validate
-                Assert.AreEqual(inArrayA, outArrayA);
-                Assert.AreEqual(inArrayB, outArrayB);
-                Assert.AreEqual(inArrayC, outArrayC);
-            }
+            // validate
+            Assert.AreEqual(inArrayA, outArrayA);
+            Assert.AreEqual(inArrayB, outArrayB);
+            Assert.AreEqual(inArrayC, outArrayC);
         }
 
         [Test]
         public void SerializeUshortArray()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                ushort[] outArrayA = null;
-                ushort[] outArrayB = new ushort[0];
-                ushort[] outArrayC = { 12345, ushort.MinValue, ushort.MaxValue };
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outArrayA);
-                outSerializer.Serialize(ref outArrayB);
-                outSerializer.Serialize(ref outArrayC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            ushort[] outArrayA = null;
+            ushort[] outArrayB = new ushort[0];
+            ushort[] outArrayC = { 12345, ushort.MinValue, ushort.MaxValue };
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outArrayA);
+            outSerializer.Serialize(ref outArrayB);
+            outSerializer.Serialize(ref outArrayC);
 
-                // deserialize
-                ushort[] inArrayA = default;
-                ushort[] inArrayB = default;
-                ushort[] inArrayC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inArrayA);
-                inSerializer.Serialize(ref inArrayB);
-                inSerializer.Serialize(ref inArrayC);
+            // deserialize
+            ushort[] inArrayA = default;
+            ushort[] inArrayB = default;
+            ushort[] inArrayC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inArrayA);
+            inSerializer.Serialize(ref inArrayB);
+            inSerializer.Serialize(ref inArrayC);
 
-                // validate
-                Assert.AreEqual(inArrayA, outArrayA);
-                Assert.AreEqual(inArrayB, outArrayB);
-                Assert.AreEqual(inArrayC, outArrayC);
-            }
+            // validate
+            Assert.AreEqual(inArrayA, outArrayA);
+            Assert.AreEqual(inArrayB, outArrayB);
+            Assert.AreEqual(inArrayC, outArrayC);
         }
 
         [Test]
         public void SerializeIntArray()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                int[] outArrayA = null;
-                int[] outArrayB = new int[0];
-                int[] outArrayC = { 1234567890, int.MinValue, int.MaxValue };
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outArrayA);
-                outSerializer.Serialize(ref outArrayB);
-                outSerializer.Serialize(ref outArrayC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            int[] outArrayA = null;
+            int[] outArrayB = new int[0];
+            int[] outArrayC = { 1234567890, int.MinValue, int.MaxValue };
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outArrayA);
+            outSerializer.Serialize(ref outArrayB);
+            outSerializer.Serialize(ref outArrayC);
 
-                // deserialize
-                int[] inArrayA = default;
-                int[] inArrayB = default;
-                int[] inArrayC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inArrayA);
-                inSerializer.Serialize(ref inArrayB);
-                inSerializer.Serialize(ref inArrayC);
+            // deserialize
+            int[] inArrayA = default;
+            int[] inArrayB = default;
+            int[] inArrayC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inArrayA);
+            inSerializer.Serialize(ref inArrayB);
+            inSerializer.Serialize(ref inArrayC);
 
-                // validate
-                Assert.AreEqual(inArrayA, outArrayA);
-                Assert.AreEqual(inArrayB, outArrayB);
-                Assert.AreEqual(inArrayC, outArrayC);
-            }
+            // validate
+            Assert.AreEqual(inArrayA, outArrayA);
+            Assert.AreEqual(inArrayB, outArrayB);
+            Assert.AreEqual(inArrayC, outArrayC);
         }
 
         [Test]
         public void SerializeUintArray()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                uint[] outArrayA = null;
-                uint[] outArrayB = new uint[0];
-                uint[] outArrayC = { 1234567890, uint.MinValue, uint.MaxValue };
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outArrayA);
-                outSerializer.Serialize(ref outArrayB);
-                outSerializer.Serialize(ref outArrayC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            uint[] outArrayA = null;
+            uint[] outArrayB = new uint[0];
+            uint[] outArrayC = { 1234567890, uint.MinValue, uint.MaxValue };
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outArrayA);
+            outSerializer.Serialize(ref outArrayB);
+            outSerializer.Serialize(ref outArrayC);
 
-                // deserialize
-                uint[] inArrayA = default;
-                uint[] inArrayB = default;
-                uint[] inArrayC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inArrayA);
-                inSerializer.Serialize(ref inArrayB);
-                inSerializer.Serialize(ref inArrayC);
+            // deserialize
+            uint[] inArrayA = default;
+            uint[] inArrayB = default;
+            uint[] inArrayC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inArrayA);
+            inSerializer.Serialize(ref inArrayB);
+            inSerializer.Serialize(ref inArrayC);
 
-                // validate
-                Assert.AreEqual(inArrayA, outArrayA);
-                Assert.AreEqual(inArrayB, outArrayB);
-                Assert.AreEqual(inArrayC, outArrayC);
-            }
+            // validate
+            Assert.AreEqual(inArrayA, outArrayA);
+            Assert.AreEqual(inArrayB, outArrayB);
+            Assert.AreEqual(inArrayC, outArrayC);
         }
 
         [Test]
         public void SerializeLongArray()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                long[] outArrayA = null;
-                long[] outArrayB = new long[0];
-                long[] outArrayC = { 9876543210, long.MinValue, long.MaxValue };
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outArrayA);
-                outSerializer.Serialize(ref outArrayB);
-                outSerializer.Serialize(ref outArrayC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            long[] outArrayA = null;
+            long[] outArrayB = new long[0];
+            long[] outArrayC = { 9876543210, long.MinValue, long.MaxValue };
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outArrayA);
+            outSerializer.Serialize(ref outArrayB);
+            outSerializer.Serialize(ref outArrayC);
 
-                // deserialize
-                long[] inArrayA = default;
-                long[] inArrayB = default;
-                long[] inArrayC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inArrayA);
-                inSerializer.Serialize(ref inArrayB);
-                inSerializer.Serialize(ref inArrayC);
+            // deserialize
+            long[] inArrayA = default;
+            long[] inArrayB = default;
+            long[] inArrayC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inArrayA);
+            inSerializer.Serialize(ref inArrayB);
+            inSerializer.Serialize(ref inArrayC);
 
-                // validate
-                Assert.AreEqual(inArrayA, outArrayA);
-                Assert.AreEqual(inArrayB, outArrayB);
-                Assert.AreEqual(inArrayC, outArrayC);
-            }
+            // validate
+            Assert.AreEqual(inArrayA, outArrayA);
+            Assert.AreEqual(inArrayB, outArrayB);
+            Assert.AreEqual(inArrayC, outArrayC);
         }
 
         [Test]
         public void SerializeUlongArray()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                ulong[] outArrayA = null;
-                ulong[] outArrayB = new ulong[0];
-                ulong[] outArrayC = { 9876543210, ulong.MinValue, ulong.MaxValue };
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outArrayA);
-                outSerializer.Serialize(ref outArrayB);
-                outSerializer.Serialize(ref outArrayC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            ulong[] outArrayA = null;
+            ulong[] outArrayB = new ulong[0];
+            ulong[] outArrayC = { 9876543210, ulong.MinValue, ulong.MaxValue };
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outArrayA);
+            outSerializer.Serialize(ref outArrayB);
+            outSerializer.Serialize(ref outArrayC);
 
-                // deserialize
-                ulong[] inArrayA = default;
-                ulong[] inArrayB = default;
-                ulong[] inArrayC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inArrayA);
-                inSerializer.Serialize(ref inArrayB);
-                inSerializer.Serialize(ref inArrayC);
+            // deserialize
+            ulong[] inArrayA = default;
+            ulong[] inArrayB = default;
+            ulong[] inArrayC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inArrayA);
+            inSerializer.Serialize(ref inArrayB);
+            inSerializer.Serialize(ref inArrayC);
 
-                // validate
-                Assert.AreEqual(inArrayA, outArrayA);
-                Assert.AreEqual(inArrayB, outArrayB);
-                Assert.AreEqual(inArrayC, outArrayC);
-            }
+            // validate
+            Assert.AreEqual(inArrayA, outArrayA);
+            Assert.AreEqual(inArrayB, outArrayB);
+            Assert.AreEqual(inArrayC, outArrayC);
         }
 
         [Test]
         public void SerializeFloatArray()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                float[] outArrayA = null;
-                float[] outArrayB = new float[0];
-                float[] outArrayC = { 12345.6789f, float.MinValue, float.MaxValue };
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outArrayA);
-                outSerializer.Serialize(ref outArrayB);
-                outSerializer.Serialize(ref outArrayC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            float[] outArrayA = null;
+            float[] outArrayB = new float[0];
+            float[] outArrayC = { 12345.6789f, float.MinValue, float.MaxValue };
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outArrayA);
+            outSerializer.Serialize(ref outArrayB);
+            outSerializer.Serialize(ref outArrayC);
 
-                // deserialize
-                float[] inArrayA = default;
-                float[] inArrayB = default;
-                float[] inArrayC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inArrayA);
-                inSerializer.Serialize(ref inArrayB);
-                inSerializer.Serialize(ref inArrayC);
+            // deserialize
+            float[] inArrayA = default;
+            float[] inArrayB = default;
+            float[] inArrayC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inArrayA);
+            inSerializer.Serialize(ref inArrayB);
+            inSerializer.Serialize(ref inArrayC);
 
-                // validate
-                Assert.AreEqual(inArrayA, outArrayA);
-                Assert.AreEqual(inArrayB, outArrayB);
-                Assert.AreEqual(inArrayC, outArrayC);
-            }
+            // validate
+            Assert.AreEqual(inArrayA, outArrayA);
+            Assert.AreEqual(inArrayB, outArrayB);
+            Assert.AreEqual(inArrayC, outArrayC);
         }
 
         [Test]
         public void SerializeDoubleArray()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                double[] outArrayA = null;
-                double[] outArrayB = new double[0];
-                double[] outArrayC = { 12345.6789, double.MinValue, double.MaxValue };
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outArrayA);
-                outSerializer.Serialize(ref outArrayB);
-                outSerializer.Serialize(ref outArrayC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            double[] outArrayA = null;
+            double[] outArrayB = new double[0];
+            double[] outArrayC = { 12345.6789, double.MinValue, double.MaxValue };
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outArrayA);
+            outSerializer.Serialize(ref outArrayB);
+            outSerializer.Serialize(ref outArrayC);
 
-                // deserialize
-                double[] inArrayA = default;
-                double[] inArrayB = default;
-                double[] inArrayC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inArrayA);
-                inSerializer.Serialize(ref inArrayB);
-                inSerializer.Serialize(ref inArrayC);
+            // deserialize
+            double[] inArrayA = default;
+            double[] inArrayB = default;
+            double[] inArrayC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inArrayA);
+            inSerializer.Serialize(ref inArrayB);
+            inSerializer.Serialize(ref inArrayC);
 
-                // validate
-                Assert.AreEqual(inArrayA, outArrayA);
-                Assert.AreEqual(inArrayB, outArrayB);
-                Assert.AreEqual(inArrayC, outArrayC);
-            }
+            // validate
+            Assert.AreEqual(inArrayA, outArrayA);
+            Assert.AreEqual(inArrayB, outArrayB);
+            Assert.AreEqual(inArrayC, outArrayC);
         }
 
         [Test]
         public void SerializeStringArray()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                string[] outArrayA = null;
-                string[] outArrayB = new string[0];
-                string[] outArrayC = { Guid.NewGuid().ToString("N"), string.Empty, null };
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outArrayA);
-                outSerializer.Serialize(ref outArrayB);
-                outSerializer.Serialize(ref outArrayC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            string[] outArrayA = null;
+            string[] outArrayB = new string[0];
+            string[] outArrayC = { Guid.NewGuid().ToString("N"), string.Empty, null };
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outArrayA);
+            outSerializer.Serialize(ref outArrayB);
+            outSerializer.Serialize(ref outArrayC);
 
-                // deserialize
-                string[] inArrayA = default;
-                string[] inArrayB = default;
-                string[] inArrayC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inArrayA);
-                inSerializer.Serialize(ref inArrayB);
-                inSerializer.Serialize(ref inArrayC);
+            // deserialize
+            string[] inArrayA = default;
+            string[] inArrayB = default;
+            string[] inArrayC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inArrayA);
+            inSerializer.Serialize(ref inArrayB);
+            inSerializer.Serialize(ref inArrayC);
 
-                // validate
-                Assert.AreEqual(inArrayA, outArrayA);
-                Assert.AreEqual(inArrayB, outArrayB);
-                Assert.AreEqual(inArrayC, outArrayC);
-            }
+            // validate
+            Assert.AreEqual(inArrayA, outArrayA);
+            Assert.AreEqual(inArrayB, outArrayB);
+            Assert.AreEqual(inArrayC, outArrayC);
         }
 
         [Test]
         public void SerializeColorArray()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                Color[] outArrayA = null;
-                var outArrayB = new Color[0];
-                Color[] outArrayC = { Color.black, Color.red, Color.white };
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outArrayA);
-                outSerializer.Serialize(ref outArrayB);
-                outSerializer.Serialize(ref outArrayC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            Color[] outArrayA = null;
+            var outArrayB = new Color[0];
+            Color[] outArrayC = { Color.black, Color.red, Color.white };
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outArrayA);
+            outSerializer.Serialize(ref outArrayB);
+            outSerializer.Serialize(ref outArrayC);
 
-                // deserialize
-                Color[] inArrayA = default;
-                Color[] inArrayB = default;
-                Color[] inArrayC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inArrayA);
-                inSerializer.Serialize(ref inArrayB);
-                inSerializer.Serialize(ref inArrayC);
+            // deserialize
+            Color[] inArrayA = default;
+            Color[] inArrayB = default;
+            Color[] inArrayC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inArrayA);
+            inSerializer.Serialize(ref inArrayB);
+            inSerializer.Serialize(ref inArrayC);
 
-                // validate
-                Assert.AreEqual(inArrayA, outArrayA);
-                Assert.AreEqual(inArrayB, outArrayB);
-                Assert.AreEqual(inArrayC, outArrayC);
-            }
+            // validate
+            Assert.AreEqual(inArrayA, outArrayA);
+            Assert.AreEqual(inArrayB, outArrayB);
+            Assert.AreEqual(inArrayC, outArrayC);
         }
 
         [Test]
         public void SerializeColor32Array()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            Color32[] outArrayA = null;
+            var outArrayB = new Color32[0];
+            Color32[] outArrayC =
             {
-                // serialize
-                Color32[] outArrayA = null;
-                var outArrayB = new Color32[0];
-                Color32[] outArrayC =
-                {
                     new Color32(0, 0, 0, byte.MaxValue),
                     new Color32(byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue),
                     new Color32(byte.MaxValue, 0, 0, byte.MaxValue)
                 };
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outArrayA);
-                outSerializer.Serialize(ref outArrayB);
-                outSerializer.Serialize(ref outArrayC);
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outArrayA);
+            outSerializer.Serialize(ref outArrayB);
+            outSerializer.Serialize(ref outArrayC);
 
-                // deserialize
-                Color32[] inArrayA = default;
-                Color32[] inArrayB = default;
-                Color32[] inArrayC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inArrayA);
-                inSerializer.Serialize(ref inArrayB);
-                inSerializer.Serialize(ref inArrayC);
+            // deserialize
+            Color32[] inArrayA = default;
+            Color32[] inArrayB = default;
+            Color32[] inArrayC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inArrayA);
+            inSerializer.Serialize(ref inArrayB);
+            inSerializer.Serialize(ref inArrayC);
 
-                // validate
-                Assert.AreEqual(inArrayA, outArrayA);
-                Assert.AreEqual(inArrayB, outArrayB);
-                Assert.AreEqual(inArrayC, outArrayC);
-            }
+            // validate
+            Assert.AreEqual(inArrayA, outArrayA);
+            Assert.AreEqual(inArrayB, outArrayB);
+            Assert.AreEqual(inArrayC, outArrayC);
         }
 
         [Test]
         public void SerializeVector2Array()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                Vector2[] outArrayA = null;
-                var outArrayB = new Vector2[0];
-                Vector2[] outArrayC = { Vector2.up, Vector2.negativeInfinity, Vector2.positiveInfinity };
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outArrayA);
-                outSerializer.Serialize(ref outArrayB);
-                outSerializer.Serialize(ref outArrayC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            Vector2[] outArrayA = null;
+            var outArrayB = new Vector2[0];
+            Vector2[] outArrayC = { Vector2.up, Vector2.negativeInfinity, Vector2.positiveInfinity };
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outArrayA);
+            outSerializer.Serialize(ref outArrayB);
+            outSerializer.Serialize(ref outArrayC);
 
-                // deserialize
-                Vector2[] inArrayA = default;
-                Vector2[] inArrayB = default;
-                Vector2[] inArrayC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inArrayA);
-                inSerializer.Serialize(ref inArrayB);
-                inSerializer.Serialize(ref inArrayC);
+            // deserialize
+            Vector2[] inArrayA = default;
+            Vector2[] inArrayB = default;
+            Vector2[] inArrayC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inArrayA);
+            inSerializer.Serialize(ref inArrayB);
+            inSerializer.Serialize(ref inArrayC);
 
-                // validate
-                Assert.AreEqual(inArrayA, outArrayA);
-                Assert.AreEqual(inArrayB, outArrayB);
-                Assert.AreEqual(inArrayC, outArrayC);
-            }
+            // validate
+            Assert.AreEqual(inArrayA, outArrayA);
+            Assert.AreEqual(inArrayB, outArrayB);
+            Assert.AreEqual(inArrayC, outArrayC);
         }
 
         [Test]
         public void SerializeVector3Array()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                Vector3[] outArrayA = null;
-                var outArrayB = new Vector3[0];
-                Vector3[] outArrayC = { Vector3.forward, Vector3.negativeInfinity, Vector3.positiveInfinity };
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outArrayA);
-                outSerializer.Serialize(ref outArrayB);
-                outSerializer.Serialize(ref outArrayC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            Vector3[] outArrayA = null;
+            var outArrayB = new Vector3[0];
+            Vector3[] outArrayC = { Vector3.forward, Vector3.negativeInfinity, Vector3.positiveInfinity };
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outArrayA);
+            outSerializer.Serialize(ref outArrayB);
+            outSerializer.Serialize(ref outArrayC);
 
-                // deserialize
-                Vector3[] inArrayA = default;
-                Vector3[] inArrayB = default;
-                Vector3[] inArrayC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inArrayA);
-                inSerializer.Serialize(ref inArrayB);
-                inSerializer.Serialize(ref inArrayC);
+            // deserialize
+            Vector3[] inArrayA = default;
+            Vector3[] inArrayB = default;
+            Vector3[] inArrayC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inArrayA);
+            inSerializer.Serialize(ref inArrayB);
+            inSerializer.Serialize(ref inArrayC);
 
-                // validate
-                Assert.AreEqual(inArrayA, outArrayA);
-                Assert.AreEqual(inArrayB, outArrayB);
-                Assert.AreEqual(inArrayC, outArrayC);
-            }
+            // validate
+            Assert.AreEqual(inArrayA, outArrayA);
+            Assert.AreEqual(inArrayB, outArrayB);
+            Assert.AreEqual(inArrayC, outArrayC);
         }
 
         [Test]
         public void SerializeVector4Array()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                Vector4[] outArrayA = null;
-                var outArrayB = new Vector4[0];
-                Vector4[] outArrayC = { Vector4.one, Vector4.negativeInfinity, Vector4.positiveInfinity };
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outArrayA);
-                outSerializer.Serialize(ref outArrayB);
-                outSerializer.Serialize(ref outArrayC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            Vector4[] outArrayA = null;
+            var outArrayB = new Vector4[0];
+            Vector4[] outArrayC = { Vector4.one, Vector4.negativeInfinity, Vector4.positiveInfinity };
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outArrayA);
+            outSerializer.Serialize(ref outArrayB);
+            outSerializer.Serialize(ref outArrayC);
 
-                // deserialize
-                Vector4[] inArrayA = default;
-                Vector4[] inArrayB = default;
-                Vector4[] inArrayC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inArrayA);
-                inSerializer.Serialize(ref inArrayB);
-                inSerializer.Serialize(ref inArrayC);
+            // deserialize
+            Vector4[] inArrayA = default;
+            Vector4[] inArrayB = default;
+            Vector4[] inArrayC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inArrayA);
+            inSerializer.Serialize(ref inArrayB);
+            inSerializer.Serialize(ref inArrayC);
 
-                // validate
-                Assert.AreEqual(inArrayA, outArrayA);
-                Assert.AreEqual(inArrayB, outArrayB);
-                Assert.AreEqual(inArrayC, outArrayC);
-            }
+            // validate
+            Assert.AreEqual(inArrayA, outArrayA);
+            Assert.AreEqual(inArrayB, outArrayB);
+            Assert.AreEqual(inArrayC, outArrayC);
         }
 
         [Test]
         public void SerializeQuaternionArray()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            Quaternion[] outArrayA = null;
+            var outArrayB = new Quaternion[0];
+            Quaternion[] outArrayC = { Quaternion.identity, Quaternion.Euler(new Vector3(30, 45, -60)), Quaternion.Euler(new Vector3(90, -90, 180)) };
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outArrayA);
+            outSerializer.Serialize(ref outArrayB);
+            outSerializer.Serialize(ref outArrayC);
+
+            // deserialize
+            Quaternion[] inArrayA = default;
+            Quaternion[] inArrayB = default;
+            Quaternion[] inArrayC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inArrayA);
+            inSerializer.Serialize(ref inArrayB);
+            inSerializer.Serialize(ref inArrayC);
+
+            // validate
+            Assert.Null(inArrayA);
+            Assert.AreEqual(inArrayB, outArrayB);
+            for (int i = 0; i < outArrayC.Length; ++i)
             {
-                // serialize
-                Quaternion[] outArrayA = null;
-                var outArrayB = new Quaternion[0];
-                Quaternion[] outArrayC = { Quaternion.identity, Quaternion.Euler(new Vector3(30, 45, -60)), Quaternion.Euler(new Vector3(90, -90, 180)) };
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outArrayA);
-                outSerializer.Serialize(ref outArrayB);
-                outSerializer.Serialize(ref outArrayC);
-
-                // deserialize
-                Quaternion[] inArrayA = default;
-                Quaternion[] inArrayB = default;
-                Quaternion[] inArrayC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inArrayA);
-                inSerializer.Serialize(ref inArrayB);
-                inSerializer.Serialize(ref inArrayC);
-
-                // validate
-                Assert.Null(inArrayA);
-                Assert.AreEqual(inArrayB, outArrayB);
-                for (int i = 0; i < outArrayC.Length; ++i)
-                {
-                    Assert.Greater(Mathf.Abs(Quaternion.Dot(inArrayC[i], outArrayC[i])), 0.999f);
-                }
+                Assert.Greater(Mathf.Abs(Quaternion.Dot(inArrayC[i], outArrayC[i])), 0.999f);
             }
         }
 
         [Test]
         public void SerializeRayArray()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            Ray[] outArrayA = null;
+            var outArrayB = new Ray[0];
+            Ray[] outArrayC =
             {
-                // serialize
-                Ray[] outArrayA = null;
-                var outArrayB = new Ray[0];
-                Ray[] outArrayC =
-                {
                     new Ray(Vector3.zero, Vector3.forward),
                     new Ray(Vector3.zero, Vector3.left),
                     new Ray(Vector3.zero, Vector3.up)
                 };
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outArrayA);
-                outSerializer.Serialize(ref outArrayB);
-                outSerializer.Serialize(ref outArrayC);
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outArrayA);
+            outSerializer.Serialize(ref outArrayB);
+            outSerializer.Serialize(ref outArrayC);
 
-                // deserialize
-                Ray[] inArrayA = default;
-                Ray[] inArrayB = default;
-                Ray[] inArrayC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inArrayA);
-                inSerializer.Serialize(ref inArrayB);
-                inSerializer.Serialize(ref inArrayC);
+            // deserialize
+            Ray[] inArrayA = default;
+            Ray[] inArrayB = default;
+            Ray[] inArrayC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inArrayA);
+            inSerializer.Serialize(ref inArrayB);
+            inSerializer.Serialize(ref inArrayC);
 
-                // validate
-                Assert.AreEqual(inArrayA, outArrayA);
-                Assert.AreEqual(inArrayB, outArrayB);
-                Assert.AreEqual(inArrayC, outArrayC);
-            }
+            // validate
+            Assert.AreEqual(inArrayA, outArrayA);
+            Assert.AreEqual(inArrayB, outArrayB);
+            Assert.AreEqual(inArrayC, outArrayC);
         }
 
         [Test]
         public void SerializeRay2DArray()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            Ray2D[] outArrayA = null;
+            var outArrayB = new Ray2D[0];
+            Ray2D[] outArrayC =
             {
-                // serialize
-                Ray2D[] outArrayA = null;
-                var outArrayB = new Ray2D[0];
-                Ray2D[] outArrayC =
-                {
                     new Ray2D(Vector2.zero, Vector2.up),
                     new Ray2D(Vector2.zero, Vector2.left),
                     new Ray2D(Vector2.zero, Vector2.right)
                 };
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outArrayA);
-                outSerializer.Serialize(ref outArrayB);
-                outSerializer.Serialize(ref outArrayC);
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outArrayA);
+            outSerializer.Serialize(ref outArrayB);
+            outSerializer.Serialize(ref outArrayC);
 
-                // deserialize
-                Ray2D[] inArrayA = default;
-                Ray2D[] inArrayB = default;
-                Ray2D[] inArrayC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inArrayA);
-                inSerializer.Serialize(ref inArrayB);
-                inSerializer.Serialize(ref inArrayC);
+            // deserialize
+            Ray2D[] inArrayA = default;
+            Ray2D[] inArrayB = default;
+            Ray2D[] inArrayC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inArrayA);
+            inSerializer.Serialize(ref inArrayB);
+            inSerializer.Serialize(ref inArrayC);
 
-                // validate
-                Assert.AreEqual(inArrayA, outArrayA);
-                Assert.AreEqual(inArrayB, outArrayB);
-                Assert.AreEqual(inArrayC, outArrayC);
-            }
+            // validate
+            Assert.AreEqual(inArrayA, outArrayA);
+            Assert.AreEqual(inArrayB, outArrayB);
+            Assert.AreEqual(inArrayC, outArrayC);
         }
 
         [Test]
         public void SerializeEnumArray()
         {
-            using (var outStream = PooledNetworkBuffer.Get())
-            using (var outWriter = PooledNetworkWriter.Get(outStream))
-            using (var inStream = PooledNetworkBuffer.Get())
-            using (var inReader = PooledNetworkReader.Get(inStream))
-            {
-                // serialize
-                EnumA[] outArrayA = null;
-                var outArrayB = new EnumB[0];
-                EnumC[] outArrayC = { EnumC.U, EnumC.N, EnumC.I, EnumC.T, EnumC.Y, (EnumC)128 };
-                var outSerializer = new NetworkSerializer(outWriter);
-                outSerializer.Serialize(ref outArrayA);
-                outSerializer.Serialize(ref outArrayB);
-                outSerializer.Serialize(ref outArrayC);
+            using var outStream = PooledNetworkBuffer.Get();
+            using var outWriter = PooledNetworkWriter.Get(outStream);
+            using var inStream = PooledNetworkBuffer.Get();
+            using var inReader = PooledNetworkReader.Get(inStream);
+            // serialize
+            EnumA[] outArrayA = null;
+            var outArrayB = new EnumB[0];
+            EnumC[] outArrayC = { EnumC.U, EnumC.N, EnumC.I, EnumC.T, EnumC.Y, (EnumC)128 };
+            var outSerializer = new NetworkSerializer(outWriter);
+            outSerializer.Serialize(ref outArrayA);
+            outSerializer.Serialize(ref outArrayB);
+            outSerializer.Serialize(ref outArrayC);
 
-                // deserialize
-                EnumA[] inArrayA = default;
-                EnumB[] inArrayB = default;
-                EnumC[] inArrayC = default;
-                inStream.Write(outStream.ToArray());
-                inStream.Position = 0;
-                var inSerializer = new NetworkSerializer(inReader);
-                inSerializer.Serialize(ref inArrayA);
-                inSerializer.Serialize(ref inArrayB);
-                inSerializer.Serialize(ref inArrayC);
+            // deserialize
+            EnumA[] inArrayA = default;
+            EnumB[] inArrayB = default;
+            EnumC[] inArrayC = default;
+            inStream.Write(outStream.ToArray());
+            inStream.Position = 0;
+            var inSerializer = new NetworkSerializer(inReader);
+            inSerializer.Serialize(ref inArrayA);
+            inSerializer.Serialize(ref inArrayB);
+            inSerializer.Serialize(ref inArrayC);
 
-                // validate
-                Assert.AreEqual(inArrayA, outArrayA);
-                Assert.AreEqual(inArrayB, outArrayB);
-                Assert.AreEqual(inArrayC, outArrayC);
-            }
+            // validate
+            Assert.AreEqual(inArrayA, outArrayA);
+            Assert.AreEqual(inArrayB, outArrayB);
+            Assert.AreEqual(inArrayC, outArrayC);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkUpdateLoopTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkUpdateLoopTests.cs
@@ -200,78 +200,76 @@ namespace Unity.Netcode.RuntimeTests
             int[] netUpdates = new int[7];
 
             bool isTesting = false;
-            using (var plainScript = new MyPlainScript())
+            using var plainScript = new MyPlainScript();
+            plainScript.UpdateCallbacks = new NetworkUpdateCallbacks
             {
-                plainScript.UpdateCallbacks = new NetworkUpdateCallbacks
+                OnInitialization = () =>
                 {
-                    OnInitialization = () =>
+                    if (isTesting)
                     {
-                        if (isTesting)
-                        {
-                            netUpdates[kNetInitializationIndex]++;
-                        }
-                    },
-                    OnEarlyUpdate = () =>
-                    {
-                        if (isTesting)
-                        {
-                            netUpdates[kNetEarlyUpdateIndex]++;
-                        }
-                    },
-                    OnFixedUpdate = () =>
-                    {
-                        if (isTesting)
-                        {
-                            netUpdates[kNetFixedUpdateIndex]++;
-                        }
-                    },
-                    OnPreUpdate = () =>
-                    {
-                        if (isTesting)
-                        {
-                            netUpdates[kNetPreUpdateIndex]++;
-                        }
-                    },
-                    OnUpdate = () =>
-                    {
-                        if (isTesting)
-                        {
-                            netUpdates[kNetUpdateIndex]++;
-                        }
-                    },
-                    OnPreLateUpdate = () =>
-                    {
-                        if (isTesting)
-                        {
-                            netUpdates[kNetPreLateUpdateIndex]++;
-                        }
-                    },
-                    OnPostLateUpdate = () =>
-                    {
-                        if (isTesting)
-                        {
-                            netUpdates[kNetPostLateUpdateIndex]++;
-                        }
+                        netUpdates[kNetInitializationIndex]++;
                     }
-                };
+                },
+                OnEarlyUpdate = () =>
+                {
+                    if (isTesting)
+                    {
+                        netUpdates[kNetEarlyUpdateIndex]++;
+                    }
+                },
+                OnFixedUpdate = () =>
+                {
+                    if (isTesting)
+                    {
+                        netUpdates[kNetFixedUpdateIndex]++;
+                    }
+                },
+                OnPreUpdate = () =>
+                {
+                    if (isTesting)
+                    {
+                        netUpdates[kNetPreUpdateIndex]++;
+                    }
+                },
+                OnUpdate = () =>
+                {
+                    if (isTesting)
+                    {
+                        netUpdates[kNetUpdateIndex]++;
+                    }
+                },
+                OnPreLateUpdate = () =>
+                {
+                    if (isTesting)
+                    {
+                        netUpdates[kNetPreLateUpdateIndex]++;
+                    }
+                },
+                OnPostLateUpdate = () =>
+                {
+                    if (isTesting)
+                    {
+                        netUpdates[kNetPostLateUpdateIndex]++;
+                    }
+                }
+            };
 
-                plainScript.Initialize();
-                int nextFrameNumber = Time.frameCount + 1;
-                yield return new WaitUntil(() => Time.frameCount >= nextFrameNumber);
-                isTesting = true;
+            plainScript.Initialize();
+            int nextFrameNumber = Time.frameCount + 1;
+            yield return new WaitUntil(() => Time.frameCount >= nextFrameNumber);
+            isTesting = true;
 
-                const int kRunTotalFrames = 16;
-                int waitFrameNumber = Time.frameCount + kRunTotalFrames;
-                yield return new WaitUntil(() => Time.frameCount >= waitFrameNumber);
+            const int kRunTotalFrames = 16;
+            int waitFrameNumber = Time.frameCount + kRunTotalFrames;
+            yield return new WaitUntil(() => Time.frameCount >= waitFrameNumber);
 
-                Assert.AreEqual(0, netUpdates[kNetInitializationIndex]);
-                Assert.AreEqual(kRunTotalFrames, netUpdates[kNetEarlyUpdateIndex]);
-                Assert.AreEqual(0, netUpdates[kNetFixedUpdateIndex]);
-                Assert.AreEqual(0, netUpdates[kNetPreUpdateIndex]);
-                Assert.AreEqual(0, netUpdates[kNetUpdateIndex]);
-                Assert.AreEqual(kRunTotalFrames, netUpdates[kNetPreLateUpdateIndex]);
-                Assert.AreEqual(0, netUpdates[kNetPostLateUpdateIndex]);
-            }
+            Assert.AreEqual(0, netUpdates[kNetInitializationIndex]);
+            Assert.AreEqual(kRunTotalFrames, netUpdates[kNetEarlyUpdateIndex]);
+            Assert.AreEqual(0, netUpdates[kNetFixedUpdateIndex]);
+            Assert.AreEqual(0, netUpdates[kNetPreUpdateIndex]);
+            Assert.AreEqual(0, netUpdates[kNetUpdateIndex]);
+            Assert.AreEqual(kRunTotalFrames, netUpdates[kNetPreLateUpdateIndex]);
+            Assert.AreEqual(0, netUpdates[kNetPostLateUpdateIndex]);
         }
 
         private struct MonoBehaviourCallbacks

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVarBufferCopyTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVarBufferCopyTest.cs
@@ -28,44 +28,36 @@ namespace Unity.Netcode.RuntimeTests
 
             public override void WriteDelta(Stream stream)
             {
-                using (var writer = PooledNetworkWriter.Get(stream))
-                {
-                    writer.WriteBits((byte)1, 1);
-                    writer.WriteInt32(k_DummyValue);
-                }
+                using var writer = PooledNetworkWriter.Get(stream);
+                writer.WriteBits((byte)1, 1);
+                writer.WriteInt32(k_DummyValue);
 
                 DeltaWritten = true;
             }
 
             public override void WriteField(Stream stream)
             {
-                using (var writer = PooledNetworkWriter.Get(stream))
-                {
-                    writer.WriteBits((byte)1, 1);
-                    writer.WriteInt32(k_DummyValue);
-                }
+                using var writer = PooledNetworkWriter.Get(stream);
+                writer.WriteBits((byte)1, 1);
+                writer.WriteInt32(k_DummyValue);
 
                 FieldWritten = true;
             }
 
             public override void ReadField(Stream stream)
             {
-                using (var reader = PooledNetworkReader.Get(stream))
-                {
-                    reader.ReadBits(1);
-                    Assert.AreEqual(k_DummyValue, reader.ReadInt32());
-                }
+                using var reader = PooledNetworkReader.Get(stream);
+                reader.ReadBits(1);
+                Assert.AreEqual(k_DummyValue, reader.ReadInt32());
 
                 FieldRead = true;
             }
 
             public override void ReadDelta(Stream stream, bool keepDirtyDelta)
             {
-                using (var reader = PooledNetworkReader.Get(stream))
-                {
-                    reader.ReadBits(1);
-                    Assert.AreEqual(k_DummyValue, reader.ReadInt32());
-                }
+                using var reader = PooledNetworkReader.Get(stream);
+                reader.ReadBits(1);
+                Assert.AreEqual(k_DummyValue, reader.ReadInt32());
 
                 DeltaRead = true;
             }


### PR DESCRIPTION
our base version 2020.3 LTS is already above C# 8.0+ so let's use fancy `using var bla` declarations instead of `using (var bla` statements! :)

(another follow up on PR #1092)