### PR TITLE
refactor: remove TempGlobalObjectIdHashOverride

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -19,10 +19,6 @@ namespace Unity.Netcode
         internal uint GlobalObjectIdHash;
 
 #if UNITY_EDITOR
-        // HEAD: DO NOT USE! TEST ONLY TEMP IMPL, WILL BE REMOVED
-        internal uint TempGlobalObjectIdHashOverride = 0;
-        // TAIL: DO NOT USE! TEST ONLY TEMP IMPL, WILL BE REMOVED
-
         private void OnValidate()
         {
             GenerateGlobalObjectIdHash();
@@ -30,14 +26,6 @@ namespace Unity.Netcode
 
         internal void GenerateGlobalObjectIdHash()
         {
-            // HEAD: DO NOT USE! TEST ONLY TEMP IMPL, WILL BE REMOVED
-            if (TempGlobalObjectIdHashOverride != 0)
-            {
-                GlobalObjectIdHash = TempGlobalObjectIdHashOverride;
-                return;
-            }
-            // TAIL: DO NOT USE! TEST ONLY TEMP IMPL, WILL BE REMOVED
-
             // do NOT regenerate GlobalObjectIdHash for NetworkPrefabs while Editor is in PlayMode
             if (UnityEditor.EditorApplication.isPlaying && !string.IsNullOrEmpty(gameObject.scene.name))
             {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/MultiInstanceHelpers.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/MultiInstanceHelpers.cs
@@ -217,16 +217,13 @@ namespace Unity.Netcode.RuntimeTests
         /// <param name="globalObjectIdHash">The GlobalObjectId to force</param>
         public static void MakeNetworkObjectTestPrefab(NetworkObject networkObject, uint globalObjectIdHash = default)
         {
-            // Set a globalObjectId for prefab
+            // Override `GlobalObjectIdHash` if `globalObjectIdHash` param is set
             if (globalObjectIdHash != default)
             {
-                networkObject.TempGlobalObjectIdHashOverride = globalObjectIdHash;
+                networkObject.GlobalObjectIdHash = globalObjectIdHash;
             }
 
-            // Force generation
-            networkObject.GenerateGlobalObjectIdHash();
-
-            // Fallback to auto-increment if generation fails
+            // Fallback to auto-increment if `GlobalObjectIdHash` was never set
             if (networkObject.GlobalObjectIdHash == default)
             {
                 networkObject.GlobalObjectIdHash = ++s_AutoIncrementGlobalObjectIdHashCounter;


### PR DESCRIPTION
removing this workaround since it looks like this might not be needed any longer.

> DO NOT USE! TEST ONLY TEMP IMPL, WILL BE REMOVED