### PR TITLE
fix: client connected InvokeOnClientConnectedCallback with scene management disabled

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1495,13 +1495,16 @@ namespace Unity.Netcode
                     {
                         SceneManager.SynchronizeNetworkObjects(ownerClientId);
                     }
+                    else
+                    {
+                        InvokeOnClientConnectedCallback(ownerClientId);
+                    }
                 }
                 else // Server just adds itself as an observer to all spawned NetworkObjects
                 {
                     SpawnManager.UpdateObservedNetworkObjects(ownerClientId);
+                    InvokeOnClientConnectedCallback(ownerClientId);
                 }
-
-                OnClientConnectedCallback?.Invoke(ownerClientId);
 
                 if (!createPlayerObject || (playerPrefabHash == null && NetworkConfig.PlayerPrefab == null))
                 {

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/InternalMessageHandler.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/InternalMessageHandler.cs
@@ -76,6 +76,11 @@ namespace Unity.Netcode
                 {
                     NetworkObject.DeserializeSceneObject(reader.GetStream() as NetworkBuffer, reader, m_NetworkManager);
                 }
+
+                // Mark the client being connected
+                m_NetworkManager.IsConnectedClient = true;
+                // When scene management is disabled we notify after everything is synchronized
+                m_NetworkManager.InvokeOnClientConnectedCallback(clientId);
             }
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -547,7 +547,7 @@ namespace Unity.Netcode
             }
 
             var sceneEventProgress = new SceneEventProgress(m_NetworkManager);
-            sceneEventProgress.SceneIndex = GetBuildIndexFromSceneName(sceneName);
+            sceneEventProgress.SceneBuildIndex = GetBuildIndexFromSceneName(sceneName);
             SceneEventProgressTracking.Add(sceneEventProgress.Guid, sceneEventProgress);
 
             if (!isUnloading)
@@ -582,7 +582,7 @@ namespace Unity.Netcode
             {
                 using var nonNullContext = (InternalCommandContext)context;
                 ClientSynchEventData.SceneEventGuid = sceneEventProgress.Guid;
-                ClientSynchEventData.SceneIndex = sceneEventProgress.SceneIndex;
+                ClientSynchEventData.SceneIndex = sceneEventProgress.SceneBuildIndex;
                 ClientSynchEventData.SceneEventType = sceneEventProgress.SceneEventType;
                 ClientSynchEventData.ClientsCompleted = sceneEventProgress.DoneClients;
                 ClientSynchEventData.ClientsTimedOut = m_NetworkManager.ConnectedClients.Keys.Except(sceneEventProgress.DoneClients).ToList();
@@ -596,7 +596,7 @@ namespace Unity.Netcode
                 m_NetworkManager.NetworkMetrics.TrackSceneEventSent(
                     m_NetworkManager.ConnectedClientsIds,
                     (uint)sceneEventProgress.SceneEventType,
-                    ScenesInBuild[(int)sceneEventProgress.SceneIndex],
+                    ScenesInBuild[(int)sceneEventProgress.SceneBuildIndex],
                     size);
             }
 
@@ -604,7 +604,7 @@ namespace Unity.Netcode
             OnSceneEvent?.Invoke(new SceneEvent()
             {
                 SceneEventType = sceneEventProgress.SceneEventType,
-                SceneName = ScenesInBuild[(int)sceneEventProgress.SceneIndex],
+                SceneName = ScenesInBuild[(int)sceneEventProgress.SceneBuildIndex],
                 ClientId = m_NetworkManager.ServerClientId,
                 LoadSceneMode = sceneEventProgress.LoadSceneMode,
                 ClientsThatCompleted = sceneEventProgress.DoneClients,

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1377,7 +1377,6 @@ namespace Unity.Netcode
 
                             // All scenes are synchronized, let the server know we are done synchronizing
                             m_NetworkManager.IsConnectedClient = true;
-                            m_NetworkManager.InvokeOnClientConnectedCallback(m_NetworkManager.LocalClientId);
 
                             // Notify the client that they have finished synchronizing
                             OnSceneEvent?.Invoke(new SceneEvent()
@@ -1385,6 +1384,9 @@ namespace Unity.Netcode
                                 SceneEventType = SceneEventData.SceneEventType,
                                 ClientId = m_NetworkManager.LocalClientId, // Client sent this to the server
                             });
+
+                            // Client is now synchronized and fully "connected".  This also means the client can send "RPCs" at this time
+                            m_NetworkManager.InvokeOnClientConnectedCallback(m_NetworkManager.LocalClientId);
                         }
                         break;
                     }
@@ -1476,6 +1478,10 @@ namespace Unity.Netcode
                             SceneName = string.Empty,
                             ClientId = clientId
                         });
+
+                        // While we did invoke the C2S_SyncComplete event notification, we will also call the traditional client connected callback on the server
+                        // which assures the client is "ready to receive RPCs" as well.
+                        m_NetworkManager.InvokeOnClientConnectedCallback(clientId);
 
                         if (SceneEventData.ClientNeedsReSynchronization() && !DisableReSynchronization)
                         {

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
@@ -88,7 +88,7 @@ namespace Unity.Netcode
         /// </summary>
         internal bool AreAllClientsDoneLoading { get; private set; }
 
-        internal uint SceneIndex { get; set; }
+        internal uint SceneBuildIndex { get; set; }
 
         internal Guid Guid { get; } = Guid.NewGuid();
 

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/Pooled/NetworkBufferPool.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/Pooled/NetworkBufferPool.cs
@@ -12,8 +12,11 @@ namespace Unity.Netcode
         private static Queue<WeakReference> s_OverflowBuffers = new Queue<WeakReference>();
         private static Queue<PooledNetworkBuffer> s_Buffers = new Queue<PooledNetworkBuffer>();
 
-        private const uint k_MaxBitPoolBuffers = 1024;
-        private const uint k_MaxCreatedDelta = 768;
+        // Increasing this value for various reasons:
+        // Some tests (i.e. MessageHandlerReceivedMessageServerClient) expect certain log messages and if we happen to hit the threshold it will cause those tests to fail
+        // This slows down tests having to log warnings repeatedly.
+        private const uint k_MaxBitPoolBuffers = 2048;
+        private const uint k_MaxCreatedDelta = 1512;
 
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/Pooled/NetworkBufferPool.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/Pooled/NetworkBufferPool.cs
@@ -12,11 +12,8 @@ namespace Unity.Netcode
         private static Queue<WeakReference> s_OverflowBuffers = new Queue<WeakReference>();
         private static Queue<PooledNetworkBuffer> s_Buffers = new Queue<PooledNetworkBuffer>();
 
-        // Increasing this value for various reasons:
-        // Some tests (i.e. MessageHandlerReceivedMessageServerClient) expect certain log messages and if we happen to hit the threshold it will cause those tests to fail
-        // This slows down tests having to log warnings repeatedly.
-        private const uint k_MaxBitPoolBuffers = 2048;
-        private const uint k_MaxCreatedDelta = 1512;
+        private const uint k_MaxBitPoolBuffers = 1024;
+        private const uint k_MaxCreatedDelta = 512;
 
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Tests/Editor/NetworkManagerMessageHandlerTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/NetworkManagerMessageHandlerTests.cs
@@ -140,6 +140,7 @@ namespace Unity.Netcode.EditorTests
             using var messageStream13 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.CreateObject, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
             networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream13.GetBuffer(), 0, (int)messageStream13.Length), 0);
 
+
             // Should cause log (client only)
             // Everything should log MessageReceiveQueueItem even if ignored
             LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));

--- a/com.unity.netcode.gameobjects/Tests/Editor/NetworkManagerMessageHandlerTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/NetworkManagerMessageHandlerTests.cs
@@ -140,7 +140,6 @@ namespace Unity.Netcode.EditorTests
             using var messageStream13 = MessagePacker.WrapMessage(MessageQueueContainer.MessageType.CreateObject, inputBuffer, networkManager.MessageQueueContainer.IsUsingBatching());
             networkManager.HandleIncomingData(0, NetworkChannel.Internal, new ArraySegment<byte>(messageStream13.GetBuffer(), 0, (int)messageStream13.Length), 0);
 
-
             // Should cause log (client only)
             // Everything should log MessageReceiveQueueItem even if ignored
             LogAssert.Expect(LogType.Log, nameof(DummyMessageHandler.MessageReceiveQueueItem));

--- a/testproject/Assets/Tests/Runtime/MultiClientConnectionApproval.cs
+++ b/testproject/Assets/Tests/Runtime/MultiClientConnectionApproval.cs
@@ -43,8 +43,6 @@ namespace TestProject.RuntimeTests
         }
 
 
-
-
         /// <summary>
         /// Allows for several connection approval related configurations
         /// </summary>

--- a/testproject/Assets/Tests/Runtime/ObjectParenting/NetworkObjectParentingTests.cs
+++ b/testproject/Assets/Tests/Runtime/ObjectParenting/NetworkObjectParentingTests.cs
@@ -51,8 +51,6 @@ namespace Unity.Netcode.RuntimeTests
         {
             SceneManager.sceneLoaded += OnSceneLoaded;
 
-            // We need NetworkManager to be instantiated first before you load scenes externally in order to be able to determine if
-            // we are running a unit test or not. (it is this or manually setting a property)
             Assert.That(MultiInstanceHelpers.Create(k_ClientInstanceCount, out m_ServerNetworkManager, out m_ClientNetworkManagers));
 
             const string scenePath = "Assets/Tests/Runtime/ObjectParenting/" + nameof(NetworkObjectParentingTests) + ".unity";


### PR DESCRIPTION
This fixes the issue where a client would not receive the OnClientConnectedCallback event when scene management was disabled.
It also does some slight refactoring to when it is invoked as well as invokes it on the server after the client has notified the server that its synchronization is complete (as opposed to invoking right when the client was approved) in order to assure a user can start sending RPCs to a client from a server when this is invoked.  
Side note: Users can also use the C2S_SyncComplete scene event notification to determine if it is ok to send RPCs to a client.

This includes an OnClientConnectedCallback integration test to verify this is working when scene management is enabled and disabled.

_This includes a bump in the number of NetworkBufferPools to remove the spamming which is causing performance issues and finally reached a point where it was causing MessageHandlerReceivedMessageServerClient to fail due to the warning messages._