### PR TITLE
fix: networkscenemanager not releasing buffers from pool

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -983,6 +983,7 @@ namespace Unity.Netcode
 
             if (SceneManager != null)
             {
+                SceneManager.Dispose();
                 SceneManager = null;
             }
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -983,6 +983,7 @@ namespace Unity.Netcode
 
             if (SceneManager != null)
             {
+                // Let the NetworkSceneManager clean up its two SceneEvenData instances
                 SceneManager.Dispose();
                 SceneManager = null;
             }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -202,7 +202,9 @@ namespace Unity.Netcode
 
         internal Scene DontDestroyOnLoadScene;
 
-
+        /// <summary>
+        /// Handle NetworkSeneManager clean up
+        /// </summary>
         public void Dispose()
         {
             SceneEventData.Dispose();

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -85,7 +85,7 @@ namespace Unity.Netcode
     /// Main class for managing network scenes when <see cref="NetworkConfig.EnableSceneManagement"/> is enabled.
     /// Uses the <see cref="MessageQueueContainer.MessageType.SceneEvent"/> message to communicate <see cref="SceneEventData"/> between the server and client(s)
     /// </summary>
-    public class NetworkSceneManager:IDisposable
+    public class NetworkSceneManager : IDisposable
     {
         // Used to be able to turn re-synchronization off for future snapshot development purposes.
         internal static bool DisableReSynchronization;
@@ -1068,7 +1068,7 @@ namespace Unity.Netcode
                         SceneEventData.OnWrite(nonNullContext.NetworkWriter);
 
                         var size = bufferSizeCapture.StopMeasureSegment();
-                            m_NetworkManager.NetworkMetrics.TrackSceneEventSent(clientId, (uint)SceneEventData.SceneEventType, scene.name, size);
+                        m_NetworkManager.NetworkMetrics.TrackSceneEventSent(clientId, (uint)SceneEventData.SceneEventType, scene.name, size);
                     }
                     else
                     {
@@ -1184,8 +1184,7 @@ namespace Unity.Netcode
                 var size = bufferSizeCapture.StopMeasureSegment();
                 foreach (var sceneIndex in ClientSynchEventData.ScenesToSynchronize)
                 {
-                    m_NetworkManager.NetworkMetrics.TrackSceneEventSent(
-                        clientId, (uint)ClientSynchEventData.SceneEventType,ScenesInBuild[(int)sceneIndex], size);
+                    m_NetworkManager.NetworkMetrics.TrackSceneEventSent(clientId, (uint)ClientSynchEventData.SceneEventType, ScenesInBuild[(int)sceneIndex], size);
                 }
             }
 
@@ -1334,7 +1333,7 @@ namespace Unity.Netcode
                 ClientSynchEventData.OnWrite(nonNullContext.NetworkWriter);
 
                 var size = bufferSizeCapture.StopMeasureSegment();
-                    m_NetworkManager.NetworkMetrics.TrackSceneEventSent(m_NetworkManager.ServerClientId, (uint)ClientSynchEventData.SceneEventType, sceneName, size);
+                m_NetworkManager.NetworkMetrics.TrackSceneEventSent(m_NetworkManager.ServerClientId, (uint)ClientSynchEventData.SceneEventType, sceneName, size);
             }
 
             // Send notification to local client that the scene has finished loading
@@ -1538,16 +1537,14 @@ namespace Unity.Netcode
                         // to track a metric for each one.
                         foreach (var sceneIndex in SceneEventData.ScenesToSynchronize)
                         {
-                            m_NetworkManager.NetworkMetrics.TrackSceneEventReceived(
-                                clientId, (uint) SceneEventData.SceneEventType, ScenesInBuild[(int)sceneIndex], stream.Length);
+                            m_NetworkManager.NetworkMetrics.TrackSceneEventReceived(clientId, (uint)SceneEventData.SceneEventType, ScenesInBuild[(int)sceneIndex], stream.Length);
                         }
                     }
                     else
                     {
                         // For all other scene event types, we are only dealing with one scene at a time, so we can read it
                         // from the SceneEventData directly.
-                        m_NetworkManager.NetworkMetrics.TrackSceneEventReceived(
-                            clientId, (uint) SceneEventData.SceneEventType, ScenesInBuild[(int)SceneEventData.SceneIndex], stream.Length);
+                        m_NetworkManager.NetworkMetrics.TrackSceneEventReceived(clientId, (uint)SceneEventData.SceneEventType, ScenesInBuild[(int)SceneEventData.SceneIndex], stream.Length);
                     }
 
                     if (SceneEventData.IsSceneEventClientSide())

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -85,7 +85,7 @@ namespace Unity.Netcode
     /// Main class for managing network scenes when <see cref="NetworkConfig.EnableSceneManagement"/> is enabled.
     /// Uses the <see cref="MessageQueueContainer.MessageType.SceneEvent"/> message to communicate <see cref="SceneEventData"/> between the server and client(s)
     /// </summary>
-    public class NetworkSceneManager
+    public class NetworkSceneManager:IDisposable
     {
         // Used to be able to turn re-synchronization off for future snapshot development purposes.
         internal static bool DisableReSynchronization;
@@ -201,6 +201,15 @@ namespace Unity.Netcode
 
 
         internal Scene DontDestroyOnLoadScene;
+
+
+        public void Dispose()
+        {
+            SceneEventData.Dispose();
+            SceneEventData = null;
+            ClientSynchEventData.Dispose();
+            ClientSynchEventData = null;
+        }
 
         /// <summary>
         /// Gets the scene name from full path to the scene

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
@@ -119,7 +119,7 @@ namespace Unity.Netcode
         /// </summary>
         private List<ulong> m_NetworkObjectsToBeRemoved = new List<ulong>();
 
-        internal PooledNetworkBuffer InternalBuffer;
+        internal NetworkBuffer InternalBuffer;
 
         private NetworkManager m_NetworkManager;
 
@@ -743,7 +743,7 @@ namespace Unity.Netcode
         {
             if (InternalBuffer != null)
             {
-                NetworkBufferPool.PutBackInPool(InternalBuffer);
+                InternalBuffer.Dispose();
                 InternalBuffer = null;
             }
         }
@@ -754,7 +754,7 @@ namespace Unity.Netcode
         internal SceneEventData(NetworkManager networkManager)
         {
             m_NetworkManager = networkManager;
-            InternalBuffer = NetworkBufferPool.GetBuffer();
+            InternalBuffer = new NetworkBuffer(1024, 256);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
@@ -762,7 +762,6 @@ namespace Unity.Netcode
             }
         }
 
-
         /// <summary>
         /// Used to release the pooled network buffer
         /// </summary>
@@ -772,12 +771,11 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// Constructor
+        /// Constructor for SceneEventData
         /// </summary>
         internal SceneEventData(NetworkManager networkManager)
         {
             m_NetworkManager = networkManager;
-
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
@@ -485,7 +485,6 @@ namespace Unity.Netcode
                     }
                 case SceneEventTypes.S2C_Load:
                     {
-
                         SetInternalBuffer();
                         // We store off the trailing in-scene placed serialized NetworkObject data to
                         // be processed once we are done loading.
@@ -740,8 +739,10 @@ namespace Unity.Netcode
             }
         }
 
-
-        internal void SetInternalBuffer()
+        /// <summary>
+        /// Gets a PooledNetworkBuffer if needed
+        /// </summary>
+        private void SetInternalBuffer()
         {
             if (InternalBuffer == null)
             {
@@ -749,7 +750,10 @@ namespace Unity.Netcode
             }
         }
 
-        internal void ReleaseInternalBuffer()
+        /// <summary>
+        /// Releases the PooledNetworkBuffer when no longer needed
+        /// </summary>
+        private void ReleaseInternalBuffer()
         {
             if (InternalBuffer != null)
             {


### PR DESCRIPTION
This fixes the issue where the two SceneEventData instances in NetworkSceneManager were not putting their PooledNetworkBuffers back into the pool.  After further consideration, it seemed better to not hold onto PooledNetworkBuffers for the duration of the NetworkSceneManager's life time.  
Included in this fix:

-  SceneEventData creates one dedicated NetworkBuffer per instance
- NetworkSceneManager is now IDisposable
- NetworkSceneManager.Dispose now disposes both SceneEventData instances
- NetworkManager.Shutdown now disposes the NetworkSceneManager instance.