### PR TITLE
chore: remove `--yamato` param from `standards.py`

### DIFF
--- a/.yamato/project-standards.yml
+++ b/.yamato/project-standards.yml
@@ -13,4 +13,4 @@ standards_{{ projects.first.name }}:
     - pip install unity-downloader-cli --upgrade --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - unity-downloader-cli -u {{ projects.first.test_editors.first }} -c editor --wait --fast
     - .Editor/Unity -batchmode -nographics -logFile - -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -projectPath {{ projects.first.path }} -quit
-    - ./standards.py --tool-path $HOME/.dotnet/tools/dotnet-format --project-path {{ projects.first.path }} --yamato
+    - ./standards.py --tool-path $HOME/.dotnet/tools/dotnet-format --project-path {{ projects.first.path }} --check

--- a/standards.py
+++ b/standards.py
@@ -14,7 +14,6 @@ parser.add_argument("--hook", action="store_true")
 parser.add_argument("--unhook", action="store_true")
 parser.add_argument("--check", action="store_true")
 parser.add_argument("--fix", action="store_true")
-parser.add_argument("--yamato", action="store_true")
 
 parser.add_argument("--verbosity", default="minimal")
 parser.add_argument("--tool-path", default="dotnet-format")
@@ -72,7 +71,7 @@ if args.unhook:
     print("unhook: succeeded")
 
 
-if args.check or args.fix or args.yamato:
+if args.check or args.fix:
     glob_match = os.path.join(args.project_path, args.project_glob)
     glob_files = glob.glob(glob_match)
     print(f"glob: found {len(glob_files)} files matching -> {glob_match}")
@@ -123,14 +122,3 @@ if args.fix:
         exit("fix: failed")
 
     print("fix: succeeded")
-
-if args.yamato:
-    print("yamato: execute")
-
-    for project_file in glob_files:
-        print(f"yamato: project -> {project_file}")
-        yamato_exec = os.system(f"{args.tool_path} {project_file} --fix-style error --check --verbosity {args.verbosity}")
-        if yamato_exec != 0:
-            exit(f"yamato: failed, exit code -> {yamato_exec}")
-
-    print("yamato: succeeded")

--- a/testproject/Assets/Tests/Manual/Scripts/ConnectionApprovalComponent.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/ConnectionApprovalComponent.cs
@@ -137,7 +137,7 @@ namespace TestProject.ManualTests
         /// </summary>
         public void OnDisconnectClient()
         {
-            if ( NetworkManager != null && NetworkManager.IsListening && !NetworkManager.IsServer)
+            if (NetworkManager != null && NetworkManager.IsListening && !NetworkManager.IsServer)
             {
                 NetworkManager.Shutdown();
                 m_ConnectionModeButtons.Reset();

--- a/testproject/Assets/Tests/Runtime/MultiClientConnectionApproval.cs
+++ b/testproject/Assets/Tests/Runtime/MultiClientConnectionApproval.cs
@@ -250,7 +250,7 @@ namespace TestProject.RuntimeTests
         /// </summary>
         /// <returns></returns>
         [UnityTest]
-        public IEnumerator ConnectionApprovalMismatchTest([Values(true, false)] bool enableSceneManagement, [Values(true,false)] bool connectionApproval)
+        public IEnumerator ConnectionApprovalMismatchTest([Values(true, false)] bool enableSceneManagement, [Values(true, false)] bool connectionApproval)
         {
             m_ServerClientDisconnectedInvocations = 0;
 


### PR DESCRIPTION
This PR removes `--yamato` parameter from `./standards.py`.
Yamato CI will now use `./standards.py --check` instead which also check for whitespace errors.
I checked out this branch on MacOS and Windows to test `./standards.py --check` and `./standards.py --fix` commands, they both work fine and produce identical results (in terms of warnings, errors, fixes etc.)
With this PR, there will be no difference between local and Yamato checks, also no difference between Windows & MacOS since we're explicitly setting encoding to UTF-8 and line-endings to LF in `.editorconfig` ruleset.