### PR TITLE
fix: Only track one metric for scene sync and do not report scene name

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1180,11 +1180,8 @@ namespace Unity.Netcode
                 ClientSynchEventData.OnWrite(nonNullContext.NetworkWriter);
 
                 var size = bufferSizeCapture.StopMeasureSegment();
-                foreach (var sceneIndex in ClientSynchEventData.ScenesToSynchronize)
-                {
                     m_NetworkManager.NetworkMetrics.TrackSceneEventSent(
-                       clientId, (uint)ClientSynchEventData.SceneEventType, ScenesInBuild[(int)sceneIndex], size);
-                }
+                       clientId, (uint)ClientSynchEventData.SceneEventType, "", size);
             }
 
             // Notify the local server that the client has been sent the SceneEventData.SceneEventTypes.S2C_Event_Sync event
@@ -1530,23 +1527,8 @@ namespace Unity.Netcode
                     SceneEventData.OnRead(reader);
                     NetworkReaderPool.PutBackInPool(reader);
 
-                    if (SceneEventData.SceneEventType == SceneEventData.SceneEventTypes.S2C_Sync)
-                    {
-                        // For this event the server may be sending scene event data about multiple scenes, so we need
-                        // to track a metric for each one.
-                        foreach (var sceneIndex in SceneEventData.ScenesToSynchronize)
-                        {
-                            m_NetworkManager.NetworkMetrics.TrackSceneEventReceived(
-                               clientId, (uint)SceneEventData.SceneEventType, ScenesInBuild[(int)sceneIndex], stream.Length);
-                        }
-                    }
-                    else
-                    {
-                        // For all other scene event types, we are only dealing with one scene at a time, so we can read it
-                        // from the SceneEventData directly.
-                        m_NetworkManager.NetworkMetrics.TrackSceneEventReceived(
-                           clientId, (uint)SceneEventData.SceneEventType, ScenesInBuild[(int)SceneEventData.SceneIndex], stream.Length);
-                    }
+                    m_NetworkManager.NetworkMetrics.TrackSceneEventReceived(
+                       clientId, (uint)SceneEventData.SceneEventType, ScenesInBuild[(int)SceneEventData.SceneIndex], stream.Length);
 
                     if (SceneEventData.IsSceneEventClientSide())
                     {

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1180,8 +1180,8 @@ namespace Unity.Netcode
                 ClientSynchEventData.OnWrite(nonNullContext.NetworkWriter);
 
                 var size = bufferSizeCapture.StopMeasureSegment();
-                    m_NetworkManager.NetworkMetrics.TrackSceneEventSent(
-                       clientId, (uint)ClientSynchEventData.SceneEventType, "", size);
+                m_NetworkManager.NetworkMetrics.TrackSceneEventSent(
+                    clientId, (uint)ClientSynchEventData.SceneEventType, "", size);
             }
 
             // Notify the local server that the client has been sent the SceneEventData.SceneEventTypes.S2C_Event_Sync event


### PR DESCRIPTION
Previously we were tracking all scenes that were included in the message when an S2C_Sync message was sent or received. Now we have a better understanding of this scene event type, this feels like the wrong level of detail for this metric so we are now just reporting the scene event type and not the specific scenes.

This will also make this metric consistent for C2S_SyncComplete where the scene names is not a core part of the message (the important thing is the event type itself and the number of network objects synced, not the scenes themselves). 

Similarly, S2C_Resync will not report each scene name, to keep consistent with the rest of the scene flow.