### PR TITLE
chore: Disable test while we reevaluate the assumption that INetworkM…

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Editor/Metrics/NetworkMetricsRegistrationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Metrics/NetworkMetricsRegistrationTests.cs
@@ -15,7 +15,8 @@ namespace Unity.Netcode.EditorTests.Metrics
             .Where(x => x.GetInterfaces().Contains(typeof(INetworkMetricEvent)))
             .ToArray();
 
-        [TestCaseSource(nameof(s_MetricTypes))]
+        // Disable test while we reevaluate the assumption that INetworkMetricEvent interfaces must be reported from MLAPI.
+        //[TestCaseSource(nameof(s_MetricTypes))]
         public void ValidateThatAllMetricTypesAreRegistered(Type metricType)
         {
             var dispatcher = new NetworkMetrics().Dispatcher as MetricDispatcher;

--- a/com.unity.netcode.gameobjects/Tests/Editor/Metrics/NetworkMetricsRegistrationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Metrics/NetworkMetricsRegistrationTests.cs
@@ -15,8 +15,7 @@ namespace Unity.Netcode.EditorTests.Metrics
             .Where(x => x.GetInterfaces().Contains(typeof(INetworkMetricEvent)))
             .ToArray();
 
-        // Disable test while we reevaluate the assumption that INetworkMetricEvent interfaces must be reported from MLAPI.
-        //[TestCaseSource(nameof(s_MetricTypes))]
+        [TestCaseSource(nameof(s_MetricTypes))][Ignore("Disable test while we reevaluate the assumption that INetworkMetricEvent interfaces must be reported from MLAPI.")]
         public void ValidateThatAllMetricTypesAreRegistered(Type metricType)
         {
             var dispatcher = new NetworkMetrics().Dispatcher as MetricDispatcher;


### PR DESCRIPTION
…etricEvent interfaces must be reported from MLAPI.