### PR TITLE
feat: client scene synchronization mode

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -205,7 +205,21 @@ namespace Unity.Netcode
 
         internal Scene DontDestroyOnLoadScene;
 
+        /// <summary>
+        /// LoadSceneMode.Single: All currently loaded scenes on the client will be unloaded and
+        /// the server's currently active scene will be loaded in single mode on the client
+        /// unless it was already loaded.
+        ///
+        /// LoadSceneMode.Additive: All currently loaded scenes are left as they are and any newly loaded
+        /// scenes will be loaded additively.  Uses need to determine which scenes are valid to load via the
+        /// <see cref="VerifySceneBeforeLoading"/> method.
+        /// </summary>
         public LoadSceneMode ClientSynchronizationMode { get; internal set; }
+
+        /// <summary>
+        /// When true, the <see cref="Debug.LogWarning(object)"/> messages will be turned off
+        /// </summary>
+        private bool m_DisableValidationWarningMessages;
 
         /// <summary>
         /// Handle NetworkSeneManager clean up
@@ -242,6 +256,16 @@ namespace Unity.Netcode
         }
 
         /// <summary>
+        /// When set to true, this will disable the console warnings about
+        /// a scene being invalidated.
+        /// </summary>
+        /// <param name="disabled"></param>
+        public void DisableValidationWarnings(bool disabled)
+        {
+            m_DisableValidationWarningMessages = disabled;
+        }
+
+        /// <summary>
         /// This will change how clients are initially synchronized.
         /// LoadSceneMode.Single: All currently loaded scenes on the client will be unloaded and
         /// the server's currently active scene will be loaded in single mode on the client
@@ -263,7 +287,6 @@ namespace Unity.Netcode
         /// <param name="networkManager"></param>
         internal NetworkSceneManager(NetworkManager networkManager)
         {
-            ClientSynchronizationMode = LoadSceneMode.Additive;
             m_NetworkManager = networkManager;
             SceneEventData = new SceneEventData(networkManager);
             ClientSynchEventData = new SceneEventData(networkManager);
@@ -318,7 +341,7 @@ namespace Unity.Netcode
             {
                 validated = VerifySceneBeforeLoading.Invoke((int)sceneIndex, sceneName, loadSceneMode);
             }
-            if (!validated && ClientSynchronizationMode == LoadSceneMode.Single)
+            if (!validated && !m_DisableValidationWarningMessages)
             {
                 var serverHostorClient = "Client";
                 if (m_NetworkManager.IsServer)

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -211,7 +211,7 @@ namespace Unity.Netcode
         /// unless it was already loaded.
         ///
         /// LoadSceneMode.Additive: All currently loaded scenes are left as they are and any newly loaded
-        /// scenes will be loaded additively.  Uses need to determine which scenes are valid to load via the
+        /// scenes will be loaded additively.  Users need to determine which scenes are valid to load via the
         /// <see cref="VerifySceneBeforeLoading"/> method.
         /// </summary>
         public LoadSceneMode ClientSynchronizationMode { get; internal set; }
@@ -272,7 +272,7 @@ namespace Unity.Netcode
         /// unless it was already loaded.
         ///
         /// LoadSceneMode.Additive: All currently loaded scenes are left as they are and any newly loaded
-        /// scenes will be loaded additively.  Uses need to determine which scenes are valid to load via the
+        /// scenes will be loaded additively.  Users need to determine which scenes are valid to load via the
         /// <see cref="VerifySceneBeforeLoading"/> method.
         /// </summary>
         /// <param name="mode"><see cref="LoadSceneMode"/> for initial client synchronization</param>

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -205,6 +205,8 @@ namespace Unity.Netcode
 
         internal Scene DontDestroyOnLoadScene;
 
+        public LoadSceneMode ClientSynchronizationMode { get; internal set; }
+
         /// <summary>
         /// Handle NetworkSeneManager clean up
         /// </summary>
@@ -240,11 +242,28 @@ namespace Unity.Netcode
         }
 
         /// <summary>
+        /// This will change how clients are initially synchronized.
+        /// LoadSceneMode.Single: All currently loaded scenes on the client will be unloaded and
+        /// the server's currently active scene will be loaded in single mode on the client
+        /// unless it was already loaded.
+        ///
+        /// LoadSceneMode.Additive: All currently loaded scenes are left as they are and any newly loaded
+        /// scenes will be loaded additively.  Uses need to determine which scenes are valid to load via the
+        /// <see cref="VerifySceneBeforeLoading"/> method.
+        /// </summary>
+        /// <param name="mode"><see cref="LoadSceneMode"/> for initial client synchronization</param>
+        public void SetClientSynchronizationMode(LoadSceneMode mode)
+        {
+            ClientSynchronizationMode = mode;
+        }
+
+        /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="networkManager"></param>
         internal NetworkSceneManager(NetworkManager networkManager)
         {
+            ClientSynchronizationMode = LoadSceneMode.Additive;
             m_NetworkManager = networkManager;
             SceneEventData = new SceneEventData(networkManager);
             ClientSynchEventData = new SceneEventData(networkManager);
@@ -299,7 +318,7 @@ namespace Unity.Netcode
             {
                 validated = VerifySceneBeforeLoading.Invoke((int)sceneIndex, sceneName, loadSceneMode);
             }
-            if (!validated)
+            if (!validated && ClientSynchronizationMode == LoadSceneMode.Single)
             {
                 var serverHostorClient = "Client";
                 if (m_NetworkManager.IsServer)
@@ -1139,7 +1158,7 @@ namespace Unity.Netcode
 
             ClientSynchEventData.InitializeForSynch();
             ClientSynchEventData.TargetClientId = clientId;
-            ClientSynchEventData.LoadSceneMode = LoadSceneMode.Single;
+            ClientSynchEventData.LoadSceneMode = ClientSynchronizationMode;
             var activeScene = SceneManager.GetActiveScene();
             ClientSynchEventData.SceneEventType = SceneEventData.SceneEventTypes.S2C_Sync;
 
@@ -1158,7 +1177,7 @@ namespace Unity.Netcode
                 // If we are the base scene, then we set the root scene index;
                 if (activeScene == scene)
                 {
-                    if (!ValidateSceneBeforeLoading(sceneIndex, LoadSceneMode.Single))
+                    if (!ValidateSceneBeforeLoading(sceneIndex, ClientSynchEventData.LoadSceneMode))
                     {
                         continue;
                     }

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -43,7 +43,7 @@ namespace TestProject.RuntimeTests
 
 
         [UnityTest]
-        public IEnumerator SceneLoadingAndNotifications([Values(LoadSceneMode.Single,LoadSceneMode.Additive)] LoadSceneMode clientSynchronizationMode)
+        public IEnumerator SceneLoadingAndNotifications([Values(LoadSceneMode.Single, LoadSceneMode.Additive)] LoadSceneMode clientSynchronizationMode)
         {
             m_ServerNetworkManager.SceneManager.OnSceneEvent += SceneManager_OnSceneEvent;
             m_CurrentSceneName = "AdditiveScene1";

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -154,6 +154,7 @@ namespace TestProject.RuntimeTests
                 if (enableSceneVerification)
                 {
                     manager.SceneManager.VerifySceneBeforeLoading = ClientVerifySceneBeforeLoading;
+                    manager.SceneManager.SetClientSynchronizationMode(clientSynchronizationMode);
                 }
             }
         }
@@ -257,9 +258,16 @@ namespace TestProject.RuntimeTests
         {
             switch (sceneEvent.SceneEventType)
             {
+                case SceneEventData.SceneEventTypes.S2C_Sync:
+                    {
+                        // Verify that the Client Synchronization Mode set by the server is being received by the client (which means it is applied when loading the first scene)
+                        Assert.AreEqual(m_ClientNetworkManagers.ToArray().Where(c => c.LocalClientId == sceneEvent.ClientId).First().SceneManager.ClientSynchronizationMode, sceneEvent.LoadSceneMode);
+                        break;
+                    }
                 case SceneEventData.SceneEventTypes.S2C_Load:
                 case SceneEventData.SceneEventTypes.S2C_Unload:
                     {
+
                         Assert.AreEqual(sceneEvent.SceneName, m_CurrentSceneName);
                         Assert.IsTrue(ContainsClient(sceneEvent.ClientId));
                         Assert.IsNotNull(sceneEvent.AsyncOperation);

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -43,7 +43,7 @@ namespace TestProject.RuntimeTests
 
 
         [UnityTest]
-        public IEnumerator SceneLoadingAndNotifications()
+        public IEnumerator SceneLoadingAndNotifications([Values(LoadSceneMode.Single,LoadSceneMode.Additive)] LoadSceneMode clientSynchronizationMode)
         {
             m_ServerNetworkManager.SceneManager.OnSceneEvent += SceneManager_OnSceneEvent;
             m_CurrentSceneName = "AdditiveScene1";
@@ -85,7 +85,7 @@ namespace TestProject.RuntimeTests
 
 
             // Now prepare for the loading and unloading additive scene testing
-            InitializeSceneTestInfo();
+            InitializeSceneTestInfo(clientSynchronizationMode);
 
             // Test loading additive scenes and the associated event messaging and notification pipelines
             ResetWait();
@@ -139,12 +139,13 @@ namespace TestProject.RuntimeTests
         /// <summary>
         /// Initializes the m_ShouldWaitList
         /// </summary>
-        private void InitializeSceneTestInfo(bool enableSceneVerification = false)
+        private void InitializeSceneTestInfo(LoadSceneMode clientSynchronizationMode, bool enableSceneVerification = false)
         {
             m_ShouldWaitList.Add(new SceneTestInfo() { ClientId = m_ServerNetworkManager.ServerClientId, ShouldWait = false });
             if (enableSceneVerification)
             {
                 m_ServerNetworkManager.SceneManager.VerifySceneBeforeLoading = ServerVerifySceneBeforeLoading;
+                m_ServerNetworkManager.SceneManager.SetClientSynchronizationMode(clientSynchronizationMode);
             }
 
             foreach (var manager in m_ClientNetworkManagers)
@@ -342,13 +343,13 @@ namespace TestProject.RuntimeTests
         /// </summary>
         /// <returns></returns>
         [UnityTest]
-        public IEnumerator SceneVerifyBeforeLoadTest()
+        public IEnumerator SceneVerifyBeforeLoadTest([Values(LoadSceneMode.Single, LoadSceneMode.Additive)] LoadSceneMode clientSynchronizationMode)
         {
             m_ServerNetworkManager.SceneManager.OnSceneEvent += SceneManager_OnSceneEvent;
             m_CurrentSceneName = "AdditiveScene1";
 
             // Now prepare for the loading and unloading additive scene testing
-            InitializeSceneTestInfo(true);
+            InitializeSceneTestInfo(clientSynchronizationMode, true);
 
             // Test VerifySceneBeforeLoading with both server and client set to true
             ResetWait();


### PR DESCRIPTION
This is a very minor tweak to how clients are synchronized in order to support two different styles of scene loading during client synchronization.  There is a new method, NetworkSceneManager.SetClientSynchronizationMode, that provides users with the ability to configure this feature.
 
**When the ClientSynchronizationMode is set to LoadSceneMode.Single:**
If the server's currently active scene is not already loaded on the client then it will be loaded in single mode. This means that all currently loaded scenes on the client will be unloaded.

**When the ClientSynchronizationMode is set to LoadSceneMode.Additive:**
All currently loaded scenes are left as they are on the client and any newly loaded scenes will be loaded additively.  Users control which scenes are valid for the server to instruct the client to load via the <see cref="VerifySceneBeforeLoading"/> method.

This update also includes the ability to squelch the VerifySceneBeforeLoading console messages which would commonly be used when ClientSynchronizationMode is set to LoadSceneMode.Additive.

The default ClientSynchronizationMode is LoadSceneMode.Single which behaves like the traditional MLAPI initial client synchronization loading pattern.