### PR TITLE
fix: add `link.xml` to prevent IL2CPP stripping `Unity.PerformanceTesting`

### DIFF
--- a/testproject/Assets/link.xml
+++ b/testproject/Assets/link.xml
@@ -1,0 +1,3 @@
+<linker>
+       <assembly fullname="Unity.PerformanceTesting" preserve="all"/>
+</linker>


### PR DESCRIPTION
adding `link.xml` to prevent IL2CPP stripping the `Unity.PerformanceTesting` assembly which breaks standalone testing on all IL2CPP-based platforms.