### PR TITLE
fix: Fixed remote disconnects not properly cleaning up

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1294,21 +1294,12 @@ namespace Unity.Netcode
                 throw new NotServerException("Only server can disconnect remote clients. Use StopClient instead.");
             }
 
-            ConnectedClients.Remove(clientId);
-            PendingClients.Remove(clientId);
-
-            for (int i = ConnectedClientsList.Count - 1; i > -1; i--)
-            {
-                if (ConnectedClientsList[i].ClientId == clientId)
-                {
-                    ConnectedClientsList.RemoveAt(i);
-                }
-            }
+            OnClientDisconnectFromServer(clientId);
 
             NetworkConfig.NetworkTransport.DisconnectRemoteClient(clientId);
         }
 
-        internal void OnClientDisconnectFromServer(ulong clientId)
+        private void OnClientDisconnectFromServer(ulong clientId)
         {
             PendingClients.Remove(clientId);
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DisconnectTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DisconnectTests.cs
@@ -39,8 +39,12 @@ namespace Unity.Netcode.RuntimeTests
             // disconnect the remote client
             server.DisconnectClient(clients[0].LocalClientId);
 
+            // wait 1 frame because destroys are delayed
+            var nextFrameNumber = Time.frameCount + 1;
+            yield return new WaitUntil(() => Time.frameCount >= nextFrameNumber);
+
             // ensure the object was destroyed
-            Assert.That(server.SpawnManager.SpawnedObjects.Any(x => x.Value.IsPlayerObject && x.Value.OwnerClientId == clients[0].LocalClientId));
+            Assert.False(server.SpawnManager.SpawnedObjects.Any(x => x.Value.IsPlayerObject && x.Value.OwnerClientId == clients[0].LocalClientId));
 
             // cleanup
             MultiInstanceHelpers.Destroy();

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DisconnectTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DisconnectTests.cs
@@ -1,0 +1,50 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    public class DisconnectTests
+    {
+        [UnityTest]
+        public IEnumerator RemoteDisconnectPlayerObjectCleanup()
+        {
+            // create server and client instances
+            MultiInstanceHelpers.Create(1, out NetworkManager server, out NetworkManager[] clients);
+
+            // create prefab
+            var gameObject = new GameObject("PlayerObject");
+            var networkObject = gameObject.AddComponent<NetworkObject>();
+            networkObject.DontDestroyWithOwner = true;
+            MultiInstanceHelpers.MakeNetworkObjectTestPrefab(networkObject);
+
+            server.NetworkConfig.PlayerPrefab = gameObject;
+
+            for (int i = 0; i < clients.Length; i++)
+            {
+                clients[i].NetworkConfig.PlayerPrefab = gameObject;
+            }
+
+            // start server and connect clients
+            MultiInstanceHelpers.Start(false, server, clients);
+
+            // wait for connection on client side
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(clients));
+
+            // wait for connection on server side
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientConnectedToServer(server));
+
+            // disconnect the remote client
+            server.DisconnectClient(clients[0].LocalClientId);
+
+            // ensure the object was destroyed
+            Assert.That(server.SpawnManager.SpawnedObjects.Any(x => x.Value.IsLocalPlayer && x.Value.OwnerClientId == clients[0].LocalClientId));
+
+            // cleanup
+            MultiInstanceHelpers.Destroy();
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DisconnectTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DisconnectTests.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using UnityEngine;
@@ -41,7 +40,7 @@ namespace Unity.Netcode.RuntimeTests
             server.DisconnectClient(clients[0].LocalClientId);
 
             // ensure the object was destroyed
-            Assert.That(server.SpawnManager.SpawnedObjects.Any(x => x.Value.IsLocalPlayer && x.Value.OwnerClientId == clients[0].LocalClientId));
+            Assert.That(server.SpawnManager.SpawnedObjects.Any(x => x.Value.IsPlayerObject && x.Value.OwnerClientId == clients[0].LocalClientId));
 
             // cleanup
             MultiInstanceHelpers.Destroy();

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DisconnectTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DisconnectTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b05b4daca3854ff6b01a1f002d433dd6
+timeCreated: 1631652586


### PR DESCRIPTION
Disconnecting a client from the server does not trigger the same disconnect path as if the client disconnected itself. As an example, despawn handlers, owned objects and the player object do not get properly cleaned up. As a server you cannot disconnect clients without leaving the library in a broken state.

MTT-1213