### PR TITLE
feat: NetworkBehaviour.IsSpawned 

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -270,6 +270,12 @@ namespace Unity.Netcode
         public bool IsOwnedByServer => NetworkObject.IsOwnedByServer;
 
         /// <summary>
+        /// Used to determine if it is safe to access NetworkObject and NetworkManager from within a NetworkBehaviour component
+        /// Primarily useful when checking NetworkObject/NetworkManager properties within FixedUpate
+        /// </summary>
+        public bool IsSpawned => HasNetworkObject ? NetworkObject.IsSpawned : false;
+
+        /// <summary>
         /// Gets the NetworkObject that owns this NetworkBehaviour instance
         /// </summary>
         public NetworkObject NetworkObject
@@ -337,21 +343,13 @@ namespace Unity.Netcode
         /// </summary>
         public virtual void OnNetworkDespawn() { }
 
-        /// <summary>
-        /// Used to determine if it is safe to access NetworkObject and NetworkManager from within a NetworkBehaviour component
-        /// Primarily useful when checking NetworkObject/NetworkManager properties within FixedUpate
-        /// </summary>
-        public bool IsSpawned { get; internal set; }
-
         internal void InternalOnNetworkSpawn()
         {
-            IsSpawned = true;
             InitializeVariables();
         }
 
         internal void InternalOnNetworkDespawn()
         {
-            IsSpawned = false;
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -337,14 +337,21 @@ namespace Unity.Netcode
         /// </summary>
         public virtual void OnNetworkDespawn() { }
 
+        /// <summary>
+        /// Used to determine if it is safe to access NetworkObject and NetworkManager from within a NetworkBehaviour component
+        /// Primarily useful when checking NetworkObject/NetworkManager properties within FixedUpate
+        /// </summary>
+        public bool IsSpawned { get; internal set; }
+
         internal void InternalOnNetworkSpawn()
         {
+            IsSpawned = true;
             InitializeVariables();
         }
 
         internal void InternalOnNetworkDespawn()
         {
-
+            IsSpawned = false;
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -350,6 +350,7 @@ namespace Unity.Netcode
 
         internal void InternalOnNetworkDespawn()
         {
+
         }
 
         /// <summary>


### PR DESCRIPTION
This allows a user to determine if the associated NetworkObject is considered spawned or not without having to check the NetworkObject first (which can, under specific conditions, generate a warning message).