### PR TITLE
fix: network time arguments

### DIFF
--- a/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
+++ b/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
@@ -16,14 +16,14 @@ namespace Unity.Netcode
         {
             double BufferedServerTime { get; }
             double BufferedServerFixedTime { get; }
-            int TickRate { get; }
+            uint TickRate { get; }
         }
 
         private class InterpolatorTime : IInterpolatorTime
         {
             public double BufferedServerTime => NetworkManager.Singleton.ServerTime.Time;
             public double BufferedServerFixedTime => NetworkManager.Singleton.ServerTime.FixedTime;
-            public int TickRate => NetworkManager.Singleton.ServerTime.TickRate;
+            public uint TickRate => NetworkManager.Singleton.ServerTime.TickRate;
         }
 
         internal IInterpolatorTime InterpolatorTimeProxy = new InterpolatorTime();

--- a/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkConfig.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkConfig.cs
@@ -49,7 +49,7 @@ namespace Unity.Netcode
         /// The tickrate of network ticks. This value controls how often netcode runs user code and sends out data.
         /// </summary>
         [Tooltip("The tickrate. This value controls how often netcode runs user code and sends out data. The value is in 'ticks per seconds' which means a value of 50 will result in 50 ticks being executed per second or a fixed delta time of 0.02.")]
-        public int TickRate = 30;
+        public uint TickRate = 30;
 
         /// <summary>
         /// The amount of seconds to wait for handshake to complete before timing out a client
@@ -162,7 +162,7 @@ namespace Unity.Netcode
             using var buffer = PooledNetworkBuffer.Get();
             using var writer = PooledNetworkWriter.Get(buffer);
             writer.WriteUInt16Packed(config.ProtocolVersion);
-            writer.WriteInt32Packed(config.TickRate);
+            writer.WriteUInt32Packed(config.TickRate);
             writer.WriteInt32Packed(config.ClientConnectionBufferTimeout);
             writer.WriteBool(config.ConnectionApproval);
             writer.WriteInt32Packed(config.LoadSceneTimeOut);
@@ -192,7 +192,7 @@ namespace Unity.Netcode
 
             config.ProtocolVersion = reader.ReadUInt16Packed();
             ushort sceneCount = reader.ReadUInt16Packed();
-            config.TickRate = reader.ReadInt32Packed();
+            config.TickRate = reader.ReadUInt32Packed();
             config.ClientConnectionBufferTimeout = reader.ReadInt32Packed();
             config.ConnectionApproval = reader.ReadBool();
             config.LoadSceneTimeOut = reader.ReadInt32Packed();

--- a/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTickSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTickSystem.cs
@@ -17,7 +17,7 @@ namespace Unity.Netcode
         /// <summary>
         /// The TickRate of the tick system. This is used to decide how often a fixed network tick is run.
         /// </summary>
-        public int TickRate { get; }
+        public uint TickRate { get; }
 
         /// <summary>
         /// The current local time. This is the time at which predicted or client authoritative objects move. This value is accurate when called in Update or during the <see cref="Tick"/> event but does not work correctly for FixedUpdate.
@@ -40,8 +40,13 @@ namespace Unity.Netcode
         /// <param name="tickRate">The tick rate</param>
         /// <param name="localTimeSec">The initial local time to start at.</param>
         /// <param name="serverTimeSec">The initial server time to start at.</param>
-        public NetworkTickSystem(int tickRate, double localTimeSec, double serverTimeSec)
+        public NetworkTickSystem(uint tickRate, double localTimeSec, double serverTimeSec)
         {
+            if (tickRate == 0)
+            {
+                throw new ArgumentException("Tickrate must be a positive value.", nameof(tickRate));
+            }
+
             TickRate = tickRate;
             Tick = null;
             LocalTime = new NetworkTime(tickRate, localTimeSec);

--- a/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTime.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTime.cs
@@ -13,7 +13,7 @@ namespace Unity.Netcode
     {
         private double m_TimeSec;
 
-        private int m_TickRate;
+        private uint m_TickRate;
         private double m_TickInterval;
 
         private int m_CachedTick;
@@ -52,13 +52,13 @@ namespace Unity.Netcode
         /// <summary>
         /// Gets the tickrate of the system of this <see cref="NetworkTime"/>.
         /// </summary>
-        public int TickRate => m_TickRate;
+        public uint TickRate => m_TickRate;
 
         /// <summary>
         /// Creates a new instance of the <see cref="NetworkTime"/> struct.
         /// </summary>
         /// <param name="tickRate">The tickrate.</param>
-        public NetworkTime(int tickRate)
+        public NetworkTime(uint tickRate)
         {
             Assert.IsTrue(tickRate > 0, "Tickrate must be a positive value.");
 
@@ -75,7 +75,7 @@ namespace Unity.Netcode
         /// <param name="tickRate">The tickrate.</param>
         /// <param name="tick">The time will be created with a value where this many tick have already passed.</param>
         /// <param name="tickOffset">Can be used to create a <see cref="NetworkTime"/> with a non fixed time value by adding an offset to the given tick value.</param>
-        public NetworkTime(int tickRate, int tick, double tickOffset = 0d)
+        public NetworkTime(uint tickRate, int tick, double tickOffset = 0d)
             : this(tickRate)
         {
             Assert.IsTrue(tickOffset < 1d / tickRate);
@@ -87,7 +87,7 @@ namespace Unity.Netcode
         /// </summary>
         /// <param name="tickRate">The tickrate.</param>
         /// <param name="timeSec">The time value as a float.</param>
-        public NetworkTime(int tickRate, double timeSec)
+        public NetworkTime(uint tickRate, double timeSec)
             : this(tickRate)
         {
             this += timeSec;

--- a/com.unity.netcode.gameobjects/Tests/Editor/InterpolatorTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/InterpolatorTests.cs
@@ -11,9 +11,9 @@ namespace Unity.Netcode.EditorTests
         {
             public double BufferedServerTime { get; set; }
             public double BufferedServerFixedTime { get; }
-            public int TickRate { get; set; }
+            public uint TickRate { get; set; }
 
-            public MockInterpolatorTime(double serverTime, int tickRate)
+            public MockInterpolatorTime(double serverTime, uint tickRate)
             {
                 BufferedServerTime = serverTime;
                 TickRate = tickRate;
@@ -22,7 +22,7 @@ namespace Unity.Netcode.EditorTests
 
         private const int k_MockTickRate = 1;
 
-        private NetworkTime T(float time, int tickRate = k_MockTickRate)
+        private NetworkTime T(float time, uint tickRate = k_MockTickRate)
         {
             return new NetworkTime(tickRate, timeSec: time);
         }

--- a/com.unity.netcode.gameobjects/Tests/Editor/Timing/NetworkTimeTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Timing/NetworkTimeTests.cs
@@ -10,33 +10,30 @@ namespace Unity.Netcode.EditorTests
     public class NetworkTimeTests
     {
         [Test]
-        [TestCase(0d, 0)]
-        [TestCase(5d, 0)]
-        [TestCase(-5d, 0)]
-        [TestCase(0d, -20)]
-        [TestCase(5d, int.MinValue)]
-        [TestCase(-5d, -1)]
+        [TestCase(0d, 0u)]
+        [TestCase(5d, 0u)]
+        [TestCase(-5d, 0u)]
         public void TestFailCreateInvalidTime(double time, uint tickrate)
         {
             Assert.Throws<UnityEngine.Assertions.AssertionException>(() => new NetworkTime(tickrate, time));
         }
 
         [Test]
-        [TestCase(0d, 0f, 20)]
-        [TestCase(0d, 0f, 30)]
-        [TestCase(0d, 0f, 60)]
+        [TestCase(0d, 0f, 20u)]
+        [TestCase(0d, 0f, 30u)]
+        [TestCase(0d, 0f, 60u)]
 
-        [TestCase(201d, 201f, 20)]
-        [TestCase(201d, 201f, 30)]
-        [TestCase(201d, 201f, 60)]
+        [TestCase(201d, 201f, 20u)]
+        [TestCase(201d, 201f, 30u)]
+        [TestCase(201d, 201f, 60u)]
 
-        [TestCase(-4301d, -4301f, 20)]
-        [TestCase(-4301d, -4301f, 30)]
-        [TestCase(-4301d, -4301f, 60)]
+        [TestCase(-4301d, -4301f, 20u)]
+        [TestCase(-4301d, -4301f, 30u)]
+        [TestCase(-4301d, -4301f, 60u)]
 
-        [TestCase(float.MaxValue, float.MaxValue, 20)]
-        [TestCase(float.MaxValue, float.MaxValue, 30)]
-        [TestCase(float.MaxValue, float.MaxValue, 60)]
+        [TestCase(float.MaxValue, float.MaxValue, 20u)]
+        [TestCase(float.MaxValue, float.MaxValue, 30u)]
+        [TestCase(float.MaxValue, float.MaxValue, 60u)]
         public void TestTimeAsFloat(double d, float f, uint tickRate)
         {
             var networkTime = new NetworkTime(tickRate, d);
@@ -44,52 +41,33 @@ namespace Unity.Netcode.EditorTests
         }
 
         [Test]
-        [TestCase(53.55d, 53.5d, 10)]
-        [TestCase(1013553.55d, 1013553.5d, 10)]
-        [TestCase(0d, 0d, 10)]
-        [TestCase(-27.41d, -27.5d, 10)]
+        [TestCase(53.55d, 53.5d, 10u)]
+        [TestCase(1013553.55d, 1013553.5d, 10u)]
+        [TestCase(0d, 0d, 10u)]
+        [TestCase(-27.41d, -27.5d, 10u)]
 
-        [TestCase(53.55d, 53.54d, 50)]
-        [TestCase(1013553.55d, 1013553.54d, 50)]
-        [TestCase(0d, 0d, 50)]
-        [TestCase(-27.4133d, -27.42d, 50)]
+        [TestCase(53.55d, 53.54d, 50u)]
+        [TestCase(1013553.55d, 1013553.54d, 50u)]
+        [TestCase(0d, 0d, 50u)]
+        [TestCase(-27.4133d, -27.42d, 50u)]
         public void TestToFixedTime(double time, double expectedFixedTime, uint tickRate)
         {
             Assert.AreEqual(expectedFixedTime, new NetworkTime(tickRate, time).ToFixedTime().Time);
         }
 
         [Test]
-        public void NetworkTimeCreate()
+        [TestCase(34d, 0)]
+        [TestCase(17.32d, 0.2d / 60d)]
+        [TestCase(-42.44d,  1d / 60d - 0.4d / 60d)]
+        [TestCase(-6d, 0)]
+        [TestCase(int.MaxValue / 61d, 0.00082, 10d)] // Int.Max / 61 / (1/60) to get divisor then: Int.Max - divisor * 1 / 60
+        public void NetworkTimeCreate(double time, double tickOffset, double epsilon = 0.0001d)
         {
-            double a = 34d;
-            double b = 17.32d;
-            double c = -42.44d;
-            double d = -6d;
-            double e = int.MaxValue / 61d;
+            var networkTime = new NetworkTime(60, time);
 
-            var timeA = new NetworkTime(60, a);
-            var timeB = new NetworkTime(60, b);
-            var timeC = new NetworkTime(60, c);
-            var timeD = new NetworkTime(60, d);
-            var timeE = new NetworkTime(60, e);
-
-            Assert.IsTrue(Approximately(a, timeA.Time));
-            Assert.IsTrue(Approximately(b, timeB.Time));
-            Assert.IsTrue(Approximately(c, timeC.Time));
-            Assert.IsTrue(Approximately(d, timeD.Time));
-            Assert.IsTrue(Approximately(e, timeE.Time));
-
-            Assert.IsTrue(Approximately(timeA.Tick * timeA.FixedDeltaTime + timeA.TickOffset, timeA.Time, 0.0001d));
-            Assert.IsTrue(Approximately(timeB.Tick * timeB.FixedDeltaTime + timeB.TickOffset, timeB.Time, 0.0001d));
-            Assert.IsTrue(Approximately(timeC.Tick * timeC.FixedDeltaTime + timeC.TickOffset, timeC.Time, 0.0001d));
-            Assert.IsTrue(Approximately(timeD.Tick * timeD.FixedDeltaTime + timeD.TickOffset, timeD.Time, 0.0001d));
-            Assert.IsTrue(Approximately(timeE.Tick * timeE.FixedDeltaTime + timeE.TickOffset, timeE.Time, 10d));
-
-            Assert.IsTrue(Approximately(timeA.TickOffset, 0));
-            Assert.IsTrue(Approximately(timeB.TickOffset, 0.2d / 60d));
-            Assert.IsTrue(Approximately(timeC.TickOffset, 1d / 60d - 0.4d / 60d));
-            Assert.IsTrue(Approximately(timeD.TickOffset, 0));
-            Assert.IsTrue(Approximately(timeE.TickOffset, 0.00082)); // Int.Max / 61 / (1/60) to get divisor then: Int.Max - divisor * 1 / 60
+            Assert.IsTrue(Approximately(time, networkTime.Time));
+            Assert.IsTrue(Approximately(networkTime.Tick * networkTime.FixedDeltaTime + networkTime.TickOffset, networkTime.Time, epsilon));
+            Assert.IsTrue(Approximately(networkTime.TickOffset, tickOffset));
         }
 
         [Test]
@@ -101,107 +79,70 @@ namespace Unity.Netcode.EditorTests
         }
 
         [Test]
-        public void NetworkTimeAddFloatTest()
+        [TestCase(17.32d)]
+        [TestCase(34d)]
+        [TestCase(-42.4d)]
+        [TestCase(-6d)]
+        [TestCase(int.MaxValue / 61d)]
+        public void NetworkTimeAddFloatTest(double time)
         {
             double a = 34d;
-            double b = 17.32d;
-            double c = -42.4d;
-            double d = -6d;
-            double e = int.MaxValue / 61d;
-
-            double floatResultB = a + b;
-            double floatResultC = a + c;
-            double floatResultD = a + d;
-            double floatResultE = a + e;
+            double floatResultB = a + time;
 
             var timeA = new NetworkTime(60, a);
-            NetworkTime timeB = timeA + b;
-            NetworkTime timeC = timeA + c;
-            NetworkTime timeD = timeA + d;
-            NetworkTime timeE = timeA + e;
+            NetworkTime timeB = timeA + time;
 
             Assert.IsTrue(Approximately(floatResultB, timeB.Time));
-            Assert.IsTrue(Approximately(floatResultC, timeC.Time));
-            Assert.IsTrue(Approximately(floatResultD, timeD.Time));
-            Assert.IsTrue(Approximately(floatResultE, timeE.Time));
         }
 
         [Test]
-        public void NetworkTimeSubFloatTest()
+        [TestCase(17.32d)]
+        [TestCase(34d)]
+        [TestCase(-42.4d)]
+        [TestCase(-6d)]
+        [TestCase(int.MaxValue / 61d)]
+        public void NetworkTimeSubFloatTest(double time)
         {
             double a = 34d;
-            double b = 17.32d;
-            double c = -42.4d;
-            double d = -6d;
-            double e = int.MaxValue / 61d;
-
-            double floatResultB = a - b;
-            double floatResultC = a - c;
-            double floatResultD = a - d;
-            double floatResultE = a - e;
+            double floatResultB = a - time;
 
             var timeA = new NetworkTime(60, a);
-            NetworkTime timeB = timeA - b;
-            NetworkTime timeC = timeA - c;
-            NetworkTime timeD = timeA - d;
-            NetworkTime timeE = timeA - e;
+            NetworkTime timeB = timeA - time;
 
             Assert.IsTrue(Approximately(floatResultB, timeB.Time));
-            Assert.IsTrue(Approximately(floatResultC, timeC.Time));
-            Assert.IsTrue(Approximately(floatResultD, timeD.Time));
-            Assert.IsTrue(Approximately(floatResultE, timeE.Time));
         }
 
         [Test]
-        public void NetworkTimeAddNetworkTimeTest()
+        [TestCase(17.32d)]
+        [TestCase(34d)]
+        [TestCase(-42.4d)]
+        [TestCase(-6d)]
+        [TestCase(int.MaxValue / 61d)]
+        public void NetworkTimeAddNetworkTimeTest(double time)
         {
             double a = 34d;
-            double b = 17.32d;
-            double c = -42.4d;
-            double d = -6d;
-            double e = int.MaxValue / 61d;
-
-            double floatResultB = a + b;
-            double floatResultC = a + c;
-            double floatResultD = a + d;
-            double floatResultE = a + e;
+            double floatResultB = a + time;
 
             var timeA = new NetworkTime(60, a);
-            NetworkTime timeB = timeA + new NetworkTime(60, b);
-            NetworkTime timeC = timeA + new NetworkTime(60, c);
-            NetworkTime timeD = timeA + new NetworkTime(60, d);
-            NetworkTime timeE = timeA + new NetworkTime(60, e);
-
+            NetworkTime timeB = timeA + new NetworkTime(60, time);
             Assert.IsTrue(Approximately(floatResultB, timeB.Time));
-            Assert.IsTrue(Approximately(floatResultC, timeC.Time));
-            Assert.IsTrue(Approximately(floatResultD, timeD.Time));
-            Assert.IsTrue(Approximately(floatResultE, timeE.Time));
         }
 
         [Test]
-        public void NetworkTimeSubNetworkTimeTest()
+        [TestCase(17.32d)]
+        [TestCase(34d)]
+        [TestCase(-42.4d)]
+        [TestCase(-6d)]
+        [TestCase(int.MaxValue / 61d)]
+        public void NetworkTimeSubNetworkTimeTest(double time)
         {
             double a = 34d;
-            double b = 17.32d;
-            double c = -42.4d;
-            double d = -6d;
-            double e = int.MaxValue / 61d;
 
-            double floatResultB = a - b;
-            double floatResultC = a - c;
-            double floatResultD = a - d;
-            double floatResultE = a - e;
+            double floatResultB = a - time;
 
             var timeA = new NetworkTime(60, a);
-            NetworkTime timeB = timeA - new NetworkTime(60, b);
-            NetworkTime timeC = timeA - new NetworkTime(60, c);
-            NetworkTime timeD = timeA - new NetworkTime(60, d);
-            NetworkTime timeE = timeA - new NetworkTime(60, e);
-
+            NetworkTime timeB = timeA - new NetworkTime(60, time);
             Assert.IsTrue(Approximately(floatResultB, timeB.Time));
-            Assert.IsTrue(Approximately(floatResultC, timeC.Time));
-            Assert.IsTrue(Approximately(floatResultD, timeD.Time));
-            Assert.IsTrue(Approximately(floatResultE, timeE.Time));
         }
 
         [Test]

--- a/com.unity.netcode.gameobjects/Tests/Editor/Timing/NetworkTimeTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Timing/NetworkTimeTests.cs
@@ -22,15 +22,12 @@ namespace Unity.Netcode.EditorTests
         [TestCase(0d, 0f, 20u)]
         [TestCase(0d, 0f, 30u)]
         [TestCase(0d, 0f, 60u)]
-
         [TestCase(201d, 201f, 20u)]
         [TestCase(201d, 201f, 30u)]
         [TestCase(201d, 201f, 60u)]
-
         [TestCase(-4301d, -4301f, 20u)]
         [TestCase(-4301d, -4301f, 30u)]
         [TestCase(-4301d, -4301f, 60u)]
-
         [TestCase(float.MaxValue, float.MaxValue, 20u)]
         [TestCase(float.MaxValue, float.MaxValue, 30u)]
         [TestCase(float.MaxValue, float.MaxValue, 60u)]
@@ -45,7 +42,6 @@ namespace Unity.Netcode.EditorTests
         [TestCase(1013553.55d, 1013553.5d, 10u)]
         [TestCase(0d, 0d, 10u)]
         [TestCase(-27.41d, -27.5d, 10u)]
-
         [TestCase(53.55d, 53.54d, 50u)]
         [TestCase(1013553.55d, 1013553.54d, 50u)]
         [TestCase(0d, 0d, 50u)]
@@ -58,7 +54,7 @@ namespace Unity.Netcode.EditorTests
         [Test]
         [TestCase(34d, 0)]
         [TestCase(17.32d, 0.2d / 60d)]
-        [TestCase(-42.44d,  1d / 60d - 0.4d / 60d)]
+        [TestCase(-42.44d, 1d / 60d - 0.4d / 60d)]
         [TestCase(-6d, 0)]
         [TestCase(int.MaxValue / 61d, 0.00082, 10d)] // Int.Max / 61 / (1/60) to get divisor then: Int.Max - divisor * 1 / 60
         public void NetworkTimeCreate(double time, double tickOffset, double epsilon = 0.0001d)

--- a/com.unity.netcode.gameobjects/Tests/Editor/Timing/NetworkTimeTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Timing/NetworkTimeTests.cs
@@ -16,7 +16,7 @@ namespace Unity.Netcode.EditorTests
         [TestCase(0d, -20)]
         [TestCase(5d, int.MinValue)]
         [TestCase(-5d, -1)]
-        public void TestFailCreateInvalidTime(double time, int tickrate)
+        public void TestFailCreateInvalidTime(double time, uint tickrate)
         {
             Assert.Throws<UnityEngine.Assertions.AssertionException>(() => new NetworkTime(tickrate, time));
         }
@@ -37,7 +37,7 @@ namespace Unity.Netcode.EditorTests
         [TestCase(float.MaxValue, float.MaxValue, 20)]
         [TestCase(float.MaxValue, float.MaxValue, 30)]
         [TestCase(float.MaxValue, float.MaxValue, 60)]
-        public void TestTimeAsFloat(double d, float f, int tickRate)
+        public void TestTimeAsFloat(double d, float f, uint tickRate)
         {
             var networkTime = new NetworkTime(tickRate, d);
             Assert.True(Mathf.Approximately(networkTime.TimeAsFloat, f));
@@ -53,7 +53,7 @@ namespace Unity.Netcode.EditorTests
         [TestCase(1013553.55d, 1013553.54d, 50)]
         [TestCase(0d, 0d, 50)]
         [TestCase(-27.4133d, -27.42d, 50)]
-        public void TestToFixedTime(double time, double expectedFixedTime, int tickRate)
+        public void TestToFixedTime(double time, double expectedFixedTime, uint tickRate)
         {
             Assert.AreEqual(expectedFixedTime, new NetworkTime(tickRate, time).ToFixedTime().Time);
         }
@@ -243,7 +243,7 @@ namespace Unity.Netcode.EditorTests
             NetworkTimeAdvanceTestInternal(shortSteps, 144, 1000000f);
         }
 
-        private void NetworkTimeAdvanceTestInternal(IEnumerable<float> steps, int tickRate, float start, float start2 = 0f)
+        private void NetworkTimeAdvanceTestInternal(IEnumerable<float> steps, uint tickRate, float start, float start2 = 0f)
         {
             float maxAcceptableTotalOffset = 0.005f;
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeMultiInstanceTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeMultiInstanceTest.cs
@@ -40,12 +40,12 @@ namespace Unity.Netcode.RuntimeTests
         }
 
         [UnityTest]
-        [TestCase(60, 30, ExpectedResult = null)]
-        [TestCase(30, 30, ExpectedResult = null)]
-        [TestCase(40, 30, ExpectedResult = null)]
-        [TestCase(10, 30, ExpectedResult = null)]
-        [TestCase(60, 60, ExpectedResult = null)]
-        [TestCase(60, 10, ExpectedResult = null)]
+        [TestCase(60, 30u, ExpectedResult = null)]
+        [TestCase(30, 30u, ExpectedResult = null)]
+        [TestCase(40, 30u, ExpectedResult = null)]
+        [TestCase(10, 30u, ExpectedResult = null)]
+        [TestCase(60, 60u, ExpectedResult = null)]
+        [TestCase(60, 10u, ExpectedResult = null)]
         public IEnumerator TestTimeMultiInstance(int targetFrameRate, uint tickRate)
         {
             yield return StartSomeClientsAndServerWithPlayersCustom(true, NbClients, targetFrameRate, tickRate);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeMultiInstanceTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeMultiInstanceTest.cs
@@ -46,7 +46,7 @@ namespace Unity.Netcode.RuntimeTests
         [TestCase(10, 30, ExpectedResult = null)]
         [TestCase(60, 60, ExpectedResult = null)]
         [TestCase(60, 10, ExpectedResult = null)]
-        public IEnumerator TestTimeMultiInstance(int targetFrameRate, int tickRate)
+        public IEnumerator TestTimeMultiInstance(int targetFrameRate, uint tickRate)
         {
             yield return StartSomeClientsAndServerWithPlayersCustom(true, NbClients, targetFrameRate, tickRate);
 
@@ -92,7 +92,7 @@ namespace Unity.Netcode.RuntimeTests
         }
 
         // This is from BaseMultiInstanceTest but we need a custom version of this to modifiy the config
-        private IEnumerator StartSomeClientsAndServerWithPlayersCustom(bool useHost, int nbClients, int targetFrameRate, int tickRate)
+        private IEnumerator StartSomeClientsAndServerWithPlayersCustom(bool useHost, int nbClients, int targetFrameRate, uint tickRate)
         {
             // Create multiple NetworkManager instances
             if (!MultiInstanceHelpers.Create(nbClients, out NetworkManager server, out NetworkManager[] clients, targetFrameRate))


### PR DESCRIPTION
A small improvement to networktime to ensure that tickrate is a positive value
- Using uint in the config will force the inspector value to be positive to prevent user error.
- checking for 0 in the NetworkTickSystem allows us to immediately throw an exception on startup.

Makes sure no negative tick values can be used as mentioned in #1185 (but not directly related)