### PR TITLE
fix: remove optimization that breaks Unity Transport Adapter

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -4,7 +4,6 @@ using UnityEngine;
 using System.Reflection;
 using System.Linq;
 using Unity.Collections;
-using Unity.Collections.LowLevel.Unsafe;
 
 namespace Unity.Netcode
 {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using System.Reflection;
 using System.Linq;
 using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
 
 namespace Unity.Netcode
 {
@@ -69,9 +70,8 @@ namespace Unity.Netcode
                 RpcData = writer
             };
 
-            // I would love to remove this hack but it seems that we have behaviour that requires it :/ especially in
-            // testing. It seems very broken that we need to be able to send data to ourself.
-            if (IsServer && NetworkBehaviourId == NetworkManager.ServerClientId)
+            // If we are a server/host then we just no op and send to ourself
+            if (IsHost || IsServer)
             {
                 var tempBuffer = new FastBufferReader(ref writer, Allocator.Temp);
                 message.Handle(ref tempBuffer, NetworkManager, NetworkBehaviourId);

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
@@ -420,23 +420,6 @@ namespace Unity.Netcode
                         MessageType = m_MessageTypes[typeof(TMessageType)],
                     };
 
-
-                    if (clientId == m_LocalClientId)
-                    {
-                        m_IncomingMessageQueue.Add(new ReceiveQueueItem
-                        {
-                            Header = header,
-                            Reader = new FastBufferReader(ref tmpSerializer, Allocator.TempJob),
-                            SenderId = clientId,
-                            Timestamp = Time.realtimeSinceStartup
-                        });
-                        for (var hookIdx = 0; hookIdx < m_Hooks.Count; ++hookIdx)
-                        {
-                            m_Hooks[hookIdx].OnAfterSendMessage(clientId, typeof(TMessageType), delivery, tmpSerializer.Length + sizeof(MessageHeader));
-                        }
-                        continue;
-                    }
-
                     writeQueueItem.Writer.WriteValue(header);
                     writeQueueItem.Writer.WriteBytes(tmpSerializer.GetUnsafePtr(), tmpSerializer.Length);
                     writeQueueItem.BatchHeader.BatchSize++;


### PR DESCRIPTION
This code breaks the Unity Transport Adapter and assumes specific behavior that wasn't present before, in UTA we assume that these kind of checks are not happening in the SDK. This is because its very possible that you're clientID on the server (which is synchronized via OwnerClientId) and your ServerId could indeed be the same and it shouldn't really matter if they are as one side should not impact the other side. So for this reason we have removed this check.