### PR TITLE
Give Custom NetVars custom Initializtion Behaviour

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
@@ -14,9 +14,17 @@ namespace Unity.Netcode
 
         private protected NetworkBehaviour m_NetworkBehaviour;
 
+        public NetworkBehaviour NetworkBehaviour => m_NetworkBehaviour;
+
         public void Initialize(NetworkBehaviour networkBehaviour)
         {
             m_NetworkBehaviour = networkBehaviour;
+            OnInitialize();
+        }
+
+        protected virtual void OnInitialize()
+        {
+
         }
 
         protected NetworkVariableBase(NetworkVariableReadPermission readPermIn = NetworkVariableReadPermission.Everyone)


### PR DESCRIPTION
Allow Custom Network Variables to know when they are being initialized. Also allow classes with access to the instance variable to have access to the owner of the instance,