### PR TITLE
refactor!: NetworkObject.Despawn defaults destroy objects to 'true'

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -514,7 +514,7 @@ namespace Unity.Netcode
         /// Despawns the <see cref="GameObject"/> of this <see cref="NetworkObject"/> and sends a destroy message for it to all connected clients.
         /// </summary>
         /// <param name="destroy">(true) the <see cref="GameObject"/> will be destroyed (false) the <see cref="GameObject"/> will persist after being despawned</param>
-        public void Despawn(bool destroy = false)
+        public void Despawn(bool destroy = true)
         {
             NetworkManager.SpawnManager.DespawnObject(this, destroy);
         }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1574,7 +1574,7 @@ namespace Unity.Netcode
                 }
                 else if (m_NetworkManager.IsServer)
                 {
-                    sobj.Despawn(true);
+                    sobj.Despawn();
                 }
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTickSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTickSystem.cs
@@ -20,12 +20,14 @@ namespace Unity.Netcode
         public uint TickRate { get; }
 
         /// <summary>
-        /// The current local time. This is the time at which predicted or client authoritative objects move. This value is accurate when called in Update or during the <see cref="Tick"/> event but does not work correctly for FixedUpdate.
+        /// The current local time. This is the time at which predicted or client authoritative objects move.
+        ///  This value is accurate when called in Update or during the <see cref="Tick"/> event but does not work correctly for FixedUpdate.
         /// </summary>
         public NetworkTime LocalTime { get; internal set; }
 
         /// <summary>
-        /// The current server time. This value is mostly used for internal purposes and to interpolate state received from the server. This value is accurate when called in Update or during the <see cref="Tick"/> event but does not work correctly for FixedUpdate.
+        /// The current server time. This value is mostly used for internal purposes and to interpolate state received from the server.
+        ///  This value is accurate when called in Update or during the <see cref="Tick"/> event but does not work correctly for FixedUpdate.
         /// </summary>
         public NetworkTime ServerTime { get; internal set; }
 

--- a/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTime.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTime.cs
@@ -40,7 +40,8 @@ namespace Unity.Netcode
         public double FixedTime => m_CachedTick * m_TickInterval;
 
         /// <summary>
-        /// Gets the fixed delta time. This value is based on the <see cref="TickRate"/> and stays constant. Similar to <see cref="Time.fixedDeltaTime"/> There is no equivalent to <see cref="Time.deltaTime"/>
+        /// Gets the fixed delta time. This value is based on the <see cref="TickRate"/> and stays constant.
+        /// Similar to <see cref="Time.fixedDeltaTime"/> There is no equivalent to <see cref="Time.deltaTime"/>
         /// </summary>
         public float FixedDeltaTime => (float)m_TickInterval;
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOnSpawnTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOnSpawnTests.cs
@@ -111,8 +111,8 @@ namespace Unity.Netcode.RuntimeTests
                 Assert.AreEqual(0, clientInstance.OnNetworkDespawnCalledCount);
             }
 
-            // despawn on server
-            serverInstance.GetComponent<NetworkObject>().Despawn();
+            // despawn on server.  However, since we'll be using this object later in the test, don't delete it (false)
+            serverInstance.GetComponent<NetworkObject>().Despawn(false);
 
             // check despawned on server
             Assert.AreEqual(1, serverInstance.OnNetworkDespawnCalledCount);
@@ -135,8 +135,7 @@ namespace Unity.Netcode.RuntimeTests
             nextFrameNumber = Time.frameCount + 2;
             yield return new WaitUntil(() => Time.frameCount >= nextFrameNumber);
 
-
-            // check spawned again on server this is 2 becaue we are reusing the object which was already spawned once.
+            // check spawned again on server this is 2 because we are reusing the object which was already spawned once.
             Assert.AreEqual(2, serverInstance.OnNetworkSpawnCalledCount);
 
             // check spawned on client

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbody2DTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbody2DTest.cs
@@ -63,7 +63,7 @@ namespace Unity.Netcode.RuntimeTests.Physics
             // client rigidbody has no authority and should have a kinematic mode of true
             Assert.True(clientPlayer.GetComponent<Rigidbody2D>().isKinematic);
 
-            // despawn the server player
+            // despawn the server player, (but keep it around on the server)
             serverPlayer.GetComponent<NetworkObject>().Despawn(false);
 
             yield return null;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbodyTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbodyTest.cs
@@ -63,7 +63,7 @@ namespace Unity.Netcode.RuntimeTests.Physics
             // client rigidbody has no authority and should have a kinematic mode of true
             Assert.True(clientPlayer.GetComponent<Rigidbody>().isKinematic);
 
-            // despawn the server player
+            // despawn the server player (but keep it around on the server)
             serverPlayer.GetComponent<NetworkObject>().Despawn(false);
 
             yield return null;

--- a/testproject/Assets/Tests/Manual/Scripts/GenericNetworkObjectBehaviour.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/GenericNetworkObjectBehaviour.cs
@@ -145,7 +145,7 @@ namespace TestProject.ManualTests
                 m_ShouldDespawn = false;
                 if (NetworkObject.NetworkManager != null)
                 {
-                    NetworkObject.Despawn(true);
+                    NetworkObject.Despawn();
                 }
             }
             else if (!IsServer)

--- a/testproject/Assets/Tests/Manual/Scripts/NetworkPrefabPool.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/NetworkPrefabPool.cs
@@ -266,7 +266,7 @@ namespace TestProject.ManualTests
                             {
                                 if (networkObject.IsSpawned)
                                 {
-                                    networkObject.Despawn(true);
+                                    networkObject.Despawn();
                                 }
                                 else if (!DontDestroy)
                                 {

--- a/testproject/Assets/Tests/Manual/Scripts/NetworkPrefabPoolAdditive.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/NetworkPrefabPoolAdditive.cs
@@ -155,7 +155,7 @@ namespace TestProject.ManualTests
                         {
                             if (DestroyOnUnload)
                             {
-                                networkObject.Despawn(true);
+                                networkObject.Despawn();
                             }
                             else if (SpawnInSourceScene)
                             {

--- a/testproject/Assets/Tests/Runtime/MultiprocessRuntime/NetworkVariablePerformanceTests.cs
+++ b/testproject/Assets/Tests/Runtime/MultiprocessRuntime/NetworkVariablePerformanceTests.cs
@@ -201,7 +201,7 @@ namespace Unity.Netcode.MultiprocessRuntimeTests
                 {
                     foreach (var spawnedObject in m_ServerSpawnedObjects)
                     {
-                        spawnedObject.NetworkObject.Despawn();
+                        spawnedObject.NetworkObject.Despawn(false);
                         s_ServerObjectPool.Release(spawnedObject);
                         StopSpawnedObject(spawnedObject);
                     }

--- a/testproject/Assets/Tests/Runtime/Support/SpawnRpcDespawn.cs
+++ b/testproject/Assets/Tests/Runtime/Support/SpawnRpcDespawn.cs
@@ -64,7 +64,7 @@ namespace TestProject.RuntimeTests.Support
             Debug.Log("Running test...");
             GetComponent<NetworkObject>().Spawn();
             IncrementUpdateCount();
-            GetComponent<NetworkObject>().Despawn();
+            GetComponent<NetworkObject>().Despawn(false);
             m_Active = false;
         }
 


### PR DESCRIPTION
There is actually a followup needed here, because when you do Despawn(false) it won't delete the object on the server (correct) but does on the client.  But this at least avoids a usability pitfall