### PR TITLE
test: Remove multiprocess build and sign from test project job

### DIFF
--- a/.yamato/project-tests.yml
+++ b/.yamato/project-tests.yml
@@ -54,5 +54,3 @@ test_{{ project.name }}_{{ editor }}_{{ platform.name }}:
 {% endfor -%}
 {% endfor -%}
 {% endfor -%}
-
-

--- a/.yamato/project-tests.yml
+++ b/.yamato/project-tests.yml
@@ -43,14 +43,11 @@ test_{{ project.name }}_{{ editor }}_{{ platform.name }}:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - unity-downloader-cli -u {{ editor }} -c editor -w --fast
-    - {% if platform.name == "ubuntu" %}DISPLAY=:0 && {% endif %}{{ platform.editorpath }} -projectpath testproject -batchmode -nographics -quit -logfile BuildMultiprocessTestPlayer.log -executeMethod Unity.Netcode.MultiprocessRuntimeTests.BuildMultiprocessTestPlayer.BuildDebug
-{% if platform.name == "mac" %}    -  sudo codesign --force --deep --sign - ./testproject/Builds/MultiprocessTests/MultiprocessTestPlayer.app{% endif %}
     - {% if platform.name == "ubuntu" %}DISPLAY=:0 && {% endif %}upm-ci project test -u {{ editor }} --project-path {{ project.path }} --type project-tests
   artifacts:
     logs:
       paths:
         - "upm-ci~/test-results/**/*"
-        - BuildMultiprocessTestPlayer.log
   dependencies:
     - .yamato/project-pack.yml#pack_{{ project.name }}
 


### PR DESCRIPTION
Quick change to remove the multiprocess test player from the project tests, next step is to put it into its own job.