### PR TITLE
revert: Removed an unnecessary (and almost certainly invalid) call to m_MessagingSystem.ClientConnected() in StartClient()

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -803,6 +803,7 @@ namespace Unity.Netcode
             }
 
             Initialize(false);
+            m_MessagingSystem.ClientConnected(ServerClientId);
 
             var socketTasks = NetworkConfig.NetworkTransport.StartClient();
 


### PR DESCRIPTION
Reverts Unity-Technologies/com.unity.netcode.gameobjects#1219

Even though this PR attempted to address an issue with uninitialized variables during async Start it failed to do so, and ended up making behavior worse. A proper fix will be forthcoming soon.