### PR TITLE
fix: network scene manager scenes in build message

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -587,6 +587,7 @@ namespace Unity.Netcode
             // Return invalid scene name status if the scene name is invalid... :)
             if (!IsSceneNameValid(sceneName))
             {
+                Debug.LogError($"Scene '{sceneName}' couldn't be loaded because it has not been added to the build settings or the AssetBundle has not been loaded.");
                 return new SceneEventProgress(null, SceneEventProgressStatus.InvalidSceneName);
             }
 

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -578,16 +578,16 @@ namespace Unity.Netcode
         /// <returns><see cref="SceneEventProgress"/> that should have a <see cref="SceneEventProgress.Status"/> of <see cref="SceneEventProgressStatus.Started"/> otherwise it failed.</returns>
         private SceneEventProgress ValidateSceneEvent(string sceneName, bool isUnloading = false)
         {
-            // Return scene event already in progress if one is already in progress... :)
+            // Return scene event already in progress if one is already in progress.
             if (s_IsSceneEventActive)
             {
                 return new SceneEventProgress(null, SceneEventProgressStatus.SceneEventInProgress);
             }
 
-            // Return invalid scene name status if the scene name is invalid... :)
+            // Return invalid scene name status if the scene name is invalid.
             if (!IsSceneNameValid(sceneName))
             {
-                Debug.LogError($"Scene '{sceneName}' couldn't be loaded because it has not been added to the build settings or the AssetBundle has not been loaded.");
+                Debug.LogError($"Scene '{sceneName}' couldn't be loaded because it has not been added to the build settings scenes in build list.");
                 return new SceneEventProgress(null, SceneEventProgressStatus.InvalidSceneName);
             }
 

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -40,7 +40,7 @@ namespace TestProject.RuntimeTests
         private string m_CurrentSceneName;
         private List<SceneTestInfo> m_ShouldWaitList;
         private Scene m_CurrentScene;
-
+        private const string k_InvalidSceneName = "SomeInvalidSceneName";
 
         [UnityTest]
         public IEnumerator SceneLoadingAndNotifications([Values(LoadSceneMode.Single, LoadSceneMode.Additive)] LoadSceneMode clientSynchronizationMode)
@@ -129,9 +129,9 @@ namespace TestProject.RuntimeTests
             result = m_ServerNetworkManager.SceneManager.UnloadScene(m_CurrentScene);
             Assert.True(result == SceneEventProgressStatus.SceneNotLoaded);
 
-            LogAssert.Expect(LogType.Error, "Scene 'SomeInvalidSceneName' couldn't be loaded because it has not been added to the build settings scenes in build list.");
+            LogAssert.Expect(LogType.Error,$"Scene '{k_InvalidSceneName}' couldn't be loaded because it has not been added to the build settings scenes in build list.");
             // Check error status for trying to load an invalid scene name
-            result = m_ServerNetworkManager.SceneManager.LoadScene("SomeInvalidSceneName", LoadSceneMode.Additive);
+            result = m_ServerNetworkManager.SceneManager.LoadScene(k_InvalidSceneName, LoadSceneMode.Additive);
             Assert.True(result == SceneEventProgressStatus.InvalidSceneName);
 
             yield break;

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -129,6 +129,7 @@ namespace TestProject.RuntimeTests
             result = m_ServerNetworkManager.SceneManager.UnloadScene(m_CurrentScene);
             Assert.True(result == SceneEventProgressStatus.SceneNotLoaded);
 
+            LogAssert.Expect(LogType.Error, "Scene 'SomeInvalidSceneName' couldn't be loaded because it has not been added to the build settings scenes in build list.");
             // Check error status for trying to load an invalid scene name
             result = m_ServerNetworkManager.SceneManager.LoadScene("SomeInvalidSceneName", LoadSceneMode.Additive);
             Assert.True(result == SceneEventProgressStatus.InvalidSceneName);

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -129,7 +129,7 @@ namespace TestProject.RuntimeTests
             result = m_ServerNetworkManager.SceneManager.UnloadScene(m_CurrentScene);
             Assert.True(result == SceneEventProgressStatus.SceneNotLoaded);
 
-            LogAssert.Expect(LogType.Error,$"Scene '{k_InvalidSceneName}' couldn't be loaded because it has not been added to the build settings scenes in build list.");
+            LogAssert.Expect(LogType.Error, $"Scene '{k_InvalidSceneName}' couldn't be loaded because it has not been added to the build settings scenes in build list.");
             // Check error status for trying to load an invalid scene name
             result = m_ServerNetworkManager.SceneManager.LoadScene(k_InvalidSceneName, LoadSceneMode.Additive);
             Assert.True(result == SceneEventProgressStatus.InvalidSceneName);


### PR DESCRIPTION
[MTT-1267](https://jira.unity3d.com/browse/MTT-1267)
This adds an error message to the console if a user tries to load a scene that is not in the build settings scenes in build list.