### PR TITLE
fix: fixing MTT-1299

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -83,7 +83,7 @@ namespace Unity.Netcode
                 rpcMessageSize = NetworkManager.SendMessage(message, networkDelivery, NetworkManager.ServerClientId, true);
             }
 
-             
+
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
             if (NetworkManager.__rpc_name_table.TryGetValue(rpcMethodId, out var rpcMethodName))
             {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -146,8 +146,8 @@ namespace Unity.Netcode
                         break;
                     }
                 }
-                
-                messageSize = NetworkManager.SendMessage(message, networkDelivery,  in rpcParams.Send.TargetClientIds);
+
+                messageSize = NetworkManager.SendMessage(message, networkDelivery, in rpcParams.Send.TargetClientIds);
             }
             else if (rpcParams.Send.TargetClientIdsNativeArray != null)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -179,7 +179,11 @@ namespace Unity.Netcode
             // If we are a server/host then we just no op and send to ourself
             if (serverClientId != ulong.MaxValue && (IsHost || IsServer))
             {
-                messageSize = NetworkManager.SendMessage(message, networkDelivery, serverClientId, true);
+                var tempBuffer = new FastBufferReader(writer, Allocator.Temp);
+                message.Handle(tempBuffer, NetworkManager, serverClientId);
+                tempBuffer.Dispose();
+
+                messageSize = tempBuffer.Length;
             }
 
 #if DEVELOPMENT_BUILD || UNITY_EDITOR

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1255,12 +1255,12 @@ namespace Unity.Netcode
             }
         }
 
-        public unsafe int SendMessage<TMessageType, TClientIdListType>(in TMessageType message, NetworkDelivery delivery, in TClientIdListType clientIds, bool serverCanSendToServerId = false)
+        public unsafe int SendMessage<TMessageType, TClientIdListType>(in TMessageType message, NetworkDelivery delivery, in TClientIdListType clientIds)
             where TMessageType : INetworkMessage
             where TClientIdListType : IReadOnlyList<ulong>
         {
             // Prevent server sending to itself
-            if (IsServer && !serverCanSendToServerId)
+            if (IsServer)
             {
                 ulong* nonServerIds = stackalloc ulong[clientIds.Count];
                 int newIdx = 0;
@@ -1284,11 +1284,11 @@ namespace Unity.Netcode
         }
 
         public unsafe int SendMessage<T>(in T message, NetworkDelivery delivery,
-            ulong* clientIds, int numClientIds, bool serverCanSendToServerId = false)
+            ulong* clientIds, int numClientIds)
             where T : INetworkMessage
         {
             // Prevent server sending to itself
-            if (IsServer && !serverCanSendToServerId)
+            if (IsServer)
             {
                 ulong* nonServerIds = stackalloc ulong[numClientIds];
                 int newIdx = 0;
@@ -1318,11 +1318,11 @@ namespace Unity.Netcode
             return SendMessage(message, delivery, (ulong*)clientIds.GetUnsafePtr(), clientIds.Length);
         }
 
-        public int SendMessage<T>(in T message, NetworkDelivery delivery, ulong clientId, bool serverCanSendToServerId = false)
+        public int SendMessage<T>(in T message, NetworkDelivery delivery, ulong clientId)
             where T : INetworkMessage
         {
             // Prevent server sending to itself
-            if (IsServer && clientId == ServerClientId && !serverCanSendToServerId)
+            if (IsServer && clientId == ServerClientId)
             {
                 return 0;
             }

--- a/testproject/Assets/Tests/Runtime/MessageOrdering.cs
+++ b/testproject/Assets/Tests/Runtime/MessageOrdering.cs
@@ -147,7 +147,7 @@ namespace TestProject.RuntimeTests
             int expectedCount = Support.SpawnRpcDespawn.ClientUpdateCount + 1;
             const int maxFrames = 240;
             var doubleCheckTime = Time.realtimeSinceStartup + 5.0f;
-            while (Support.SpawnRpcDespawn.ClientUpdateCount < expectedCount)
+            while (Support.SpawnRpcDespawn.ClientUpdateCount < expectedCount && !handler.WasSpawned)
             {
                 if (Time.frameCount > maxFrames)
                 {
@@ -165,7 +165,6 @@ namespace TestProject.RuntimeTests
 
             Assert.AreEqual(NetworkUpdateStage.EarlyUpdate, Support.SpawnRpcDespawn.StageExecutedByReceiver);
             Assert.AreEqual(Support.SpawnRpcDespawn.ServerUpdateCount, Support.SpawnRpcDespawn.ClientUpdateCount);
-            Assert.True(handler.WasSpawned);
             var lastFrameNumber = Time.frameCount + 1;
             yield return new WaitUntil(() => Time.frameCount >= lastFrameNumber);
             Assert.True(handler.WasDestroyed);


### PR DESCRIPTION
* This code breaks the Unity Transport Adapter and assumes specific behavior that wasn't present before, in UTA we assume that these kind of checks are not happening in the SDK. This is because its very possible that you're clientID on the server (which is synchronized via OwnerClientId) and your ServerId could indeed be the same and it shouldn't really matter if they are as one side should not impact the other side. So for this reason we have removed this check.