### PR TITLE
fix: NetworkVariable render code triggering value set (MTT-1288)

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -178,6 +178,12 @@ namespace Unity.Netcode.Editor
             bool expanded = true;
             while (property.NextVisible(expanded))
             {
+                if (m_NetworkVariableNames.Contains(property.name))
+                {
+                    // Skip rendering of NetworkVars, they have special rendering
+                    continue;
+                }
+
                 if (property.propertyType == SerializedPropertyType.ObjectReference)
                 {
                     if (property.name == "m_Script")

--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -90,7 +90,8 @@ namespace Unity.Netcode.Editor
 
             var behaviour = (NetworkBehaviour)target;
 
-            if (behaviour.NetworkManager != null && behaviour.NetworkManager.IsListening)
+            // Only server can MODIFY. So allow modification if network is either not running or we are server
+            if (behaviour.NetworkManager == null || !behaviour.NetworkManager.IsListening || behaviour.NetworkManager.IsServer)
             {
                 if (type == typeof(int))
                 {
@@ -168,12 +169,9 @@ namespace Unity.Netcode.Editor
             EditorGUI.BeginChangeCheck();
             serializedObject.Update();
 
-            if (EditorApplication.isPlaying)
+            for (int i = 0; i < m_NetworkVariableNames.Count; i++)
             {
-                for (int i = 0; i < m_NetworkVariableNames.Count; i++)
-                {
-                    RenderNetworkVariable(i);
-                }
+                RenderNetworkVariable(i);
             }
 
             var property = serializedObject.GetIterator();


### PR DESCRIPTION
Previously, NetworkVars would trigger a value set in the rendering code, even if the value never changed.
It would also be possible to change the value as a client and the rendering would not work outside of play mode.

This PR addresses all of this. It will now always render the value, and allow editing when outside play mode, in play mode (as long as the network is not started OR you are the server).

This fixes old code from the times when clients could set values.

MTT-1288