### PR TITLE
fix: NetworkVars rendering twice

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -178,6 +178,12 @@ namespace Unity.Netcode.Editor
             bool expanded = true;
             while (property.NextVisible(expanded))
             {
+                if (m_NetworkVariableNames.Contains(property.name))
+                {
+                    // Skip rendering of NetworkVars, they have special rendering
+                    continue;
+                }
+
                 if (property.propertyType == SerializedPropertyType.ObjectReference)
                 {
                     if (property.name == "m_Script")


### PR DESCRIPTION
Previously, NetworkVars would render twice in the inspector (both custom rendering and the built in Unity rendering). This fixes this, but depends on #1229 as we need to ensure our custom rendering ALWAYS runs. Otherwise we might be left with no rendering at all.

MTT-1289