### PR TITLE
fix: Flush the UnityTransport send queue on shutdown

### DIFF
--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -680,6 +680,11 @@ namespace Unity.Netcode
 
         public override void Shutdown()
         {
+            // Flush the driver's internal send queue. If we're shutting down because the
+            // NetworkManager is shutting down, it probably has disconnected some peer(s)
+            // in the process and we want to get these disconnect messages on the wire.
+            m_Driver.ScheduleFlushSend(default).Complete();
+
             DisposeDriver();
 
             foreach (var queue in m_SendQueue.Values)

--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -680,6 +680,9 @@ namespace Unity.Netcode
 
         public override void Shutdown()
         {
+            if (!m_Driver.IsCreated)
+                return;
+
             // Flush the driver's internal send queue. If we're shutting down because the
             // NetworkManager is shutting down, it probably has disconnected some peer(s)
             // in the process and we want to get these disconnect messages on the wire.

--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -681,7 +681,9 @@ namespace Unity.Netcode
         public override void Shutdown()
         {
             if (!m_Driver.IsCreated)
+            {
                 return;
+            }
 
             // Flush the driver's internal send queue. If we're shutting down because the
             // NetworkManager is shutting down, it probably has disconnected some peer(s)

--- a/com.unity.netcode.adapter.utp/Tests/Runtime/ConnectionTests.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/ConnectionTests.cs
@@ -263,8 +263,6 @@ namespace Unity.Netcode.RuntimeTests
             Assert.AreEqual(m_ServerEvents.Count, previousServerEventsCount);
             Assert.AreEqual(m_ClientsEvents[0].Count, previousClientEventsCount);
 
-            m_Server.Shutdown();
-
             yield return null;
         }
     }


### PR DESCRIPTION
When `NetworkManager.Shutdown` is called, all clients are disconnected and the transport is immediately shut down. For `UnityTransport`, that means disconnect messages are not actually sent to the remote peers, because nothing goes out on the wire until an internal update of the driver is scheduled (which doesn't happen between the disconnect calls and the transport's shutdown).

This is fixed by flushing the internal send queue when shutting down the transport. This will send out any disconnect messages that might still be pending. The downside is that `UnityTransport.Shutdown` might take a bit longer to execute, since it will need to perform network activity. But when you're shutting down, you're presumably not in a situation where performance is critical, so this is probably acceptable.