### PR TITLE
chore: adding a PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,5 @@
 <!-- Replace this line with what this PR does and why.  Describe what you'd like reviewers to know, how you applied the Engineering principles, and any interesting tradeoffs made.  Delete bullet points below that don't apply, and update the changelog section as appropriate. -->
 
-<!-- Add performance testing results here. Replace with a short explanation if not applicable. -->
-
 <!-- Add JIRA link here. Short version (e.g. MTT-123) also works and gets auto-linked. -->
 
 <!-- Add RFC link here if applicable. -->
@@ -17,7 +15,6 @@
 
 * No tests have been added.
 * Includes unit tests.
-* Includes performance tests.
 * Includes integration tests.
 * No documentation changes or additions were necessary.
 * Includes documentation for previously-undocumented public API entry points.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+<!-- Replace this line with what this PR does and why.  Describe what you'd like reviewers to know, how you applied the Engineering principles, and any interesting tradeoffs made.  Delete bullet points below that don't apply, and update the changelog section as appropriate. -->
+
+<!-- Add performance testing results here. Replace with a short explanation if not applicable. -->
+
+<!-- Add JIRA link here. Short version (e.g. MTT-123) also works and gets auto-linked. -->
+
+<!-- Add RFC link here if applicable. -->
+
+## Changelog
+
+### com.unity.netcode.gameobjects
+- Added: The package whose Changelog should be added to should be in the header. Delete the changelog section entirely if it's not needed.
+- Fixed: If you update multiple packages, create a new section with a new header for the other package. 
+- Removed/Deprecated/Changed: Each bullet should be prefixed with Added, Fixed, Removed, Deprecated, or Changed to indicate where the entry should go.
+
+## Testing and Documentation
+
+* No tests have been added.
+* Includes unit tests.
+* Includes performance tests.
+* Includes integration tests.
+* No documentation changes or additions were necessary.
+* Includes documentation for previously-undocumented public API entry points.
+* Includes edits to existing public API documentation.
+
+<!--  Uncomment and mark items off with a * if this PR deprecates any API:
+### Deprecated API
+- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
+- [ ] An [api updater] was added.
+- [ ] Deprecation of the API is explained in the CHANGELOG.
+- [ ] The users can understand why this API was removed and what they should use instead.
+-->


### PR DESCRIPTION
This is to add a new PR Template to help encourage reasonable PR information and is consistent with other package templates. 