### PR TITLE
fix: MTT-1387 Address GC allocations caused by access to Object.name when recording metrics

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -89,8 +89,7 @@ namespace Unity.Netcode
             {
                 NetworkManager.NetworkMetrics.TrackRpcSent(
                     NetworkManager.ServerClientId,
-                    NetworkObjectId,
-                    NetworkObject.GetNameForMetrics(),
+                    NetworkObject,
                     rpcMethodName,
                     __getTypeName(),
                     rpcMessageSize);
@@ -134,7 +133,7 @@ namespace Unity.Netcode
             int messageSize;
 
             // We check to see if we need to shortcut for the case where we are the host/server and we can send a clientRPC
-            // to ourself. Sadly we have to figure that out from the list of clientIds :( 
+            // to ourself. Sadly we have to figure that out from the list of clientIds :(
             bool shouldSendToHost = false;
 
             if (rpcParams.Send.TargetClientIds != null)
@@ -187,8 +186,7 @@ namespace Unity.Netcode
                         : messageSize;
                     NetworkManager.NetworkMetrics.TrackRpcSent(
                         client.Key,
-                        NetworkObjectId,
-                        NetworkObject.GetNameForMetrics(),
+                        NetworkObject,
                         rpcMethodName,
                         __getTypeName(),
                         bytesReported);

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -134,7 +134,7 @@ namespace Unity.Netcode
             int messageSize;
 
             // We check to see if we need to shortcut for the case where we are the host/server and we can send a clientRPC
-            // to ourself. Sadly we have to figure that out from the list of clientIds :(
+            // to ourself. Sadly we have to figure that out from the list of clientIds :( 
             bool shouldSendToHost = false;
 
             if (rpcParams.Send.TargetClientIds != null)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -90,6 +90,7 @@ namespace Unity.Netcode
                 NetworkManager.NetworkMetrics.TrackRpcSent(
                     NetworkManager.ServerClientId,
                     NetworkObjectId,
+                    NetworkObject.GetNameForMetrics(),
                     rpcMethodName,
                     __getTypeName(),
                     rpcMessageSize);
@@ -133,7 +134,7 @@ namespace Unity.Netcode
             int messageSize;
 
             // We check to see if we need to shortcut for the case where we are the host/server and we can send a clientRPC
-            // to ourself. Sadly we have to figure that out from the list of clientIds :( 
+            // to ourself. Sadly we have to figure that out from the list of clientIds :(
             bool shouldSendToHost = false;
 
             if (rpcParams.Send.TargetClientIds != null)
@@ -187,6 +188,7 @@ namespace Unity.Netcode
                     NetworkManager.NetworkMetrics.TrackRpcSent(
                         client.Key,
                         NetworkObjectId,
+                        NetworkObject.GetNameForMetrics(),
                         rpcMethodName,
                         __getTypeName(),
                         bytesReported);

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -167,6 +167,18 @@ namespace Unity.Netcode
 
         internal readonly HashSet<ulong> Observers = new HashSet<ulong>();
 
+#if MULTIPLAYER_TOOLS
+        private string m_CachedNameForMetrics;
+#endif
+        internal string GetNameForMetrics()
+        {
+#if MULTIPLAYER_TOOLS
+            return m_CachedNameForMetrics ??= name;
+#else
+            return null;
+#endif
+        }
+
         /// <summary>
         /// Returns Observers enumerator
         /// </summary>
@@ -320,7 +332,7 @@ namespace Unity.Netcode
                 var bytesReported = NetworkManager.LocalClientId == clientId
                         ? 0
                         : size;
-                NetworkManager.NetworkMetrics.TrackObjectDestroySent(clientId, NetworkObjectId, name, bytesReported);
+                NetworkManager.NetworkMetrics.TrackObjectDestroySent(clientId, NetworkObjectId, GetNameForMetrics(), bytesReported);
             }
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -332,7 +332,7 @@ namespace Unity.Netcode
                 var bytesReported = NetworkManager.LocalClientId == clientId
                         ? 0
                         : size;
-                NetworkManager.NetworkMetrics.TrackObjectDestroySent(clientId, NetworkObjectId, GetNameForMetrics(), bytesReported);
+                NetworkManager.NetworkMetrics.TrackObjectDestroySent(clientId, this, bytesReported);
             }
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ChangeOwnershipMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ChangeOwnershipMessage.cs
@@ -50,7 +50,7 @@ namespace Unity.Netcode
             var bytesReported = networkManager.LocalClientId == senderId
                 ? 0
                 : messageSize;
-            networkManager.NetworkMetrics.TrackOwnershipChangeReceived(senderId, networkObject.NetworkObjectId, networkObject.GetNameForMetrics(), bytesReported);
+            networkManager.NetworkMetrics.TrackOwnershipChangeReceived(senderId, networkObject, bytesReported);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ChangeOwnershipMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ChangeOwnershipMessage.cs
@@ -50,7 +50,7 @@ namespace Unity.Netcode
             var bytesReported = networkManager.LocalClientId == senderId
                 ? 0
                 : messageSize;
-            networkManager.NetworkMetrics.TrackOwnershipChangeReceived(senderId, networkObject.NetworkObjectId, networkObject.name, bytesReported);
+            networkManager.NetworkMetrics.TrackOwnershipChangeReceived(senderId, networkObject.NetworkObjectId, networkObject.GetNameForMetrics(), bytesReported);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/CreateObjectMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/CreateObjectMessage.cs
@@ -27,7 +27,7 @@ namespace Unity.Netcode
             var bytesReported = networkManager.LocalClientId == senderId
                 ? 0
                 : reader.Length;
-            networkManager.NetworkMetrics.TrackObjectSpawnReceived(senderId, networkObject.NetworkObjectId, networkObject.name, bytesReported);
+            networkManager.NetworkMetrics.TrackObjectSpawnReceived(senderId, networkObject.NetworkObjectId, networkObject.GetNameForMetrics(), bytesReported);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/CreateObjectMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/CreateObjectMessage.cs
@@ -27,7 +27,7 @@ namespace Unity.Netcode
             var bytesReported = networkManager.LocalClientId == senderId
                 ? 0
                 : reader.Length;
-            networkManager.NetworkMetrics.TrackObjectSpawnReceived(senderId, networkObject.NetworkObjectId, networkObject.GetNameForMetrics(), bytesReported);
+            networkManager.NetworkMetrics.TrackObjectSpawnReceived(senderId, networkObject, bytesReported);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/DestroyObjectMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/DestroyObjectMessage.cs
@@ -37,7 +37,7 @@ namespace Unity.Netcode
             var bytesReported = networkManager.LocalClientId == senderId
                 ? 0
                 : messageSize;
-            networkManager.NetworkMetrics.TrackObjectDestroyReceived(senderId, NetworkObjectId, networkObject.GetNameForMetrics(), bytesReported);
+            networkManager.NetworkMetrics.TrackObjectDestroyReceived(senderId, networkObject, bytesReported);
             networkManager.SpawnManager.OnDespawnObject(networkObject, true);
         }
     }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/DestroyObjectMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/DestroyObjectMessage.cs
@@ -37,7 +37,7 @@ namespace Unity.Netcode
             var bytesReported = networkManager.LocalClientId == senderId
                 ? 0
                 : messageSize;
-            networkManager.NetworkMetrics.TrackObjectDestroyReceived(senderId, NetworkObjectId, networkObject.name, bytesReported);
+            networkManager.NetworkMetrics.TrackObjectDestroyReceived(senderId, NetworkObjectId, networkObject.GetNameForMetrics(), bytesReported);
             networkManager.SpawnManager.OnDespawnObject(networkObject, true);
         }
     }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkVariableDeltaMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkVariableDeltaMessage.cs
@@ -88,8 +88,7 @@ namespace Unity.Netcode
                         : writer.Length;
                     NetworkBehaviour.NetworkManager.NetworkMetrics.TrackNetworkVariableDeltaSent(
                         ClientId,
-                        NetworkBehaviour.NetworkObjectId,
-                        NetworkBehaviour.NetworkObject.GetNameForMetrics(),
+                        NetworkBehaviour.NetworkObject,
                         NetworkBehaviour.NetworkVariableFields[k].Name,
                         NetworkBehaviour.__getTypeName(),
                         bytesReported);
@@ -188,8 +187,7 @@ namespace Unity.Netcode
                             : reader.Length;
                         networkManager.NetworkMetrics.TrackNetworkVariableDeltaReceived(
                             senderId,
-                            behaviour.NetworkObjectId,
-                            behaviour.NetworkObject.GetNameForMetrics(),
+                            networkObject,
                             behaviour.NetworkVariableFields[i].Name,
                             behaviour.__getTypeName(),
                             bytesReported);

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkVariableDeltaMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkVariableDeltaMessage.cs
@@ -89,7 +89,7 @@ namespace Unity.Netcode
                     NetworkBehaviour.NetworkManager.NetworkMetrics.TrackNetworkVariableDeltaSent(
                         ClientId,
                         NetworkBehaviour.NetworkObjectId,
-                        NetworkBehaviour.name,
+                        NetworkBehaviour.NetworkObject.GetNameForMetrics(),
                         NetworkBehaviour.NetworkVariableFields[k].Name,
                         NetworkBehaviour.__getTypeName(),
                         bytesReported);
@@ -189,7 +189,7 @@ namespace Unity.Netcode
                         networkManager.NetworkMetrics.TrackNetworkVariableDeltaReceived(
                             senderId,
                             behaviour.NetworkObjectId,
-                            behaviour.name,
+                            behaviour.NetworkObject.GetNameForMetrics(),
                             behaviour.NetworkVariableFields[i].Name,
                             behaviour.__getTypeName(),
                             bytesReported);

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/RpcMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/RpcMessage.cs
@@ -89,8 +89,7 @@ namespace Unity.Netcode
                 {
                     networkManager.NetworkMetrics.TrackRpcReceived(
                         senderId,
-                        networkBehaviour.NetworkObjectId,
-                        networkBehaviour.NetworkObject.GetNameForMetrics(),
+                        networkObject,
                         rpcMethodName,
                         networkBehaviour.__getTypeName(),
                         reader.Length);

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/RpcMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/RpcMessage.cs
@@ -89,7 +89,8 @@ namespace Unity.Netcode
                 {
                     networkManager.NetworkMetrics.TrackRpcReceived(
                         senderId,
-                        Header.NetworkObjectId,
+                        networkBehaviour.NetworkObjectId,
+                        networkBehaviour.NetworkObject.GetNameForMetrics(),
                         rpcMethodName,
                         networkBehaviour.__getTypeName(),
                         reader.Length);

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/INetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/INetworkMetrics.cs
@@ -12,8 +12,6 @@ namespace Unity.Netcode
 
         void TrackNetworkMessageReceived(ulong senderClientId, string messageType, long bytesCount);
 
-        void TrackNetworkObject(NetworkObject networkObject);
-
         void TrackNamedMessageSent(ulong receiverClientId, string messageName, long bytesCount);
 
         void TrackNamedMessageSent(IReadOnlyCollection<ulong> receiverClientIds, string messageName, long bytesCount);
@@ -59,6 +57,7 @@ namespace Unity.Netcode
         void TrackRpcSent(
             ulong receiverClientId,
             ulong networkObjectId,
+            string gameObjectName,
             string rpcName,
             string networkBehaviourName,
             long bytesCount);
@@ -66,6 +65,7 @@ namespace Unity.Netcode
         void TrackRpcSent(
             ulong[] receiverClientIds,
             ulong networkObjectId,
+            string gameObjectName,
             string rpcName,
             string networkBehaviourName,
             long bytesCount);
@@ -73,6 +73,7 @@ namespace Unity.Netcode
         void TrackRpcReceived(
             ulong senderClientId,
             ulong networkObjectId,
+            string gameObjectName,
             string rpcName,
             string networkBehaviourName,
             long bytesCount);

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/INetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/INetworkMetrics.cs
@@ -26,54 +26,49 @@ namespace Unity.Netcode
 
         void TrackNetworkVariableDeltaSent(
             ulong receiverClientId,
-            ulong networkObjectId,
-            string gameObjectName,
+            NetworkObject networkObject,
             string variableName,
             string networkBehaviourName,
             long bytesCount);
 
         void TrackNetworkVariableDeltaReceived(
             ulong senderClientId,
-            ulong networkObjectId,
-            string gameObjectName,
+            NetworkObject networkObject,
             string variableName,
             string networkBehaviourName,
             long bytesCount);
 
-        void TrackOwnershipChangeSent(ulong receiverClientId, ulong networkObjectId, string gameObjectName, long bytesCount);
+        void TrackOwnershipChangeSent(ulong receiverClientId, NetworkObject networkObject, long bytesCount);
 
-        void TrackOwnershipChangeReceived(ulong senderClientId, ulong networkObjectId, string gameObjectName, long bytesCount);
+        void TrackOwnershipChangeReceived(ulong senderClientId, NetworkObject networkObject, long bytesCount);
 
-        void TrackObjectSpawnSent(ulong receiverClientId, ulong networkObjectId, string gameObjectName, long bytesCount);
+        void TrackObjectSpawnSent(ulong receiverClientId, NetworkObject networkObject, long bytesCount);
 
-        void TrackObjectSpawnReceived(ulong senderClientId, ulong networkObjectId, string gameObjectName, long bytesCount);
+        void TrackObjectSpawnReceived(ulong senderClientId, NetworkObject networkObject, long bytesCount);
 
-        void TrackObjectDestroySent(ulong receiverClientId, ulong networkObjectId, string gameObjectName, long bytesCount);
+        void TrackObjectDestroySent(ulong receiverClientId, NetworkObject networkObject, long bytesCount);
 
-        void TrackObjectDestroySent(IReadOnlyCollection<ulong> receiverClientIds, ulong networkObjectId, string gameObjectName, long bytesCount);
+        void TrackObjectDestroySent(IReadOnlyCollection<ulong> receiverClientIds, NetworkObject networkObject, long bytesCount);
 
-        void TrackObjectDestroyReceived(ulong senderClientId, ulong networkObjectId, string gameObjectName, long bytesCount);
+        void TrackObjectDestroyReceived(ulong senderClientId, NetworkObject networkObject, long bytesCount);
 
         void TrackRpcSent(
             ulong receiverClientId,
-            ulong networkObjectId,
-            string gameObjectName,
+            NetworkObject networkObject,
             string rpcName,
             string networkBehaviourName,
             long bytesCount);
 
         void TrackRpcSent(
             ulong[] receiverClientIds,
-            ulong networkObjectId,
-            string gameObjectName,
+            NetworkObject networkObject,
             string rpcName,
             string networkBehaviourName,
             long bytesCount);
 
         void TrackRpcReceived(
             ulong senderClientId,
-            ulong networkObjectId,
-            string gameObjectName,
+            NetworkObject networkObject,
             string rpcName,
             string networkBehaviourName,
             long bytesCount);

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
@@ -117,8 +117,7 @@ namespace Unity.Netcode
 
         public void TrackNetworkVariableDeltaSent(
             ulong receiverClientId,
-            ulong networkObjectId,
-            string gameObjectName,
+            NetworkObject networkObject,
             string variableName,
             string networkBehaviourName,
             long bytesCount)
@@ -126,7 +125,7 @@ namespace Unity.Netcode
             m_NetworkVariableDeltaSentEvent.Mark(
                 new NetworkVariableEvent(
                     new ConnectionInfo(receiverClientId),
-                    new NetworkObjectIdentifier(gameObjectName, networkObjectId),
+                    GetObjectIdentifier(networkObject),
                     variableName,
                     networkBehaviourName,
                     bytesCount));
@@ -134,8 +133,7 @@ namespace Unity.Netcode
 
         public void TrackNetworkVariableDeltaReceived(
             ulong senderClientId,
-            ulong networkObjectId,
-            string gameObjectName,
+            NetworkObject networkObject,
             string variableName,
             string networkBehaviourName,
             long bytesCount)
@@ -143,55 +141,59 @@ namespace Unity.Netcode
             m_NetworkVariableDeltaReceivedEvent.Mark(
                 new NetworkVariableEvent(
                     new ConnectionInfo(senderClientId),
-                    new NetworkObjectIdentifier(gameObjectName, networkObjectId),
+                    GetObjectIdentifier(networkObject),
                     variableName,
                     networkBehaviourName,
                     bytesCount));
         }
 
-        public void TrackOwnershipChangeSent(ulong receiverClientId, ulong networkObjectId, string gameObjectName, long bytesCount)
+        public void TrackOwnershipChangeSent(ulong receiverClientId, NetworkObject networkObject, long bytesCount)
         {
-            m_OwnershipChangeSentEvent.Mark(new OwnershipChangeEvent(new ConnectionInfo(receiverClientId), new NetworkObjectIdentifier(gameObjectName, networkObjectId), bytesCount));
+            m_OwnershipChangeSentEvent.Mark(
+                new OwnershipChangeEvent(new ConnectionInfo(receiverClientId),
+                    GetObjectIdentifier(networkObject),
+                    bytesCount));
         }
 
-        public void TrackOwnershipChangeReceived(ulong senderClientId, ulong networkObjectId, string gameObjectName, long bytesCount)
+        public void TrackOwnershipChangeReceived(ulong senderClientId, NetworkObject networkObject, long bytesCount)
         {
-            m_OwnershipChangeReceivedEvent.Mark(new OwnershipChangeEvent(new ConnectionInfo(senderClientId),
-                new NetworkObjectIdentifier(gameObjectName, networkObjectId), bytesCount));
+            m_OwnershipChangeReceivedEvent.Mark(
+                new OwnershipChangeEvent(new ConnectionInfo(senderClientId),
+                GetObjectIdentifier(networkObject),
+                bytesCount));
         }
 
-        public void TrackObjectSpawnSent(ulong receiverClientId, ulong networkObjectId, string gameObjectName, long bytesCount)
+        public void TrackObjectSpawnSent(ulong receiverClientId, NetworkObject networkObject, long bytesCount)
         {
-            m_ObjectSpawnSentEvent.Mark(new ObjectSpawnedEvent(new ConnectionInfo(receiverClientId), new NetworkObjectIdentifier(gameObjectName, networkObjectId), bytesCount));
+            m_ObjectSpawnSentEvent.Mark(new ObjectSpawnedEvent(new ConnectionInfo(receiverClientId), GetObjectIdentifier(networkObject), bytesCount));
         }
 
-        public void TrackObjectSpawnReceived(ulong senderClientId, ulong networkObjectId, string gameObjectName, long bytesCount)
+        public void TrackObjectSpawnReceived(ulong senderClientId, NetworkObject networkObject, long bytesCount)
         {
-            m_ObjectSpawnReceivedEvent.Mark(new ObjectSpawnedEvent(new ConnectionInfo(senderClientId), new NetworkObjectIdentifier(gameObjectName, networkObjectId), bytesCount));
+            m_ObjectSpawnReceivedEvent.Mark(new ObjectSpawnedEvent(new ConnectionInfo(senderClientId), GetObjectIdentifier(networkObject), bytesCount));
         }
 
-        public void TrackObjectDestroySent(ulong receiverClientId, ulong networkObjectId, string gameObjectName, long bytesCount)
+        public void TrackObjectDestroySent(ulong receiverClientId, NetworkObject networkObject, long bytesCount)
         {
-            m_ObjectDestroySentEvent.Mark(new ObjectDestroyedEvent(new ConnectionInfo(receiverClientId), new NetworkObjectIdentifier(gameObjectName, networkObjectId), bytesCount));
+            m_ObjectDestroySentEvent.Mark(new ObjectDestroyedEvent(new ConnectionInfo(receiverClientId), GetObjectIdentifier(networkObject), bytesCount));
         }
 
-        public void TrackObjectDestroySent(IReadOnlyCollection<ulong> receiverClientIds, ulong networkObjectId, string gameObjectName, long bytesCount)
+        public void TrackObjectDestroySent(IReadOnlyCollection<ulong> receiverClientIds, NetworkObject networkObject, long bytesCount)
         {
             foreach (var receiverClientId in receiverClientIds)
             {
-                TrackObjectDestroySent(receiverClientId, networkObjectId, gameObjectName, bytesCount);
+                TrackObjectDestroySent(receiverClientId, networkObject, bytesCount);
             }
         }
 
-        public void TrackObjectDestroyReceived(ulong senderClientId, ulong networkObjectId, string gameObjectName, long bytesCount)
+        public void TrackObjectDestroyReceived(ulong senderClientId, NetworkObject networkObject, long bytesCount)
         {
-            m_ObjectDestroyReceivedEvent.Mark(new ObjectDestroyedEvent(new ConnectionInfo(senderClientId), new NetworkObjectIdentifier(gameObjectName, networkObjectId), bytesCount));
+            m_ObjectDestroyReceivedEvent.Mark(new ObjectDestroyedEvent(new ConnectionInfo(senderClientId), GetObjectIdentifier(networkObject), bytesCount));
         }
 
         public void TrackRpcSent(
             ulong receiverClientId,
-            ulong networkObjectId,
-            string gameObjectName,
+            NetworkObject networkObject,
             string rpcName,
             string networkBehaviourName,
             long bytesCount)
@@ -199,7 +201,7 @@ namespace Unity.Netcode
             m_RpcSentEvent.Mark(
                 new RpcEvent(
                     new ConnectionInfo(receiverClientId),
-                    new NetworkObjectIdentifier(gameObjectName, networkObjectId),
+                    GetObjectIdentifier(networkObject),
                     rpcName,
                     networkBehaviourName,
                     bytesCount));
@@ -207,29 +209,27 @@ namespace Unity.Netcode
 
         public void TrackRpcSent(
             ulong[] receiverClientIds,
-            ulong networkObjectId,
-            string gameObjectName,
+            NetworkObject networkObject,
             string rpcName,
             string networkBehaviourName,
             long bytesCount)
         {
             foreach (var receiverClientId in receiverClientIds)
             {
-                TrackRpcSent(receiverClientId, networkObjectId, gameObjectName, rpcName, networkBehaviourName, bytesCount);
+                TrackRpcSent(receiverClientId, networkObject, rpcName, networkBehaviourName, bytesCount);
             }
         }
 
         public void TrackRpcReceived(
             ulong senderClientId,
-            ulong networkObjectId,
-            string gameObjectName,
+            NetworkObject networkObject,
             string rpcName,
             string networkBehaviourName,
             long bytesCount)
         {
             m_RpcReceivedEvent.Mark(
                 new RpcEvent(new ConnectionInfo(senderClientId),
-                    new NetworkObjectIdentifier(gameObjectName, networkObjectId),
+                    GetObjectIdentifier(networkObject),
                     rpcName,
                     networkBehaviourName,
                     bytesCount));
@@ -266,6 +266,11 @@ namespace Unity.Netcode
         public void DispatchFrame()
         {
             Dispatcher.Dispatch();
+        }
+
+        private static NetworkObjectIdentifier GetObjectIdentifier(NetworkObject networkObject)
+        {
+            return new NetworkObjectIdentifier(networkObject.GetNameForMetrics(), networkObject.NetworkObjectId);
         }
     }
 

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/NullNetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/NullNetworkMetrics.cs
@@ -46,8 +46,7 @@ namespace Unity.Netcode
 
         public void TrackNetworkVariableDeltaSent(
             ulong receiverClientId,
-            ulong networkObjectId,
-            string gameObjectName,
+            NetworkObject networkObject,
             string variableName,
             string networkBehaviourName,
             long bytesCount)
@@ -56,46 +55,44 @@ namespace Unity.Netcode
 
         public void TrackNetworkVariableDeltaReceived(
             ulong senderClientId,
-            ulong networkObjectId,
-            string gameObjectName,
+            NetworkObject networkObject,
             string variableName,
             string networkBehaviourName,
             long bytesCount)
         {
         }
 
-        public void TrackOwnershipChangeSent(ulong receiverClientId, ulong networkObjectId, string gameObjectName, long bytesCount)
+        public void TrackOwnershipChangeSent(ulong receiverClientId, NetworkObject networkObject, long bytesCount)
         {
         }
 
-        public void TrackOwnershipChangeReceived(ulong senderClientId, ulong networkObjectId, string gameObjectName, long bytesCount)
+        public void TrackOwnershipChangeReceived(ulong senderClientId, NetworkObject networkObject, long bytesCount)
         {
         }
 
-        public void TrackObjectSpawnSent(ulong receiverClientId, ulong networkObjectId, string gameObjectName, long bytesCount)
+        public void TrackObjectSpawnSent(ulong receiverClientId, NetworkObject networkObject, long bytesCount)
         {
         }
 
-        public void TrackObjectSpawnReceived(ulong senderClientId, ulong networkObjectId, string gameObjectName, long bytesCount)
+        public void TrackObjectSpawnReceived(ulong senderClientId, NetworkObject networkObject, long bytesCount)
         {
         }
 
-        public void TrackObjectDestroySent(ulong senderClientId, ulong networkObjectId, string gameObjectName, long bytesCount)
+        public void TrackObjectDestroySent(ulong senderClientId, NetworkObject networkObject, long bytesCount)
         {
         }
 
-        public void TrackObjectDestroySent(IReadOnlyCollection<ulong> receiverClientIds, ulong networkObjectId, string gameObjectName, long bytesCount)
+        public void TrackObjectDestroySent(IReadOnlyCollection<ulong> receiverClientIds, NetworkObject networkObject, long bytesCount)
         {
         }
 
-        public void TrackObjectDestroyReceived(ulong senderClientId, ulong networkObjectId, string gameObjectName, long bytesCount)
+        public void TrackObjectDestroyReceived(ulong senderClientId, NetworkObject networkObject, long bytesCount)
         {
         }
 
         public void TrackRpcSent(
             ulong receiverClientId,
-            ulong networkObjectId,
-            string gameObjectName,
+            NetworkObject networkObject,
             string rpcName,
             string networkBehaviourName,
             long bytesCount)
@@ -104,8 +101,7 @@ namespace Unity.Netcode
 
         public void TrackRpcSent(
             ulong[] receiverClientIds,
-            ulong networkObjectId,
-            string gameObjectName,
+            NetworkObject networkObject,
             string rpcName,
             string networkBehaviourName,
             long bytesCount)
@@ -114,8 +110,7 @@ namespace Unity.Netcode
 
         public void TrackRpcReceived(
             ulong senderClientId,
-            ulong networkObjectId,
-            string gameObjectName,
+            NetworkObject networkObject,
             string rpcName,
             string networkBehaviourName,
             long bytesCount)

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/NullNetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/NullNetworkMetrics.cs
@@ -20,10 +20,6 @@ namespace Unity.Netcode
         {
         }
 
-        public void TrackNetworkObject(NetworkObject networkObject)
-        {
-        }
-
         public void TrackNamedMessageSent(ulong receiverClientId, string messageName, long bytesCount)
         {
         }
@@ -99,6 +95,7 @@ namespace Unity.Netcode
         public void TrackRpcSent(
             ulong receiverClientId,
             ulong networkObjectId,
+            string gameObjectName,
             string rpcName,
             string networkBehaviourName,
             long bytesCount)
@@ -108,6 +105,7 @@ namespace Unity.Netcode
         public void TrackRpcSent(
             ulong[] receiverClientIds,
             ulong networkObjectId,
+            string gameObjectName,
             string rpcName,
             string networkBehaviourName,
             long bytesCount)
@@ -117,6 +115,7 @@ namespace Unity.Netcode
         public void TrackRpcReceived(
             ulong senderClientId,
             ulong networkObjectId,
+            string gameObjectName,
             string rpcName,
             string networkBehaviourName,
             long bytesCount)

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -112,7 +112,7 @@ namespace Unity.Netcode
                 var bytesReported = NetworkManager.LocalClientId == client.Key
                       ? 0
                       : size;
-                NetworkManager.NetworkMetrics.TrackOwnershipChangeSent(client.Key, networkObject.NetworkObjectId, networkObject.GetNameForMetrics(), bytesReported);
+                NetworkManager.NetworkMetrics.TrackOwnershipChangeSent(client.Key, networkObject, bytesReported);
             }
         }
 
@@ -181,7 +181,7 @@ namespace Unity.Netcode
                 var bytesReported = NetworkManager.LocalClientId == client.Key
                     ? 0
                     : size;
-                NetworkManager.NetworkMetrics.TrackOwnershipChangeSent(client.Key, networkObject.NetworkObjectId, networkObject.GetNameForMetrics(), bytesReported);
+                NetworkManager.NetworkMetrics.TrackOwnershipChangeSent(client.Key, networkObject, bytesReported);
             }
         }
 
@@ -366,7 +366,7 @@ namespace Unity.Netcode
             SpawnedObjects.Add(networkObject.NetworkObjectId, networkObject);
             SpawnedObjectsList.Add(networkObject);
 
-            NetworkManager.NetworkMetrics.TrackObjectSpawnSent(NetworkManager.LocalClientId, networkObject.NetworkObjectId, networkObject.GetNameForMetrics(), 0);
+            NetworkManager.NetworkMetrics.TrackObjectSpawnSent(NetworkManager.LocalClientId, networkObject, 0);
 
             if (ownerClientId != null)
             {
@@ -424,7 +424,7 @@ namespace Unity.Netcode
                 var bytesReported = NetworkManager.LocalClientId == clientId
                     ? 0
                     : size;
-                NetworkManager.NetworkMetrics.TrackObjectSpawnSent(clientId, networkObject.NetworkObjectId, networkObject.GetNameForMetrics(), bytesReported);
+                NetworkManager.NetworkMetrics.TrackObjectSpawnSent(clientId, networkObject, bytesReported);
 
                 networkObject.MarkVariablesDirty();
             }
@@ -657,7 +657,7 @@ namespace Unity.Netcode
                                 var bytesReported = NetworkManager.LocalClientId == targetClientId
                                     ? 0
                                     : size;
-                                NetworkManager.NetworkMetrics.TrackObjectDestroySent(targetClientId, networkObject.NetworkObjectId, networkObject.GetNameForMetrics(), bytesReported);
+                                NetworkManager.NetworkMetrics.TrackObjectDestroySent(targetClientId, networkObject, bytesReported);
                             }
                         }
                     }

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -112,7 +112,7 @@ namespace Unity.Netcode
                 var bytesReported = NetworkManager.LocalClientId == client.Key
                       ? 0
                       : size;
-                NetworkManager.NetworkMetrics.TrackOwnershipChangeSent(client.Key, networkObject.NetworkObjectId, networkObject.name, bytesReported);
+                NetworkManager.NetworkMetrics.TrackOwnershipChangeSent(client.Key, networkObject.NetworkObjectId, networkObject.GetNameForMetrics(), bytesReported);
             }
         }
 
@@ -181,7 +181,7 @@ namespace Unity.Netcode
                 var bytesReported = NetworkManager.LocalClientId == client.Key
                     ? 0
                     : size;
-                NetworkManager.NetworkMetrics.TrackOwnershipChangeSent(client.Key, networkObject.NetworkObjectId, networkObject.name, bytesReported);
+                NetworkManager.NetworkMetrics.TrackOwnershipChangeSent(client.Key, networkObject.NetworkObjectId, networkObject.GetNameForMetrics(), bytesReported);
             }
         }
 
@@ -366,8 +366,7 @@ namespace Unity.Netcode
             SpawnedObjects.Add(networkObject.NetworkObjectId, networkObject);
             SpawnedObjectsList.Add(networkObject);
 
-            NetworkManager.NetworkMetrics.TrackNetworkObject(networkObject);
-            NetworkManager.NetworkMetrics.TrackObjectSpawnSent(NetworkManager.LocalClientId, networkObject.NetworkObjectId, networkObject.name, 0);
+            NetworkManager.NetworkMetrics.TrackObjectSpawnSent(NetworkManager.LocalClientId, networkObject.NetworkObjectId, networkObject.GetNameForMetrics(), 0);
 
             if (ownerClientId != null)
             {
@@ -425,7 +424,7 @@ namespace Unity.Netcode
                 var bytesReported = NetworkManager.LocalClientId == clientId
                     ? 0
                     : size;
-                NetworkManager.NetworkMetrics.TrackObjectSpawnSent(clientId, networkObject.NetworkObjectId, networkObject.name, bytesReported);
+                NetworkManager.NetworkMetrics.TrackObjectSpawnSent(clientId, networkObject.NetworkObjectId, networkObject.GetNameForMetrics(), bytesReported);
 
                 networkObject.MarkVariablesDirty();
             }
@@ -658,7 +657,7 @@ namespace Unity.Netcode
                                 var bytesReported = NetworkManager.LocalClientId == targetClientId
                                     ? 0
                                     : size;
-                                NetworkManager.NetworkMetrics.TrackObjectDestroySent(targetClientId, networkObject.NetworkObjectId, networkObject.name, bytesReported);
+                                NetworkManager.NetworkMetrics.TrackObjectDestroySent(targetClientId, networkObject.NetworkObjectId, networkObject.GetNameForMetrics(), bytesReported);
                             }
                         }
                     }


### PR DESCRIPTION
- Moved caching of Object.Name for metrics usage to the NetworkObject instead of caching separately in a dictionary on NetworkMetrics. This removes a memory leak (names were not discarded when network object lifecycle ends).
- Also updated all instances where we need the name of a network object to reference the cached version on NetworkObject
- Because NetworkMetrics is constructed conditionally based on when the multiplayer tools package is installed, I maintained this same behavior in the network metrics cache. If Tools are not installed, the internal GetNameForMetrics method returns null. Although this method should not be used for something other than metrics, the decision to return null instead of throwing an invalid operation exception was arbitrary.

https://jira.unity3d.com/browse/MTT-1387
(Note - this PR does not address all aspects of the ticket)

## Changelog

N/A - fixing regression introduced within release

## Testing and Documentation

* No tests have been added