### PR TITLE
chore: Adding dry-run jobs and fixing deps fpr the actual per package publish

### DIFF
--- a/.yamato/project-publish.yml
+++ b/.yamato/project-publish.yml
@@ -24,6 +24,28 @@ publish_{{ project.name }}_{{ package.name }}:
 {% endfor -%}
 {% endfor -%}
 
+publish_{{ project.name }}_{{ package.name }}:
+  name: Publish Project {{project.name }} - Package {{ package.name }} to Internal Registry (dry-run)
+  agent:
+    type: Unity::VM
+    image: package-ci/win10:stable
+    flavor: b1.large
+  commands:
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    - upm-ci package publish --package-path {{ package.path }} --dry-run
+  artifacts:
+    artifacts:
+      paths:
+        - "upm-ci~/packages/*.tgz"
+  dependencies:
+    - .yamato/project-pack.yml#pack_{{ project.name }}
+    - .yamato/project-tests.yml#validate_{{ project.name }}_{{ package.name }}_{{ test_platforms.first.name }}_{{ validation_editor }}
+{% for editor in project.test_editors -%}
+{% for platform in test_platforms -%}
+    - .yamato/project-tests.yml#test_{{ project.name }}_{{ package.name }}_{{ platform.name }}_{{ editor }}
+{% endfor -%}
+{% endfor -%}
+
 {% endfor -%}
 
 publish_{{ project.name }}:

--- a/.yamato/project-publish.yml
+++ b/.yamato/project-publish.yml
@@ -65,4 +65,21 @@ publish_{{ project.name }}:
     - .yamato/project-pack.yml#pack_{{ project.name }}
     - .yamato/_run-all.yml#run_all_tests
 
+publish_{{ project.name }}_dry_run:
+  name: Publish ALL {{ project.name }} packages to Internal Registry
+  agent:
+    type: Unity::VM
+    image: package-ci/win10:stable
+    flavor: b1.large
+  commands:
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    - upm-ci project publish --project-path {{ project.path }} --dry-run
+  artifacts:
+    artifacts:
+      paths:
+        - "upm-ci~/packages/*.tgz"
+  dependencies:
+    - .yamato/project-pack.yml#pack_{{ project.name }}
+    - .yamato/_run-all.yml#run_all_tests
+
 {% endfor -%}

--- a/.yamato/project-publish.yml
+++ b/.yamato/project-publish.yml
@@ -17,12 +17,7 @@ publish_{{ project.name }}_{{ package.name }}:
         - "upm-ci~/packages/*.tgz"
   dependencies:
     - .yamato/project-pack.yml#pack_{{ project.name }}
-    - .yamato/project-tests.yml#validate_{{ project.name }}_{{ package.name }}_{{ test_platforms.first.name }}_{{ validation_editor }}
-{% for editor in project.test_editors -%}
-{% for platform in test_platforms -%}
-    - .yamato/project-tests.yml#test_{{ project.name }}_{{ package.name }}_{{ platform.name }}_{{ editor }}
-{% endfor -%}
-{% endfor -%}
+    - .yamato/project-tests.yml#validate_{{ package.name }}_{{ test_platforms.first.name }}_{{ validation_editor }}
 
 publish_{{ project.name }}_{{ package.name }}_dry_run:
   name: Publish Project {{project.name }} - Package {{ package.name }} to Internal Registry (dry-run)

--- a/.yamato/project-publish.yml
+++ b/.yamato/project-publish.yml
@@ -66,7 +66,7 @@ publish_{{ project.name }}:
     - .yamato/_run-all.yml#run_all_tests
 
 publish_{{ project.name }}_dry_run:
-  name: Publish ALL {{ project.name }} packages to Internal Registry
+  name: Publish ALL {{ project.name }} packages to Internal Registry (dry-run)
   agent:
     type: Unity::VM
     image: package-ci/win10:stable

--- a/.yamato/project-publish.yml
+++ b/.yamato/project-publish.yml
@@ -24,7 +24,7 @@ publish_{{ project.name }}_{{ package.name }}:
 {% endfor -%}
 {% endfor -%}
 
-publish_{{ project.name }}_{{ package.name }}:
+publish_{{ project.name }}_{{ package.name }}_dry_run:
   name: Publish Project {{project.name }} - Package {{ package.name }} to Internal Registry (dry-run)
   agent:
     type: Unity::VM

--- a/.yamato/project-publish.yml
+++ b/.yamato/project-publish.yml
@@ -39,12 +39,7 @@ publish_{{ project.name }}_{{ package.name }}_dry_run:
         - "upm-ci~/packages/*.tgz"
   dependencies:
     - .yamato/project-pack.yml#pack_{{ project.name }}
-    - .yamato/project-tests.yml#validate_{{ project.name }}_{{ package.name }}_{{ test_platforms.first.name }}_{{ validation_editor }}
-{% for editor in project.test_editors -%}
-{% for platform in test_platforms -%}
-    - .yamato/project-tests.yml#test_{{ project.name }}_{{ package.name }}_{{ platform.name }}_{{ editor }}
-{% endfor -%}
-{% endfor -%}
+    - .yamato/project-tests.yml#validate_{{ package.name }}_{{ test_platforms.first.name }}_{{ validation_editor }}
 
 {% endfor -%}
 

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -1,4 +1,4 @@
-validation_editor: 2021.1
+validation_editor: 2020.3
 
 # Platforms that will be tested. The first entry in this array will also
 # be used for validation

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -2,7 +2,7 @@
     "name": "com.unity.netcode.gameobjects",
     "displayName": "Netcode for GameObjects",
     "description": "Netcode for GameObjects is a high-level netcode SDK that provides networking capabilities to GameObject/MonoBehaviour workflows within Unity and sits on top of underlying transport layer.",
-    "version": "0.2.0",
+    "version": "0.2.0-preview.1",
     "unity": "2020.3",
     "dependencies": {
         "com.unity.modules.ai": "1.0.0",


### PR DESCRIPTION
This PR adds supports for dry-run jobs for the internal publish at a per packet level and also changes the validation editor to 2020.3 and fixes the dependencies for package specific publishes. 

Also adds the "prewiew.1" value to the package version. 
