### PR TITLE
fix: replace scenes in build index with full scene path hash value

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -292,8 +292,10 @@ namespace Unity.Netcode
         /// </summary>
         internal string SceneNameFromHash(uint sceneHash)
         {
-            // In the event there is no scene associated with the scene event
-            // (this can happen) then just return "No Scene";
+            // In the event there is no scene associated with the scene event then just return "No Scene"
+            // This can happen during unit tests when clients first connect and the only scene loaded is the 
+            // unit test scene (which is ignored by default) that results in a scene event that has no associated
+            // scene.  Under this specific special case, we just return "No Scene".
             if (sceneHash == 0)
             {
                 return "No Scene";

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -258,7 +258,6 @@ namespace Unity.Netcode
             }
         }
 
-
         /// <summary>
         /// Gets the scene name from full path to the scene
         /// </summary>

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -87,6 +87,7 @@ namespace Unity.Netcode
     public class NetworkSceneManager : IDisposable
     {
         private const NetworkDelivery k_DeliveryType = NetworkDelivery.ReliableFragmentedSequenced;
+        internal const int InvalidSceneNameOrPath = -1;
 
         // Used to be able to turn re-synchronization off for future snapshot development purposes.
         internal static bool DisableReSynchronization;
@@ -630,7 +631,7 @@ namespace Unity.Netcode
             }
 
             // Return invalid scene name status if the scene name is invalid
-            if (SceneUtility.GetBuildIndexByScenePath(sceneName) == -1)
+            if (SceneUtility.GetBuildIndexByScenePath(sceneName) == InvalidSceneNameOrPath)
             {
                 Debug.LogError($"Scene '{sceneName}' couldn't be loaded because it has not been added to the build settings scenes in build list.");
                 return new SceneEventProgress(null, SceneEventProgressStatus.InvalidSceneName);

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -565,16 +565,6 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// Gets the build Index value for the scene name
-        /// </summary>
-        /// <param name="sceneName">scene name</param>
-        /// <returns>build index</returns>
-        internal int GetBuildIndexFromSceneName(string sceneName)
-        {
-            return SceneUtility.GetBuildIndexByScenePath(sceneName);
-        }
-
-        /// <summary>
         /// Entry method for scene unloading validation
         /// </summary>
         /// <param name="scene">the scene to be unloaded</param>

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
@@ -94,7 +94,7 @@ namespace Unity.Netcode
         internal uint SceneEventId;
 
 
-        internal uint SceneIndex;
+        internal uint SceneHash;
         internal int SceneHandle;
 
         /// Only used for S2C_Synch scene events, this assures permissions when writing
@@ -154,18 +154,18 @@ namespace Unity.Netcode
         /// </summary>
         /// <param name="sceneIndex"></param>
         /// <param name="sceneHandle"></param>
-        internal void AddSceneToSynchronize(uint sceneIndex, int sceneHandle)
+        internal void AddSceneToSynchronize(uint sceneHash, int sceneHandle)
         {
-            ScenesToSynchronize.Enqueue(sceneIndex);
+            ScenesToSynchronize.Enqueue(sceneHash);
             SceneHandlesToSynchronize.Enqueue((uint)sceneHandle);
         }
 
         /// <summary>
         /// Client Side:
-        /// Gets the next scene index to be loaded for approval and/or late joining
+        /// Gets the next scene hash to be loaded for approval and/or late joining
         /// </summary>
         /// <returns></returns>
-        internal uint GetNextSceneSynchronizationIndex()
+        internal uint GetNextSceneSynchronizationHash()
         {
             return ScenesToSynchronize.Dequeue();
         }
@@ -323,7 +323,7 @@ namespace Unity.Netcode
             }
 
             // Write the scene index and handle
-            writer.WriteValueSafe(SceneIndex);
+            writer.WriteValueSafe(SceneHash);
             writer.WriteValueSafe(SceneHandle);
 
             switch (SceneEventType)
@@ -453,7 +453,7 @@ namespace Unity.Netcode
                 reader.ReadValueSafe(out SceneEventProgressId);
             }
 
-            reader.ReadValueSafe(out SceneIndex);
+            reader.ReadValueSafe(out SceneHash);
             reader.ReadValueSafe(out SceneHandle);
 
             switch (SceneEventType)

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
@@ -88,6 +88,9 @@ namespace Unity.Netcode
         /// </summary>
         internal bool AreAllClientsDoneLoading { get; private set; }
 
+        /// <summary>
+        /// The hash value generated from the full scene path
+        /// </summary>
         internal uint SceneHash { get; set; }
 
         internal Guid Guid { get; } = Guid.NewGuid();

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
@@ -88,7 +88,7 @@ namespace Unity.Netcode
         /// </summary>
         internal bool AreAllClientsDoneLoading { get; private set; }
 
-        internal uint SceneBuildIndex { get; set; }
+        internal uint SceneHash { get; set; }
 
         internal Guid Guid { get; } = Guid.NewGuid();
 

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -386,7 +386,7 @@ namespace TestProject.RuntimeTests
             // Test VerifySceneBeforeLoading with both server and client set to true
             ResetWait();
             m_ServerVerifyScene = m_ClientVerifyScene = true;
-            m_ExpectedSceneIndex = (int)m_ServerNetworkManager.SceneManager.GetBuildIndexFromSceneName(m_CurrentSceneName);
+            m_ExpectedSceneIndex = SceneUtility.GetBuildIndexByScenePath(m_CurrentSceneName);
             m_ExpectedSceneName = m_CurrentSceneName;
             m_ExpectedLoadMode = LoadSceneMode.Additive;
             var result = m_ServerNetworkManager.SceneManager.LoadScene(m_CurrentSceneName, LoadSceneMode.Additive);
@@ -416,7 +416,7 @@ namespace TestProject.RuntimeTests
             ResetWait();
             m_CurrentSceneName = "AdditiveScene2";
             m_ExpectedSceneName = m_CurrentSceneName;
-            m_ExpectedSceneIndex = (int)m_ServerNetworkManager.SceneManager.GetBuildIndexFromSceneName(m_CurrentSceneName);
+            m_ExpectedSceneIndex = SceneUtility.GetBuildIndexByScenePath(m_CurrentSceneName);
             m_ServerVerifyScene = true;
             m_ClientVerifyScene = false;
             m_IsTestingVerifyScene = true;
@@ -446,7 +446,7 @@ namespace TestProject.RuntimeTests
             // Test VerifySceneBeforeLoading with both server and client set to true
             ResetWait();
             m_ServerVerifyScene = m_ClientVerifyScene = true;
-            m_ExpectedSceneIndex = (int)m_ServerNetworkManager.SceneManager.GetBuildIndexFromSceneName(m_CurrentSceneName);
+            m_ExpectedSceneIndex = SceneUtility.GetBuildIndexByScenePath(m_CurrentSceneName);
             m_ExpectedSceneName = m_CurrentSceneName;
             m_ExpectedLoadMode = LoadSceneMode.Additive;
             var result = m_ServerNetworkManager.SceneManager.LoadScene(m_CurrentSceneName, LoadSceneMode.Additive);

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -576,7 +576,7 @@ namespace TestProject.RuntimeTests
 
             var sceneEventData = new SceneEventData(networkManager);
             sceneEventData.SceneEventType = SceneEventData.SceneEventTypes.S2C_Load;
-            sceneEventData.SceneIndex = 0;
+            sceneEventData.SceneHash = XXHash.Hash32("SomeRandomSceneName");
             sceneEventData.SceneEventProgressId = Guid.NewGuid();
             sceneEventData.LoadSceneMode = LoadSceneMode.Single;
             sceneEventData.SceneHandle = 32768;

--- a/testproject/Assets/Tests/Runtime/ObjectParenting/NetworkObjectParentingTests.cs
+++ b/testproject/Assets/Tests/Runtime/ObjectParenting/NetworkObjectParentingTests.cs
@@ -91,15 +91,11 @@ namespace Unity.Netcode.RuntimeTests
 
             // Start server and client NetworkManager instances
             Assert.That(MultiInstanceHelpers.Start(true, m_ServerNetworkManager, m_ClientNetworkManagers));
-            m_ServerNetworkManager.SceneManager.ScenesInBuild.Add(nameof(NetworkObjectParentingTests));
+
             // Register our scene verification delegate handler so we don't load the unit test scene
             m_ServerNetworkManager.SceneManager.VerifySceneBeforeLoading = VerifySceneBeforeLoading;
             foreach (var entry in m_ClientNetworkManagers)
             {
-                if (!entry.SceneManager.ScenesInBuild.Contains(nameof(NetworkObjectParentingTests)))
-                {
-                    entry.SceneManager.ScenesInBuild.Add(nameof(NetworkObjectParentingTests));
-                }
                 // Register our scene verification delegate handler so we don't load the unit test scene
                 entry.SceneManager.VerifySceneBeforeLoading = VerifySceneBeforeLoading;
             }

--- a/testproject/ProjectSettings/EditorBuildSettings.asset
+++ b/testproject/ProjectSettings/EditorBuildSettings.asset
@@ -92,4 +92,7 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Samples/Physics/PhysicsSample.unity
     guid: 2c76877ad66aa22458c62a0d74514a91
+  - enabled: 1
+    path: Assets/Tests/Runtime/ObjectParenting/NetworkObjectParentingTests.unity
+    guid: 7522f8723c5674939a3c24acfd83a688
   m_configObjects: {}


### PR DESCRIPTION
Migrate from Scenes in Build Index to hash value generated from full scene path.

It was determined that the NetworkSceneManager's implementation/usage of the Scenes in Build indices would create additional user pain in having to include all scenes in the build for both the client and on a server (specifically dedicated server). To avoid this issue, it was suggested/recommended using hash values of the full scene path in place of the scenes in build index values.  This would allow a dedicated server to not be required to have the exact same scenes in build settings and would provide a more robust solution to communicating "which scene" is to be loaded or unloaded.

[MTT-1389](https://jira.unity3d.com/browse/MTT-1389)
[MTT-1286](https://jira.unity3d.com/browse/MTT-1286) 


## Testing and Documentation
* Existing NetworkSceneManager unit tests are still working ( and passing )
* Validation of unique build settings has to be done manually 
* No documentation changes or additions were necessary.
