### PR TITLE
fix: Prevent multiple NetworkTransforms on the same object

### DIFF
--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -10,6 +10,7 @@ namespace Unity.Netcode.Components
     /// NetworkTransform will read the underlying transform and replicate it to clients.
     /// The replicated value will be automatically be interpolated (if active) and applied to the underlying GameObject's transform
     /// </summary>
+    [DisallowMultipleComponent]
     [AddComponentMenu("Netcode/" + nameof(NetworkTransform))]
     [DefaultExecutionOrder(100000)] // this is needed to catch the update time after the transform was updated by user scripts
     public class NetworkTransform : NetworkBehaviour

--- a/com.unity.netcode.gameobjects/Samples/ClientNetworkTransform/Scripts/ClientNetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Samples/ClientNetworkTransform/Scripts/ClientNetworkTransform.cs
@@ -1,4 +1,5 @@
 using Unity.Netcode.Components;
+using UnityEngine;
 
 namespace Unity.Netcode.Samples
 {
@@ -6,6 +7,7 @@ namespace Unity.Netcode.Samples
     /// Used for syncing a transform with client side changes. This includes host. Pure server as owner isn't supported by this. Please use NetworkTransform
     /// for transforms that'll always be owned by the server.
     /// </summary>
+    [DisallowMultipleComponent]
     public class ClientNetworkTransform : NetworkTransform
     {
         /// <summary>


### PR DESCRIPTION
<!-- Replace this line with what this PR does and why.  Describe what you'd like reviewers to know, how you applied the Engineering principles, and any interesting tradeoffs made.  Delete bullet points below that don't apply, and update the changelog section as appropriate. -->
Prevents multiple NetworkTransforms from being added. This prevents user confusion where a user could think a NetworkTransform and ClientNetworkTransform would have to be added. Now only one can be added.

<!-- Add JIRA link here. Short version (e.g. MTT-123) also works and gets auto-linked. -->
MTT-1248

<!-- Add RFC link here if applicable. -->

## Changelog

### com.unity.netcode.gameobjects
- Fixed: Multiple NetworkTransforms can no longer be added

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->