### PR TITLE
refactor: snapshot dependency injection

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkConfig.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkConfig.cs
@@ -141,11 +141,11 @@ namespace Unity.Netcode
         /// <summary>
         /// Whether or not to enable Snapshot System for variable updates. Not supported in this version.
         /// </summary>
-        public bool UseSnapshotDelta { get; } = false;
+        public bool UseSnapshotDelta { get; internal set;} = false;
         /// <summary>
         /// Whether or not to enable Snapshot System for spawn and despawn commands. Not supported in this version.
         /// </summary>
-        public bool UseSnapshotSpawn { get; } = false;
+        public bool UseSnapshotSpawn { get; internal set; } = false;
         /// <summary>
         /// When Snapshot System spawn is enabled: max size of Snapshot Messages. Meant to fit MTU.
         /// </summary>

--- a/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkConfig.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkConfig.cs
@@ -141,7 +141,7 @@ namespace Unity.Netcode
         /// <summary>
         /// Whether or not to enable Snapshot System for variable updates. Not supported in this version.
         /// </summary>
-        public bool UseSnapshotDelta { get; internal set;} = false;
+        public bool UseSnapshotDelta { get; internal set; } = false;
         /// <summary>
         /// Whether or not to enable Snapshot System for spawn and despawn commands. Not supported in this version.
         /// </summary>

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -21,7 +21,6 @@ namespace Unity.Netcode
         public bool IsServer { get; }
         public ulong ServerClientId { get; }
         public IReadOnlyList<ulong> ConnectedClientsIds { get; }
-        public IReadOnlyList<NetworkClient> ConnectedClientsList { get; }
         public bool IsConnectedClient { get; }
 
         public ulong LocalClientId { get; }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -16,11 +16,24 @@ using Debug = UnityEngine.Debug;
 
 namespace Unity.Netcode
 {
+    internal interface IClientServer
+    {
+        public bool IsServer { get; }
+        public ulong ServerClientId { get; }
+        public IReadOnlyList<ulong> ConnectedClientsIds { get; }
+        public NetworkSpawnManager SpawnManager { get; }
+        public IReadOnlyList<NetworkClient> ConnectedClientsList { get; }
+        public bool IsConnectedClient { get; }
+
+        public ulong LocalClientId { get; }
+
+        public int SendMessageInterface(in INetworkMessage message, NetworkDelivery delivery, ulong clientId);
+    };
     /// <summary>
     /// The main component of the library
     /// </summary>
     [AddComponentMenu("Netcode/" + nameof(NetworkManager), -100)]
-    public class NetworkManager : MonoBehaviour, INetworkUpdateSystem
+    public class NetworkManager : MonoBehaviour, INetworkUpdateSystem, IClientServer
     {
 #pragma warning disable IDE1006 // disable naming rule violation check
 
@@ -557,7 +570,7 @@ namespace Unity.Netcode
                 SnapshotSystem = null;
             }
 
-            SnapshotSystem = new SnapshotSystem(this);
+            SnapshotSystem = new SnapshotSystem(this, NetworkConfig, NetworkTickSystem);
 
             if (server)
             {
@@ -1295,6 +1308,11 @@ namespace Unity.Netcode
 #endif
                     break;
             }
+        }
+
+        public int SendMessageInterface(in INetworkMessage message, NetworkDelivery delivery, ulong clientId)
+        {
+            return SendMessage(message, delivery, clientId);
         }
 
         internal unsafe int SendMessage<TMessageType, TClientIdListType>(in TMessageType message, NetworkDelivery delivery, in TClientIdListType clientIds)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -26,7 +26,8 @@ namespace Unity.Netcode
 
         public ulong LocalClientId { get; }
 
-        public int SendMessageInterface(in INetworkMessage message, NetworkDelivery delivery, ulong clientId);
+        int SendMessage<T>(in T message, NetworkDelivery delivery, ulong clientId)
+            where T : INetworkMessage;
     };
     /// <summary>
     /// The main component of the library
@@ -1309,11 +1310,6 @@ namespace Unity.Netcode
             }
         }
 
-        public int SendMessageInterface(in INetworkMessage message, NetworkDelivery delivery, ulong clientId)
-        {
-            return SendMessage(message, delivery, clientId);
-        }
-
         internal unsafe int SendMessage<TMessageType, TClientIdListType>(in TMessageType message, NetworkDelivery delivery, in TClientIdListType clientIds)
             where TMessageType : INetworkMessage
             where TClientIdListType : IReadOnlyList<ulong>
@@ -1377,7 +1373,7 @@ namespace Unity.Netcode
             return SendMessage(message, delivery, (ulong*)clientIds.GetUnsafePtr(), clientIds.Length);
         }
 
-        internal int SendMessage<T>(in T message, NetworkDelivery delivery, ulong clientId)
+        public int SendMessage<T>(in T message, NetworkDelivery delivery, ulong clientId)
             where T : INetworkMessage
         {
             // Prevent server sending to itself

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -21,7 +21,6 @@ namespace Unity.Netcode
         public bool IsServer { get; }
         public ulong ServerClientId { get; }
         public IReadOnlyList<ulong> ConnectedClientsIds { get; }
-        public NetworkSpawnManager SpawnManager { get; }
         public IReadOnlyList<NetworkClient> ConnectedClientsList { get; }
         public bool IsConnectedClient { get; }
 
@@ -570,7 +569,7 @@ namespace Unity.Netcode
                 SnapshotSystem = null;
             }
 
-            SnapshotSystem = new SnapshotSystem(this, NetworkConfig, NetworkTickSystem);
+            SnapshotSystem = new SnapshotSystem(this, NetworkConfig, NetworkTickSystem, SpawnManager);
 
             if (server)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1373,7 +1373,13 @@ namespace Unity.Netcode
             return SendMessage(message, delivery, (ulong*)clientIds.GetUnsafePtr(), clientIds.Length);
         }
 
-        public int SendMessage<T>(in T message, NetworkDelivery delivery, ulong clientId)
+        int IClientServer.SendMessage<T>(in T message, NetworkDelivery delivery,
+            ulong clientId)
+        {
+            return SendMessage(message, delivery, clientId);
+        }
+
+        internal int SendMessage<T>(in T message, NetworkDelivery delivery, ulong clientId)
             where T : INetworkMessage
         {
             // Prevent server sending to itself

--- a/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
@@ -91,7 +91,7 @@ namespace Unity.Netcode
         internal int NumDespawns = 0;
 
         internal IClientServer NetworkManager;
-        internal NetworkSpawnManager networkSpawnManager;
+        internal NetworkSpawnManager NetworkSpawnManager;
 
         // indexed by ObjectId
         internal Dictionary<ulong, int> TickAppliedSpawn = new Dictionary<ulong, int>();
@@ -439,13 +439,13 @@ namespace Unity.Netcode
 
                 if (spawnCommand.ParentNetworkId == spawnCommand.NetworkObjectId)
                 {
-                    var networkObject = networkSpawnManager.CreateLocalNetworkObject(false, spawnCommand.GlobalObjectIdHash, spawnCommand.OwnerClientId, null, spawnCommand.ObjectPosition, spawnCommand.ObjectRotation);
-                    networkSpawnManager.SpawnNetworkObjectLocally(networkObject, spawnCommand.NetworkObjectId, true, spawnCommand.IsPlayerObject, spawnCommand.OwnerClientId, false);
+                    var networkObject = NetworkSpawnManager.CreateLocalNetworkObject(false, spawnCommand.GlobalObjectIdHash, spawnCommand.OwnerClientId, null, spawnCommand.ObjectPosition, spawnCommand.ObjectRotation);
+                    NetworkSpawnManager.SpawnNetworkObjectLocally(networkObject, spawnCommand.NetworkObjectId, true, spawnCommand.IsPlayerObject, spawnCommand.OwnerClientId, false);
                 }
                 else
                 {
-                    var networkObject = networkSpawnManager.CreateLocalNetworkObject(false, spawnCommand.GlobalObjectIdHash, spawnCommand.OwnerClientId, spawnCommand.ParentNetworkId, spawnCommand.ObjectPosition, spawnCommand.ObjectRotation);
-                    networkSpawnManager.SpawnNetworkObjectLocally(networkObject, spawnCommand.NetworkObjectId, true, spawnCommand.IsPlayerObject, spawnCommand.OwnerClientId, false);
+                    var networkObject = NetworkSpawnManager.CreateLocalNetworkObject(false, spawnCommand.GlobalObjectIdHash, spawnCommand.OwnerClientId, spawnCommand.ParentNetworkId, spawnCommand.ObjectPosition, spawnCommand.ObjectRotation);
+                    NetworkSpawnManager.SpawnNetworkObjectLocally(networkObject, spawnCommand.NetworkObjectId, true, spawnCommand.IsPlayerObject, spawnCommand.OwnerClientId, false);
                 }
             }
             for (var i = 0; i < message.Despawns.Length; i++)
@@ -462,10 +462,10 @@ namespace Unity.Netcode
 
                 // Debug.Log($"[DeSpawn] {despawnCommand.NetworkObjectId} {despawnCommand.TickWritten}");
 
-                networkSpawnManager.SpawnedObjects.TryGetValue(despawnCommand.NetworkObjectId,
+                NetworkSpawnManager.SpawnedObjects.TryGetValue(despawnCommand.NetworkObjectId,
                     out NetworkObject networkObject);
 
-                networkSpawnManager.OnDespawnObject(networkObject, true);
+                NetworkSpawnManager.OnDespawnObject(networkObject, true);
             }
         }
 
@@ -570,7 +570,7 @@ namespace Unity.Netcode
         /// <param name="key">The key to search for</param>
         private NetworkVariableBase FindNetworkVar(VariableKey key)
         {
-            var spawnedObjects = networkSpawnManager.SpawnedObjects;
+            var spawnedObjects = NetworkSpawnManager.SpawnedObjects;
 
             if (spawnedObjects.ContainsKey(key.NetworkObjectId))
             {
@@ -639,7 +639,7 @@ namespace Unity.Netcode
             m_NetworkSpawnManager = networkSpawnManager;
 
             m_Snapshot = new Snapshot();
-            m_Snapshot.networkSpawnManager = networkSpawnManager;
+            m_Snapshot.NetworkSpawnManager = networkSpawnManager;
             m_Snapshot.NetworkManager = networkManager;
 
             this.RegisterNetworkUpdate(NetworkUpdateStage.EarlyUpdate);

--- a/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
@@ -680,9 +680,9 @@ namespace Unity.Netcode
                     m_CurrentTick = tick;
                     if (m_NetworkManager.IsServer)
                     {
-                        for (int i = 0; i < m_NetworkManager.ConnectedClientsList.Count; i++)
+                        for (int i = 0; i < m_NetworkManager.ConnectedClientsIds.Count; i++)
                         {
-                            var clientId = m_NetworkManager.ConnectedClientsList[i].ClientId;
+                            var clientId = m_NetworkManager.ConnectedClientsIds[i];
 
                             // don't send to ourselves
                             if (clientId != m_NetworkManager.ServerClientId)

--- a/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
@@ -748,7 +748,7 @@ namespace Unity.Netcode
             WriteIndex(ref message);
             WriteSpawns(ref message, clientId);
 
-            m_NetworkManager.SendMessageInterface(message, NetworkDelivery.Unreliable, clientId);
+            m_NetworkManager.SendMessage(message, NetworkDelivery.Unreliable, clientId);
 
             m_ClientData[clientId].LastReceivedSequence = 0;
 

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/INetworkMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/INetworkMessage.cs
@@ -38,7 +38,7 @@ namespace Unity.Netcode
     /// <see cref="NetworkManager.SendMessage{T, U}(T, NetworkDelivery, U, bool)"/>
     /// <see cref="NetworkManager.SendMessage{T}(T, NetworkDelivery, NativeArray{ulong}, bool)"/>
     /// </summary>
-    public interface INetworkMessage
+    internal interface INetworkMessage
     {
         /// <summary>
         /// Used to serialize the message.

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/INetworkMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/INetworkMessage.cs
@@ -38,7 +38,7 @@ namespace Unity.Netcode
     /// <see cref="NetworkManager.SendMessage{T, U}(T, NetworkDelivery, U, bool)"/>
     /// <see cref="NetworkManager.SendMessage{T}(T, NetworkDelivery, NativeArray{ulong}, bool)"/>
     /// </summary>
-    internal interface INetworkMessage
+    public interface INetworkMessage
     {
         /// <summary>
         /// Used to serialize the message.

--- a/com.unity.netcode.gameobjects/Tests/Editor/SnapshotRttTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/SnapshotRttTests.cs
@@ -9,7 +9,7 @@ namespace Unity.Netcode.EditorTests
         [Test]
         public void TestBasicRtt()
         {
-            var snapshot = new SnapshotSystem(default, default, default);
+            var snapshot = new SnapshotSystem(default, default, default, default);
             var client1 = snapshot.GetConnectionRtt(0);
 
             client1.NotifySend(0, 0.0);
@@ -40,7 +40,7 @@ namespace Unity.Netcode.EditorTests
         [Test]
         public void TestEdgeCasesRtt()
         {
-            var snapshot = new SnapshotSystem(NetworkManager.Singleton, default, default);
+            var snapshot = new SnapshotSystem(NetworkManager.Singleton, default, default, default);
             var client1 = snapshot.GetConnectionRtt(0);
             var iterationCount = NetworkConfig.RttWindowSize * 3;
             var extraCount = NetworkConfig.RttWindowSize * 2;

--- a/com.unity.netcode.gameobjects/Tests/Editor/SnapshotRttTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/SnapshotRttTests.cs
@@ -9,7 +9,7 @@ namespace Unity.Netcode.EditorTests
         [Test]
         public void TestBasicRtt()
         {
-            var snapshot = new SnapshotSystem(default);
+            var snapshot = new SnapshotSystem(default, default, default);
             var client1 = snapshot.GetConnectionRtt(0);
 
             client1.NotifySend(0, 0.0);
@@ -40,7 +40,7 @@ namespace Unity.Netcode.EditorTests
         [Test]
         public void TestEdgeCasesRtt()
         {
-            var snapshot = new SnapshotSystem(NetworkManager.Singleton);
+            var snapshot = new SnapshotSystem(NetworkManager.Singleton, default, default);
             var client1 = snapshot.GetConnectionRtt(0);
             var iterationCount = NetworkConfig.RttWindowSize * 3;
             var extraCount = NetworkConfig.RttWindowSize * 2;


### PR DESCRIPTION
I would like comments on the approach shown in this PR.

In order to allow Snapshot testing, Snapshot is modified to rely on an interface instead of directly accessing the NetworkManager. This way, unit tests can trigger Snapshot to send just one message, for example, and verify that it does.

It that seems palatable, then the same would be done for the SpawnManager.