### PR TITLE
fix: dispatch metrics once per frame instead of once per tick (MTT-1391)

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -533,6 +533,7 @@ namespace Unity.Netcode
                 NetworkMetrics = new NullNetworkMetrics();
 #endif
             }
+            m_LastMetricsTickId = 0;
 
 #if MULTIPLAYER_TOOLS
             NetworkSolutionInterface.SetInterface(new NetworkSolutionInterfaceParameters

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -385,6 +385,7 @@ namespace Unity.Netcode
         public string ConnectedHostname { get; private set; }
 
         internal INetworkMetrics NetworkMetrics { get; private set; }
+        private int m_LastMetricsTickId;
 
         internal static event Action OnSingletonReady;
 
@@ -1165,6 +1166,11 @@ namespace Unity.Netcode
         private void OnNetworkPostLateUpdate()
         {
             m_MessagingSystem.ProcessSendQueues();
+            if (m_LastMetricsTickId != NetworkTickSystem.LocalTime.Tick)
+            {
+                NetworkMetrics.DispatchFrame();
+                m_LastMetricsTickId = NetworkTickSystem.LocalTime.Tick;
+            }
         }
 
         /// <summary>
@@ -1183,8 +1189,6 @@ namespace Unity.Netcode
             {
                 SyncTime();
             }
-
-            NetworkMetrics.DispatchFrame();
         }
 
         private void SendConnectionRequest()

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -385,7 +385,6 @@ namespace Unity.Netcode
         public string ConnectedHostname { get; private set; }
 
         internal INetworkMetrics NetworkMetrics { get; private set; }
-        private int m_LastMetricsTickId;
 
         internal static event Action OnSingletonReady;
 
@@ -533,7 +532,6 @@ namespace Unity.Netcode
                 NetworkMetrics = new NullNetworkMetrics();
 #endif
             }
-            m_LastMetricsTickId = 0;
 
 #if MULTIPLAYER_TOOLS
             NetworkSolutionInterface.SetInterface(new NetworkSolutionInterfaceParameters
@@ -1167,11 +1165,7 @@ namespace Unity.Netcode
         private void OnNetworkPostLateUpdate()
         {
             m_MessagingSystem.ProcessSendQueues();
-            if (m_LastMetricsTickId != NetworkTickSystem.LocalTime.Tick)
-            {
-                NetworkMetrics.DispatchFrame();
-                m_LastMetricsTickId = NetworkTickSystem.LocalTime.Tick;
-            }
+            NetworkMetrics.DispatchFrame();
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
@@ -37,6 +37,7 @@ namespace Unity.Netcode
         readonly EventMetric<ServerLogEvent> m_ServerLogReceivedEvent = new EventMetric<ServerLogEvent>(NetworkMetricTypes.ServerLogReceived.Id);
         readonly EventMetric<SceneEventMetric> m_SceneEventSentEvent = new EventMetric<SceneEventMetric>(NetworkMetricTypes.SceneEventSent.Id);
         readonly EventMetric<SceneEventMetric> m_SceneEventReceivedEvent = new EventMetric<SceneEventMetric>(NetworkMetricTypes.SceneEventReceived.Id);
+        private bool m_Dirty;
 
         readonly Dictionary<ulong, NetworkObjectIdentifier> m_NetworkGameObjects = new Dictionary<ulong, NetworkObjectIdentifier>();
 
@@ -82,16 +83,19 @@ namespace Unity.Netcode
         public void TrackNetworkMessageSent(ulong receivedClientId, string messageType, long bytesCount)
         {
             m_NetworkMessageSentEvent.Mark(new NetworkMessageEvent(new ConnectionInfo(receivedClientId), messageType, bytesCount));
+            MarkDirty();
         }
 
         public void TrackNetworkMessageReceived(ulong senderClientId, string messageType, long bytesCount)
         {
             m_NetworkMessageReceivedEvent.Mark(new NetworkMessageEvent(new ConnectionInfo(senderClientId), messageType, bytesCount));
+            MarkDirty();
         }
 
         public void TrackNamedMessageSent(ulong receiverClientId, string messageName, long bytesCount)
         {
             m_NamedMessageSentEvent.Mark(new NamedMessageEvent(new ConnectionInfo(receiverClientId), messageName, bytesCount));
+            MarkDirty();
         }
 
         public void TrackNamedMessageSent(IReadOnlyCollection<ulong> receiverClientIds, string messageName, long bytesCount)
@@ -105,11 +109,13 @@ namespace Unity.Netcode
         public void TrackNamedMessageReceived(ulong senderClientId, string messageName, long bytesCount)
         {
             m_NamedMessageReceivedEvent.Mark(new NamedMessageEvent(new ConnectionInfo(senderClientId), messageName, bytesCount));
+            MarkDirty();
         }
 
         public void TrackUnnamedMessageSent(ulong receiverClientId, long bytesCount)
         {
             m_UnnamedMessageSentEvent.Mark(new UnnamedMessageEvent(new ConnectionInfo(receiverClientId), bytesCount));
+            MarkDirty();
         }
 
         public void TrackUnnamedMessageSent(IReadOnlyCollection<ulong> receiverClientIds, long bytesCount)
@@ -123,6 +129,7 @@ namespace Unity.Netcode
         public void TrackUnnamedMessageReceived(ulong senderClientId, long bytesCount)
         {
             m_UnnamedMessageReceivedEvent.Mark(new UnnamedMessageEvent(new ConnectionInfo(senderClientId), bytesCount));
+            MarkDirty();
         }
 
         public void TrackNetworkVariableDeltaSent(
@@ -140,6 +147,7 @@ namespace Unity.Netcode
                     variableName,
                     networkBehaviourName,
                     bytesCount));
+            MarkDirty();
         }
 
         public void TrackNetworkVariableDeltaReceived(
@@ -157,32 +165,38 @@ namespace Unity.Netcode
                     variableName,
                     networkBehaviourName,
                     bytesCount));
+            MarkDirty();
         }
 
         public void TrackOwnershipChangeSent(ulong receiverClientId, ulong networkObjectId, string gameObjectName, long bytesCount)
         {
             m_OwnershipChangeSentEvent.Mark(new OwnershipChangeEvent(new ConnectionInfo(receiverClientId), new NetworkObjectIdentifier(gameObjectName, networkObjectId), bytesCount));
+            MarkDirty();
         }
 
         public void TrackOwnershipChangeReceived(ulong senderClientId, ulong networkObjectId, string gameObjectName, long bytesCount)
         {
             m_OwnershipChangeReceivedEvent.Mark(new OwnershipChangeEvent(new ConnectionInfo(senderClientId),
                 new NetworkObjectIdentifier(gameObjectName, networkObjectId), bytesCount));
+            MarkDirty();
         }
 
         public void TrackObjectSpawnSent(ulong receiverClientId, ulong networkObjectId, string gameObjectName, long bytesCount)
         {
             m_ObjectSpawnSentEvent.Mark(new ObjectSpawnedEvent(new ConnectionInfo(receiverClientId), new NetworkObjectIdentifier(gameObjectName, networkObjectId), bytesCount));
+            MarkDirty();
         }
 
         public void TrackObjectSpawnReceived(ulong senderClientId, ulong networkObjectId, string gameObjectName, long bytesCount)
         {
             m_ObjectSpawnReceivedEvent.Mark(new ObjectSpawnedEvent(new ConnectionInfo(senderClientId), new NetworkObjectIdentifier(gameObjectName, networkObjectId), bytesCount));
+            MarkDirty();
         }
 
         public void TrackObjectDestroySent(ulong receiverClientId, ulong networkObjectId, string gameObjectName, long bytesCount)
         {
             m_ObjectDestroySentEvent.Mark(new ObjectDestroyedEvent(new ConnectionInfo(receiverClientId), new NetworkObjectIdentifier(gameObjectName, networkObjectId), bytesCount));
+            MarkDirty();
         }
 
         public void TrackObjectDestroySent(IReadOnlyCollection<ulong> receiverClientIds, ulong networkObjectId, string gameObjectName, long bytesCount)
@@ -196,6 +210,7 @@ namespace Unity.Netcode
         public void TrackObjectDestroyReceived(ulong senderClientId, ulong networkObjectId, string gameObjectName, long bytesCount)
         {
             m_ObjectDestroyReceivedEvent.Mark(new ObjectDestroyedEvent(new ConnectionInfo(senderClientId), new NetworkObjectIdentifier(gameObjectName, networkObjectId), bytesCount));
+            MarkDirty();
         }
 
         public void TrackRpcSent(
@@ -217,6 +232,7 @@ namespace Unity.Netcode
                     rpcName,
                     networkBehaviourName,
                     bytesCount));
+            MarkDirty();
         }
 
         public void TrackRpcSent(
@@ -250,16 +266,19 @@ namespace Unity.Netcode
                     rpcName,
                     networkBehaviourName,
                     bytesCount));
+            MarkDirty();
         }
 
         public void TrackServerLogSent(ulong receiverClientId, uint logType, long bytesCount)
         {
             m_ServerLogSentEvent.Mark(new ServerLogEvent(new ConnectionInfo(receiverClientId), (Unity.Multiplayer.Tools.MetricTypes.LogLevel)logType, bytesCount));
+            MarkDirty();
         }
 
         public void TrackServerLogReceived(ulong senderClientId, uint logType, long bytesCount)
         {
             m_ServerLogReceivedEvent.Mark(new ServerLogEvent(new ConnectionInfo(senderClientId), (Unity.Multiplayer.Tools.MetricTypes.LogLevel)logType, bytesCount));
+            MarkDirty();
         }
 
         public void TrackSceneEventSent(IReadOnlyList<ulong> receiverClientIds, uint sceneEventType, string sceneName, long bytesCount)
@@ -273,16 +292,27 @@ namespace Unity.Netcode
         public void TrackSceneEventSent(ulong receiverClientId, uint sceneEventType, string sceneName, long bytesCount)
         {
             m_SceneEventSentEvent.Mark(new SceneEventMetric(new ConnectionInfo(receiverClientId), (SceneEventType)sceneEventType, sceneName, bytesCount));
+            MarkDirty();
         }
 
         public void TrackSceneEventReceived(ulong senderClientId, uint sceneEventType, string sceneName, long bytesCount)
         {
             m_SceneEventReceivedEvent.Mark(new SceneEventMetric(new ConnectionInfo(senderClientId), (SceneEventType)sceneEventType, sceneName, bytesCount));
+            MarkDirty();
         }
 
         public void DispatchFrame()
         {
-            Dispatcher.Dispatch();
+            if (m_Dirty)
+            {
+                Dispatcher.Dispatch();
+                m_Dirty = false;
+            }
+        }
+
+        private void MarkDirty()
+        {
+            m_Dirty = true;
         }
     }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/MetricsDispatchTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/MetricsDispatchTests.cs
@@ -35,13 +35,18 @@ namespace Unity.Netcode.RuntimeTests.Metrics
                 TickRate = m_TickRate
             }));
 
-            tickSystem.Tick += ()=> m_NumTicks++;
+            InitNetworkManager();
 
             var networkMetrics = m_NetworkManager.NetworkMetrics as NetworkMetrics;
             networkMetrics.Dispatcher.RegisterObserver(new MockMetricsObserver()
             {
                 OnObserve = ()=> m_NumDispatches++
             });
+        }
+
+        private void InitNetworkManager()
+        {
+            tickSystem.Tick += ()=> m_NumTicks++;
         }
 
         [TearDown]
@@ -84,6 +89,26 @@ namespace Unity.Netcode.RuntimeTests.Metrics
 
             Assert.AreEqual(0, m_NumTicks);
             Assert.AreEqual(0, m_NumDispatches);
+        }
+
+        [UnityTest]
+        public IEnumerator GivenReinitializedNetworkManagerAfterOneTickExecuted_WhenFirstTickExecuted_MetricsDispatch()
+        {
+            AdvanceTicks(1);
+            yield return null;
+
+            Assert.AreEqual(1, m_NumTicks);
+            Assert.AreEqual(1, m_NumDispatches);
+
+            m_NetworkManager.Shutdown();
+            m_NetworkManager.StartHost();
+            InitNetworkManager();
+
+            AdvanceTicks(1);
+            yield return null;
+
+            Assert.AreEqual(2, m_NumTicks);
+            Assert.AreEqual(2, m_NumDispatches);
         }
 
         private void AdvanceTicks(int numTicks)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/MetricsDispatchTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/MetricsDispatchTests.cs
@@ -1,0 +1,97 @@
+﻿#if MULTIPLAYER_TOOLS
+using System;
+using System.Collections;
+using NUnit.Framework;
+using Unity.Multiplayer.Tools.NetStats;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests.Metrics
+{
+    public class MetricsDispatchTests
+    {
+        private class MockMetricsObserver : IMetricObserver
+        {
+            public Action OnObserve;
+            public void Observe(MetricCollection collection) => OnObserve?.Invoke();
+        }
+
+        private int m_NumTicks;
+        private int m_NumDispatches;
+
+        private NetworkManager m_NetworkManager;
+        private NetworkTimeSystem timeSystem => m_NetworkManager.NetworkTimeSystem;
+        private NetworkTickSystem tickSystem => m_NetworkManager.NetworkTickSystem;
+        private uint m_TickRate = 1;
+
+        [SetUp]
+        public void SetUp()
+        {
+            Assert.IsTrue(NetworkManagerHelper.StartNetworkManager(
+                out m_NetworkManager,
+                NetworkManagerHelper.NetworkManagerOperatingMode.Host,
+                new NetworkConfig()
+            {
+                TickRate = m_TickRate
+            }));
+
+            tickSystem.Tick += ()=> m_NumTicks++;
+
+            var networkMetrics = m_NetworkManager.NetworkMetrics as NetworkMetrics;
+            networkMetrics.Dispatcher.RegisterObserver(new MockMetricsObserver()
+            {
+                OnObserve = ()=> m_NumDispatches++
+            });
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            NetworkManagerHelper.ShutdownNetworkManager();
+            m_NumTicks = default;
+            m_NumDispatches = default;
+            m_NetworkManager = default;
+        }
+
+        [UnityTest]
+        public IEnumerator GivenMultipleTicks_OneDispatchOccurs()
+        {
+            AdvanceTicks(2);
+
+            // Wait one frame so dispatch occurs
+            yield return null;
+
+            Assert.AreEqual(2, m_NumTicks);
+            Assert.AreEqual(1, m_NumDispatches);
+        }
+
+        [UnityTest]
+        public IEnumerator GivenOneTick_OneDispatchOccurs()
+        {
+            AdvanceTicks(1);
+
+            // Wait one frame so dispatch occurs
+            yield return null;
+
+            Assert.AreEqual(1, m_NumTicks);
+            Assert.AreEqual(1, m_NumDispatches);
+        }
+
+        [UnityTest]
+        public IEnumerator GivenZeroTicks_ZeroDispatchesOccur()
+        {
+            yield return null;
+
+            Assert.AreEqual(0, m_NumTicks);
+            Assert.AreEqual(0, m_NumDispatches);
+        }
+
+        private void AdvanceTicks(int numTicks)
+        {
+            timeSystem.Advance(1f / m_TickRate * (numTicks + 0.1f));
+            tickSystem.UpdateTick(timeSystem.LocalTime, timeSystem.ServerTime);
+        }
+
+    }
+}
+#endif

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/MetricsDispatchTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/MetricsDispatchTests.cs
@@ -1,4 +1,4 @@
-﻿#if MULTIPLAYER_TOOLS
+#if MULTIPLAYER_TOOLS
 using System;
 using System.Collections;
 using NUnit.Framework;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/MetricsDispatchTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/MetricsDispatchTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4833f15c8a59407abbb8532ea64b5683
+timeCreated: 1633451646


### PR DESCRIPTION
Currently the profiler only supports displaying one piece of data per frame, so this PR aligns the NGO metrics dispatch with that cycle. This fixes an issue where the profiler was not accurate when multiple ticks occur in a single frame.

https://jira.unity3d.com/browse/MTT-1391

## Changelog

N/A - regression within this release

## Testing and Documentation

* Added tests for metrics dispatch cycle
