### PR TITLE
fix: reduce debug string overhead in interpolation

### DIFF
--- a/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/RuntimeTestsHelpers.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/RuntimeTestsHelpers.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using System;
+using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;

--- a/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/RuntimeTestsHelpers.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/RuntimeTestsHelpers.cs
@@ -2,7 +2,6 @@ using NUnit.Framework;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 
 namespace Unity.Netcode.UTP.RuntimeTests

--- a/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
+++ b/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
@@ -151,7 +151,11 @@ namespace Unity.Netcode
 
                 if (Debug.isDebugBuild)
                 {
-                    Debug.Assert(t >= 0, $"t must be bigger than or equal to 0. range {range}, RenderTime {RenderTime}, Start time {m_StartTimeConsumed.Time}, end time {m_EndTimeConsumed.Time}");
+                    if (t >= 0)
+                    {
+                        string msg =  $"t must be bigger than or equal to 0. range {range}, RenderTime {RenderTime}, Start time {m_StartTimeConsumed.Time}, end time {m_EndTimeConsumed.Time}";
+                        Debug.LogWarning(msg);
+                    }
                 }
 
                 var target = InterpolateUnclamped(m_InterpStartValue, m_InterpEndValue, t);

--- a/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
+++ b/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
@@ -131,24 +131,24 @@ namespace Unity.Netcode
 
             if (m_LifetimeConsumedCount >= 1) // shouldn't interpolate between default values, let's wait to receive data first, should only interpolate between real measurements
             {
-                double range = m_EndTimeConsumed.Time - m_StartTimeConsumed.Time;
-                float t;
-                if (range == 0)
+                float t = 1.0f;
+                if (m_EndTimeConsumed.Time != m_StartTimeConsumed.Time)
                 {
-                    t = 1;
-                }
-                else
-                {
+                    double range = m_EndTimeConsumed.Time - m_StartTimeConsumed.Time;
                     t = (float)((RenderTime - m_StartTimeConsumed.Time) / range);
-                }
 
-                if (t > 3) // max extrapolation
-                {
-                    // TODO this causes issues with teleport, investigate
-                    // todo make this configurable
-                    t = 1;
-                }
+                    if (t < 0.0f)
+                    {
+                        throw new OverflowException($"t = {t} but must be >= 0. range {range}, RenderTime {RenderTime}, Start time {m_StartTimeConsumed.Time}, end time {m_EndTimeConsumed.Time}");
+                    }
 
+                    if (t > 3.0f) // max extrapolation
+                    {
+                        // TODO this causes issues with teleport, investigate
+                        // todo make this configurable
+                        t = 1.0f;
+                    }
+                }
 
                 var target = InterpolateUnclamped(m_InterpStartValue, m_InterpEndValue, t);
                 float maxInterpTime = 0.1f;

--- a/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
+++ b/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
@@ -149,14 +149,6 @@ namespace Unity.Netcode
                     t = 1;
                 }
 
-                if (Debug.isDebugBuild)
-                {
-                    if (t < 0)
-                    {
-                        Debug.LogWarning(
-                            $"t must be bigger than or equal to 0. range {range}, RenderTime {RenderTime}, Start time {m_StartTimeConsumed.Time}, end time {m_EndTimeConsumed.Time}");
-                    }
-                }
 
                 var target = InterpolateUnclamped(m_InterpStartValue, m_InterpEndValue, t);
                 float maxInterpTime = 0.1f;

--- a/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
+++ b/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
@@ -151,10 +151,10 @@ namespace Unity.Netcode
 
                 if (Debug.isDebugBuild)
                 {
-                    if (t >= 0)
+                    if (t < 0)
                     {
-                        string msg =  $"t must be bigger than or equal to 0. range {range}, RenderTime {RenderTime}, Start time {m_StartTimeConsumed.Time}, end time {m_EndTimeConsumed.Time}";
-                        Debug.LogWarning(msg);
+                        Debug.LogWarning(
+                            $"t must be bigger than or equal to 0. range {range}, RenderTime {RenderTime}, Start time {m_StartTimeConsumed.Time}, end time {m_EndTimeConsumed.Time}");
                     }
                 }
 


### PR DESCRIPTION
I replaced the `Debug.Assert()` message with the if check and log because otherwise at runtime the string is being generated whether the condition is true or not, and this at the very least blows out the results in the profiler

MTT-1392

## Changelog

## Testing and Documentation
* No tests have been added.