### PR TITLE
fix: improved scene event type names and new events with associated delegate declarations

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Unity.Multiplayer.Tools;
 using Unity.Multiplayer.Tools.MetricTypes;
 using Unity.Multiplayer.Tools.NetStats;
+using ToolsSceneEventType = Unity.Multiplayer.Tools.MetricTypes.SceneEventType;
 
 namespace Unity.Netcode
 {
@@ -266,13 +267,13 @@ namespace Unity.Netcode
 
         public void TrackSceneEventSent(ulong receiverClientId, uint sceneEventType, string sceneName, long bytesCount)
         {
-            m_SceneEventSentEvent.Mark(new SceneEventMetric(new ConnectionInfo(receiverClientId), (Multiplayer.Tools.MetricTypes.SceneEventType)sceneEventType, sceneName, bytesCount));
+            m_SceneEventSentEvent.Mark(new SceneEventMetric(new ConnectionInfo(receiverClientId), (ToolsSceneEventType)sceneEventType, sceneName, bytesCount));
             MarkDirty();
         }
 
         public void TrackSceneEventReceived(ulong senderClientId, uint sceneEventType, string sceneName, long bytesCount)
         {
-            m_SceneEventReceivedEvent.Mark(new SceneEventMetric(new ConnectionInfo(senderClientId), (Multiplayer.Tools.MetricTypes.SceneEventType)sceneEventType, sceneName, bytesCount));
+            m_SceneEventReceivedEvent.Mark(new SceneEventMetric(new ConnectionInfo(senderClientId), (ToolsSceneEventType)sceneEventType, sceneName, bytesCount));
             MarkDirty();
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
@@ -8,38 +8,38 @@ namespace Unity.Netcode
 {
     internal class NetworkMetrics : INetworkMetrics
     {
-        readonly Counter m_TransportBytesSent = new Counter(NetworkMetricTypes.TotalBytesSent.Id)
+        private readonly Counter m_TransportBytesSent = new Counter(NetworkMetricTypes.TotalBytesSent.Id)
         {
             ShouldResetOnDispatch = true,
         };
-        readonly Counter m_TransportBytesReceived = new Counter(NetworkMetricTypes.TotalBytesReceived.Id)
+        private readonly Counter m_TransportBytesReceived = new Counter(NetworkMetricTypes.TotalBytesReceived.Id)
         {
             ShouldResetOnDispatch = true,
         };
 
-        readonly EventMetric<NetworkMessageEvent> m_NetworkMessageSentEvent = new EventMetric<NetworkMessageEvent>(NetworkMetricTypes.NetworkMessageSent.Id);
-        readonly EventMetric<NetworkMessageEvent> m_NetworkMessageReceivedEvent = new EventMetric<NetworkMessageEvent>(NetworkMetricTypes.NetworkMessageReceived.Id);
-        readonly EventMetric<NamedMessageEvent> m_NamedMessageSentEvent = new EventMetric<NamedMessageEvent>(NetworkMetricTypes.NamedMessageSent.Id);
-        readonly EventMetric<NamedMessageEvent> m_NamedMessageReceivedEvent = new EventMetric<NamedMessageEvent>(NetworkMetricTypes.NamedMessageReceived.Id);
-        readonly EventMetric<UnnamedMessageEvent> m_UnnamedMessageSentEvent = new EventMetric<UnnamedMessageEvent>(NetworkMetricTypes.UnnamedMessageSent.Id);
-        readonly EventMetric<UnnamedMessageEvent> m_UnnamedMessageReceivedEvent = new EventMetric<UnnamedMessageEvent>(NetworkMetricTypes.UnnamedMessageReceived.Id);
-        readonly EventMetric<NetworkVariableEvent> m_NetworkVariableDeltaSentEvent = new EventMetric<NetworkVariableEvent>(NetworkMetricTypes.NetworkVariableDeltaSent.Id);
-        readonly EventMetric<NetworkVariableEvent> m_NetworkVariableDeltaReceivedEvent = new EventMetric<NetworkVariableEvent>(NetworkMetricTypes.NetworkVariableDeltaReceived.Id);
-        readonly EventMetric<OwnershipChangeEvent> m_OwnershipChangeSentEvent = new EventMetric<OwnershipChangeEvent>(NetworkMetricTypes.OwnershipChangeSent.Id);
-        readonly EventMetric<OwnershipChangeEvent> m_OwnershipChangeReceivedEvent = new EventMetric<OwnershipChangeEvent>(NetworkMetricTypes.OwnershipChangeReceived.Id);
-        readonly EventMetric<ObjectSpawnedEvent> m_ObjectSpawnSentEvent = new EventMetric<ObjectSpawnedEvent>(NetworkMetricTypes.ObjectSpawnedSent.Id);
-        readonly EventMetric<ObjectSpawnedEvent> m_ObjectSpawnReceivedEvent = new EventMetric<ObjectSpawnedEvent>(NetworkMetricTypes.ObjectSpawnedReceived.Id);
-        readonly EventMetric<ObjectDestroyedEvent> m_ObjectDestroySentEvent = new EventMetric<ObjectDestroyedEvent>(NetworkMetricTypes.ObjectDestroyedSent.Id);
-        readonly EventMetric<ObjectDestroyedEvent> m_ObjectDestroyReceivedEvent = new EventMetric<ObjectDestroyedEvent>(NetworkMetricTypes.ObjectDestroyedReceived.Id);
-        readonly EventMetric<RpcEvent> m_RpcSentEvent = new EventMetric<RpcEvent>(NetworkMetricTypes.RpcSent.Id);
-        readonly EventMetric<RpcEvent> m_RpcReceivedEvent = new EventMetric<RpcEvent>(NetworkMetricTypes.RpcReceived.Id);
-        readonly EventMetric<ServerLogEvent> m_ServerLogSentEvent = new EventMetric<ServerLogEvent>(NetworkMetricTypes.ServerLogSent.Id);
-        readonly EventMetric<ServerLogEvent> m_ServerLogReceivedEvent = new EventMetric<ServerLogEvent>(NetworkMetricTypes.ServerLogReceived.Id);
-        readonly EventMetric<SceneEventMetric> m_SceneEventSentEvent = new EventMetric<SceneEventMetric>(NetworkMetricTypes.SceneEventSent.Id);
-        readonly EventMetric<SceneEventMetric> m_SceneEventReceivedEvent = new EventMetric<SceneEventMetric>(NetworkMetricTypes.SceneEventReceived.Id);
+        private readonly EventMetric<NetworkMessageEvent> m_NetworkMessageSentEvent = new EventMetric<NetworkMessageEvent>(NetworkMetricTypes.NetworkMessageSent.Id);
+        private readonly EventMetric<NetworkMessageEvent> m_NetworkMessageReceivedEvent = new EventMetric<NetworkMessageEvent>(NetworkMetricTypes.NetworkMessageReceived.Id);
+        private readonly EventMetric<NamedMessageEvent> m_NamedMessageSentEvent = new EventMetric<NamedMessageEvent>(NetworkMetricTypes.NamedMessageSent.Id);
+        private readonly EventMetric<NamedMessageEvent> m_NamedMessageReceivedEvent = new EventMetric<NamedMessageEvent>(NetworkMetricTypes.NamedMessageReceived.Id);
+        private readonly EventMetric<UnnamedMessageEvent> m_UnnamedMessageSentEvent = new EventMetric<UnnamedMessageEvent>(NetworkMetricTypes.UnnamedMessageSent.Id);
+        private readonly EventMetric<UnnamedMessageEvent> m_UnnamedMessageReceivedEvent = new EventMetric<UnnamedMessageEvent>(NetworkMetricTypes.UnnamedMessageReceived.Id);
+        private readonly EventMetric<NetworkVariableEvent> m_NetworkVariableDeltaSentEvent = new EventMetric<NetworkVariableEvent>(NetworkMetricTypes.NetworkVariableDeltaSent.Id);
+        private readonly EventMetric<NetworkVariableEvent> m_NetworkVariableDeltaReceivedEvent = new EventMetric<NetworkVariableEvent>(NetworkMetricTypes.NetworkVariableDeltaReceived.Id);
+        private readonly EventMetric<OwnershipChangeEvent> m_OwnershipChangeSentEvent = new EventMetric<OwnershipChangeEvent>(NetworkMetricTypes.OwnershipChangeSent.Id);
+        private readonly EventMetric<OwnershipChangeEvent> m_OwnershipChangeReceivedEvent = new EventMetric<OwnershipChangeEvent>(NetworkMetricTypes.OwnershipChangeReceived.Id);
+        private readonly EventMetric<ObjectSpawnedEvent> m_ObjectSpawnSentEvent = new EventMetric<ObjectSpawnedEvent>(NetworkMetricTypes.ObjectSpawnedSent.Id);
+        private readonly EventMetric<ObjectSpawnedEvent> m_ObjectSpawnReceivedEvent = new EventMetric<ObjectSpawnedEvent>(NetworkMetricTypes.ObjectSpawnedReceived.Id);
+        private readonly EventMetric<ObjectDestroyedEvent> m_ObjectDestroySentEvent = new EventMetric<ObjectDestroyedEvent>(NetworkMetricTypes.ObjectDestroyedSent.Id);
+        private readonly EventMetric<ObjectDestroyedEvent> m_ObjectDestroyReceivedEvent = new EventMetric<ObjectDestroyedEvent>(NetworkMetricTypes.ObjectDestroyedReceived.Id);
+        private readonly EventMetric<RpcEvent> m_RpcSentEvent = new EventMetric<RpcEvent>(NetworkMetricTypes.RpcSent.Id);
+        private readonly EventMetric<RpcEvent> m_RpcReceivedEvent = new EventMetric<RpcEvent>(NetworkMetricTypes.RpcReceived.Id);
+        private readonly EventMetric<ServerLogEvent> m_ServerLogSentEvent = new EventMetric<ServerLogEvent>(NetworkMetricTypes.ServerLogSent.Id);
+        private readonly EventMetric<ServerLogEvent> m_ServerLogReceivedEvent = new EventMetric<ServerLogEvent>(NetworkMetricTypes.ServerLogReceived.Id);
+        private readonly EventMetric<SceneEventMetric> m_SceneEventSentEvent = new EventMetric<SceneEventMetric>(NetworkMetricTypes.SceneEventSent.Id);
+        private readonly EventMetric<SceneEventMetric> m_SceneEventReceivedEvent = new EventMetric<SceneEventMetric>(NetworkMetricTypes.SceneEventReceived.Id);
         private bool m_Dirty;
 
-        readonly Dictionary<ulong, NetworkObjectIdentifier> m_NetworkGameObjects = new Dictionary<ulong, NetworkObjectIdentifier>();
+        private readonly Dictionary<ulong, NetworkObjectIdentifier> m_NetworkGameObjects = new Dictionary<ulong, NetworkObjectIdentifier>();
 
         public NetworkMetrics()
         {
@@ -268,13 +268,13 @@ namespace Unity.Netcode
 
         public void TrackServerLogSent(ulong receiverClientId, uint logType, long bytesCount)
         {
-            m_ServerLogSentEvent.Mark(new ServerLogEvent(new ConnectionInfo(receiverClientId), (Unity.Multiplayer.Tools.MetricTypes.LogLevel)logType, bytesCount));
+            m_ServerLogSentEvent.Mark(new ServerLogEvent(new ConnectionInfo(receiverClientId), (Multiplayer.Tools.MetricTypes.LogLevel)logType, bytesCount));
             MarkDirty();
         }
 
         public void TrackServerLogReceived(ulong senderClientId, uint logType, long bytesCount)
         {
-            m_ServerLogReceivedEvent.Mark(new ServerLogEvent(new ConnectionInfo(senderClientId), (Unity.Multiplayer.Tools.MetricTypes.LogLevel)logType, bytesCount));
+            m_ServerLogReceivedEvent.Mark(new ServerLogEvent(new ConnectionInfo(senderClientId), (Multiplayer.Tools.MetricTypes.LogLevel)logType, bytesCount));
             MarkDirty();
         }
 
@@ -288,13 +288,13 @@ namespace Unity.Netcode
 
         public void TrackSceneEventSent(ulong receiverClientId, uint sceneEventType, string sceneName, long bytesCount)
         {
-            m_SceneEventSentEvent.Mark(new SceneEventMetric(new ConnectionInfo(receiverClientId), (SceneEventType)sceneEventType, sceneName, bytesCount));
+            m_SceneEventSentEvent.Mark(new SceneEventMetric(new ConnectionInfo(receiverClientId), (Multiplayer.Tools.MetricTypes.SceneEventType)sceneEventType, sceneName, bytesCount));
             MarkDirty();
         }
 
         public void TrackSceneEventReceived(ulong senderClientId, uint sceneEventType, string sceneName, long bytesCount)
         {
-            m_SceneEventReceivedEvent.Mark(new SceneEventMetric(new ConnectionInfo(senderClientId), (SceneEventType)sceneEventType, sceneName, bytesCount));
+            m_SceneEventReceivedEvent.Mark(new SceneEventMetric(new ConnectionInfo(senderClientId), (Multiplayer.Tools.MetricTypes.SceneEventType)sceneEventType, sceneName, bytesCount));
             MarkDirty();
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -113,8 +113,151 @@ namespace Unity.Netcode
         /// <summary>
         /// Event that will notify the local client or server of all scene events that take place
         /// For more details review over <see cref="SceneEvent"/>, <see cref="SceneEventData"/>, and <see cref="SceneEventData.SceneEventTypes"/>
+        /// Subscribe to this event to receive all <see cref="SceneEventData.SceneEventTypes"/> notifications
+        ///
+        /// Alternate Single Event Type Notification Registration Options
+        /// To receive only a specific event type notification or a limited set of notifications you can alternately subscribe to
+        /// each notification type individually via the following events:
+        /// -- <see cref="OnLoad"/> Invoked only when a <see cref="SceneEventData.SceneEventTypes.Load"/> event is being processed
+        /// -- <see cref="OnUnload"/> Invoked only when an <see cref="SceneEventData.SceneEventTypes.Unload"/> event is being processed
+        /// -- <see cref="OnSynchronize"/> Invoked only when a <see cref="SceneEventData.SceneEventTypes.Synchronize"/> event is being processed
+        /// -- <see cref="OnLoadEventCompleted"/> Invoked only when a <see cref="SceneEventData.SceneEventTypes.LoadEventCompleted"/> event is being processed
+        /// -- <see cref="OnUnloadEventCompleted"/> Invoked only when an <see cref="SceneEventData.SceneEventTypes.UnloadEventCompleted"/> event is being processed
+        /// -- <see cref="OnLoadComplete"/> Invoked only when a <see cref="SceneEventData.SceneEventTypes.LoadComplete"/> event is being processed
+        /// -- <see cref="OnUnloadComplete"/> Invoked only when an <see cref="SceneEventData.SceneEventTypes.UnloadComplete"/> event is being processed
+        /// -- <see cref="OnSynchronizeComplete"/> Invoked only when a <see cref="SceneEventData.SceneEventTypes.SynchronizeComplete"/> event is being processed
         /// </summary>
         public event SceneEventDelegate OnSceneEvent;
+
+        /// <summary>
+        /// Delegate declaration for the OnLoad event
+        /// View <see cref="SceneEventData.SceneEventTypes.Load"/> for more information
+        /// </summary>
+        /// <param name="cliendId">the client that is processing this event (the server will receive all of these events for every client and itself)</param>
+        /// <param name="sceneName">name of the scene being processed</param>
+        /// <param name="loadSceneMode">the LoadSceneMode mode for the scene being loaded</param>
+        /// <param name="asyncOperation">the associated <see cref="AsyncOperation"/> that can be used for scene loading progress</param>
+        public delegate void OnLoadDelegateHandler(ulong cliendId, string sceneName, LoadSceneMode loadSceneMode, AsyncOperation asyncOperation);
+
+        /// <summary>
+        /// Delegate declaration for the OnUnload event
+        /// View <see cref="SceneEventData.SceneEventTypes.Unload"/> for more information
+        /// </summary>
+        /// <param name="cliendId">the client that is processing this event (the server will receive all of these events for every client and itself)</param>
+        /// <param name="sceneName">name of the scene being processed</param>
+        /// <param name="asyncOperation">the associated <see cref="AsyncOperation"/> that can be used for scene unloading progress</param>
+        public delegate void OnUnloadDelegateHandler(ulong cliendId, string sceneName, AsyncOperation asyncOperation);
+
+        /// <summary>
+        /// Delegate declaration for the OnSynchronize event
+        /// View <see cref="SceneEventData.SceneEventTypes.Synchronize"/> for more information
+        /// </summary>
+        /// <param name="cliendId">the client that is processing this event (the server will receive all of these events for every client and itself)</param>
+        public delegate void OnSynchronizeDelegateHandler(ulong cliendId);
+
+        /// <summary>
+        /// Delegate declaration for the OnLoadEventCompleted event
+        /// View <see cref="SceneEventData.SceneEventTypes.LoadEventCompleted"/> for more information
+        /// </summary>
+        /// <param name="sceneName">scene pertaining to this event</param>
+        /// <param name="clientsCompleted">the clients that completed the loading event</param>
+        /// <param name="clientsTimedOut">the clients (if any) that timed out during the loading event</param>
+        public delegate void OnLoadEventCompletedDelegateHandler(string sceneName, List<ulong> clientsCompleted, List<ulong> clientsTimedOut);
+
+        /// <summary>
+        /// Delegate declaration for the OnUnloadEventCompleted event
+        /// View <see cref="SceneEventData.SceneEventTypes.UnloadEventCompleted"/> for more information
+        /// </summary>
+        /// <param name="sceneName">scene pertaining to this event</param>
+        /// <param name="clientsCompleted">the clients that completed the unloading event</param>
+        /// <param name="clientsTimedOut">the clients (if any) that timed out during the unloading event</param>
+        public delegate void OnUnloadEventCompletedDelegateHandler(string sceneName, List<ulong> clientsCompleted, List<ulong> clientsTimedOut);
+
+        /// <summary>
+        /// Delegate declaration for the OnLoadComplete event
+        /// View <see cref="SceneEventData.SceneEventTypes.LoadComplete"/> for more information
+        /// </summary>
+        /// <param name="cliendId">the client that is processing this event (the server will receive all of these events for every client and itself)</param>
+        /// <param name="sceneName">the scene name pertaining to this event</param>
+        /// <param name="loadSceneMode">the mode the scene was loaded in</param>
+        public delegate void OnLoadCompleteDelegateHandler(ulong cliendId, string sceneName, LoadSceneMode loadSceneMode);
+
+        /// <summary>
+        /// Delegate declaration for the OnUnloadComplete event
+        /// View <see cref="SceneEventData.SceneEventTypes.UnloadComplete"/> for more information
+        /// </summary>
+        /// <param name="cliendId">the client that is processing this event (the server will receive all of these events for every client and itself)</param>
+        /// <param name="sceneName">the scene name pertaining to this event</param>
+        public delegate void OnUnloadCompleteDelegateHandler(ulong cliendId, string sceneName);
+
+        /// <summary>
+        /// Delegate declaration for the OnUnloadComplete event
+        /// View <see cref="SceneEventData.SceneEventTypes.SynchronizeComplete"/> for more information
+        /// </summary>
+        /// <param name="cliendId">the client that completed this event</param>
+        public delegate void OnSynchronizeCompleteDelegateHandler(ulong cliendId);
+
+        /// <summary>
+        /// Invoked when a <see cref="SceneEventData.SceneEventTypes.Load"/> event is started by the server
+        /// The server and client(s) will receive this notification
+        /// </summary>
+        public event OnLoadDelegateHandler OnLoad;
+
+        /// <summary>
+        /// Invoked when a <see cref="SceneEventData.SceneEventTypes.Unload"/> event is started by the server
+        /// The server and client(s) will receive this notification
+        /// </summary>
+        public event OnUnloadDelegateHandler OnUnload;
+
+        /// <summary>
+        /// Invoked when a <see cref="SceneEventData.SceneEventTypes.Synchronize"/> event is started by the server
+        /// after a client is approved for connection in order to synchronize the client with the currently loaded
+        /// scenes and NetworkObjects.  This event signifies the beginning of the synchronization event.
+        /// The server and client will receive this notification
+        /// Note: this event is generated on a per newly connected and approved client basis
+        /// </summary>
+        public event OnSynchronizeDelegateHandler OnSynchronize;
+
+        /// <summary>
+        /// Invoked when a <see cref="SceneEventData.SceneEventTypes.LoadEventCompleted"/> event is generated by the server.
+        /// This event signifies the end of an existing <see cref="SceneEventData.SceneEventTypes.Load"/> event as it pertains
+        /// to all clients connected when the event was started.  This event signifies that all clients (and server) have
+        /// finished the <see cref="SceneEventData.SceneEventTypes.Load"/> event.
+        /// Note: this is useful to know when all clients have loaded the same scene (single or additive mode)
+        /// </summary>
+        public event OnLoadEventCompletedDelegateHandler OnLoadEventCompleted;
+
+        /// <summary>
+        /// Invoked when a <see cref="SceneEventData.SceneEventTypes.UnloadEventCompleted"/> event is generated by the server.
+        /// This event signifies the end of an existing <see cref="SceneEventData.SceneEventTypes.Unload"/> event as it pertains
+        /// to all clients connected when the event was started.  This event signifies that all clients (and server) have
+        /// finished the <see cref="SceneEventData.SceneEventTypes.Unload"/> event.
+        /// Note: this is useful to know when all clients have unloaded a specific scene
+        /// </summary>
+        public event OnUnloadEventCompletedDelegateHandler OnUnloadEventCompleted;
+
+        /// <summary>
+        /// Invoked when a <see cref="SceneEventData.SceneEventTypes.LoadComplete"/> event is generated by a client or server.
+        /// The server receives this message from all clients (including itself).
+        /// Each client receives their own notification sent to the server.
+        /// </summary>
+        public event OnLoadCompleteDelegateHandler OnLoadComplete;
+
+        /// <summary>
+        /// Invoked when a <see cref="SceneEventData.SceneEventTypes.UnloadComplete"/> event is generated by a client or server.
+        /// The server receives this message from all clients (including itself).
+        /// Each client receives their own notification sent to the server.
+        /// </summary>
+        public event OnUnloadCompleteDelegateHandler OnUnloadComplete;
+
+        /// <summary>
+        /// Invoked when a <see cref="SceneEventData.SceneEventTypes.SynchronizeComplete"/> event is generated by a client.
+        /// The server receives this message from the client, but will never generate this event for itself.
+        /// Each client receives their own notification sent to the server.
+        /// Note: This is useful to know that a client has completed the entire connection sequence, loaded all scenes, and
+        /// synchronized all NetworkObjects.
+        /// </summary>
+        public event OnSynchronizeCompleteDelegateHandler OnSynchronizeComplete;
 
         /// <summary>
         /// Delegate declaration for the <see cref="VerifySceneBeforeLoading"/> handler that provides
@@ -674,6 +817,16 @@ namespace Unity.Netcode
                 ClientsThatCompleted = sceneEventProgress.DoneClients,
                 ClientsThatTimedOut = m_NetworkManager.ConnectedClients.Keys.Except(sceneEventProgress.DoneClients).ToList(),
             });
+
+            if (sceneEventData.SceneEventType == SceneEventData.SceneEventTypes.LoadEventCompleted)
+            {
+                OnLoadEventCompleted?.Invoke(ScenesInBuild[(int)sceneEventData.SceneIndex], sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
+            }
+            else
+            {
+                OnUnloadEventCompleted?.Invoke(ScenesInBuild[(int)sceneEventData.SceneIndex], sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
+            }
+
             EndSceneEvent(sceneEventData.SceneEventId);
             return true;
         }
@@ -730,6 +883,8 @@ namespace Unity.Netcode
                 SceneName = sceneName,
                 ClientId = m_NetworkManager.ServerClientId  // Server can only invoke this
             });
+
+            OnUnload?.Invoke(m_NetworkManager.ServerClientId, sceneName, sceneUnload);
 
             //Return the status
             return sceneEventProgress.Status;
@@ -799,6 +954,7 @@ namespace Unity.Netcode
                 ClientId = m_NetworkManager.LocalClientId   // Server sent this message to the client, but client is executing it
             });
 
+            OnUnload?.Invoke(m_NetworkManager.ServerClientId, sceneName, sceneUnload);
 
 #if UNITY_EDITOR || DEVELOPMENT_BUILD
             if (m_IsRunningUnitTest)
@@ -841,6 +997,8 @@ namespace Unity.Netcode
                 SceneName = ScenesInBuild[(int)sceneEventData.SceneIndex],
                 ClientId = m_NetworkManager.IsServer ? m_NetworkManager.ServerClientId : m_NetworkManager.LocalClientId
             });
+
+            OnUnloadComplete?.Invoke(m_NetworkManager.ServerClientId, ScenesInBuild[(int)sceneEventData.SceneIndex]);
 
             // Clients send a notification back to the server they have completed the unload scene event
             if (!m_NetworkManager.IsServer)
@@ -942,6 +1100,8 @@ namespace Unity.Netcode
                 ClientId = m_NetworkManager.ServerClientId
             });
 
+            OnLoad?.Invoke(m_NetworkManager.ServerClientId, sceneName, sceneEventData.LoadSceneMode, sceneLoad);
+
             //Return our scene progress instance
             return sceneEventProgress.Status;
         }
@@ -985,6 +1145,9 @@ namespace Unity.Netcode
                     SceneName = sceneName,
                     ClientId = m_NetworkManager.LocalClientId
                 });
+
+                // Only for testing
+                OnLoad?.Invoke(m_NetworkManager.ServerClientId, sceneName, sceneEventData.LoadSceneMode, new AsyncOperation());
 
                 // Unit tests must mirror the server's scenes loaded dictionary, otherwise this portion will fail
                 if (ScenesLoaded.ContainsKey(sceneEventData.SceneHandle))
@@ -1031,6 +1194,8 @@ namespace Unity.Netcode
                 SceneName = sceneName,
                 ClientId = m_NetworkManager.LocalClientId
             });
+
+            OnLoad?.Invoke(m_NetworkManager.ServerClientId, sceneName, sceneEventData.LoadSceneMode, sceneLoad);
         }
 
 
@@ -1141,6 +1306,8 @@ namespace Unity.Netcode
                 Scene = scene,
             });
 
+            OnLoadComplete?.Invoke(m_NetworkManager.ServerClientId, ScenesInBuild[(int)sceneEventData.SceneIndex], sceneEventData.LoadSceneMode);
+
             //Second, set the server as having loaded for the associated SceneEventProgress
             if (SceneEventProgressTracking.ContainsKey(sceneEventData.SceneEventProgressId))
             {
@@ -1171,6 +1338,8 @@ namespace Unity.Netcode
                 ClientId = m_NetworkManager.LocalClientId,
                 Scene = scene,
             });
+
+            OnLoadComplete?.Invoke(m_NetworkManager.LocalClientId, ScenesInBuild[(int)sceneEventData.SceneIndex], sceneEventData.LoadSceneMode);
 
             EndSceneEvent(sceneEventId);
         }
@@ -1246,6 +1415,8 @@ namespace Unity.Netcode
                 ClientId = clientId
             });
 
+            OnSynchronize?.Invoke(clientId);
+
             EndSceneEvent(sceneEventData.SceneEventId);
         }
 
@@ -1288,6 +1459,8 @@ namespace Unity.Netcode
                     ClientId = m_NetworkManager.LocalClientId,
                 });
 
+                OnSynchronize?.Invoke(m_NetworkManager.LocalClientId);
+
                 // Clear the in-scene placed NetworkObjects when we load the first scene in our synchronization process
                 ScenePlacedObjects.Clear();
             }
@@ -1328,6 +1501,8 @@ namespace Unity.Netcode
                 SceneName = sceneName,
                 ClientId = m_NetworkManager.LocalClientId,
             });
+
+            OnLoad?.Invoke(m_NetworkManager.LocalClientId, sceneName, loadSceneMode, sceneLoad);
 
             if (shouldPassThrough)
             {
@@ -1400,6 +1575,8 @@ namespace Unity.Netcode
                 ClientId = m_NetworkManager.LocalClientId,
             });
 
+            OnLoadComplete?.Invoke(m_NetworkManager.LocalClientId, sceneName, loadSceneMode);
+
             // Check to see if we still have scenes to load and synchronize with
             HandleClientSceneEvent(sceneEventId);
         }
@@ -1443,6 +1620,9 @@ namespace Unity.Netcode
                             // All scenes are synchronized, let the server know we are done synchronizing
                             m_NetworkManager.IsConnectedClient = true;
 
+                            // Client is now synchronized and fully "connected".  This also means the client can send "RPCs" at this time
+                            m_NetworkManager.InvokeOnClientConnectedCallback(m_NetworkManager.LocalClientId);
+
                             // Notify the client that they have finished synchronizing
                             OnSceneEvent?.Invoke(new SceneEvent()
                             {
@@ -1450,8 +1630,7 @@ namespace Unity.Netcode
                                 ClientId = m_NetworkManager.LocalClientId, // Client sent this to the server
                             });
 
-                            // Client is now synchronized and fully "connected".  This also means the client can send "RPCs" at this time
-                            m_NetworkManager.InvokeOnClientConnectedCallback(m_NetworkManager.LocalClientId);
+                            OnSynchronizeComplete?.Invoke(m_NetworkManager.LocalClientId);
 
                             EndSceneEvent(sceneEventId);
                         }
@@ -1482,6 +1661,16 @@ namespace Unity.Netcode
                             ClientsThatCompleted = sceneEventData.ClientsCompleted,
                             ClientsThatTimedOut = sceneEventData.ClientsTimedOut,
                         });
+
+                        if(sceneEventData.SceneEventType == SceneEventData.SceneEventTypes.LoadEventCompleted)
+                        {
+                            OnLoadEventCompleted?.Invoke(ScenesInBuild[(int)sceneEventData.SceneIndex], sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
+                        }
+                        else
+                        {
+                            OnUnloadEventCompleted?.Invoke(ScenesInBuild[(int)sceneEventData.SceneIndex], sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
+                        }
+
                         EndSceneEvent(sceneEventId);
 
                         break;
@@ -1514,6 +1703,8 @@ namespace Unity.Netcode
                             ClientId = clientId
                         });
 
+                        OnLoadComplete?.Invoke(clientId, ScenesInBuild[(int)sceneEventData.SceneIndex], sceneEventData.LoadSceneMode);
+
                         if (SceneEventProgressTracking.ContainsKey(sceneEventData.SceneEventProgressId))
                         {
                             SceneEventProgressTracking[sceneEventData.SceneEventProgressId].AddClientAsDone(clientId);
@@ -1535,6 +1726,9 @@ namespace Unity.Netcode
                             SceneName = ScenesInBuild[(int)sceneEventData.SceneIndex],
                             ClientId = clientId
                         });
+
+                        OnUnloadComplete?.Invoke(clientId, ScenesInBuild[(int)sceneEventData.SceneIndex]);
+
                         EndSceneEvent(sceneEventId);
                         break;
                     }
@@ -1547,6 +1741,8 @@ namespace Unity.Netcode
                             SceneName = string.Empty,
                             ClientId = clientId
                         });
+
+                        OnSynchronizeComplete?.Invoke(clientId);
 
                         // While we did invoke the C2S_SyncComplete event notification, we will also call the traditional client connected callback on the server
                         // which assures the client is "ready to receive RPCs" as well.

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -971,7 +971,7 @@ namespace Unity.Netcode
                 ClientId = m_NetworkManager.LocalClientId   // Server sent this message to the client, but client is executing it
             });
 
-            OnUnload?.Invoke(m_NetworkManager.ServerClientId, sceneName, sceneUnload);
+            OnUnload?.Invoke(m_NetworkManager.LocalClientId, sceneName, sceneUnload);
 
 #if UNITY_INCLUDE_TESTS
             if (m_IsRunningUnitTest)
@@ -1015,7 +1015,7 @@ namespace Unity.Netcode
                 ClientId = m_NetworkManager.IsServer ? m_NetworkManager.ServerClientId : m_NetworkManager.LocalClientId
             });
 
-            OnUnloadComplete?.Invoke(m_NetworkManager.ServerClientId, SceneNameFromHash(sceneEventData.SceneHash));
+            OnUnloadComplete?.Invoke(m_NetworkManager.LocalClientId, SceneNameFromHash(sceneEventData.SceneHash));
 
             // Clients send a notification back to the server they have completed the unload scene event
             if (!m_NetworkManager.IsServer)
@@ -1202,7 +1202,7 @@ namespace Unity.Netcode
                 ClientId = m_NetworkManager.LocalClientId
             });
 
-            OnLoad?.Invoke(m_NetworkManager.ServerClientId, sceneName, sceneEventData.LoadSceneMode, sceneLoad);
+            OnLoad?.Invoke(m_NetworkManager.LocalClientId, sceneName, sceneEventData.LoadSceneMode, sceneLoad);
         }
 
 

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -15,67 +15,84 @@ namespace Unity.Netcode
     public class SceneEvent
     {
         /// <summary>
-        /// If applicable, this will be set to the <see cref="UnityEngine.AsyncOperation"/> returned by <see cref="SceneManager"/>
-        /// load scene and unload scene asynchronous methods.
+        /// The <see cref="UnityEngine.AsyncOperation"/> returned by <see cref="SceneManager"/>
+        /// This is set for the following <see cref="Netcode.SceneEventType"/>s:
+        /// <see cref="SceneEventType.Load"/>
+        /// <see cref="SceneEventType.Unload"/>
         /// </summary>
         public AsyncOperation AsyncOperation;
 
         /// <summary>
-        /// Will always be set to the current scene event type (<see cref="SceneEventData.SceneEventTypes"/>) this scene event notification pertains to
+        /// Will always be set to the current <see cref="Netcode.SceneEventType"/>
         /// </summary>
-        public SceneEventData.SceneEventTypes SceneEventType;
+        public SceneEventType SceneEventType;
 
         /// <summary>
         /// If applicable, this reflects the type of scene loading or unloading that is occurring.
-        /// Unlike <see cref="SceneManager"/>, scene unload events will have the original <see cref="LoadSceneMode"/> applied when the scene was loaded.
+        /// This is set for the following <see cref="Netcode.SceneEventType"/>s:
+        /// <see cref="SceneEventType.Load"/>
+        /// <see cref="SceneEventType.Unload"/>
+        /// <see cref="SceneEventType.LoadComplete"/>
+        /// <see cref="SceneEventType.UnloadComplete"/>
+        /// <see cref="SceneEventType.LoadEventCompleted"/>
+        /// <see cref="SceneEventType.UnloadEventCompleted"/>
         /// </summary>
         public LoadSceneMode LoadSceneMode;
 
         /// <summary>
-        /// Excluding <see cref="SceneEventData.SceneEventTypes.S2C_Event_Sync"/> and <see cref="SceneEventData.SceneEventTypes.C2S_Event_Sync_Complete"/>
         /// This will be set to the scene name that the event pertains to.
+        /// This is set for the following <see cref="Netcode.SceneEventType"/>s:
+        /// <see cref="SceneEventType.Load"/>
+        /// <see cref="SceneEventType.Unload"/>
+        /// <see cref="SceneEventType.LoadComplete"/>
+        /// <see cref="SceneEventType.UnloadComplete"/>
+        /// <see cref="SceneEventType.LoadEventCompleted"/>
+        /// <see cref="SceneEventType.UnloadEventCompleted"/>
         /// </summary>
         public string SceneName;
 
         /// <summary>
         /// When a scene is loaded, the Scene structure is returned.
+        /// This is set for the following <see cref="Netcode.SceneEventType"/>s:
+        /// <see cref="SceneEventType.LoadComplete"/>
         /// </summary>
         public Scene Scene;
 
         /// <summary>
-        /// Events that always set <see cref="ClientId"/> to the local client identifier
-        /// and only triggered locally:
-        /// <see cref="SceneEventData.SceneEventTypes.S2C_Load"/>
-        /// <see cref="SceneEventData.SceneEventTypes.S2C_Unload"/>
-        /// <see cref="SceneEventData.SceneEventTypes.S2C_Sync"/>
-        /// <see cref="SceneEventData.SceneEventTypes.S2C_ReSync"/>
+        /// Events that always set the <see cref="ClientId"/> to the local client identifier,
+        /// are initiated (and processed locally) by the server-host, and sent to all clients
+        /// to be processed:
+        /// <see cref="SceneEventType.Load"/>
+        /// <see cref="SceneEventType.Unload"/>
+        /// <see cref="SceneEventType.Synchronize"/>
+        /// <see cref="SceneEventType.ReSynchronize"/>
         ///
-        /// Events that always set <see cref="ClientId"/> to the local client identifier,
-        /// are triggered locally, and a host or server will trigger externally generated
-        /// scene event message types (i.e. sent by a client):
-        /// <see cref="SceneEventData.SceneEventTypes.C2S_UnloadComplete"/>
-        /// <see cref="SceneEventData.SceneEventTypes.C2S_LoadComplete"/>
-        /// <see cref="SceneEventData.SceneEventTypes.C2S_SyncComplete"/>
+        /// Events that always set the <see cref="ClientId"/> to the local client identifier,
+        /// are initiated (and processed locally) by a client or server-host, and if initiated
+        /// by a client will always be sent to and processed on the server-host:
+        /// <see cref="SceneEventType.LoadComplete"/>
+        /// <see cref="SceneEventType.UnloadComplete"/>
+        /// <see cref="SceneEventType.SynchronizeComplete"/>
         ///
-        /// Events that always set <see cref="ClientId"/> to the ServerId:
-        /// <see cref="SceneEventData.SceneEventTypes.S2C_LoadComplete"/>
-        /// <see cref="SceneEventData.SceneEventTypes.S2C_UnLoadComplete"/>
+        /// Events that always set the <see cref="ClientId"/> to the ServerId:
+        /// <see cref="SceneEventType.LoadEventCompleted"/>
+        /// <see cref="SceneEventType.UnloadEventCompleted"/>
         /// </summary>
         public ulong ClientId;
 
         /// <summary>
         /// List of clients that completed a loading or unloading event
-        /// Applies only to:
-        /// <see cref="SceneEventData.SceneEventTypes.S2C_LoadComplete"/>
-        /// <see cref="SceneEventData.SceneEventTypes.S2C_UnLoadComplete"/>
+        /// This is set for the following <see cref="Netcode.SceneEventType"/>s:
+        /// <see cref="SceneEventType.LoadEventCompleted"/>
+        /// <see cref="SceneEventType.UnloadEventCompleted"/>
         /// </summary>
         public List<ulong> ClientsThatCompleted;
 
         /// <summary>
         /// List of clients that timed out during a loading or unloading event
-        /// Applies only to:
-        /// <see cref="SceneEventData.SceneEventTypes.S2C_LoadComplete"/>
-        /// <see cref="SceneEventData.SceneEventTypes.S2C_UnLoadComplete"/>
+        /// This is set for the following <see cref="Netcode.SceneEventType"/>s:
+        /// <see cref="SceneEventType.LoadEventCompleted"/>
+        /// <see cref="SceneEventType.UnloadEventCompleted"/>
         /// </summary>
         public List<ulong> ClientsThatTimedOut;
     }
@@ -112,26 +129,26 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Event that will notify the local client or server of all scene events that take place
-        /// For more details review over <see cref="SceneEvent"/>, <see cref="SceneEventData"/>, and <see cref="SceneEventData.SceneEventTypes"/>
-        /// Subscribe to this event to receive all <see cref="SceneEventData.SceneEventTypes"/> notifications
+        /// For more details review over <see cref="SceneEvent"/>, <see cref="SceneEventData"/>, and <see cref="SceneEventType"/>
+        /// Subscribe to this event to receive all <see cref="SceneEventType"/> notifications
         ///
         /// Alternate Single Event Type Notification Registration Options
         /// To receive only a specific event type notification or a limited set of notifications you can alternately subscribe to
         /// each notification type individually via the following events:
-        /// -- <see cref="OnLoad"/> Invoked only when a <see cref="SceneEventData.SceneEventTypes.Load"/> event is being processed
-        /// -- <see cref="OnUnload"/> Invoked only when an <see cref="SceneEventData.SceneEventTypes.Unload"/> event is being processed
-        /// -- <see cref="OnSynchronize"/> Invoked only when a <see cref="SceneEventData.SceneEventTypes.Synchronize"/> event is being processed
-        /// -- <see cref="OnLoadEventCompleted"/> Invoked only when a <see cref="SceneEventData.SceneEventTypes.LoadEventCompleted"/> event is being processed
-        /// -- <see cref="OnUnloadEventCompleted"/> Invoked only when an <see cref="SceneEventData.SceneEventTypes.UnloadEventCompleted"/> event is being processed
-        /// -- <see cref="OnLoadComplete"/> Invoked only when a <see cref="SceneEventData.SceneEventTypes.LoadComplete"/> event is being processed
-        /// -- <see cref="OnUnloadComplete"/> Invoked only when an <see cref="SceneEventData.SceneEventTypes.UnloadComplete"/> event is being processed
-        /// -- <see cref="OnSynchronizeComplete"/> Invoked only when a <see cref="SceneEventData.SceneEventTypes.SynchronizeComplete"/> event is being processed
+        /// -- <see cref="OnLoad"/> Invoked only when a <see cref="SceneEventType.Load"/> event is being processed
+        /// -- <see cref="OnUnload"/> Invoked only when an <see cref="SceneEventType.Unload"/> event is being processed
+        /// -- <see cref="OnSynchronize"/> Invoked only when a <see cref="SceneEventType.Synchronize"/> event is being processed
+        /// -- <see cref="OnLoadEventCompleted"/> Invoked only when a <see cref="SceneEventType.LoadEventCompleted"/> event is being processed
+        /// -- <see cref="OnUnloadEventCompleted"/> Invoked only when an <see cref="SceneEventType.UnloadEventCompleted"/> event is being processed
+        /// -- <see cref="OnLoadComplete"/> Invoked only when a <see cref="SceneEventType.LoadComplete"/> event is being processed
+        /// -- <see cref="OnUnloadComplete"/> Invoked only when an <see cref="SceneEventType.UnloadComplete"/> event is being processed
+        /// -- <see cref="OnSynchronizeComplete"/> Invoked only when a <see cref="SceneEventType.SynchronizeComplete"/> event is being processed
         /// </summary>
         public event SceneEventDelegate OnSceneEvent;
 
         /// <summary>
         /// Delegate declaration for the OnLoad event
-        /// View <see cref="SceneEventData.SceneEventTypes.Load"/> for more information
+        /// View <see cref="SceneEventType.Load"/> for more information
         /// </summary>
         /// <param name="cliendId">the client that is processing this event (the server will receive all of these events for every client and itself)</param>
         /// <param name="sceneName">name of the scene being processed</param>
@@ -141,7 +158,7 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Delegate declaration for the OnUnload event
-        /// View <see cref="SceneEventData.SceneEventTypes.Unload"/> for more information
+        /// View <see cref="SceneEventType.Unload"/> for more information
         /// </summary>
         /// <param name="cliendId">the client that is processing this event (the server will receive all of these events for every client and itself)</param>
         /// <param name="sceneName">name of the scene being processed</param>
@@ -150,32 +167,25 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Delegate declaration for the OnSynchronize event
-        /// View <see cref="SceneEventData.SceneEventTypes.Synchronize"/> for more information
+        /// View <see cref="SceneEventType.Synchronize"/> for more information
         /// </summary>
         /// <param name="cliendId">the client that is processing this event (the server will receive all of these events for every client and itself)</param>
         public delegate void OnSynchronizeDelegateHandler(ulong cliendId);
 
         /// <summary>
-        /// Delegate declaration for the OnLoadEventCompleted event
-        /// View <see cref="SceneEventData.SceneEventTypes.LoadEventCompleted"/> for more information
+        /// Delegate declaration for the OnLoadEventCompleted and OnUnloadEventCompleted events
+        /// View <see cref="SceneEventType.LoadEventCompleted"/> for more information
+        /// View <see cref="SceneEventType.UnloadEventCompleted"/> for more information
         /// </summary>
         /// <param name="sceneName">scene pertaining to this event</param>
+        /// <param name="loadSceneMode"><see cref="LoadSceneMode"/> of the associated event completed</param>
         /// <param name="clientsCompleted">the clients that completed the loading event</param>
         /// <param name="clientsTimedOut">the clients (if any) that timed out during the loading event</param>
-        public delegate void OnLoadEventCompletedDelegateHandler(string sceneName, List<ulong> clientsCompleted, List<ulong> clientsTimedOut);
-
-        /// <summary>
-        /// Delegate declaration for the OnUnloadEventCompleted event
-        /// View <see cref="SceneEventData.SceneEventTypes.UnloadEventCompleted"/> for more information
-        /// </summary>
-        /// <param name="sceneName">scene pertaining to this event</param>
-        /// <param name="clientsCompleted">the clients that completed the unloading event</param>
-        /// <param name="clientsTimedOut">the clients (if any) that timed out during the unloading event</param>
-        public delegate void OnUnloadEventCompletedDelegateHandler(string sceneName, List<ulong> clientsCompleted, List<ulong> clientsTimedOut);
+        public delegate void OnEventCompletedDelegateHandler(string sceneName, LoadSceneMode loadSceneMode, List<ulong> clientsCompleted, List<ulong> clientsTimedOut);
 
         /// <summary>
         /// Delegate declaration for the OnLoadComplete event
-        /// View <see cref="SceneEventData.SceneEventTypes.LoadComplete"/> for more information
+        /// View <see cref="SceneEventType.LoadComplete"/> for more information
         /// </summary>
         /// <param name="cliendId">the client that is processing this event (the server will receive all of these events for every client and itself)</param>
         /// <param name="sceneName">the scene name pertaining to this event</param>
@@ -184,7 +194,7 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Delegate declaration for the OnUnloadComplete event
-        /// View <see cref="SceneEventData.SceneEventTypes.UnloadComplete"/> for more information
+        /// View <see cref="SceneEventType.UnloadComplete"/> for more information
         /// </summary>
         /// <param name="cliendId">the client that is processing this event (the server will receive all of these events for every client and itself)</param>
         /// <param name="sceneName">the scene name pertaining to this event</param>
@@ -192,25 +202,25 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Delegate declaration for the OnUnloadComplete event
-        /// View <see cref="SceneEventData.SceneEventTypes.SynchronizeComplete"/> for more information
+        /// View <see cref="SceneEventType.SynchronizeComplete"/> for more information
         /// </summary>
         /// <param name="cliendId">the client that completed this event</param>
         public delegate void OnSynchronizeCompleteDelegateHandler(ulong cliendId);
 
         /// <summary>
-        /// Invoked when a <see cref="SceneEventData.SceneEventTypes.Load"/> event is started by the server
+        /// Invoked when a <see cref="SceneEventType.Load"/> event is started by the server
         /// The server and client(s) will receive this notification
         /// </summary>
         public event OnLoadDelegateHandler OnLoad;
 
         /// <summary>
-        /// Invoked when a <see cref="SceneEventData.SceneEventTypes.Unload"/> event is started by the server
+        /// Invoked when a <see cref="SceneEventType.Unload"/> event is started by the server
         /// The server and client(s) will receive this notification
         /// </summary>
         public event OnUnloadDelegateHandler OnUnload;
 
         /// <summary>
-        /// Invoked when a <see cref="SceneEventData.SceneEventTypes.Synchronize"/> event is started by the server
+        /// Invoked when a <see cref="SceneEventType.Synchronize"/> event is started by the server
         /// after a client is approved for connection in order to synchronize the client with the currently loaded
         /// scenes and NetworkObjects.  This event signifies the beginning of the synchronization event.
         /// The server and client will receive this notification
@@ -219,39 +229,40 @@ namespace Unity.Netcode
         public event OnSynchronizeDelegateHandler OnSynchronize;
 
         /// <summary>
-        /// Invoked when a <see cref="SceneEventData.SceneEventTypes.LoadEventCompleted"/> event is generated by the server.
-        /// This event signifies the end of an existing <see cref="SceneEventData.SceneEventTypes.Load"/> event as it pertains
+        /// Invoked when a <see cref="SceneEventType.LoadEventCompleted"/> event is generated by the server.
+        /// This event signifies the end of an existing <see cref="SceneEventType.Load"/> event as it pertains
         /// to all clients connected when the event was started.  This event signifies that all clients (and server) have
-        /// finished the <see cref="SceneEventData.SceneEventTypes.Load"/> event.
+        /// finished the <see cref="SceneEventType.Load"/> event.
         /// Note: this is useful to know when all clients have loaded the same scene (single or additive mode)
         /// </summary>
-        public event OnLoadEventCompletedDelegateHandler OnLoadEventCompleted;
+        public event OnEventCompletedDelegateHandler OnLoadEventCompleted;
 
         /// <summary>
-        /// Invoked when a <see cref="SceneEventData.SceneEventTypes.UnloadEventCompleted"/> event is generated by the server.
-        /// This event signifies the end of an existing <see cref="SceneEventData.SceneEventTypes.Unload"/> event as it pertains
+        /// Invoked when a <see cref="SceneEventType.UnloadEventCompleted"/> event is generated by the server.
+        /// This event signifies the end of an existing <see cref="SceneEventType.Unload"/> event as it pertains
         /// to all clients connected when the event was started.  This event signifies that all clients (and server) have
-        /// finished the <see cref="SceneEventData.SceneEventTypes.Unload"/> event.
-        /// Note: this is useful to know when all clients have unloaded a specific scene
+        /// finished the <see cref="SceneEventType.Unload"/> event.
+        /// Note: this is useful to know when all clients have unloaded a specific scene.  The <see cref="LoadSceneMode"/> will
+        /// always be <see cref="LoadSceneMode.Additive"/> for this event
         /// </summary>
-        public event OnUnloadEventCompletedDelegateHandler OnUnloadEventCompleted;
+        public event OnEventCompletedDelegateHandler OnUnloadEventCompleted;
 
         /// <summary>
-        /// Invoked when a <see cref="SceneEventData.SceneEventTypes.LoadComplete"/> event is generated by a client or server.
+        /// Invoked when a <see cref="SceneEventType.LoadComplete"/> event is generated by a client or server.
         /// The server receives this message from all clients (including itself).
         /// Each client receives their own notification sent to the server.
         /// </summary>
         public event OnLoadCompleteDelegateHandler OnLoadComplete;
 
         /// <summary>
-        /// Invoked when a <see cref="SceneEventData.SceneEventTypes.UnloadComplete"/> event is generated by a client or server.
+        /// Invoked when a <see cref="SceneEventType.UnloadComplete"/> event is generated by a client or server.
         /// The server receives this message from all clients (including itself).
         /// Each client receives their own notification sent to the server.
         /// </summary>
         public event OnUnloadCompleteDelegateHandler OnUnloadComplete;
 
         /// <summary>
-        /// Invoked when a <see cref="SceneEventData.SceneEventTypes.SynchronizeComplete"/> event is generated by a client.
+        /// Invoked when a <see cref="SceneEventType.SynchronizeComplete"/> event is generated by a client.
         /// The server receives this message from the client, but will never generate this event for itself.
         /// Each client receives their own notification sent to the server.
         /// Note: This is useful to know that a client has completed the entire connection sequence, loaded all scenes, and
@@ -793,6 +804,7 @@ namespace Unity.Netcode
             sceneEventData.SceneIndex = sceneEventProgress.SceneBuildIndex;
             sceneEventData.SceneEventType = sceneEventProgress.SceneEventType;
             sceneEventData.ClientsCompleted = sceneEventProgress.DoneClients;
+            sceneEventData.LoadSceneMode = sceneEventProgress.LoadSceneMode;
             sceneEventData.ClientsTimedOut = m_NetworkManager.ConnectedClients.Keys.Except(sceneEventProgress.DoneClients).ToList();
 
             var message = new SceneEventMessage
@@ -812,19 +824,19 @@ namespace Unity.Netcode
             {
                 SceneEventType = sceneEventProgress.SceneEventType,
                 SceneName = ScenesInBuild[(int)sceneEventProgress.SceneBuildIndex],
-                ClientId = m_NetworkManager.ServerClientId,
                 LoadSceneMode = sceneEventProgress.LoadSceneMode,
+                ClientId = m_NetworkManager.ServerClientId,
                 ClientsThatCompleted = sceneEventProgress.DoneClients,
                 ClientsThatTimedOut = m_NetworkManager.ConnectedClients.Keys.Except(sceneEventProgress.DoneClients).ToList(),
             });
 
-            if (sceneEventData.SceneEventType == SceneEventData.SceneEventTypes.LoadEventCompleted)
+            if (sceneEventData.SceneEventType == SceneEventType.LoadEventCompleted)
             {
-                OnLoadEventCompleted?.Invoke(ScenesInBuild[(int)sceneEventData.SceneIndex], sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
+                OnLoadEventCompleted?.Invoke(ScenesInBuild[(int)sceneEventData.SceneIndex], sceneEventProgress.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
             }
             else
             {
-                OnUnloadEventCompleted?.Invoke(ScenesInBuild[(int)sceneEventData.SceneIndex], sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
+                OnUnloadEventCompleted?.Invoke(ScenesInBuild[(int)sceneEventData.SceneIndex], sceneEventProgress.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
             }
 
             EndSceneEvent(sceneEventData.SceneEventId);
@@ -861,12 +873,13 @@ namespace Unity.Netcode
             }
             var sceneEventData = BeginSceneEvent();
             sceneEventData.SceneEventProgressId = sceneEventProgress.Guid;
-            sceneEventData.SceneEventType = SceneEventData.SceneEventTypes.Unload;
+            sceneEventData.SceneEventType = SceneEventType.Unload;
             sceneEventData.SceneIndex = GetBuildIndexFromSceneName(sceneName);
+            sceneEventData.LoadSceneMode = LoadSceneMode.Additive; // The only scenes unloaded are scenes that were additively loaded
             sceneEventData.SceneHandle = sceneHandle;
 
             // This will be the message we send to everyone when this scene event sceneEventProgress is complete
-            sceneEventProgress.SceneEventType = SceneEventData.SceneEventTypes.UnloadEventCompleted;
+            sceneEventProgress.SceneEventType = SceneEventType.UnloadEventCompleted;
 
             ScenesLoaded.Remove(scene.handle);
 
@@ -892,7 +905,7 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Client Side:
-        /// Handles <see cref="SceneEventData.SceneEventTypes.S2C_Unload"/> scene events.
+        /// Handles <see cref="SceneEventType.Unload"/> scene events.
         /// </summary>
         private void OnClientUnloadScene(uint sceneEventId)
         {
@@ -949,7 +962,7 @@ namespace Unity.Netcode
             {
                 AsyncOperation = sceneUnload,
                 SceneEventType = sceneEventData.SceneEventType,
-                LoadSceneMode = sceneEventData.LoadSceneMode,
+                LoadSceneMode = LoadSceneMode.Additive,     // The only scenes unloaded are scenes that were additively loaded
                 SceneName = sceneName,
                 ClientId = m_NetworkManager.LocalClientId   // Server sent this message to the client, but client is executing it
             });
@@ -987,14 +1000,14 @@ namespace Unity.Netcode
             }
 
             // Next we prepare to send local notifications for unload complete
-            sceneEventData.SceneEventType = SceneEventData.SceneEventTypes.UnloadComplete;
+            sceneEventData.SceneEventType = SceneEventType.UnloadComplete;
 
             //Notify the client or server that a scene was unloaded
             OnSceneEvent?.Invoke(new SceneEvent()
             {
                 SceneEventType = sceneEventData.SceneEventType,
-                LoadSceneMode = sceneEventData.LoadSceneMode,
                 SceneName = ScenesInBuild[(int)sceneEventData.SceneIndex],
+                LoadSceneMode = LoadSceneMode.Additive, // The only scenes unloaded are scenes that were additively loaded
                 ClientId = m_NetworkManager.IsServer ? m_NetworkManager.ServerClientId : m_NetworkManager.LocalClientId
             });
 
@@ -1027,9 +1040,9 @@ namespace Unity.Netcode
                     OnSceneEvent?.Invoke(new SceneEvent()
                     {
                         AsyncOperation = SceneManager.UnloadSceneAsync(keyHandleEntry.Value),
-                        SceneEventType = SceneEventData.SceneEventTypes.Unload,
-                        LoadSceneMode = LoadSceneMode.Additive,
+                        SceneEventType = SceneEventType.Unload,
                         SceneName = keyHandleEntry.Value.name,
+                        LoadSceneMode = LoadSceneMode.Additive, // The only scenes unloaded are scenes that were additively loaded
                         ClientId = m_NetworkManager.ServerClientId
                     });
                 }
@@ -1054,14 +1067,14 @@ namespace Unity.Netcode
             }
 
             // This will be the message we send to everyone when this scene event sceneEventProgress is complete
-            sceneEventProgress.SceneEventType = SceneEventData.SceneEventTypes.LoadEventCompleted;
+            sceneEventProgress.SceneEventType = SceneEventType.LoadEventCompleted;
             sceneEventProgress.LoadSceneMode = loadSceneMode;
 
             var sceneEventData = BeginSceneEvent();
 
             // Now set up the current scene event
             sceneEventData.SceneEventProgressId = sceneEventProgress.Guid;
-            sceneEventData.SceneEventType = SceneEventData.SceneEventTypes.Load;
+            sceneEventData.SceneEventType = SceneEventType.Load;
             sceneEventData.SceneIndex = GetBuildIndexFromSceneName(sceneName);
             sceneEventData.LoadSceneMode = loadSceneMode;
 
@@ -1299,7 +1312,7 @@ namespace Unity.Netcode
             //First, notify local server that the scene was loaded
             OnSceneEvent?.Invoke(new SceneEvent()
             {
-                SceneEventType = SceneEventData.SceneEventTypes.LoadComplete,
+                SceneEventType = SceneEventType.LoadComplete,
                 LoadSceneMode = sceneEventData.LoadSceneMode,
                 SceneName = ScenesInBuild[(int)sceneEventData.SceneIndex],
                 ClientId = m_NetworkManager.ServerClientId,
@@ -1325,14 +1338,14 @@ namespace Unity.Netcode
             var sceneEventData = SceneEventDataStore[sceneEventId];
             sceneEventData.DeserializeScenePlacedObjects();
 
-            sceneEventData.SceneEventType = SceneEventData.SceneEventTypes.LoadComplete;
+            sceneEventData.SceneEventType = SceneEventType.LoadComplete;
             SendSceneEventData(sceneEventId, new ulong[] { m_NetworkManager.ServerClientId });
             s_IsSceneEventActive = false;
 
             // Notify local client that the scene was loaded
             OnSceneEvent?.Invoke(new SceneEvent()
             {
-                SceneEventType = SceneEventData.SceneEventTypes.LoadComplete,
+                SceneEventType = SceneEventType.LoadComplete,
                 LoadSceneMode = sceneEventData.LoadSceneMode,
                 SceneName = ScenesInBuild[(int)sceneEventData.SceneIndex],
                 ClientId = m_NetworkManager.LocalClientId,
@@ -1363,7 +1376,7 @@ namespace Unity.Netcode
             sceneEventData.TargetClientId = clientId;
             sceneEventData.LoadSceneMode = ClientSynchronizationMode;
             var activeScene = SceneManager.GetActiveScene();
-            sceneEventData.SceneEventType = SceneEventData.SceneEventTypes.Synchronize;
+            sceneEventData.SceneEventType = SceneEventType.Synchronize;
 
             // Organize how (and when) we serialize our NetworkObjects
             for (int i = 0; i < SceneManager.sceneCount; i++)
@@ -1408,7 +1421,7 @@ namespace Unity.Netcode
             m_NetworkManager.NetworkMetrics.TrackSceneEventSent(
                 clientId, (uint)sceneEventData.SceneEventType, "", bytesReported);
 
-            // Notify the local server that the client has been sent the SceneEventData.SceneEventTypes.S2C_Event_Sync event
+            // Notify the local server that the client has been sent the synchronize event
             OnSceneEvent?.Invoke(new SceneEvent()
             {
                 SceneEventType = sceneEventData.SceneEventType,
@@ -1421,7 +1434,7 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// This is called when the client receives the SCENE_EVENT of type SceneEventData.SceneEventTypes.SYNC
+        /// This is called when the client receives the <see cref="SceneEventType.Synchronize"/> event
         /// Note: This can recurse one additional time by the client if the current scene loaded by the client
         /// is already loaded.
         /// </summary>
@@ -1455,7 +1468,7 @@ namespace Unity.Netcode
             {
                 OnSceneEvent?.Invoke(new SceneEvent()
                 {
-                    SceneEventType = SceneEventData.SceneEventTypes.Synchronize,
+                    SceneEventType = SceneEventType.Synchronize,
                     ClientId = m_NetworkManager.LocalClientId,
                 });
 
@@ -1496,7 +1509,7 @@ namespace Unity.Netcode
             OnSceneEvent?.Invoke(new SceneEvent()
             {
                 AsyncOperation = sceneLoad,
-                SceneEventType = SceneEventData.SceneEventTypes.Load,
+                SceneEventType = SceneEventType.Load,
                 LoadSceneMode = loadSceneMode,
                 SceneName = sceneName,
                 ClientId = m_NetworkManager.LocalClientId,
@@ -1551,7 +1564,7 @@ namespace Unity.Netcode
             // Send notification back to server that we finished loading this scene
             var responseSceneEventData = BeginSceneEvent();
             responseSceneEventData.LoadSceneMode = loadSceneMode;
-            responseSceneEventData.SceneEventType = SceneEventData.SceneEventTypes.LoadComplete;
+            responseSceneEventData.SceneEventType = SceneEventType.LoadComplete;
             responseSceneEventData.SceneIndex = sceneIndex;
 
 
@@ -1568,7 +1581,7 @@ namespace Unity.Netcode
             // Send notification to local client that the scene has finished loading
             OnSceneEvent?.Invoke(new SceneEvent()
             {
-                SceneEventType = SceneEventData.SceneEventTypes.LoadComplete,
+                SceneEventType = SceneEventType.LoadComplete,
                 LoadSceneMode = loadSceneMode,
                 SceneName = sceneName,
                 Scene = nextScene,
@@ -1591,17 +1604,17 @@ namespace Unity.Netcode
             var sceneEventData = SceneEventDataStore[sceneEventId];
             switch (sceneEventData.SceneEventType)
             {
-                case SceneEventData.SceneEventTypes.Load:
+                case SceneEventType.Load:
                     {
                         OnClientSceneLoadingEvent(sceneEventId);
                         break;
                     }
-                case SceneEventData.SceneEventTypes.Unload:
+                case SceneEventType.Unload:
                     {
                         OnClientUnloadScene(sceneEventId);
                         break;
                     }
-                case SceneEventData.SceneEventTypes.Synchronize:
+                case SceneEventType.Synchronize:
                     {
                         if (!sceneEventData.IsDoneWithSynchronization())
                         {
@@ -1614,7 +1627,7 @@ namespace Unity.Netcode
                             // Synchronize the NetworkObjects for this scene
                             sceneEventData.SynchronizeSceneNetworkObjects(m_NetworkManager);
 
-                            sceneEventData.SceneEventType = SceneEventData.SceneEventTypes.SynchronizeComplete;
+                            sceneEventData.SceneEventType = SceneEventType.SynchronizeComplete;
                             SendSceneEventData(sceneEventId, new ulong[] { m_NetworkManager.ServerClientId });
 
                             // All scenes are synchronized, let the server know we are done synchronizing
@@ -1636,7 +1649,7 @@ namespace Unity.Netcode
                         }
                         break;
                     }
-                case SceneEventData.SceneEventTypes.ReSynchronize:
+                case SceneEventType.ReSynchronize:
                     {
                         // Notify the local client that they have been re-synchronized after being synchronized with an in progress game session
                         OnSceneEvent?.Invoke(new SceneEvent()
@@ -1648,27 +1661,27 @@ namespace Unity.Netcode
                         EndSceneEvent(sceneEventId);
                         break;
                     }
-                case SceneEventData.SceneEventTypes.LoadEventCompleted:
-                case SceneEventData.SceneEventTypes.UnloadEventCompleted:
+                case SceneEventType.LoadEventCompleted:
+                case SceneEventType.UnloadEventCompleted:
                     {
                         // Notify the local client that all clients have finished loading or unloading
                         OnSceneEvent?.Invoke(new SceneEvent()
                         {
                             SceneEventType = sceneEventData.SceneEventType,
+                            LoadSceneMode = sceneEventData.LoadSceneMode,
                             SceneName = ScenesInBuild[(int)sceneEventData.SceneIndex],
                             ClientId = m_NetworkManager.ServerClientId,
-                            LoadSceneMode = sceneEventData.LoadSceneMode,
                             ClientsThatCompleted = sceneEventData.ClientsCompleted,
                             ClientsThatTimedOut = sceneEventData.ClientsTimedOut,
                         });
 
-                        if (sceneEventData.SceneEventType == SceneEventData.SceneEventTypes.LoadEventCompleted)
+                        if (sceneEventData.SceneEventType == SceneEventType.LoadEventCompleted)
                         {
-                            OnLoadEventCompleted?.Invoke(ScenesInBuild[(int)sceneEventData.SceneIndex], sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
+                            OnLoadEventCompleted?.Invoke(ScenesInBuild[(int)sceneEventData.SceneIndex], sceneEventData.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
                         }
                         else
                         {
-                            OnUnloadEventCompleted?.Invoke(ScenesInBuild[(int)sceneEventData.SceneIndex], sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
+                            OnUnloadEventCompleted?.Invoke(ScenesInBuild[(int)sceneEventData.SceneIndex], sceneEventData.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
                         }
 
                         EndSceneEvent(sceneEventId);
@@ -1692,7 +1705,7 @@ namespace Unity.Netcode
             var sceneEventData = SceneEventDataStore[sceneEventId];
             switch (sceneEventData.SceneEventType)
             {
-                case SceneEventData.SceneEventTypes.LoadComplete:
+                case SceneEventType.LoadComplete:
                     {
                         // Notify the local server that the client has finished loading a scene
                         OnSceneEvent?.Invoke(new SceneEvent()
@@ -1712,7 +1725,7 @@ namespace Unity.Netcode
                         EndSceneEvent(sceneEventId);
                         break;
                     }
-                case SceneEventData.SceneEventTypes.UnloadComplete:
+                case SceneEventType.UnloadComplete:
                     {
                         if (SceneEventProgressTracking.ContainsKey(sceneEventData.SceneEventProgressId))
                         {
@@ -1722,7 +1735,6 @@ namespace Unity.Netcode
                         OnSceneEvent?.Invoke(new SceneEvent()
                         {
                             SceneEventType = sceneEventData.SceneEventType,
-                            LoadSceneMode = sceneEventData.LoadSceneMode,
                             SceneName = ScenesInBuild[(int)sceneEventData.SceneIndex],
                             ClientId = clientId
                         });
@@ -1732,7 +1744,7 @@ namespace Unity.Netcode
                         EndSceneEvent(sceneEventId);
                         break;
                     }
-                case SceneEventData.SceneEventTypes.SynchronizeComplete:
+                case SceneEventType.SynchronizeComplete:
                     {
                         // Notify the local server that a client has finished synchronizing
                         OnSceneEvent?.Invoke(new SceneEvent()
@@ -1744,13 +1756,16 @@ namespace Unity.Netcode
 
                         OnSynchronizeComplete?.Invoke(clientId);
 
-                        // While we did invoke the C2S_SyncComplete event notification, we will also call the traditional client connected callback on the server
-                        // which assures the client is "ready to receive RPCs" as well.
+                        // We now can call the client connected callback on the server at this time
+                        // This assures the client is fully synchronized with all loaded scenes and
+                        // NetworkObjects
                         m_NetworkManager.InvokeOnClientConnectedCallback(clientId);
 
+                        // TODO: This check and associated code can be removed once we determine all
+                        // snapshot destroy messages are being updated until the server receives ACKs
                         if (sceneEventData.ClientNeedsReSynchronization() && !DisableReSynchronization)
                         {
-                            sceneEventData.SceneEventType = SceneEventData.SceneEventTypes.ReSynchronize;
+                            sceneEventData.SceneEventType = SceneEventType.ReSynchronize;
                             SendSceneEventData(sceneEventId, new ulong[] { clientId });
 
                             OnSceneEvent?.Invoke(new SceneEvent()

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -202,7 +202,7 @@ namespace Unity.Netcode
         public delegate void OnUnloadCompleteDelegateHandler(ulong clientId, string sceneName);
 
         /// <summary>
-        /// Delegate declaration for the OnUnloadComplete event
+        /// Delegate declaration for the OnSynchronizeComplete event
         /// View <see cref="SceneEventType.SynchronizeComplete"/> for more information
         /// </summary>
         /// <param name="clientId">the client that completed this event</param>

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -447,7 +447,7 @@ namespace Unity.Netcode
         internal string SceneNameFromHash(uint sceneHash)
         {
             // In the event there is no scene associated with the scene event then just return "No Scene"
-            // This can happen during unit tests when clients first connect and the only scene loaded is the 
+            // This can happen during unit tests when clients first connect and the only scene loaded is the
             // unit test scene (which is ignored by default) that results in a scene event that has no associated
             // scene.  Under this specific special case, we just return "No Scene".
             if (sceneHash == 0)
@@ -846,11 +846,11 @@ namespace Unity.Netcode
 
             if (sceneEventData.SceneEventType == SceneEventType.LoadEventCompleted)
             {
-                OnLoadEventCompleted?.Invoke(ScenesInBuild[(int)sceneEventData.SceneIndex], sceneEventProgress.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
+                OnLoadEventCompleted?.Invoke(SceneNameFromHash(sceneEventProgress.SceneHash), sceneEventProgress.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
             }
             else
             {
-                OnUnloadEventCompleted?.Invoke(ScenesInBuild[(int)sceneEventData.SceneIndex], sceneEventProgress.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
+                OnUnloadEventCompleted?.Invoke(SceneNameFromHash(sceneEventProgress.SceneHash), sceneEventProgress.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
             }
 
             EndSceneEvent(sceneEventData.SceneEventId);
@@ -887,7 +887,7 @@ namespace Unity.Netcode
             }
             var sceneEventData = BeginSceneEvent();
             sceneEventData.SceneEventProgressId = sceneEventProgress.Guid;
-            sceneEventData.SceneEventType = SceneEventData.SceneEventTypes.S2C_Unload;
+            sceneEventData.SceneEventType = SceneEventType.Unload;
             sceneEventData.SceneHash = SceneHashFromNameOrPath(sceneName);
             sceneEventData.LoadSceneMode = LoadSceneMode.Additive; // The only scenes unloaded are scenes that were additively loaded
             sceneEventData.SceneHandle = sceneHandle;
@@ -1015,7 +1015,7 @@ namespace Unity.Netcode
                 ClientId = m_NetworkManager.IsServer ? m_NetworkManager.ServerClientId : m_NetworkManager.LocalClientId
             });
 
-            OnUnloadComplete?.Invoke(m_NetworkManager.ServerClientId, ScenesInBuild[(int)sceneEventData.SceneIndex]);
+            OnUnloadComplete?.Invoke(m_NetworkManager.ServerClientId, SceneNameFromHash(sceneEventData.SceneHash));
 
             // Clients send a notification back to the server they have completed the unload scene event
             if (!m_NetworkManager.IsServer)
@@ -1310,7 +1310,7 @@ namespace Unity.Netcode
                 Scene = scene,
             });
 
-            OnLoadComplete?.Invoke(m_NetworkManager.ServerClientId, ScenesInBuild[(int)sceneEventData.SceneIndex], sceneEventData.LoadSceneMode);
+            OnLoadComplete?.Invoke(m_NetworkManager.ServerClientId, SceneNameFromHash(sceneEventData.SceneHash), sceneEventData.LoadSceneMode);
 
             //Second, set the server as having loaded for the associated SceneEventProgress
             if (SceneEventProgressTracking.ContainsKey(sceneEventData.SceneEventProgressId))
@@ -1343,7 +1343,7 @@ namespace Unity.Netcode
                 Scene = scene,
             });
 
-            OnLoadComplete?.Invoke(m_NetworkManager.LocalClientId, ScenesInBuild[(int)sceneEventData.SceneIndex], sceneEventData.LoadSceneMode);
+            OnLoadComplete?.Invoke(m_NetworkManager.LocalClientId, SceneNameFromHash(sceneEventData.SceneHash), sceneEventData.LoadSceneMode);
 
             EndSceneEvent(sceneEventId);
         }
@@ -1653,11 +1653,11 @@ namespace Unity.Netcode
 
                         if (sceneEventData.SceneEventType == SceneEventType.LoadEventCompleted)
                         {
-                            OnLoadEventCompleted?.Invoke(ScenesInBuild[(int)sceneEventData.SceneIndex], sceneEventData.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
+                            OnLoadEventCompleted?.Invoke(SceneNameFromHash(sceneEventData.SceneHash), sceneEventData.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
                         }
                         else
                         {
-                            OnUnloadEventCompleted?.Invoke(ScenesInBuild[(int)sceneEventData.SceneIndex], sceneEventData.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
+                            OnUnloadEventCompleted?.Invoke(SceneNameFromHash(sceneEventData.SceneHash), sceneEventData.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
                         }
 
                         EndSceneEvent(sceneEventId);
@@ -1692,7 +1692,7 @@ namespace Unity.Netcode
                             ClientId = clientId
                         });
 
-                        OnLoadComplete?.Invoke(clientId, ScenesInBuild[(int)sceneEventData.SceneIndex], sceneEventData.LoadSceneMode);
+                        OnLoadComplete?.Invoke(clientId, SceneNameFromHash(sceneEventData.SceneHash), sceneEventData.LoadSceneMode);
 
                         if (SceneEventProgressTracking.ContainsKey(sceneEventData.SceneEventProgressId))
                         {
@@ -1716,7 +1716,7 @@ namespace Unity.Netcode
                             ClientId = clientId
                         });
 
-                        OnUnloadComplete?.Invoke(clientId, ScenesInBuild[(int)sceneEventData.SceneIndex]);
+                        OnUnloadComplete?.Invoke(clientId, SceneNameFromHash(sceneEventData.SceneHash));
 
                         EndSceneEvent(sceneEventId);
                         break;

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -971,7 +971,7 @@ namespace Unity.Netcode
                 ClientId = m_NetworkManager.LocalClientId   // Server sent this message to the client, but client is executing it
             });
 
-         OnUnload?.Invoke(m_NetworkManager.ServerClientId, sceneName, sceneUnload);
+            OnUnload?.Invoke(m_NetworkManager.ServerClientId, sceneName, sceneUnload);
 
 #if UNITY_INCLUDE_TESTS
             if (m_IsRunningUnitTest)

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1662,7 +1662,7 @@ namespace Unity.Netcode
                             ClientsThatTimedOut = sceneEventData.ClientsTimedOut,
                         });
 
-                        if(sceneEventData.SceneEventType == SceneEventData.SceneEventTypes.LoadEventCompleted)
+                        if (sceneEventData.SceneEventType == SceneEventData.SceneEventTypes.LoadEventCompleted)
                         {
                             OnLoadEventCompleted?.Invoke(ScenesInBuild[(int)sceneEventData.SceneIndex], sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
                         }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
@@ -8,96 +8,96 @@ using UnityEngine.SceneManagement;
 namespace Unity.Netcode
 {
     /// <summary>
+    /// The different types of scene events communicated between a server and client.
+    /// Used by <see cref="NetworkSceneManager"/> for <see cref="SceneEventMessage"/> messages
+    /// Note: This is only when <see cref="NetworkConfig.EnableSceneManagement"/> is enabled
+    /// See also: <see cref="SceneEvent"/>
+    /// </summary>
+    public enum SceneEventType : byte
+    {
+        /// <summary>
+        /// Load a scene
+        /// Invocation: Server Side
+        /// Message Flow: Server to client
+        /// Event Notification: Both server and client are notified a load scene event started
+        /// </summary>
+        Load,
+        /// <summary>
+        /// Unload a scene
+        /// Invocation: Server Side
+        /// Message Flow: Server to client
+        /// Event Notification: Both server and client are notified an unload scene event started
+        /// </summary>
+        Unload,
+        /// <summary>
+        /// Synchronize current game session state for approved clients
+        /// Invocation: Server Side
+        /// Message Flow: Server to client
+        /// Event Notification: Server and Client receives a local notification (server receives the ClientId being synchronized)
+        /// </summary>
+        Synchronize,
+        /// <summary>
+        /// Game session re-synchronization of NetworkOjects that were destroyed during a <see cref="Synchronize"/> event
+        /// Invocation: Server Side
+        /// Message Flow: Server to client
+        /// Event Notification: Both server and client receive a local notification
+        /// Note: This will be removed once snapshot and buffered messages are finalized as it will no longer be needed at that point
+        /// </summary>
+        ReSynchronize,
+        /// <summary>
+        /// All clients have finished loading a scene
+        /// Invocation: Server Side
+        /// Message Flow: Server to Client
+        /// Event Notification: Both server and client receive a local notification containing the clients that finished
+        /// as well as the clients that timed out (if any).
+        /// </summary>
+        LoadEventCompleted,
+        /// <summary>
+        /// All clients have unloaded a scene
+        /// Invocation: Server Side
+        /// Message Flow: Server to Client
+        /// Event Notification: Both server and client receive a local notification containing the clients that finished
+        /// as well as the clients that timed out (if any).
+        /// </summary>
+        UnloadEventCompleted,
+        /// <summary>
+        /// A client has finished loading a scene
+        /// Invocation: Client Side
+        /// Message Flow: Client to Server
+        /// Event Notification: Both server and client receive a local notification
+        /// </summary>
+        LoadComplete,
+        /// <summary>
+        /// A client has finished unloading a scene
+        /// Invocation: Client Side
+        /// Message Flow: Client to Server
+        /// Event Notification: Both server and client receive a local notification
+        /// </summary>
+        UnloadComplete,
+        /// <summary>
+        /// A client has finished synchronizing from a <see cref="Synchronize"/> event
+        /// Invocation: Client Side
+        /// Message Flow: Client to Server
+        /// Event Notification: Both server and client receive a local notification
+        /// </summary>
+        SynchronizeComplete,
+    }
+
+    /// <summary>
     /// Used by <see cref="NetworkSceneManager"/> for <see cref="SceneEventMessage"/> messages
     /// Note: This is only when <see cref="NetworkConfig.EnableSceneManagement"/> is enabled
     /// </summary>
-    public class SceneEventData : IDisposable
+    internal class SceneEventData : IDisposable
     {
-        /// <summary>
-        /// The different types of scene events communicated between a server and client.
-        /// </summary>
-        public enum SceneEventTypes : byte
-        {
-            /// <summary>
-            /// Load a scene
-            /// Invocation: Server Side
-            /// Message Flow: Server to client
-            /// Event Notification: Both server and client are notified a load scene event started
-            /// </summary>
-            Load,
-            /// <summary>
-            /// Unload a scene
-            /// Invocation: Server Side
-            /// Message Flow: Server to client
-            /// Event Notification: Both server and client are notified an unload scene event started
-            /// </summary>
-            Unload,
-            /// <summary>
-            /// Synchronize current game session state for approved clients
-            /// Invocation: Server Side
-            /// Message Flow: Server to client
-            /// Event Notification: Server and Client receives a local notification (server receives the ClientId being synchronized)
-            /// </summary>
-            Synchronize,
-            /// <summary>
-            /// Game session re-synchronization of NetworkOjects that were destroyed during a <see cref="Synchronize"/> event
-            /// Invocation: Server Side
-            /// Message Flow: Server to client
-            /// Event Notification: Both server and client receive a local notification
-            /// Note: This will be removed once snapshot and buffered messages are finalized as it will no longer be needed at that point
-            /// </summary>
-            ReSynchronize,
-            /// <summary>
-            /// All clients have finished loading a scene
-            /// Invocation: Server Side
-            /// Message Flow: Server to Client
-            /// Event Notification: Both server and client receive a local notification containing the clients that finished
-            /// as well as the clients that timed out (if any).
-            /// </summary>
-            LoadEventCompleted,
-            /// <summary>
-            /// All clients have unloaded a scene
-            /// Invocation: Server Side
-            /// Message Flow: Server to Client
-            /// Event Notification: Both server and client receive a local notification containing the clients that finished
-            /// as well as the clients that timed out (if any).
-            /// </summary>
-            UnloadEventCompleted,
-            /// <summary>
-            /// A client has finished loading a scene
-            /// Invocation: Client Side
-            /// Message Flow: Client to Server
-            /// Event Notification: Both server and client receive a local notification
-            /// </summary>
-            LoadComplete,
-            /// <summary>
-            /// A client has finished unloading a scene
-            /// Invocation: Client Side
-            /// Message Flow: Client to Server
-            /// Event Notification: Both server and client receive a local notification
-            /// </summary>
-            UnloadComplete,
-            /// <summary>
-            /// A client has finished synchronizing from a <see cref="Synchronize"/> event
-            /// Invocation: Client Side
-            /// Message Flow: Client to Server
-            /// Event Notification: Both server and client receive a local notification
-            /// </summary>
-            SynchronizeComplete,
-        }
-
-        internal SceneEventTypes SceneEventType;
+        internal SceneEventType SceneEventType;
         internal LoadSceneMode LoadSceneMode;
         internal Guid SceneEventProgressId;
         internal uint SceneEventId;
-
-
         internal uint SceneIndex;
         internal int SceneHandle;
 
-        /// Only used for S2C_Synch scene events, this assures permissions when writing
-        /// NetworkVariable information.  If that process changes, then we need to update
-        /// this
+        /// Only used for <see cref="SceneEventType.Synchronize"/> scene events, this assures permissions when writing
+        /// NetworkVariable information.  If that process changes, then we need to update this
         internal ulong TargetClientId;
 
         private Dictionary<uint, List<NetworkObject>> m_SceneNetworkObjects;
@@ -123,13 +123,6 @@ namespace Unity.Netcode
         internal FastBufferReader InternalBuffer;
 
         private NetworkManager m_NetworkManager;
-
-        /// <summary>
-        /// Client side and only applies to the following scene event types:
-        /// <see cref="C2S_LoadComplete"/>
-        /// <see cref="C2S_UnLoadComplete"/>
-        /// </summary>
-        internal SceneEvent SceneEvent;
 
         internal List<ulong> ClientsCompleted;
         internal List<ulong> ClientsTimedOut;
@@ -262,12 +255,12 @@ namespace Unity.Netcode
         {
             switch (SceneEventType)
             {
-                case SceneEventTypes.Load:
-                case SceneEventTypes.Unload:
-                case SceneEventTypes.Synchronize:
-                case SceneEventTypes.ReSynchronize:
-                case SceneEventTypes.LoadEventCompleted:
-                case SceneEventTypes.UnloadEventCompleted:
+                case SceneEventType.Load:
+                case SceneEventType.Unload:
+                case SceneEventType.Synchronize:
+                case SceneEventType.ReSynchronize:
+                case SceneEventType.LoadEventCompleted:
+                case SceneEventType.UnloadEventCompleted:
                     {
                         return true;
                     }
@@ -303,7 +296,7 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Client and Server Side:
-        /// Serializes data based on the SceneEvent type (<see cref="SceneEventTypes"/>)
+        /// Serializes data based on the SceneEvent type (<see cref="SceneEventType"/>)
         /// </summary>
         /// <param name="writer"><see cref="FastBufferWriter"/> to write the scene event data</param>
         internal void Serialize(FastBufferWriter writer)
@@ -315,7 +308,7 @@ namespace Unity.Netcode
             writer.WriteValueSafe(LoadSceneMode);
 
             // Write the scene event progress Guid
-            if (SceneEventType != SceneEventTypes.Synchronize)
+            if (SceneEventType != SceneEventType.Synchronize)
             {
                 writer.WriteValueSafe(SceneEventProgressId);
             }
@@ -326,28 +319,28 @@ namespace Unity.Netcode
 
             switch (SceneEventType)
             {
-                case SceneEventTypes.Synchronize:
+                case SceneEventType.Synchronize:
                     {
                         WriteSceneSynchronizationData(writer);
                         break;
                     }
-                case SceneEventTypes.Load:
+                case SceneEventType.Load:
                     {
                         SerializeScenePlacedObjects(writer);
                         break;
                     }
-                case SceneEventTypes.SynchronizeComplete:
+                case SceneEventType.SynchronizeComplete:
                     {
                         WriteClientSynchronizationResults(writer);
                         break;
                     }
-                case SceneEventTypes.ReSynchronize:
+                case SceneEventType.ReSynchronize:
                     {
                         WriteClientReSynchronizationData(writer);
                         break;
                     }
-                case SceneEventTypes.LoadEventCompleted:
-                case SceneEventTypes.UnloadEventCompleted:
+                case SceneEventType.LoadEventCompleted:
+                case SceneEventType.UnloadEventCompleted:
                     {
                         WriteSceneEventProgressDone(writer);
                         break;
@@ -357,7 +350,7 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Server Side:
-        /// Called at the end of an S2C_Load event once the scene is loaded and scene placed NetworkObjects
+        /// Called at the end of a <see cref="SceneEventType.Load"/> event once the scene is loaded and scene placed NetworkObjects
         /// have been locally spawned
         /// </summary>
         internal void WriteSceneSynchronizationData(FastBufferWriter writer)
@@ -399,7 +392,7 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Server Side:
-        /// Called at the end of an S2C_Load event once the scene is loaded and scene placed NetworkObjects
+        /// Called at the end of a <see cref="SceneEventType.Load"/> event once the scene is loaded and scene placed NetworkObjects
         /// have been locally spawned
         /// Maximum number of objects that could theoretically be synchronized is 65536
         /// </summary>
@@ -446,7 +439,7 @@ namespace Unity.Netcode
             reader.ReadValueSafe(out SceneEventType);
             reader.ReadValueSafe(out LoadSceneMode);
 
-            if (SceneEventType != SceneEventTypes.Synchronize)
+            if (SceneEventType != SceneEventType.Synchronize)
             {
                 reader.ReadValueSafe(out SceneEventProgressId);
             }
@@ -456,17 +449,17 @@ namespace Unity.Netcode
 
             switch (SceneEventType)
             {
-                case SceneEventTypes.Synchronize:
+                case SceneEventType.Synchronize:
                     {
                         CopySceneSyncrhonizationData(reader);
                         break;
                     }
-                case SceneEventTypes.SynchronizeComplete:
+                case SceneEventType.SynchronizeComplete:
                     {
                         CheckClientSynchronizationResults(reader);
                         break;
                     }
-                case SceneEventTypes.Load:
+                case SceneEventType.Load:
                     {
                         unsafe
                         {
@@ -477,13 +470,13 @@ namespace Unity.Netcode
                         }
                         break;
                     }
-                case SceneEventTypes.ReSynchronize:
+                case SceneEventType.ReSynchronize:
                     {
                         ReadClientReSynchronizationData(reader);
                         break;
                     }
-                case SceneEventTypes.LoadEventCompleted:
-                case SceneEventTypes.UnloadEventCompleted:
+                case SceneEventType.LoadEventCompleted:
+                case SceneEventType.UnloadEventCompleted:
                     {
                         ReadSceneEventProgressDone(reader);
                         break;
@@ -521,7 +514,7 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Client Side:
-        /// This needs to occur at the end of a S2C_Load event when the scene has finished loading
+        /// This needs to occur at the end of a <see cref="SceneEventType.Load"/> event when the scene has finished loading
         /// Maximum number of objects that could theoretically be synchronized is 65536
         /// </summary>
         internal void DeserializeScenePlacedObjects()

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
@@ -99,7 +99,7 @@ namespace Unity.Netcode
 
         internal SceneEventProgressStatus Status { get; set; }
 
-        internal SceneEventData.SceneEventTypes SceneEventType { get; set; }
+        internal SceneEventType SceneEventType { get; set; }
 
         internal LoadSceneMode LoadSceneMode;
 

--- a/testproject-tools-integration/Assets/Tests/Runtime/SceneEventTests.cs
+++ b/testproject-tools-integration/Assets/Tests/Runtime/SceneEventTests.cs
@@ -8,13 +8,15 @@ using Unity.Netcode.RuntimeTests;
 using Unity.Netcode.RuntimeTests.Metrics.Utility;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
+using ToolsSceneEventType = Unity.Multiplayer.Tools.MetricTypes.SceneEventType;
+using SceneEventType = Unity.Netcode.SceneEventType;
 
 namespace TestProject.ToolsIntegration.RuntimeTests
 {
-    class SceneEventTests : SingleClientMetricTestBase
+    internal class SceneEventTests : SingleClientMetricTestBase
     {
         // scenes referenced in this test must also be in the build settings of the project.
-        private const string SimpleSceneName = "SimpleScene";
+        private const string k_SimpleSceneName = "SimpleScene";
 
         private NetworkSceneManager m_ClientNetworkSceneManager;
         private NetworkSceneManager m_ServerNetworkSceneManager;
@@ -47,7 +49,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             // the message is sent to the client. AsyncOperation is the ScceneManager.LoadSceneAsync operation.
             m_ServerNetworkSceneManager.OnSceneEvent += sceneEvent =>
             {
-                if (sceneEvent.SceneEventType.Equals(SceneEventData.SceneEventTypes.S2C_Load))
+                if (sceneEvent.SceneEventType.Equals(SceneEventType.Load))
                 {
                     serverSceneLoaded = sceneEvent.AsyncOperation.isDone;
                     sceneEvent.AsyncOperation.completed += _ => serverSceneLoaded = true;
@@ -70,9 +72,9 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             Assert.AreEqual(1, sentMetrics.Count);
 
             var sentMetric = sentMetrics.First();
-            Assert.AreEqual(SceneEventType.S2C_Load, sentMetric.SceneEventType);
+            Assert.AreEqual(ToolsSceneEventType.S2C_Load, sentMetric.SceneEventType);
             Assert.AreEqual(Client.LocalClientId, sentMetric.Connection.Id);
-            Assert.AreEqual(SimpleSceneName, sentMetric.SceneName);
+            Assert.AreEqual(k_SimpleSceneName, sentMetric.SceneName);
         }
 
         [UnityTest]
@@ -83,7 +85,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             // the message is sent to the client. AsyncOperation is the ScceneManager.LoadSceneAsync operation.
             m_ServerNetworkSceneManager.OnSceneEvent += sceneEvent =>
             {
-                if (sceneEvent.SceneEventType.Equals(SceneEventData.SceneEventTypes.S2C_Load))
+                if (sceneEvent.SceneEventType.Equals(SceneEventType.Load))
                 {
                     serverSceneLoaded = sceneEvent.AsyncOperation.isDone;
                     sceneEvent.AsyncOperation.completed += _ => serverSceneLoaded = true;
@@ -95,7 +97,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             // Load a scene to trigger the messages
             StartServerLoadScene();
 
-            // Wait for th eserver to load the scene locally first.
+            // Wait for the server to load the scene locally first.
             yield return WaitForCondition(() => serverSceneLoaded);
             Assert.IsTrue(serverSceneLoaded);
 
@@ -106,9 +108,9 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             Assert.AreEqual(1, receivedMetrics.Count);
 
             var receivedMetric = receivedMetrics.First();
-            Assert.AreEqual(SceneEventType.S2C_Load, receivedMetric.SceneEventType);
+            Assert.AreEqual(ToolsSceneEventType.S2C_Load, receivedMetric.SceneEventType);
             Assert.AreEqual(Server.LocalClientId, receivedMetric.Connection.Id);
-            Assert.AreEqual(SimpleSceneName, receivedMetric.SceneName);
+            Assert.AreEqual(k_SimpleSceneName, receivedMetric.SceneName);
         }
 
         [UnityTest]
@@ -118,7 +120,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             // as this is when the message is sent
             var waitForClientLoadComplete = new WaitForSceneEvent(
                 m_ClientNetworkSceneManager,
-                SceneEventData.SceneEventTypes.C2S_LoadComplete);
+                SceneEventType.LoadComplete);
 
             var waitForSentMetric = new WaitForMetricValues<SceneEventMetric>(ClientMetrics.Dispatcher, NetworkMetricTypes.SceneEventSent);
 
@@ -137,9 +139,9 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             Assert.AreEqual(1, sentMetrics.Count);
 
             var sentMetric = sentMetrics.First();
-            Assert.AreEqual(SceneEventType.C2S_LoadComplete, sentMetric.SceneEventType);
+            Assert.AreEqual(ToolsSceneEventType.C2S_LoadComplete, sentMetric.SceneEventType);
             Assert.AreEqual(Server.LocalClientId, sentMetric.Connection.Id);
-            Assert.AreEqual(SimpleSceneName, sentMetric.SceneName);
+            Assert.AreEqual(k_SimpleSceneName, sentMetric.SceneName);
         }
 
         [UnityTest]
@@ -149,7 +151,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             // as this is when the message is sent
             var waitForClientLoadComplete = new WaitForSceneEvent(
                 m_ClientNetworkSceneManager,
-                SceneEventData.SceneEventTypes.C2S_LoadComplete);
+                SceneEventType.LoadComplete);
 
             var waitForReceivedMetric = new WaitForMetricValues<SceneEventMetric>(ServerMetrics.Dispatcher, NetworkMetricTypes.SceneEventReceived);
 
@@ -168,9 +170,9 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             Assert.AreEqual(1, receivedMetrics.Count);
 
             var receivedMetric = receivedMetrics.First();
-            Assert.AreEqual(SceneEventType.C2S_LoadComplete, receivedMetric.SceneEventType);
+            Assert.AreEqual(ToolsSceneEventType.C2S_LoadComplete, receivedMetric.SceneEventType);
             Assert.AreEqual(Client.LocalClientId, receivedMetric.Connection.Id);
-            Assert.AreEqual(SimpleSceneName, receivedMetric.SceneName);
+            Assert.AreEqual(k_SimpleSceneName, receivedMetric.SceneName);
         }
 
         [UnityTest]
@@ -180,12 +182,12 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             // as this is when the message is sent
             var waitForServerLoadComplete = new WaitForSceneEvent(
                 m_ServerNetworkSceneManager,
-                SceneEventData.SceneEventTypes.S2C_LoadComplete);
+                SceneEventType.LoadEventCompleted);
 
             var waitForSentMetric = new WaitForMetricValues<SceneEventMetric>(
                 ServerMetrics.Dispatcher,
                 NetworkMetricTypes.SceneEventSent,
-                metric => metric.SceneEventType.Equals(SceneEventType.S2C_LoadComplete));
+                metric => metric.SceneEventType.Equals(ToolsSceneEventType.S2C_LoadComplete));
 
             // Load a scene to trigger the messages
             StartServerLoadScene();
@@ -201,8 +203,8 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             Assert.AreEqual(Server.ConnectedClients.Count, sentMetrics.Count);
 
             var filteredSentMetrics = sentMetrics
-                .Where(metric => metric.SceneEventType == SceneEventType.S2C_LoadComplete)
-                .Where(metric => metric.SceneName == SimpleSceneName);
+                .Where(metric => metric.SceneEventType == ToolsSceneEventType.S2C_LoadComplete)
+                .Where(metric => metric.SceneName == k_SimpleSceneName);
             CollectionAssert.AreEquivalent(filteredSentMetrics.Select(x => x.Connection.Id), Server.ConnectedClients.Select(x => x.Key));
         }
 
@@ -213,12 +215,12 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             // as this is when the message is sent
             var waitForServerLoadComplete = new WaitForSceneEvent(
                 m_ServerNetworkSceneManager,
-                SceneEventData.SceneEventTypes.S2C_LoadComplete);
+                SceneEventType.LoadEventCompleted);
 
             var waitForReceivedMetric = new WaitForMetricValues<SceneEventMetric>(
                 ClientMetrics.Dispatcher,
                 NetworkMetricTypes.SceneEventReceived,
-                metric => metric.SceneEventType.Equals(SceneEventType.S2C_LoadComplete));
+                metric => metric.SceneEventType.Equals(ToolsSceneEventType.S2C_LoadComplete));
 
             // Load a scene to trigger the messages
             StartServerLoadScene();
@@ -234,23 +236,23 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             Assert.AreEqual(1, receivedMetrics.Count);
             var receivedMetric = receivedMetrics.First();
 
-            Assert.AreEqual(SceneEventType.S2C_LoadComplete, receivedMetric.SceneEventType);
+            Assert.AreEqual(ToolsSceneEventType.S2C_LoadComplete, receivedMetric.SceneEventType);
             Assert.AreEqual(Server.LocalClientId, receivedMetric.Connection.Id);
-            Assert.AreEqual(SimpleSceneName, receivedMetric.SceneName);
+            Assert.AreEqual(k_SimpleSceneName, receivedMetric.SceneName);
         }
 
         [UnityTest]
         public IEnumerator TestS2CUnloadSent()
         {
             // Load a scene so that we can unload it
-            yield return LoadTestScene(SimpleSceneName);
+            yield return LoadTestScene(k_SimpleSceneName);
 
             var serverSceneUnloaded = false;
             // Register a callback so we can notify the test when the scene has started to unload server side
             // as this is when the message is sent
             m_ServerNetworkSceneManager.OnSceneEvent += sceneEvent =>
             {
-                if (sceneEvent.SceneEventType.Equals(SceneEventData.SceneEventTypes.S2C_Unload))
+                if (sceneEvent.SceneEventType.Equals(SceneEventType.Unload))
                 {
                     serverSceneUnloaded = sceneEvent.AsyncOperation.isDone;
                     sceneEvent.AsyncOperation.completed += _ => serverSceneUnloaded = true;
@@ -260,7 +262,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             var waitForSentMetric = new WaitForMetricValues<SceneEventMetric>(
                 ServerMetrics.Dispatcher,
                 NetworkMetricTypes.SceneEventSent,
-                metric => metric.SceneEventType.Equals(SceneEventType.S2C_Unload));
+                metric => metric.SceneEventType.Equals(ToolsSceneEventType.S2C_Unload));
 
             // Unload the scene to trigger the messages
             StartServerUnloadScene();
@@ -276,16 +278,16 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             Assert.AreEqual(1, sentMetrics.Count);
 
             var sentMetric = sentMetrics.First();
-            Assert.AreEqual(SceneEventType.S2C_Unload, sentMetric.SceneEventType);
+            Assert.AreEqual(ToolsSceneEventType.S2C_Unload, sentMetric.SceneEventType);
             Assert.AreEqual(Client.LocalClientId, sentMetric.Connection.Id);
-            Assert.AreEqual(SimpleSceneName, sentMetric.SceneName);
+            Assert.AreEqual(k_SimpleSceneName, sentMetric.SceneName);
         }
 
         [UnityTest]
         public IEnumerator TestS2CUnloadReceived()
         {
             // Load a scene so that we can unload it.
-            yield return LoadTestScene(SimpleSceneName);
+            yield return LoadTestScene(k_SimpleSceneName);
 
             var serverSceneUnloaded = false;
 
@@ -293,7 +295,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             // as this is when the message is sent
             m_ServerNetworkSceneManager.OnSceneEvent += sceneEvent =>
             {
-                if (sceneEvent.SceneEventType.Equals(SceneEventData.SceneEventTypes.S2C_Unload))
+                if (sceneEvent.SceneEventType.Equals(SceneEventType.Unload))
                 {
                     serverSceneUnloaded = sceneEvent.AsyncOperation.isDone;
                     sceneEvent.AsyncOperation.completed += _ => serverSceneUnloaded = true;
@@ -303,7 +305,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             var waitForReceivedMetric = new WaitForMetricValues<SceneEventMetric>(
                 ClientMetrics.Dispatcher,
                 NetworkMetricTypes.SceneEventReceived,
-                metric => metric.SceneEventType.Equals(SceneEventType.S2C_Unload));
+                metric => metric.SceneEventType.Equals(ToolsSceneEventType.S2C_Unload));
 
             // Unload the scene to trigger the messages
             StartServerUnloadScene();
@@ -319,27 +321,27 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             Assert.AreEqual(1, receivedMetrics.Count);
 
             var receivedMetric = receivedMetrics.First();
-            Assert.AreEqual(SceneEventType.S2C_Unload, receivedMetric.SceneEventType);
+            Assert.AreEqual(ToolsSceneEventType.S2C_Unload, receivedMetric.SceneEventType);
             Assert.AreEqual(Server.LocalClientId, receivedMetric.Connection.Id);
-            Assert.AreEqual(SimpleSceneName, receivedMetric.SceneName);
+            Assert.AreEqual(k_SimpleSceneName, receivedMetric.SceneName);
         }
 
         [UnityTest]
         public IEnumerator TestC2SUnloadCompleteSent()
         {
             // Load a scene so that we can unload it
-            yield return LoadTestScene(SimpleSceneName);
+            yield return LoadTestScene(k_SimpleSceneName);
 
             // Register a callback so we can notify the test when the scene has finished unloading client side
             // as this is when the message is sent.
             var waitForClientUnloadComplete = new WaitForSceneEvent(
                 m_ClientNetworkSceneManager,
-                SceneEventData.SceneEventTypes.C2S_UnloadComplete);
+                SceneEventType.UnloadComplete);
 
             var waitForSentMetric = new WaitForMetricValues<SceneEventMetric>(
                 ClientMetrics.Dispatcher,
                 NetworkMetricTypes.SceneEventSent,
-                metric => metric.SceneEventType.Equals(SceneEventType.C2S_UnloadComplete));
+                metric => metric.SceneEventType.Equals(ToolsSceneEventType.C2S_UnloadComplete));
 
             // Unload a scene to trigger the messages
             StartServerUnloadScene();
@@ -355,27 +357,27 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             Assert.AreEqual(1, sentMetrics.Count);
 
             var sentMetric = sentMetrics.First();
-            Assert.AreEqual(SceneEventType.C2S_UnloadComplete, sentMetric.SceneEventType);
+            Assert.AreEqual(ToolsSceneEventType.C2S_UnloadComplete, sentMetric.SceneEventType);
             Assert.AreEqual(Server.LocalClientId, sentMetric.Connection.Id);
-            Assert.AreEqual(SimpleSceneName, sentMetric.SceneName);
+            Assert.AreEqual(k_SimpleSceneName, sentMetric.SceneName);
         }
 
         [UnityTest]
         public IEnumerator TestC2SUnloadCompleteReceived()
         {
             // Load a scene so that we can unload it
-            yield return LoadTestScene(SimpleSceneName);
+            yield return LoadTestScene(k_SimpleSceneName);
 
-            // Register a callback we we can notify the test when the scene has finished unloading client side
+            // Register a callback we can notify the test when the scene has finished unloading client side
             // as this is when the message is sent
             var waitForClientUnloadComplete = new WaitForSceneEvent(
                 m_ClientNetworkSceneManager,
-                SceneEventData.SceneEventTypes.C2S_UnloadComplete);
+                SceneEventType.UnloadComplete);
 
             var waitForReceivedMetric = new WaitForMetricValues<SceneEventMetric>(
                 ServerMetrics.Dispatcher,
                 NetworkMetricTypes.SceneEventReceived,
-                metric => metric.SceneEventType.Equals(SceneEventType.C2S_UnloadComplete));
+                metric => metric.SceneEventType.Equals(ToolsSceneEventType.C2S_UnloadComplete));
 
             // Unload a scene to trigger the messages
             StartServerUnloadScene();
@@ -391,27 +393,27 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             Assert.AreEqual(1, receivedMetrics.Count);
 
             var receivedMetric = receivedMetrics.First();
-            Assert.AreEqual(SceneEventType.C2S_UnloadComplete, receivedMetric.SceneEventType);
+            Assert.AreEqual(ToolsSceneEventType.C2S_UnloadComplete, receivedMetric.SceneEventType);
             Assert.AreEqual(Client.LocalClientId, receivedMetric.Connection.Id);
-            Assert.AreEqual(SimpleSceneName, receivedMetric.SceneName);
+            Assert.AreEqual(k_SimpleSceneName, receivedMetric.SceneName);
         }
 
         [UnityTest]
         public IEnumerator TestS2CUnloadCompleteSent()
         {
             // Load a scene so that we can unload it
-            yield return LoadTestScene(SimpleSceneName);
+            yield return LoadTestScene(k_SimpleSceneName);
 
             // Register a callback so we can notify the test when the scene has finished unloading server side
             // as this is when the message is sent
             var waitForServerUnloadComplete = new WaitForSceneEvent(
                 m_ServerNetworkSceneManager,
-                SceneEventData.SceneEventTypes.S2C_UnLoadComplete);
+                SceneEventType.UnloadEventCompleted);
 
             var waitForSentMetric = new WaitForMetricValues<SceneEventMetric>(
                 ServerMetrics.Dispatcher,
                 NetworkMetricTypes.SceneEventSent,
-                metric => metric.SceneEventType.Equals(SceneEventType.S2C_UnLoadComplete));
+                metric => metric.SceneEventType.Equals(ToolsSceneEventType.S2C_UnLoadComplete));
 
             // Unload a scene to trigger the messages
             StartServerUnloadScene();
@@ -430,8 +432,8 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             // so iterate over the connected client list on the server to ensure that we have a 1-1 match of connected
             // clients to sent metrics.
             var filteredSentMetrics = sentMetrics
-                .Where(metric => metric.SceneEventType == SceneEventType.S2C_UnLoadComplete)
-                .Where(metric => metric.SceneName == SimpleSceneName);
+                .Where(metric => metric.SceneEventType == ToolsSceneEventType.S2C_UnLoadComplete)
+                .Where(metric => metric.SceneName == k_SimpleSceneName);
             CollectionAssert.AreEquivalent(filteredSentMetrics.Select(x => x.Connection.Id), Server.ConnectedClients.Select(x => x.Key));
         }
 
@@ -439,18 +441,18 @@ namespace TestProject.ToolsIntegration.RuntimeTests
         public IEnumerator TestS2CUnloadCompleteReceived()
         {
             // Load a scene so that we can unload it
-            yield return LoadTestScene(SimpleSceneName);
+            yield return LoadTestScene(k_SimpleSceneName);
 
             // Register a callback so we can notify the test when the scene has finished unloading server side
             // as this is when the message is sent
             var waitForServerUnloadComplete = new WaitForSceneEvent(
                 m_ServerNetworkSceneManager,
-                SceneEventData.SceneEventTypes.S2C_UnLoadComplete);
+                SceneEventType.UnloadEventCompleted);
 
             var waitForReceivedMetric = new WaitForMetricValues<SceneEventMetric>(
                 ClientMetrics.Dispatcher,
                 NetworkMetricTypes.SceneEventReceived,
-                metric => metric.SceneEventType.Equals(SceneEventType.S2C_UnLoadComplete));
+                metric => metric.SceneEventType.Equals(ToolsSceneEventType.S2C_UnLoadComplete));
 
             // Unload the scene to trigger the messages
             StartServerUnloadScene();
@@ -466,9 +468,9 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             Assert.AreEqual(1, receivedMetrics.Count);
             var receivedMetric = receivedMetrics.First();
 
-            Assert.AreEqual(SceneEventType.S2C_UnLoadComplete, receivedMetric.SceneEventType);
+            Assert.AreEqual(ToolsSceneEventType.S2C_UnLoadComplete, receivedMetric.SceneEventType);
             Assert.AreEqual(Server.LocalClientId, receivedMetric.Connection.Id);
-            Assert.AreEqual(SimpleSceneName, receivedMetric.SceneName);
+            Assert.AreEqual(k_SimpleSceneName, receivedMetric.SceneName);
         }
 
         [UnityTest]
@@ -477,12 +479,12 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             // Register a callback so we can notify the test when the client and server have completed their sync
             var waitForServerSyncComplete = new WaitForSceneEvent(
                 m_ServerNetworkSceneManager,
-                SceneEventData.SceneEventTypes.C2S_SyncComplete);
+                SceneEventType.SynchronizeComplete);
 
             var waitForSentMetric = new WaitForMetricValues<SceneEventMetric>(
                 ServerMetrics.Dispatcher,
                 NetworkMetricTypes.SceneEventSent,
-                metric => metric.SceneEventType.Equals(SceneEventType.S2C_Sync));
+                metric => metric.SceneEventType.Equals(ToolsSceneEventType.S2C_Sync));
 
             // To trigger a sync, we need to connect a new client to an already started server, so create a client
             var newClient = CreateAndStartClient();
@@ -494,13 +496,13 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             Assert.AreEqual(1, sentMetrics.Count);
 
             // Although the metric should have been emitted, wait for the sync to complete
-            // as the client/server IDs have not been fully initialised until this is done.
+            // as the client/server IDs have not been fully initialized until this is done.
             yield return waitForServerSyncComplete.Wait();
             Assert.IsTrue(waitForServerSyncComplete.Done);
 
             var sentMetric = sentMetrics.First();
 
-            Assert.AreEqual(SceneEventType.S2C_Sync, sentMetric.SceneEventType);
+            Assert.AreEqual(ToolsSceneEventType.S2C_Sync, sentMetric.SceneEventType);
             Assert.AreEqual(newClient.LocalClientId, sentMetric.Connection.Id);
 
             MultiInstanceHelpers.StopOneClient(newClient);
@@ -518,7 +520,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             var waitForReceivedMetric = new WaitForMetricValues<SceneEventMetric>(
                 newClientMetrics.Dispatcher,
                 NetworkMetricTypes.SceneEventReceived,
-                metric => metric.SceneEventType.Equals(SceneEventType.S2C_Sync));
+                metric => metric.SceneEventType.Equals(ToolsSceneEventType.S2C_Sync));
 
             // Wait for the metric to be emitted when the message is received on the client from the server
             yield return waitForReceivedMetric.WaitForMetricsReceived();
@@ -527,7 +529,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             Assert.AreEqual(1, receivedMetrics.Count);
             var receivedMetric = receivedMetrics.First();
 
-            Assert.AreEqual(SceneEventType.S2C_Sync, receivedMetric.SceneEventType);
+            Assert.AreEqual(ToolsSceneEventType.S2C_Sync, receivedMetric.SceneEventType);
             Assert.AreEqual(Server.LocalClientId, receivedMetric.Connection.Id);
 
             MultiInstanceHelpers.StopOneClient(newClient);
@@ -545,7 +547,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             var waitForSentMetric = new WaitForMetricValues<SceneEventMetric>(
                 newClientMetrics.Dispatcher,
                 NetworkMetricTypes.SceneEventSent,
-                metric => metric.SceneEventType.Equals(SceneEventType.C2S_SyncComplete));
+                metric => metric.SceneEventType.Equals(ToolsSceneEventType.C2S_SyncComplete));
 
             // Wait for the metric to be emitted when the client has completed the sync locally and sends the message
             // to the server
@@ -555,7 +557,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             Assert.AreEqual(1, sentMetrics.Count);
             var sentMetric = sentMetrics.First();
 
-            Assert.AreEqual(SceneEventType.C2S_SyncComplete, sentMetric.SceneEventType);
+            Assert.AreEqual(ToolsSceneEventType.C2S_SyncComplete, sentMetric.SceneEventType);
             Assert.AreEqual(Server.LocalClientId, sentMetric.Connection.Id);
 
             MultiInstanceHelpers.StopOneClient(newClient);
@@ -567,7 +569,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             var waitForReceivedMetric = new WaitForMetricValues<SceneEventMetric>(
                 ServerMetrics.Dispatcher,
                 NetworkMetricTypes.SceneEventReceived,
-                metric => metric.SceneEventType.Equals(SceneEventType.C2S_SyncComplete));
+                metric => metric.SceneEventType.Equals(ToolsSceneEventType.C2S_SyncComplete));
 
             // To trigger a sync, we need to connect a new client to an already started server, so create a client
             var newClient = CreateAndStartClient();
@@ -581,7 +583,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
 
             var receivedMetric = receivedMetrics.First();
 
-            Assert.AreEqual(SceneEventType.C2S_SyncComplete, receivedMetric.SceneEventType);
+            Assert.AreEqual(ToolsSceneEventType.C2S_SyncComplete, receivedMetric.SceneEventType);
             Assert.AreEqual(newClient.LocalClientId, receivedMetric.Connection.Id);
 
             MultiInstanceHelpers.StopOneClient(newClient);
@@ -605,7 +607,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
 
         private void StartServerLoadScene()
         {
-            var loadSceneResult = m_ServerNetworkSceneManager.LoadScene(SimpleSceneName, LoadSceneMode.Additive);
+            var loadSceneResult = m_ServerNetworkSceneManager.LoadScene(k_SimpleSceneName, LoadSceneMode.Additive);
             Assert.AreEqual(SceneEventProgressStatus.Started, loadSceneResult);
         }
 
@@ -622,7 +624,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             var sceneLoadComplete = false;
             m_ClientNetworkSceneManager.OnSceneEvent += sceneEvent =>
             {
-                if (sceneEvent.SceneEventType == SceneEventData.SceneEventTypes.S2C_LoadComplete)
+                if (sceneEvent.SceneEventType == SceneEventType.LoadEventCompleted)
                 {
                     sceneLoadComplete = true;
                 }
@@ -639,13 +641,16 @@ namespace TestProject.ToolsIntegration.RuntimeTests
         // Unloads a loaded scene. If the scene is not loaded, this is a no-op
         private IEnumerator UnloadTestScene(Scene scene)
         {
-            if (!scene.isLoaded) yield break;
+            if (!scene.isLoaded)
+            {
+                yield break;
+            }
 
             m_ServerNetworkSceneManager.UnloadScene(scene);
             var sceneUnloaded = false;
             m_ServerNetworkSceneManager.OnSceneEvent += sceneEvent =>
             {
-                if (sceneEvent.SceneEventType == SceneEventData.SceneEventTypes.C2S_UnloadComplete)
+                if (sceneEvent.SceneEventType == SceneEventType.UnloadComplete)
                 {
                     sceneUnloaded = true;
                 }
@@ -669,12 +674,12 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             }
         }
 
-        // Registers a callback for the client's NetworkSceneManager which will synchronise the scene handles from
+        // Registers a callback for the client's NetworkSceneManager which will synchronize the scene handles from
         // the server to the client. This only needs to be done in multi-instance unit tests as the client and the
         // server share a (Unity) SceneManager.
         private void RegisterLoadedSceneCallback(SceneEvent sceneEvent)
         {
-            if (!sceneEvent.SceneEventType.Equals(SceneEventData.SceneEventTypes.S2C_Load))
+            if (!sceneEvent.SceneEventType.Equals(SceneEventType.Load))
             {
                 return;
             }
@@ -693,7 +698,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
 
         private class WaitForSceneEvent
         {
-            public WaitForSceneEvent(NetworkSceneManager sceneManager, SceneEventData.SceneEventTypes sceneEventType)
+            public WaitForSceneEvent(NetworkSceneManager sceneManager, SceneEventType sceneEventType)
             {
                 sceneManager.OnSceneEvent += sceneEvent =>
                 {

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/AdditiveSceneToggleHandler.cs
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/AdditiveSceneToggleHandler.cs
@@ -93,7 +93,7 @@ namespace TestProject.ManualTests
         {
             if (NetworkManager.Singleton != null && NetworkManager.Singleton.IsListening && NetworkManager.Singleton.IsServer)
             {
-                if (sceneEvent.SceneEventType == SceneEventData.SceneEventTypes.C2S_LoadComplete)
+                if (sceneEvent.SceneEventType == SceneEventData.SceneEventTypes.LoadComplete)
                 {
                     if (sceneEvent.ClientId == NetworkManager.Singleton.ServerClientId && !m_SceneLoaded.IsValid()
                         && sceneEvent.Scene.IsValid() && sceneEvent.Scene.name == m_SceneToLoad)
@@ -102,7 +102,7 @@ namespace TestProject.ManualTests
                         m_WaitForSceneLoadOrUnload = false;
                     }
                 }
-                else if (sceneEvent.SceneEventType == SceneEventData.SceneEventTypes.C2S_UnloadComplete)
+                else if (sceneEvent.SceneEventType == SceneEventData.SceneEventTypes.UnloadComplete)
                 {
                     if (sceneEvent.ClientId == NetworkManager.Singleton.ServerClientId && !m_SceneLoaded.isLoaded)
                     {

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/AdditiveSceneToggleHandler.cs
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/AdditiveSceneToggleHandler.cs
@@ -93,7 +93,7 @@ namespace TestProject.ManualTests
         {
             if (NetworkManager.Singleton != null && NetworkManager.Singleton.IsListening && NetworkManager.Singleton.IsServer)
             {
-                if (sceneEvent.SceneEventType == SceneEventData.SceneEventTypes.LoadComplete)
+                if (sceneEvent.SceneEventType == SceneEventType.LoadComplete)
                 {
                     if (sceneEvent.ClientId == NetworkManager.Singleton.ServerClientId && !m_SceneLoaded.IsValid()
                         && sceneEvent.Scene.IsValid() && sceneEvent.Scene.name == m_SceneToLoad)
@@ -102,7 +102,7 @@ namespace TestProject.ManualTests
                         m_WaitForSceneLoadOrUnload = false;
                     }
                 }
-                else if (sceneEvent.SceneEventType == SceneEventData.SceneEventTypes.UnloadComplete)
+                else if (sceneEvent.SceneEventType == SceneEventType.UnloadComplete)
                 {
                     if (sceneEvent.ClientId == NetworkManager.Singleton.ServerClientId && !m_SceneLoaded.isLoaded)
                     {

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/SceneEventNotificationQueue.cs
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/SceneEventNotificationQueue.cs
@@ -64,12 +64,12 @@ namespace TestProject.ManualTests
         private void OnSceneEvent(SceneEvent sceneEvent)
         {
             var sceneEventMsg = $"({NetworkManager.Singleton.LocalClientId})-[{sceneEvent.ClientId} | {sceneEvent.SceneEventType} | {sceneEvent.SceneName}";
-            if (sceneEvent.SceneEventType == SceneEventData.SceneEventTypes.Load || sceneEvent.SceneEventType == SceneEventData.SceneEventTypes.LoadComplete)
+            if (sceneEvent.SceneEventType == SceneEventType.Load || sceneEvent.SceneEventType == SceneEventType.LoadComplete)
             {
                 sceneEventMsg += $" | { sceneEvent.LoadSceneMode}";
             }
 
-            if (sceneEvent.SceneEventType == SceneEventData.SceneEventTypes.UnloadEventCompleted || sceneEvent.SceneEventType == SceneEventData.SceneEventTypes.LoadEventCompleted)
+            if (sceneEvent.SceneEventType == SceneEventType.UnloadEventCompleted || sceneEvent.SceneEventType == SceneEventType.LoadEventCompleted)
             {
                 sceneEventMsg += $" | Loaded ({sceneEvent.ClientsThatCompleted.Count}) : (";
                 foreach (var clientId in sceneEvent.ClientsThatCompleted)

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/SceneEventNotificationQueue.cs
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/SceneEventNotificationQueue.cs
@@ -64,12 +64,12 @@ namespace TestProject.ManualTests
         private void OnSceneEvent(SceneEvent sceneEvent)
         {
             var sceneEventMsg = $"({NetworkManager.Singleton.LocalClientId})-[{sceneEvent.ClientId} | {sceneEvent.SceneEventType} | {sceneEvent.SceneName}";
-            if (sceneEvent.SceneEventType == SceneEventData.SceneEventTypes.S2C_Load || sceneEvent.SceneEventType == SceneEventData.SceneEventTypes.C2S_LoadComplete)
+            if (sceneEvent.SceneEventType == SceneEventData.SceneEventTypes.Load || sceneEvent.SceneEventType == SceneEventData.SceneEventTypes.LoadComplete)
             {
                 sceneEventMsg += $" | { sceneEvent.LoadSceneMode}";
             }
 
-            if (sceneEvent.SceneEventType == SceneEventData.SceneEventTypes.S2C_UnLoadComplete || sceneEvent.SceneEventType == SceneEventData.SceneEventTypes.S2C_LoadComplete)
+            if (sceneEvent.SceneEventType == SceneEventData.SceneEventTypes.UnloadEventCompleted || sceneEvent.SceneEventType == SceneEventData.SceneEventTypes.LoadEventCompleted)
             {
                 sceneEventMsg += $" | Loaded ({sceneEvent.ClientsThatCompleted.Count}) : (";
                 foreach (var clientId in sceneEvent.ClientsThatCompleted)

--- a/testproject/Assets/Tests/Manual/Scripts/NetworkPrefabPool.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/NetworkPrefabPool.cs
@@ -179,7 +179,7 @@ namespace TestProject.ManualTests
         {
             switch (sceneEvent.SceneEventType)
             {
-                case SceneEventData.SceneEventTypes.S2C_Unload:
+                case SceneEventData.SceneEventTypes.Unload:
                     {
                         if (sceneEvent.LoadSceneMode == LoadSceneMode.Single && (gameObject.scene.name == sceneEvent.SceneName))
                         {

--- a/testproject/Assets/Tests/Manual/Scripts/NetworkPrefabPool.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/NetworkPrefabPool.cs
@@ -179,7 +179,7 @@ namespace TestProject.ManualTests
         {
             switch (sceneEvent.SceneEventType)
             {
-                case SceneEventData.SceneEventTypes.Unload:
+                case SceneEventType.Unload:
                     {
                         if (sceneEvent.LoadSceneMode == LoadSceneMode.Single && (gameObject.scene.name == sceneEvent.SceneName))
                         {

--- a/testproject/Assets/Tests/Manual/Scripts/NetworkPrefabPoolAdditive.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/NetworkPrefabPoolAdditive.cs
@@ -117,7 +117,7 @@ namespace TestProject.ManualTests
         {
             switch (sceneEvent.SceneEventType)
             {
-                case SceneEventData.SceneEventTypes.S2C_Unload:
+                case SceneEventData.SceneEventTypes.Unload:
                     {
                         if (sceneEvent.LoadSceneMode == LoadSceneMode.Additive && (gameObject.scene.name == sceneEvent.SceneName))
                         {
@@ -125,7 +125,7 @@ namespace TestProject.ManualTests
                         }
                         break;
                     }
-                case SceneEventData.SceneEventTypes.S2C_Load:
+                case SceneEventData.SceneEventTypes.Load:
                     {
                         if (sceneEvent.LoadSceneMode == LoadSceneMode.Single && ((gameObject.scene.name == sceneEvent.SceneName) || !SpawnInSourceScene))
                         {

--- a/testproject/Assets/Tests/Manual/Scripts/NetworkPrefabPoolAdditive.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/NetworkPrefabPoolAdditive.cs
@@ -117,7 +117,7 @@ namespace TestProject.ManualTests
         {
             switch (sceneEvent.SceneEventType)
             {
-                case SceneEventData.SceneEventTypes.Unload:
+                case SceneEventType.Unload:
                     {
                         if (sceneEvent.LoadSceneMode == LoadSceneMode.Additive && (gameObject.scene.name == sceneEvent.SceneName))
                         {
@@ -125,7 +125,7 @@ namespace TestProject.ManualTests
                         }
                         break;
                     }
-                case SceneEventData.SceneEventTypes.Load:
+                case SceneEventType.Load:
                     {
                         if (sceneEvent.LoadSceneMode == LoadSceneMode.Single && ((gameObject.scene.name == sceneEvent.SceneName) || !SpawnInSourceScene))
                         {

--- a/testproject/Assets/Tests/Manual/Scripts/NotifyClientRpc.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/NotifyClientRpc.cs
@@ -56,12 +56,12 @@ namespace TestProject.ManualTests
             {
                 switch (sceneEvent.SceneEventType)
                 {
-                    case SceneEventData.SceneEventTypes.LoadComplete:
+                    case SceneEventType.LoadComplete:
                         {
                             SendRpcOnLoadClientRpc(sceneEvent.SceneName);
                             break;
                         }
-                    case SceneEventData.SceneEventTypes.SynchronizeComplete:
+                    case SceneEventType.SynchronizeComplete:
                         {
                             SendRpcOnSynchClientRpc();
                             break;

--- a/testproject/Assets/Tests/Manual/Scripts/NotifyClientRpc.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/NotifyClientRpc.cs
@@ -56,12 +56,12 @@ namespace TestProject.ManualTests
             {
                 switch (sceneEvent.SceneEventType)
                 {
-                    case SceneEventData.SceneEventTypes.S2C_LoadComplete:
+                    case SceneEventData.SceneEventTypes.LoadComplete:
                         {
                             SendRpcOnLoadClientRpc(sceneEvent.SceneName);
                             break;
                         }
-                    case SceneEventData.SceneEventTypes.C2S_SyncComplete:
+                    case SceneEventData.SceneEventTypes.SynchronizeComplete:
                         {
                             SendRpcOnSynchClientRpc();
                             break;

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -194,7 +194,6 @@ namespace TestProject.RuntimeTests
         /// Wait until all clients have processed the event and the server has determined the event is completed
         /// Will bail if it takes too long via m_TimeOutMarker
         /// </summary>
-        /// <returns></returns>
         private bool ShouldWait()
         {
             m_TimedOut = m_TimeOutMarker < Time.realtimeSinceStartup;
@@ -212,8 +211,6 @@ namespace TestProject.RuntimeTests
         /// <summary>
         /// Determines if the clientId is valid
         /// </summary>
-        /// <param name="clientId"></param>
-        /// <returns></returns>
         private bool ContainsClient(ulong clientId)
         {
             return m_ShouldWaitList.Select(c => c.ClientId).Where(c => c == clientId).Count() > 0;
@@ -222,7 +219,6 @@ namespace TestProject.RuntimeTests
         /// <summary>
         /// Sets the specific clientId entry as having processed the current event
         /// </summary>
-        /// <param name="clientId"></param>
         private void SetClientProcessedEvent(ulong clientId)
         {
             m_ShouldWaitList.Select(c => c).Where(c => c.ClientId == clientId).First().ProcessedEvent = true;
@@ -231,7 +227,6 @@ namespace TestProject.RuntimeTests
         /// <summary>
         /// Sets all known clients' ShouldWait value to false
         /// </summary>
-        /// <param name="clientId"></param>
         private void SetClientWaitDone(List<ulong> clients)
         {
             foreach (var clientId in clients)
@@ -266,29 +261,28 @@ namespace TestProject.RuntimeTests
 
         /// <summary>
         /// This test only needs to check the server side for the proper event notifications of loading a scene, each
-        /// client response that it loaded the scene, and the final  event notifications S2C_LoadComplete and S2C_UnloadComplete
-        /// that signify all clients have processed through the loading and unloading process.
+        /// client response that it loaded the scene, and the final event notifications <see cref="SceneEventType.LoadEventCompleted"/>
+        /// and <see cref="SceneEventType.UnloadEventCompleted"/> that signifies all clients have completed a loading or unloading event.
         /// </summary>
-        /// <param name="sceneEvent"></param>
         private void SceneManager_OnSceneEvent(SceneEvent sceneEvent)
         {
             switch (sceneEvent.SceneEventType)
             {
-                case SceneEventData.SceneEventTypes.Synchronize:
+                case SceneEventType.Synchronize:
                     {
                         // Verify that the Client Synchronization Mode set by the server is being received by the client (which means it is applied when loading the first scene)
                         Assert.AreEqual(m_ClientNetworkManagers.ToArray().Where(c => c.LocalClientId == sceneEvent.ClientId).First().SceneManager.ClientSynchronizationMode, sceneEvent.LoadSceneMode);
                         break;
                     }
-                case SceneEventData.SceneEventTypes.Load:
-                case SceneEventData.SceneEventTypes.Unload:
+                case SceneEventType.Load:
+                case SceneEventType.Unload:
                     {
                         Assert.AreEqual(sceneEvent.SceneName, m_CurrentSceneName);
                         Assert.IsTrue(ContainsClient(sceneEvent.ClientId));
                         Assert.IsNotNull(sceneEvent.AsyncOperation);
                         break;
                     }
-                case SceneEventData.SceneEventTypes.LoadComplete:
+                case SceneEventType.LoadComplete:
                     {
                         if (sceneEvent.ClientId == m_ServerNetworkManager.ServerClientId)
                         {
@@ -318,15 +312,15 @@ namespace TestProject.RuntimeTests
                         SetClientProcessedEvent(sceneEvent.ClientId);
                         break;
                     }
-                case SceneEventData.SceneEventTypes.UnloadComplete:
+                case SceneEventType.UnloadComplete:
                     {
                         Assert.AreEqual(sceneEvent.SceneName, m_CurrentSceneName);
                         Assert.IsTrue(ContainsClient(sceneEvent.ClientId));
                         SetClientProcessedEvent(sceneEvent.ClientId);
                         break;
                     }
-                case SceneEventData.SceneEventTypes.LoadEventCompleted:
-                case SceneEventData.SceneEventTypes.UnloadEventCompleted:
+                case SceneEventType.LoadEventCompleted:
+                case SceneEventType.UnloadEventCompleted:
                     {
                         Assert.AreEqual(sceneEvent.SceneName, m_CurrentSceneName);
                         Assert.IsTrue(ContainsClient(sceneEvent.ClientId));

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -569,7 +569,7 @@ namespace TestProject.RuntimeTests
             networkManager.StartHost();
 
             var sceneEventData = new SceneEventData(networkManager);
-            sceneEventData.SceneEventType = SceneEventData.SceneEventTypes.S2C_Load;
+            sceneEventData.SceneEventType = SceneEventType.Load;
             sceneEventData.SceneHash = XXHash.Hash32("SomeRandomSceneName");
             sceneEventData.SceneEventProgressId = Guid.NewGuid();
             sceneEventData.LoadSceneMode = LoadSceneMode.Single;

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -274,21 +274,21 @@ namespace TestProject.RuntimeTests
         {
             switch (sceneEvent.SceneEventType)
             {
-                case SceneEventData.SceneEventTypes.S2C_Sync:
+                case SceneEventData.SceneEventTypes.Synchronize:
                     {
                         // Verify that the Client Synchronization Mode set by the server is being received by the client (which means it is applied when loading the first scene)
                         Assert.AreEqual(m_ClientNetworkManagers.ToArray().Where(c => c.LocalClientId == sceneEvent.ClientId).First().SceneManager.ClientSynchronizationMode, sceneEvent.LoadSceneMode);
                         break;
                     }
-                case SceneEventData.SceneEventTypes.S2C_Load:
-                case SceneEventData.SceneEventTypes.S2C_Unload:
+                case SceneEventData.SceneEventTypes.Load:
+                case SceneEventData.SceneEventTypes.Unload:
                     {
                         Assert.AreEqual(sceneEvent.SceneName, m_CurrentSceneName);
                         Assert.IsTrue(ContainsClient(sceneEvent.ClientId));
                         Assert.IsNotNull(sceneEvent.AsyncOperation);
                         break;
                     }
-                case SceneEventData.SceneEventTypes.C2S_LoadComplete:
+                case SceneEventData.SceneEventTypes.LoadComplete:
                     {
                         if (sceneEvent.ClientId == m_ServerNetworkManager.ServerClientId)
                         {
@@ -318,15 +318,15 @@ namespace TestProject.RuntimeTests
                         SetClientProcessedEvent(sceneEvent.ClientId);
                         break;
                     }
-                case SceneEventData.SceneEventTypes.C2S_UnloadComplete:
+                case SceneEventData.SceneEventTypes.UnloadComplete:
                     {
                         Assert.AreEqual(sceneEvent.SceneName, m_CurrentSceneName);
                         Assert.IsTrue(ContainsClient(sceneEvent.ClientId));
                         SetClientProcessedEvent(sceneEvent.ClientId);
                         break;
                     }
-                case SceneEventData.SceneEventTypes.S2C_LoadComplete:
-                case SceneEventData.SceneEventTypes.S2C_UnLoadComplete:
+                case SceneEventData.SceneEventTypes.LoadEventCompleted:
+                case SceneEventData.SceneEventTypes.UnloadEventCompleted:
                     {
                         Assert.AreEqual(sceneEvent.SceneName, m_CurrentSceneName);
                         Assert.IsTrue(ContainsClient(sceneEvent.ClientId));

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -25,6 +25,7 @@ namespace TestProject.RuntimeTests
         [UnityTearDown]
         public override IEnumerator Teardown()
         {
+            m_BypassStartAndWaitForClients = false;
             return base.Teardown();
         }
 
@@ -42,6 +43,8 @@ namespace TestProject.RuntimeTests
         private List<SceneTestInfo> m_ShouldWaitList;
         private Scene m_CurrentScene;
         private const string k_InvalidSceneName = "SomeInvalidSceneName";
+        private const string k_AdditiveScene1 = "AdditiveScene1";
+        private const string k_AdditiveScene2 = "AdditiveScene1";
 
         private List<Scene> m_ScenesLoaded = new List<Scene>();
 
@@ -57,7 +60,7 @@ namespace TestProject.RuntimeTests
         public IEnumerator SceneLoadingAndNotifications([Values(LoadSceneMode.Single, LoadSceneMode.Additive)] LoadSceneMode clientSynchronizationMode)
         {
             m_ServerNetworkManager.SceneManager.OnSceneEvent += SceneManager_OnSceneEvent;
-            m_CurrentSceneName = "AdditiveScene1";
+            m_CurrentSceneName = k_AdditiveScene1;
 
             // Check that we cannot call LoadScene when EnableSceneManagement is false (from previous legacy test)
             var threwException = false;
@@ -372,7 +375,7 @@ namespace TestProject.RuntimeTests
             m_ServerVerificationAction = ServerVerifySceneBeforeLoading;
 
             m_ServerNetworkManager.SceneManager.OnSceneEvent += SceneManager_OnSceneEvent;
-            m_CurrentSceneName = "AdditiveScene1";
+            m_CurrentSceneName = k_AdditiveScene1;
 
             // Now prepare for the loading and unloading additive scene testing
             InitializeSceneTestInfo(clientSynchronizationMode, true);
@@ -408,7 +411,7 @@ namespace TestProject.RuntimeTests
             // Test VerifySceneBeforeLoading with m_ServerVerifyScene set to true and m_ClientVerifyScene set to false
             // Server should load and clients will notify they failed scene verification
             ResetWait();
-            m_CurrentSceneName = "AdditiveScene2";
+            m_CurrentSceneName = k_AdditiveScene2;
             m_ExpectedSceneName = m_CurrentSceneName;
             m_ExpectedSceneIndex = SceneUtility.GetBuildIndexByScenePath(m_CurrentSceneName);
             m_ServerVerifyScene = true;
@@ -539,6 +542,343 @@ namespace TestProject.RuntimeTests
             m_MultiSceneTest = false;
             yield break;
         }
+
+        private class SceneEventNotificationTestInfo
+        {
+            public ulong ClientId;
+            public bool ShouldWait;
+            public List<SceneEventType> EventsProcessed;
+        }
+
+        private class SceneEventCompletedTestInfo
+        {
+            public SceneEventType EventTypeCompleted;
+            public List<ulong> ClientThatCompletedEvent;
+        }
+
+        private List<SceneEventNotificationTestInfo> m_ClientNotificationInfo = new List<SceneEventNotificationTestInfo>();
+        private List<SceneEventNotificationTestInfo> m_ServerNotificationInfo = new List<SceneEventNotificationTestInfo>();
+
+        private List<SceneEventCompletedTestInfo> m_ClientCompletedTestInfo = new List<SceneEventCompletedTestInfo>();
+        private List<SceneEventCompletedTestInfo> m_ServerCompletedTestInfo = new List<SceneEventCompletedTestInfo>();
+
+        private void ResetNotificationInfo()
+        {
+            m_ClientNotificationInfo.Clear();
+            m_ServerNotificationInfo.Clear();
+            m_ClientCompletedTestInfo.Clear();
+            m_ServerCompletedTestInfo.Clear();
+        }
+
+        private void ClientProcessedNotification(ulong clientId, SceneEventType notificationType, bool isServer, bool eventComplete = false)
+        {
+            if (clientId == m_ServerNetworkManager.LocalClientId)
+            {
+                return;
+            }
+            var notificationList = isServer ? m_ServerNotificationInfo : m_ClientNotificationInfo;
+            var clientSelection = notificationList.Select(c => c).Where(c => c.ClientId == clientId);
+            if (clientSelection == null || clientSelection.Count() == 0)
+            {
+                    notificationList.Add(new SceneEventNotificationTestInfo()
+                    {
+                        ClientId = clientId,
+                        EventsProcessed = new List<SceneEventType>(),
+                    });
+            }
+            var clientNotificationObject = notificationList.Select(c => c).Where(c => c.ClientId == clientId).First();
+            clientNotificationObject.EventsProcessed.Add(notificationType);
+            clientNotificationObject.ShouldWait = !eventComplete;
+        }
+
+        private void ProcessCompletedNotification(List<ulong> clientIds, SceneEventType notificationType, bool isServer)
+        {
+            var notificationList = isServer ? m_ServerCompletedTestInfo : m_ClientCompletedTestInfo;
+
+            notificationList.Add(new SceneEventCompletedTestInfo()
+            {
+                EventTypeCompleted = notificationType,
+                ClientThatCompletedEvent = new List<ulong>(clientIds)
+            });
+        }
+
+        private bool ValidateCompletedNotifications()
+        {
+            var isValidated = m_ClientCompletedTestInfo.Count == NbClients && m_ServerCompletedTestInfo.Count == 1;
+            if (isValidated)
+            {
+                foreach(var client in m_ClientCompletedTestInfo)
+                {
+                    Assert.That(m_ServerCompletedTestInfo[0].EventTypeCompleted == client.EventTypeCompleted);
+                    Assert.That(m_ServerCompletedTestInfo[0].ClientThatCompletedEvent.Count == client.ClientThatCompletedEvent.Count);
+                    foreach(var clientId in m_ServerCompletedTestInfo[0].ClientThatCompletedEvent)
+                    {
+                        Assert.That(client.ClientThatCompletedEvent.Contains(clientId));
+                    }
+                }
+                Debug.Log($"{m_ServerCompletedTestInfo[0].EventTypeCompleted} validated!");
+            }
+            return isValidated;
+        }
+
+        private bool NotificationTestShouldWait()
+        {
+            // if all of our clients are not done we should wait.
+            var shouldWait = m_ClientNotificationInfo.Select(c => c).Where(c => c.ShouldWait == false).Count() != m_ClientNotificationInfo.Count;
+
+            // if our client count (server side vs client side) do not match yet we should wait
+            shouldWait |= m_ServerNotificationInfo.Count() != m_ClientNotificationInfo.Count();
+
+            // if our client count is zero for either side or both sides we should wait
+            shouldWait |= m_ServerNotificationInfo.Count() == 0 || m_ClientNotificationInfo.Count() == 0;
+
+            // Early exit if we should wait at this point
+            if (shouldWait)
+            {
+                return shouldWait;
+            }
+
+            foreach (var clientEntry in m_ServerNotificationInfo)
+            {
+                var clientList = m_ClientNotificationInfo.Select(c => c).Where(c => c.ClientId == clientEntry.ClientId);
+                if (clientList == null || clientList.Count() == 0)
+                {
+                    shouldWait = true;
+                }
+                else
+                {
+                    var client = clientList.First();
+                    // Compare the events processed to make sure the events are invoked on the client,a message sent to the server,
+                    // and the same event is invoked on the server too.
+                    foreach (var sceneEventType in clientEntry.EventsProcessed)
+                    {
+                        if (!client.EventsProcessed.Contains(sceneEventType))
+                        {
+                            shouldWait = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (shouldWait)
+                {
+                    break;
+                }
+            }
+
+            return shouldWait;
+        }
+
+        [UnityTest]
+        public IEnumerator SceneEventCallbackNotifications()
+        {
+            // First we disconnect and shutdown because we want to verify the synchronize events
+            yield return Teardown();
+
+            // Give a little time for handling clean-up and the like
+            yield return new WaitForSeconds(0.01f);
+
+            // We set this to true in order to bypass the automatic starting of the host and clients
+            m_BypassStartAndWaitForClients = true;
+
+            // Now just create the instances (server and client) without starting anything
+            yield return Setup();
+
+            // Start the host and  clients
+            if (!MultiInstanceHelpers.Start(true, m_ServerNetworkManager, m_ClientNetworkManagers, SceneManagerValidationAndTestRunnerInitialization))
+            {
+                Debug.LogError("Failed to start instances");
+                Assert.Fail("Failed to start instances");
+            }
+
+            // Immediately register for all pertinent event notifications we want to test and validate working
+            // For the server:
+            m_ServerNetworkManager.SceneManager.OnLoad += Server_OnLoad;
+            m_ServerNetworkManager.SceneManager.OnLoadComplete += Server_OnLoadComplete;
+            m_ServerNetworkManager.SceneManager.OnLoadEventCompleted += Server_OnLoadEventCompleted;
+            m_ServerNetworkManager.SceneManager.OnUnload += Server_OnUnload;
+            m_ServerNetworkManager.SceneManager.OnUnloadComplete += Server_OnUnloadComplete;
+            m_ServerNetworkManager.SceneManager.OnUnloadEventCompleted += Server_OnUnloadEventCompleted;
+            m_ServerNetworkManager.SceneManager.OnSynchronizeComplete += Server_OnSynchronizeComplete;
+            m_ServerNetworkManager.SceneManager.OnSceneEvent += Server_OnSceneEvent;
+            // For the clients:
+            foreach (var client in m_ClientNetworkManagers)
+            {
+                client.SceneManager.OnLoad += Client_OnLoad;
+                client.SceneManager.OnLoadComplete += Client_OnLoadComplete;
+                client.SceneManager.OnLoadEventCompleted += Client_OnLoadEventCompleted;
+                client.SceneManager.OnUnload += Client_OnUnload;
+                client.SceneManager.OnUnloadComplete += Client_OnUnloadComplete;
+                client.SceneManager.OnUnloadEventCompleted += Client_OnUnloadEventCompleted;
+                client.SceneManager.OnSynchronizeComplete += Client_OnSynchronizeComplete;
+                client.SceneManager.OnSynchronize += Client_OnSynchronize;
+            }
+
+            // Wait for connection on client side
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(m_ClientNetworkManagers));
+
+            // Wait for connection on server side
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnectedToServer(m_ServerNetworkManager, NbClients + 1));
+
+            //////////////////////////////////////////
+            // Testing synchronize event notifications
+            var shouldWait = NotificationTestShouldWait();
+
+            while (shouldWait)
+            {
+                yield return new WaitForSeconds(0.01f);
+                shouldWait = NotificationTestShouldWait();
+            }
+
+            // Reset for next test
+            ResetNotificationInfo();
+
+            //////////////////////////////////////////
+            // Testing load event notifications
+            Assert.That(m_ServerNetworkManager.SceneManager.LoadScene(k_AdditiveScene1, LoadSceneMode.Additive) == SceneEventProgressStatus.Started);
+            shouldWait = NotificationTestShouldWait()|| !m_CurrentScene.IsValid() || !m_CurrentScene.isLoaded;
+
+            while (shouldWait)
+            {
+                yield return new WaitForSeconds(0.01f);
+                shouldWait = NotificationTestShouldWait() || !m_CurrentScene.IsValid() || !m_CurrentScene.isLoaded;
+                if (!shouldWait)
+                {
+                    shouldWait = !ValidateCompletedNotifications();
+                }
+            }
+
+            // Reset for next test
+            ResetNotificationInfo();
+
+            //////////////////////////////////////////
+            // Testing unload event notifications
+            Assert.That(m_ServerNetworkManager.SceneManager.UnloadScene(m_CurrentScene) == SceneEventProgressStatus.Started);
+            shouldWait = NotificationTestShouldWait() || m_CurrentScene.IsValid() || m_CurrentScene.isLoaded;
+            while (shouldWait)
+            {
+                yield return new WaitForSeconds(0.01f);
+                shouldWait = NotificationTestShouldWait() || m_CurrentScene.isLoaded;
+                if (!shouldWait)
+                {
+                    shouldWait = !ValidateCompletedNotifications();
+                }
+            }
+            yield break;
+        }
+
+        private void Client_OnSynchronize(ulong clientId)
+        {
+            ClientProcessedNotification(clientId,SceneEventType.Synchronize, false);
+        }
+
+        private void Client_OnSynchronizeComplete(ulong clientId)
+        {
+            Debug.Log($"Client {clientId} synchronized.");
+            ClientProcessedNotification(clientId, SceneEventType.SynchronizeComplete, false, true);
+        }
+
+        private void Client_OnUnloadEventCompleted(string sceneName, LoadSceneMode loadSceneMode, List<ulong> clientsCompleted, List<ulong> clientsTimedOut)
+        {
+            ProcessCompletedNotification(clientsCompleted, SceneEventType.UnloadEventCompleted, false);
+        }
+
+        private void Client_OnUnloadComplete(ulong clientId, string sceneName)
+        {
+            Debug.Log($"Client {clientId} unloaded {sceneName}");
+            ClientProcessedNotification(clientId, SceneEventType.UnloadComplete, false, true);
+        }
+
+        private void Client_OnUnload(ulong clientId, string sceneName, AsyncOperation asyncOperation)
+        {
+            ClientProcessedNotification(clientId, SceneEventType.Unload, false);
+        }
+
+        private void Client_OnLoadEventCompleted(string sceneName, LoadSceneMode loadSceneMode, List<ulong> clientsCompleted, List<ulong> clientsTimedOut)
+        {
+            ProcessCompletedNotification(clientsCompleted, SceneEventType.LoadEventCompleted, false);
+        }
+
+        private void Client_OnLoadComplete(ulong clientId, string sceneName, LoadSceneMode loadSceneMode)
+        {
+            Debug.Log($"Client {clientId} loaded {sceneName} in {loadSceneMode} LoadSceneMode");
+            ClientProcessedNotification(clientId, SceneEventType.LoadComplete, false, true);
+        }
+
+        private void Client_OnLoad(ulong clientId, string sceneName, LoadSceneMode loadSceneMode, AsyncOperation asyncOperation)
+        {
+            ClientProcessedNotification(clientId, SceneEventType.Load, false);
+        }
+
+        #region ServerEvents
+        private void Server_OnSceneEvent(SceneEvent sceneEvent)
+        {
+            switch (sceneEvent.SceneEventType)
+            {
+                case SceneEventType.LoadComplete:
+                    {
+                        // We have to manually add the loaded scene to the clients when server is done loading
+                        // since the clients do not load scenes in MultiInstance tests.
+                        if (sceneEvent.ClientId == m_ServerNetworkManager.LocalClientId)
+                        {
+                            m_CurrentScene = sceneEvent.Scene;
+                            var sceneHandle = sceneEvent.Scene.handle;
+                            var scene = sceneEvent.Scene;
+
+                            foreach (var manager in m_ClientNetworkManagers)
+                            {
+                                if (!manager.SceneManager.ScenesLoaded.ContainsKey(sceneHandle))
+                                {
+                                    manager.SceneManager.ScenesLoaded.Add(sceneHandle, scene);
+                                }
+
+                                if (!manager.SceneManager.ServerSceneHandleToClientSceneHandle.ContainsKey(sceneHandle))
+                                {
+                                    manager.SceneManager.ServerSceneHandleToClientSceneHandle.Add(sceneHandle, sceneHandle);
+                                }
+                            }
+                        }
+                        break;
+                    }
+            }
+        }
+
+        private void Server_OnSynchronizeComplete(ulong clientId)
+        {
+            Debug.Log($"Server Received Client {clientId} synchronized complete.");
+            ClientProcessedNotification(clientId, SceneEventType.SynchronizeComplete, true, true);
+        }
+
+        private void Server_OnUnloadEventCompleted(string sceneName, LoadSceneMode loadSceneMode, List<ulong> clientsCompleted, List<ulong> clientsTimedOut)
+        {
+            ProcessCompletedNotification(clientsCompleted, SceneEventType.UnloadEventCompleted, true);
+        }
+
+        private void Server_OnUnloadComplete(ulong clientId, string sceneName)
+        {
+            ClientProcessedNotification(clientId, SceneEventType.UnloadComplete, true, true);
+        }
+
+        private void Server_OnUnload(ulong clientId, string sceneName, AsyncOperation asyncOperation)
+        {
+            ClientProcessedNotification(clientId, SceneEventType.Unload, true);
+        }
+
+        private void Server_OnLoadEventCompleted(string sceneName, LoadSceneMode loadSceneMode, List<ulong> clientsCompleted, List<ulong> clientsTimedOut)
+        {
+            ProcessCompletedNotification(clientsCompleted, SceneEventType.LoadEventCompleted, true);
+        }
+
+        private void Server_OnLoadComplete(ulong clientId, string sceneName, LoadSceneMode loadSceneMode)
+        {
+            ClientProcessedNotification(clientId, SceneEventType.LoadComplete, true, true);
+        }
+
+        private void Server_OnLoad(ulong clientId, string sceneName, LoadSceneMode loadSceneMode, AsyncOperation asyncOperation)
+        {
+            ClientProcessedNotification(clientId, SceneEventType.Load, true);
+        }
+        #endregion
     }
 
     /// <summary>


### PR DESCRIPTION
Per feedback from MTT hack week, it was determined that we should rename the enums defined in SceneEventData.SceneEventTypes while also providing users with the option to subscribe to each scene event type individually while leaving the optional OnSceneEvent for users that preferred to receive all scene event type notifications in one place.  The individual scene event type would provide users with the parameters only associated with the scene event type making it less complicated to determine what properties within SceneEvent were populated.

[MTT-1297](https://jira.unity3d.com/browse/MTT-1297)

## Testing and Documentation
* Includes integration test NetworkSceneManagerTests.SceneEventCallbackNotifications
* This includes XML documentation for:
  * the newly added events.
  * updated/revised some areas for better clarity

## Updated API
- [X] An [api update] was added 
