### PR TITLE
fix: remove compare in networkvarible set

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using UnityEngine;
 using System;
 

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -83,11 +83,6 @@ namespace Unity.Netcode
 
         private protected void Set(T value)
         {
-            if (EqualityComparer<T>.Default.Equals(m_InternalValue, value))
-            {
-                return;
-            }
-
             m_IsDirty = true;
             T previousValue = m_InternalValue;
             m_InternalValue = value;


### PR DESCRIPTION
This PR removes the "am I modified" check in the NetworkVariable::set function.  

Motivation:
- there is GC even with plain types with the `EqualityComparer<T>` implementation
- I investigated other ways around it, like stipulating `IEquatable<T>`, but that means users would have to implement GetHash and Equals for their non-POD types, and for some types like `enum` this becomes very awkward
- I also investigated IComparable, which is somewhat less cumbersome (e.g. enum works), but by its nature it uses boxing to convert from object in its function signature which gets us to where we started
- while one could make the case that repeated calls in one tick to 'Set' with the same value should be collapsed to avoid OnValueChanged calls, on balance this seems like a costly convenience
- when we implement snapshots, that will be the more proper time to deal with delta-ing

* No tests have been added.