### PR TITLE
fix: network scene manager UNITY_INCLUDE_TESTS

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -99,7 +99,7 @@ namespace Unity.Netcode
 
         // TODO: Remove `m_IsRunningUnitTest` entirely after we switch to multi-process testing
         // In MultiInstance tests, we cannot allow clients to load additional scenes as they're sharing the same scene space / Unity instance.
-#if UNITY_EDITOR || DEVELOPMENT_BUILD
+#if UNITY_INCLUDE_TESTS
         private readonly bool m_IsRunningUnitTest = SceneManager.GetActiveScene().name.StartsWith("InitTestScene");
 #endif
 
@@ -323,7 +323,7 @@ namespace Unity.Netcode
             else // Otherwise, we have to create a GameObject and move it into the DDOL to get the scene
             {
 
-#if UNITY_EDITOR || DEVELOPMENT_BUILD
+#if UNITY_INCLUDE_TESTS
                 // During unit and integration tests, we could initialize and then enable scene management
                 // which would make this generate an extra GameObject per instance. The DontDestroyOnLoadScene
                 // is internal so tests that are using multiInstance and that are moving NetworkObjects into
@@ -973,7 +973,7 @@ namespace Unity.Netcode
                 return;
             }
 
-#if UNITY_EDITOR || DEVELOPMENT_BUILD
+#if UNITY_INCLUDE_TESTS
             if (m_IsRunningUnitTest)
             {
                 // Send the loading message

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -799,7 +799,6 @@ namespace Unity.Netcode
                 ClientId = m_NetworkManager.LocalClientId   // Server sent this message to the client, but client is executing it
             });
 
-
 #if UNITY_INCLUDE_TESTS
             if (m_IsRunningUnitTest)
             {

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -320,22 +320,10 @@ namespace Unity.Netcode
             {
                 DontDestroyOnLoadScene = networkManager.gameObject.scene;
             }
-            else // Otherwise, we have to create a GameObject and move it into the DDOL to get the scene
+            else
             {
-
-#if UNITY_INCLUDE_TESTS
-                // During unit and integration tests, we could initialize and then enable scene management
-                // which would make this generate an extra GameObject per instance. The DontDestroyOnLoadScene
-                // is internal so tests that are using multiInstance and that are moving NetworkObjects into
-                // the DDOL scene will have to manually set this. Otherwise, we can exclude DDOL stuff completely
-                // during unit testing.
-                if (m_IsRunningUnitTest)
-                {
-                    return;
-                }
-#endif
-                // Create our DDOL GameObject and move it into the DDOL scene so we can register the DDOL with
-                // the NetworkSceneManager and then destroy the DDOL GameObject
+                // Otherwise, we have to create a GameObject and move it into the DDOL in order to
+                // register the DDOL scene handle with NetworkSceneManager
                 var myDDOLObject = new GameObject("DDOL-NWSM");
                 UnityEngine.Object.DontDestroyOnLoad(myDDOLObject);
                 DontDestroyOnLoadScene = myDDOLObject.scene;


### PR DESCRIPTION
Replaces all occurrences of #if UNITY_EDITOR || DEVELOPMENT_BUILD with #if UNITY_INCLUDE_TESTS within NetworkSceneManager.cs
This fixes an issue when running as a development build and was discovered during a multiprocess test run.
This is an update to fix this issue introduced in PR-1237 that was pertaining to:
[MTT-1320](https://jira.unity3d.com/browse/MTT-1320)