### PR TITLE
fix: netvar client initialization

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -419,7 +419,7 @@ namespace Unity.Netcode
 
                 var message = new CreateObjectMessage
                 {
-                    ObjectInfo = networkObject.GetMessageSceneObject(clientId, false)
+                    ObjectInfo = networkObject.GetMessageSceneObject(clientId)
                 };
                 var size = NetworkManager.SendMessage(message, NetworkDelivery.ReliableFragmentedSequenced, clientId);
                 var bytesReported = NetworkManager.LocalClientId == clientId

--- a/testproject/Assets/Tests/Runtime/NetworkVariableInitializationOnNetworkSpawnTest.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkVariableInitializationOnNetworkSpawnTest.cs
@@ -1,0 +1,102 @@
+using System.Collections;
+using NUnit.Framework;
+using TestProject.RuntimeTests.Support;
+using Unity.Netcode;
+using Unity.Netcode.RuntimeTests;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace TestProject.RuntimeTests
+{
+    public class NetworkVariableInitializationOnNetworkSpawnTest
+    {
+        private GameObject m_Prefab;
+
+        [UnitySetUp]
+        public IEnumerator SetUp()
+        {
+            // Make sure these static values are reset
+            NetworkVariableInitOnNetworkSpawn.NetworkSpawnCalledOnClient = false;
+            NetworkVariableInitOnNetworkSpawn.NetworkSpawnCalledOnServer = false;
+            yield break;
+        }
+
+        [UnityTearDown]
+        public IEnumerator Teardown()
+        {
+            // Shutdown and clean up both of our NetworkManager instances
+            if (m_Prefab)
+            {
+                MultiInstanceHelpers.Destroy();
+                Object.Destroy(m_Prefab);
+                m_Prefab = null;
+            }
+            NetworkVariableInitOnNetworkSpawn.NetworkSpawnCalledOnClient = false;
+            NetworkVariableInitOnNetworkSpawn.NetworkSpawnCalledOnServer = false;
+            yield break;
+        }
+
+        [UnityTest]
+        [Description("When a network variable is initialized in OnNetworkSpawn on the server, the spawned object's NetworkVariable on the client is initialized with the same value.")]
+        public IEnumerator WhenANetworkVariableIsInitializedInOnNetworkSpawnOnTheServer_TheSpawnedObjectsNetworkVariableOnTheClientIsInitializedWithTheSameValue()
+        {
+            const int numClients = 1;
+            Assert.True(MultiInstanceHelpers.Create(numClients, out NetworkManager server, out NetworkManager[] clients));
+            m_Prefab = new GameObject("Object");
+            var networkObject = m_Prefab.AddComponent<NetworkObject>();
+            m_Prefab.AddComponent<NetworkVariableInitOnNetworkSpawn>();
+
+            // Make it a prefab
+            MultiInstanceHelpers.MakeNetworkObjectTestPrefab(networkObject);
+
+            var validNetworkPrefab = new NetworkPrefab();
+            validNetworkPrefab.Prefab = m_Prefab;
+            server.NetworkConfig.NetworkPrefabs.Add(validNetworkPrefab);
+            foreach (var client in clients)
+            {
+                client.NetworkConfig.NetworkPrefabs.Add(validNetworkPrefab);
+            }
+
+            // Start the instances
+            if (!MultiInstanceHelpers.Start(true, server, clients))
+            {
+                Debug.LogError("Failed to start instances");
+                Assert.Fail("Failed to start instances");
+            }
+
+            // [Client-Side] Wait for a connection to the server
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(clients, null, 512));
+
+            // [Host-Side] Check to make sure all clients are connected
+            yield return MultiInstanceHelpers.Run(
+                MultiInstanceHelpers.WaitForClientsConnectedToServer(server, clients.Length + 1, null, 512));
+
+            var serverObject = Object.Instantiate(m_Prefab, Vector3.zero, Quaternion.identity);
+            NetworkObject serverNetworkObject = serverObject.GetComponent<NetworkObject>();
+            serverNetworkObject.NetworkManagerOwner = server;
+            serverNetworkObject.Spawn();
+
+            // Wait until all objects have spawned.
+            const int expectedNetworkObjects = numClients + 2; // +2 = one for prefab, one for server.
+            const int maxFrames = 240;
+            var doubleCheckTime = Time.realtimeSinceStartup + 5.0f;
+            while (Object.FindObjectsOfType<NetworkObject>().Length != expectedNetworkObjects)
+            {
+                if (Time.frameCount > maxFrames)
+                {
+                    // This is here in the event a platform is running at a higher
+                    // frame rate than expected
+                    if (doubleCheckTime < Time.realtimeSinceStartup)
+                    {
+                        Assert.Fail("Did not successfully spawn all expected NetworkObjects");
+                        break;
+                    }
+                }
+                var nextFrameNumber = Time.frameCount + 1;
+                yield return new WaitUntil(() => Time.frameCount >= nextFrameNumber);
+            }
+            Assert.IsTrue(NetworkVariableInitOnNetworkSpawn.NetworkSpawnCalledOnServer);
+            Assert.IsTrue(NetworkVariableInitOnNetworkSpawn.NetworkSpawnCalledOnClient);
+        }
+    }
+}

--- a/testproject/Assets/Tests/Runtime/NetworkVariableInitializationOnNetworkSpawnTest.cs.meta
+++ b/testproject/Assets/Tests/Runtime/NetworkVariableInitializationOnNetworkSpawnTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7896406895a74e6c91b121904f489c16
+timeCreated: 1633473823

--- a/testproject/Assets/Tests/Runtime/Support/NetworkVariableInitOnNetworkSpawn.cs
+++ b/testproject/Assets/Tests/Runtime/Support/NetworkVariableInitOnNetworkSpawn.cs
@@ -1,0 +1,27 @@
+using Unity.Netcode;
+using NUnit.Framework;
+
+namespace TestProject.RuntimeTests.Support
+{
+    public class NetworkVariableInitOnNetworkSpawn : NetworkBehaviour
+    {
+        private NetworkVariable<int> m_Variable = new NetworkVariable<int>();
+        public static bool NetworkSpawnCalledOnServer;
+        public static bool NetworkSpawnCalledOnClient;
+
+        public override void OnNetworkSpawn()
+        {
+            base.OnNetworkSpawn();
+            if (IsServer)
+            {
+                NetworkSpawnCalledOnServer = true;
+                m_Variable.Value = 5;
+            }
+            else
+            {
+                NetworkSpawnCalledOnClient = true;
+            }
+            Assert.AreEqual(5, m_Variable.Value);
+        }
+    }
+}

--- a/testproject/Assets/Tests/Runtime/Support/NetworkVariableInitOnNetworkSpawn.cs.meta
+++ b/testproject/Assets/Tests/Runtime/Support/NetworkVariableInitOnNetworkSpawn.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0854abbd5f3749788e711a3731952013
+timeCreated: 1633473693


### PR DESCRIPTION
Ensure server netvar initialization in OnNetworkSpawn replicates correctly to clients as initialization and not delta

MTT-1351

## Changelog

### com.unity.netcode.gameobjects
- Fixed: Ensure server netvar initialization in OnNetworkSpawn replicates correctly to clients as initialization and not delta

## Testing and Documentation

* Includes integration tests.
* No documentation changes or additions were necessary.