### PR TITLE
fix: metric collection is off when tools not enabled

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -503,8 +503,10 @@ namespace Unity.Netcode
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
             m_MessagingSystem.Hook(new ProfilingHooks());
 #endif
-            m_MessagingSystem.Hook(new MetricHooks(this));
 
+#if MULTIPLAYER_TOOLS
+            m_MessagingSystem.Hook(new MetricHooks(this));
+#endif
             LocalClientId = ulong.MaxValue;
 
             PendingClients.Clear();

--- a/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTickSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTickSystem.cs
@@ -6,7 +6,7 @@ namespace Unity.Netcode
     public class NetworkTickSystem
     {
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
-        private static ProfilerMarker s_Tick = new ProfilerMarker($"{nameof(NetworkTimeSystem)}.Tick");
+        private static ProfilerMarker s_Tick = new ProfilerMarker($"{nameof(NetworkTickSystem)}.Tick");
 #endif
 
         /// <summary>


### PR DESCRIPTION
This PR disables the metrics collection dispatch from the messaging system except when tools is enabled.  I did this because, well, there's overhead but moreover the .name resolution in the callsite incurs GC.  I realize we're also improving this in a separate PR, but it seems appropriate that customers only pay for the feature when it's on.

* No tests have been added.