### PR TITLE
fix:perf opt caching of hot properties

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -198,6 +198,16 @@ namespace Unity.Netcode
         /// </summary>
         public NetworkManager NetworkManager => NetworkObject.NetworkManager;
 
+        public string CachedName
+        {
+            get;
+            internal set;
+        }
+
+        void Awake()
+        {
+            CachedName = name;
+        }
         /// <summary>
         /// Gets if the object is the the personal clients player object
         /// </summary>

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -133,7 +133,7 @@ namespace Unity.Netcode
             int messageSize;
 
             // We check to see if we need to shortcut for the case where we are the host/server and we can send a clientRPC
-            // to ourself. Sadly we have to figure that out from the list of clientIds :( 
+            // to ourself. Sadly we have to figure that out from the list of clientIds :(
             bool shouldSendToHost = false;
 
             if (rpcParams.Send.TargetClientIds != null)
@@ -194,6 +194,7 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Gets the NetworkManager that owns this NetworkBehaviour instance
+        ///  this call is costing us performance.
         /// </summary>
         public NetworkManager NetworkManager => NetworkObject.NetworkManager;
 
@@ -463,6 +464,8 @@ namespace Unity.Netcode
                 return;
             }
 
+            // significantly saves performance
+            bool cacheIsServer = IsServer;
             if (NetworkManager.NetworkConfig.UseSnapshotDelta)
             {
                 for (int k = 0; k < NetworkVariableFields.Count; k++)
@@ -478,7 +481,7 @@ namespace Unity.Netcode
                     var shouldSend = false;
                     for (int k = 0; k < NetworkVariableFields.Count; k++)
                     {
-                        if (NetworkVariableFields[k].ShouldWrite(clientId, IsServer))
+                        if (NetworkVariableFields[k].ShouldWrite(clientId, cacheIsServer))
                         {
                             shouldSend = true;
                         }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkVariableDeltaMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkVariableDeltaMessage.cs
@@ -89,7 +89,7 @@ namespace Unity.Netcode
                     cacheNetworkManager.NetworkMetrics.TrackNetworkVariableDeltaSent(
                         ClientId,
                         NetworkBehaviour.NetworkObjectId,
-                        NetworkBehaviour.name,
+                        NetworkBehaviour.CachedName,
                         NetworkBehaviour.NetworkVariableFields[k].Name,
                         NetworkBehaviour.__getTypeName(),
                         writer.Length);


### PR DESCRIPTION
experimental reduction of common hot accessors.

In both tools code and in `NetworkVariableDeltaMessage` we call GameObject.name a lot, and that costs us (in my test anyway) 1.2% of our total performance.

