### PR TITLE
fix: network transform interpolation perf improvements

### DIFF
--- a/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
+++ b/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
@@ -61,7 +61,7 @@ namespace Unity.Netcode
         private NetworkTime m_EndTimeConsumed;
         private NetworkTime m_StartTimeConsumed;
 
-        private readonly List<BufferedItem> m_Buffer;
+        private readonly List<BufferedItem> m_Buffer = new List<BufferedItem>(k_BufferCountLimit);
 
         // Buffer consumption scenarios
         // Perfect case consumption
@@ -99,13 +99,11 @@ namespace Unity.Netcode
         internal BufferedLinearInterpolator(NetworkManager manager)
         {
             InterpolatorTimeProxy = new InterpolatorTime(manager);
-            m_Buffer = new List<BufferedItem>(k_BufferCountLimit);
         }
 
         internal BufferedLinearInterpolator(IInterpolatorTime proxy)
         {
             InterpolatorTimeProxy = proxy;
-            m_Buffer = new List<BufferedItem>(k_BufferCountLimit);
         }
 
         public void ResetTo(T targetValue)
@@ -212,7 +210,6 @@ namespace Unity.Netcode
             m_NbItemsReceivedThisFrame = 0;
             return m_CurrentInterpValue;
         }
-
 
         public void AddMeasurement(T newMeasurement, NetworkTime sentTime)
         {

--- a/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
+++ b/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
@@ -63,6 +63,7 @@ namespace Unity.Netcode
 
         private readonly List<BufferedItem> m_Buffer;
 
+        // Buffer consumption scenarios
         // Perfect case consumption
         // | 1 | 2 | 3 |
         // | 2 | 3 | 4 | consume 1
@@ -75,7 +76,7 @@ namespace Unity.Netcode
         // | 3 |   |   | consume 2
         // | 4 | 5 | 6 | consume 3
         // | 5 | 6 | 7 | consume 4
-        // bursted case
+        // bursted case (assuming max count is 5)
         // | 1 | 2 | 3 |
         // | 2 | 3 |   | consume 1
         // | 3 |   |   | consume 2
@@ -83,9 +84,9 @@ namespace Unity.Netcode
         // |   |   |   |
         // | 4 | 5 | 6 | 7 | 8 | --> consume all and teleport to last value <8> --> this is the nuclear option, ideally this example would consume 4 and 5
         // instead of jumping to 8, but since in OnValueChange we don't yet have an updated server time (updated in pre-update) to know which value
-        // we should keep and which we should drop, we don't have enough information to do this. Another thing would be to not have the burst in the
-        // first place.
-        // constant absolute value here instead of dynamic time based value. This is in case we have very low tick rates, so
+        // we should keep and which we should drop, we don't have enough information to do this. Another thing would be to not have the burst in the first place.
+
+        // Constant absolute value for max buffer count instead of dynamic time based value. This is in case we have very low tick rates, so
         // that we don't have a very small buffer because of this.
         private const int k_BufferCountLimit = 100;
         private BufferedItem m_LastBufferedItemReceived;

--- a/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTime.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTime.cs
@@ -52,6 +52,7 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Gets the tickrate of the system of this <see cref="NetworkTime"/>.
+        /// Ticks per second.
         /// </summary>
         public uint TickRate => m_TickRate;
 


### PR DESCRIPTION
AddMeasurement doesn't sort anymore and relies on consumption to keep track of last item to consume.
It'll also give up interpolating beyond a certain amount of bursted incoming netvar changes.
Fixing endtime vs start time comparison, to make sure we don't have floating point approximation errors

Note: with deep profiling, there's still a spike of operations happening when pausing the editor and unpausing. If I have 100 NetworkTransform, each with 7 interpolators, that's 700 * <tickrate> * <number of seconds paused> OnValueChanges it'll receive.
This PR reduces the overhead of OnValueChanged for NetworkTransform so we don't have the spiral of death anymore, but the root issue still remains that there's too many useless OnValueChanged received.

## Testing and Documentation

* Includes unit tests.
* No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->