### PR TITLE
chore: transport adapter to 0.1.0-preview.1

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 All notable changes to this package will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+
+### Added
+
+- Support for Relay (#887)
+
+### Fixed
+
+- Fixed an issue where OnClientDisconnectCallback was not being called (#1243)
+- Flush the UnityTransport send queue on shutdown (#1234)
+- Exposed a way to set ip and port from code (#1208)
+
 ## [0.0.1-preview.1] - 2020-12-20
 This is the first release of Unity Transport for Netcode for Gameobjects

--- a/com.unity.netcode.adapter.utp/package.json
+++ b/com.unity.netcode.adapter.utp/package.json
@@ -2,10 +2,10 @@
   "name": "com.unity.netcode.adapter.utp",
   "displayName": "Unity Transport for Netcode for GameObjects",
   "description": "This package is plugging Unity Transport into Netcode for GameObjects, which is a network transport layer - the low-level interface for sending UDP data",
-  "version": "0.0.1-preview.1",
+  "version": "0.1.0-preview.1",
   "unity": "2020.3",
   "dependencies": {
-    "com.unity.netcode.gameobjects": "0.0.1-preview.1",
+    "com.unity.netcode.gameobjects": "0.2.0-preview.1",
     "com.unity.transport": "1.0.0-pre.5"
   }
 }


### PR DESCRIPTION
Bumping the transport package version to reflect latest updates (relay, some bug fixes)
Updated changelog with entries for all changes since the package rename

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.