### PR TITLE
refactor: Moved INetworkMessage discovery to ILPP

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
@@ -1,11 +1,15 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Collections.Generic;
+using System.Reflection;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+using Mono.Cecil.Rocks;
 using Unity.CompilationPipeline.Common.Diagnostics;
 using Unity.CompilationPipeline.Common.ILPostProcessing;
 using ILPPInterface = Unity.CompilationPipeline.Common.ILPostProcessing.ILPostProcessor;
+using MethodAttributes = Mono.Cecil.MethodAttributes;
 
 namespace Unity.Netcode.Editor.CodeGen
 {
@@ -14,7 +18,9 @@ namespace Unity.Netcode.Editor.CodeGen
     {
         public override ILPPInterface GetInstance() => this;
 
-        public override bool WillProcess(ICompiledAssembly compiledAssembly) => compiledAssembly.References.Any(filePath => Path.GetFileNameWithoutExtension(filePath) == CodeGenHelpers.RuntimeAssemblyName);
+        public override bool WillProcess(ICompiledAssembly compiledAssembly) =>
+            compiledAssembly.Name == CodeGenHelpers.RuntimeAssemblyName ||
+            compiledAssembly.References.Any(filePath => Path.GetFileNameWithoutExtension(filePath) == CodeGenHelpers.RuntimeAssemblyName);
 
         private readonly List<DiagnosticMessage> m_Diagnostics = new List<DiagnosticMessage>();
 
@@ -42,11 +48,24 @@ namespace Unity.Netcode.Editor.CodeGen
             {
                 if (ImportReferences(mainModule))
                 {
+                    var types = mainModule.GetTypes()
+                        .Where(t => t.Resolve().HasInterface(CodeGenHelpers.INetworkMessage_FullName) && !t.Resolve().IsAbstract)
+                        .ToList();
                     // process `INetworkMessage` types
-                    mainModule.GetTypes()
-                        .Where(t => t.HasInterface(CodeGenHelpers.INetworkMessage_FullName))
-                        .ToList()
-                        .ForEach(b => ProcessINetworkMessage(b));
+                    if (types.Count == 0)
+                    {
+                        return null;
+                    }
+
+                    try
+                    {
+                        types.ForEach(b => ProcessINetworkMessage(b));
+                        CreateModuleInitializer(assemblyDefinition, types);
+                    }
+                    catch (Exception e)
+                    {
+                        m_Diagnostics.AddError((e.ToString() + e.StackTrace.ToString()).Replace("\n", "|").Replace("\r", "|"));
+                    }
                 }
                 else
                 {
@@ -57,6 +76,8 @@ namespace Unity.Netcode.Editor.CodeGen
             {
                 m_Diagnostics.AddError($"Cannot get main module from assembly definition: {compiledAssembly.Name}");
             }
+
+            mainModule.RemoveRecursiveReferences();
 
             // write
             var pe = new MemoryStream();
@@ -77,11 +98,49 @@ namespace Unity.Netcode.Editor.CodeGen
 
         private TypeReference m_FastBufferReader_TypeRef;
         private TypeReference m_NetworkContext_TypeRef;
+        private FieldReference m_MessagingSystem___network_message_types_FieldRef;
+        private MethodReference m_Type_GetTypeFromHandle_MethodRef;
+
+        private MethodReference m_List_Add_MethodRef;
 
         private bool ImportReferences(ModuleDefinition moduleDefinition)
         {
             m_FastBufferReader_TypeRef = moduleDefinition.ImportReference(typeof(FastBufferReader));
             m_NetworkContext_TypeRef = moduleDefinition.ImportReference(typeof(NetworkContext));
+
+            var typeType = typeof(Type);
+            foreach (var methodInfo in typeType.GetMethods())
+            {
+                switch (methodInfo.Name)
+                {
+                    case nameof(Type.GetTypeFromHandle):
+                        m_Type_GetTypeFromHandle_MethodRef = moduleDefinition.ImportReference(methodInfo);
+                        break;
+                }
+            }
+
+            var messagingSystemType = typeof(MessagingSystem);
+            foreach (var fieldInfo in messagingSystemType.GetFields(BindingFlags.Static | BindingFlags.NonPublic))
+            {
+                switch (fieldInfo.Name)
+                {
+                    case nameof(MessagingSystem.__network_message_types):
+                        m_MessagingSystem___network_message_types_FieldRef = moduleDefinition.ImportReference(fieldInfo);
+                        break;
+                }
+            }
+
+            var listType = typeof(List<Type>);
+            foreach (var methodInfo in listType.GetMethods())
+            {
+                switch (methodInfo.Name)
+                {
+                    case nameof(List<Type>.Add):
+                        m_List_Add_MethodRef = moduleDefinition.ImportReference(methodInfo);
+                        break;
+                }
+            }
+
 
             return true;
         }
@@ -98,6 +157,7 @@ namespace Unity.Netcode.Editor.CodeGen
                 {
                     typeSequence = methodSequence;
                 }
+
                 if (resolved.IsStatic && resolved.IsPublic && resolved.Name == "Receive" && resolved.Parameters.Count == 2
                     && !resolved.Parameters[0].IsIn
                     && !resolved.Parameters[0].ParameterType.IsByReference
@@ -116,6 +176,63 @@ namespace Unity.Netcode.Editor.CodeGen
             if (!foundAValidMethod)
             {
                 m_Diagnostics.AddError(typeSequence, $"Class {typeDefinition.FullName} does not implement required function: `public static void Receive(FastBufferReader, in NetworkContext)`");
+            }
+        }
+
+        private MethodDefinition GetOrCreateStaticConstructor(TypeDefinition typeDefinition)
+        {
+            var staticCtorMethodDef = typeDefinition.GetStaticConstructor();
+            if (staticCtorMethodDef == null)
+            {
+                staticCtorMethodDef = new MethodDefinition(
+                    ".cctor", // Static Constructor (constant-constructor)
+                    MethodAttributes.HideBySig |
+                    MethodAttributes.SpecialName |
+                    MethodAttributes.RTSpecialName |
+                    MethodAttributes.Static,
+                    typeDefinition.Module.TypeSystem.Void);
+                staticCtorMethodDef.Body.Instructions.Add(Instruction.Create(OpCodes.Ret));
+                typeDefinition.Methods.Add(staticCtorMethodDef);
+            }
+
+            return staticCtorMethodDef;
+        }
+
+        private void CreateInstructionsToRegisterType(ILProcessor processor, List<Instruction> instructions, TypeReference type)
+        {
+            // MessagingSystem.__network_message_types.Add(typeof(type));
+            instructions.Add(processor.Create(OpCodes.Ldsfld, m_MessagingSystem___network_message_types_FieldRef));
+            instructions.Add(processor.Create(OpCodes.Ldtoken, type));
+            instructions.Add(processor.Create(OpCodes.Call, m_Type_GetTypeFromHandle_MethodRef));
+            instructions.Add(processor.Create(OpCodes.Callvirt, m_List_Add_MethodRef));
+        }
+
+        // Creates a static module constructor (which is executed when the module is loaded) that registers all the
+        // message types in the assembly with MessagingSystem.
+        // This is the same behavior as annotating a static method with [ModuleInitializer] in standardized
+        // C# (that attribute doesn't exist in Unity, but the static module constructor still works)
+        // https://docs.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.moduleinitializerattribute?view=net-5.0
+        // https://web.archive.org/web/20100212140402/http://blogs.msdn.com/junfeng/archive/2005/11/19/494914.aspx
+        private void CreateModuleInitializer(AssemblyDefinition assembly, List<TypeDefinition> networkMessageTypes)
+        {
+            foreach (var typeDefinition in assembly.MainModule.Types)
+            {
+                if (typeDefinition.FullName == "<Module>")
+                {
+                    var staticCtorMethodDef = GetOrCreateStaticConstructor(typeDefinition);
+
+                    var processor = staticCtorMethodDef.Body.GetILProcessor();
+
+                    var instructions = new List<Instruction>();
+
+                    foreach (var type in networkMessageTypes)
+                    {
+                        CreateInstructionsToRegisterType(processor, instructions, type);
+                    }
+
+                    instructions.ForEach(instruction => processor.Body.Instructions.Insert(processor.Body.Instructions.Count - 1, instruction));
+                    break;
+                }
             }
         }
     }

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -467,38 +467,7 @@ namespace Unity.Netcode.Editor.CodeGen
                 typeDefinition.Methods.Add(newGetTypeNameMethod);
             }
 
-            // Weird behavior from Cecil: When importing a reference to a specific implementation of a generic
-            // method, it's importing the main module as a reference into itself. This causes Unity to have issues
-            // when attempting to iterate the assemblies to discover unit tests, as it goes into infinite recursion
-            // and eventually hits a stack overflow. I wasn't able to find any way to stop Cecil from importing the module
-            // into itself, so at the end of it all, we're just going to go back and remove it again.
-            var moduleName = m_MainModule.Name;
-            if (moduleName.EndsWith(".dll") || moduleName.EndsWith(".exe"))
-            {
-                moduleName = moduleName.Substring(0, moduleName.Length - 4);
-            }
-
-            foreach (var reference in m_MainModule.AssemblyReferences)
-            {
-                var referenceName = reference.Name.Split(',')[0];
-                if (referenceName.EndsWith(".dll") || referenceName.EndsWith(".exe"))
-                {
-                    referenceName = referenceName.Substring(0, referenceName.Length - 4);
-                }
-
-                if (moduleName == referenceName)
-                {
-                    try
-                    {
-                        m_MainModule.AssemblyReferences.Remove(reference);
-                        break;
-                    }
-                    catch (Exception)
-                    {
-                        //
-                    }
-                }
-            }
+            m_MainModule.RemoveRecursiveReferences();
         }
 
         private CustomAttribute CheckAndGetRpcAttribute(MethodDefinition methodDefinition)


### PR DESCRIPTION
This removes the runtime reflection for discovering INetworkMessage classes and replaces it with ILPP. At the moment, this is only for discovering the list of types - it still uses some reflection methods on those types for filtering out test messages and finding the Receive handler and setting it up as a delegate, but this removes the need to iterate through all types in all assemblies, so should handle the biggest issues. I'll follow up with another PR if I can figure out how to move the other two items to ILPP as well, but they're a little tougher. Maybe I'll just remove the test filtering entirely since the test messages are all in a separate assembly anyway.

It handles this by putting the registration code in the module initializer, which is a feature supported by the common language runtime, but not exposed to C# in Unity. Mainline C# exposes it with the [ModuleInitializer] attribute. I tested and made sure module initializers do execute in editor, stand-alone builds, and IL2CPP builds.

MTT-1398

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.