### PR TITLE
test: include multiprocess tests on desktop platforms only

### DIFF
--- a/testproject/Assets/Tests/Runtime/MultiprocessRuntime/testproject.multiprocesstests.asmdef
+++ b/testproject/Assets/Tests/Runtime/MultiprocessRuntime/testproject.multiprocesstests.asmdef
@@ -10,8 +10,6 @@
     ],
     "includePlatforms": [
         "Editor",
-        "Android",
-        "iOS",
         "macOSStandalone",
         "LinuxStandalone64",
         "WindowsStandalone32",

--- a/testproject/Assets/Tests/Runtime/MultiprocessRuntime/testproject.multiprocesstests.asmdef
+++ b/testproject/Assets/Tests/Runtime/MultiprocessRuntime/testproject.multiprocesstests.asmdef
@@ -7,5 +7,13 @@
     ],
     "optionalUnityReferences": [
         "TestAssemblies"
+    ],
+    "excludePlatforms": [
+        "GameCoreScarlett",
+        "GameCoreXboxOne",
+        "XboxOne",
+        "PS4",
+        "PS5",
+        "Switch"
     ]
 }

--- a/testproject/Assets/Tests/Runtime/MultiprocessRuntime/testproject.multiprocesstests.asmdef
+++ b/testproject/Assets/Tests/Runtime/MultiprocessRuntime/testproject.multiprocesstests.asmdef
@@ -8,12 +8,13 @@
     "optionalUnityReferences": [
         "TestAssemblies"
     ],
-    "excludePlatforms": [
-        "GameCoreScarlett",
-        "GameCoreXboxOne",
-        "XboxOne",
-        "PS4",
-        "PS5",
-        "Switch"
+    "includePlatforms": [
+        "Editor",
+        "Android",
+        "iOS",
+        "macOSStandalone",
+        "LinuxStandalone64",
+        "WindowsStandalone32",
+        "WindowsStandalone64"
     ]
 }


### PR DESCRIPTION
We have no support and plans to support MultiProcess tests on console platforms.
This PR makes MultiProcessTests to be included on desktop platforms only.

## Changelog

### com.unity.netcode.gameobjects

- N/A

## Testing and Documentation

- MultiProcess Tests will be excluded from console and mobile platforms with this PR
