### PR TITLE
fix: NetworkRigidbody sets interpolation mode to none on proxies

### DIFF
--- a/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
@@ -67,6 +67,7 @@ namespace Unity.Netcode.Components
         {
             m_IsAuthority = HasAuthority;
             m_OriginalKinematic = m_Rigidbody.isKinematic;
+            m_OriginalInterpolation = m_Rigidbody.interpolation;
             UpdateRigidbodyKinematicMode();
         }
 

--- a/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
@@ -14,6 +14,7 @@ namespace Unity.Netcode.Components
         private NetworkTransform m_NetworkTransform;
 
         private bool m_OriginalKinematic;
+        private RigidbodyInterpolation m_OriginalInterpolation;
 
         // Used to cache the authority state of this rigidbody during the last frame
         private bool m_IsAuthority;
@@ -48,11 +49,16 @@ namespace Unity.Netcode.Components
             {
                 m_OriginalKinematic = m_Rigidbody.isKinematic;
                 m_Rigidbody.isKinematic = true;
+
+                m_OriginalInterpolation = m_Rigidbody.interpolation;
+                // Set interpolation to none, the NetworkTransform component interpolates the position of the object.
+                m_Rigidbody.interpolation = RigidbodyInterpolation.None;
             }
             else
             {
                 // Resets the rigidbody back to it's non replication only state. Happens on shutdown and when authority is lost
                 m_Rigidbody.isKinematic = m_OriginalKinematic;
+                m_Rigidbody.interpolation = m_OriginalInterpolation;
             }
         }
 

--- a/com.unity.netcode.gameobjects/Components/NetworkRigidbody2D.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkRigidbody2D.cs
@@ -67,6 +67,7 @@ namespace Unity.Netcode.Components
         {
             m_IsAuthority = HasAuthority;
             m_OriginalKinematic = m_Rigidbody.isKinematic;
+            m_OriginalInterpolation = m_Rigidbody.interpolation;
             UpdateRigidbodyKinematicMode();
         }
 

--- a/com.unity.netcode.gameobjects/Components/NetworkRigidbody2D.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkRigidbody2D.cs
@@ -14,6 +14,7 @@ namespace Unity.Netcode.Components
         private NetworkTransform m_NetworkTransform;
 
         private bool m_OriginalKinematic;
+        private RigidbodyInterpolation2D m_OriginalInterpolation;
 
         // Used to cache the authority state of this rigidbody during the last frame
         private bool m_IsAuthority;
@@ -48,11 +49,16 @@ namespace Unity.Netcode.Components
             {
                 m_OriginalKinematic = m_Rigidbody.isKinematic;
                 m_Rigidbody.isKinematic = true;
+
+                m_OriginalInterpolation = m_Rigidbody.interpolation;
+                // Set interpolation to none, the NetworkTransform component interpolates the position of the object.
+                m_Rigidbody.interpolation = RigidbodyInterpolation2D.None;
             }
             else
             {
                 // Resets the rigidbody back to it's non replication only state. Happens on shutdown and when authority is lost
                 m_Rigidbody.isKinematic = m_OriginalKinematic;
+                m_Rigidbody.interpolation = m_OriginalInterpolation;
             }
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbody2DTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbody2DTest.cs
@@ -30,6 +30,7 @@ namespace Unity.Netcode.RuntimeTests.Physics
                 playerPrefab.AddComponent<NetworkTransform>();
                 playerPrefab.AddComponent<Rigidbody2D>();
                 playerPrefab.AddComponent<NetworkRigidbody2D>();
+                playerPrefab.GetComponent<Rigidbody2D>().interpolation = RigidbodyInterpolation2D.Interpolate;
                 playerPrefab.GetComponent<Rigidbody2D>().isKinematic = Kinematic;
             });
         }
@@ -58,11 +59,11 @@ namespace Unity.Netcode.RuntimeTests.Physics
 
             // server rigidbody has authority and should have a kinematic mode of false
             Assert.True(serverPlayer.GetComponent<Rigidbody2D>().isKinematic == Kinematic);
-            Assert.True(serverPlayer.GetComponent<Rigidbody2D>().interpolation == RigidbodyInterpolation2D.Interpolate);
+            Assert.AreEqual(RigidbodyInterpolation2D.Interpolate, serverPlayer.GetComponent<Rigidbody2D>().interpolation);
 
             // client rigidbody has no authority and should have a kinematic mode of true
             Assert.True(clientPlayer.GetComponent<Rigidbody2D>().isKinematic);
-            Assert.True(serverPlayer.GetComponent<Rigidbody2D>().interpolation == RigidbodyInterpolation2D.None);
+            Assert.AreEqual(RigidbodyInterpolation2D.None, clientPlayer.GetComponent<Rigidbody2D>().interpolation);
 
             // despawn the server player, (but keep it around on the server)
             serverPlayer.GetComponent<NetworkObject>().Despawn(false);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbody2DTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbody2DTest.cs
@@ -58,9 +58,11 @@ namespace Unity.Netcode.RuntimeTests.Physics
 
             // server rigidbody has authority and should have a kinematic mode of false
             Assert.True(serverPlayer.GetComponent<Rigidbody2D>().isKinematic == Kinematic);
+            Assert.True(serverPlayer.GetComponent<Rigidbody2D>().interpolation == RigidbodyInterpolation2D.Interpolate);
 
             // client rigidbody has no authority and should have a kinematic mode of true
             Assert.True(clientPlayer.GetComponent<Rigidbody2D>().isKinematic);
+            Assert.True(serverPlayer.GetComponent<Rigidbody2D>().interpolation == RigidbodyInterpolation2D.None);
 
             // despawn the server player, (but keep it around on the server)
             serverPlayer.GetComponent<NetworkObject>().Despawn(false);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbodyTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbodyTest.cs
@@ -58,9 +58,11 @@ namespace Unity.Netcode.RuntimeTests.Physics
 
             // server rigidbody has authority and should have a kinematic mode of false
             Assert.True(serverPlayer.GetComponent<Rigidbody>().isKinematic == Kinematic);
+            Assert.True(serverPlayer.GetComponent<Rigidbody>().interpolation == RigidbodyInterpolation.Interpolate);
 
             // client rigidbody has no authority and should have a kinematic mode of true
             Assert.True(clientPlayer.GetComponent<Rigidbody>().isKinematic);
+            Assert.True(serverPlayer.GetComponent<Rigidbody>().interpolation == RigidbodyInterpolation.None);
 
             // despawn the server player (but keep it around on the server)
             serverPlayer.GetComponent<NetworkObject>().Despawn(false);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbodyTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbodyTest.cs
@@ -30,6 +30,7 @@ namespace Unity.Netcode.RuntimeTests.Physics
                 playerPrefab.AddComponent<NetworkTransform>();
                 playerPrefab.AddComponent<Rigidbody>();
                 playerPrefab.AddComponent<NetworkRigidbody>();
+                playerPrefab.GetComponent<Rigidbody>().interpolation = RigidbodyInterpolation.Interpolate;
                 playerPrefab.GetComponent<Rigidbody>().isKinematic = Kinematic;
             });
         }
@@ -58,11 +59,11 @@ namespace Unity.Netcode.RuntimeTests.Physics
 
             // server rigidbody has authority and should have a kinematic mode of false
             Assert.True(serverPlayer.GetComponent<Rigidbody>().isKinematic == Kinematic);
-            Assert.True(serverPlayer.GetComponent<Rigidbody>().interpolation == RigidbodyInterpolation.Interpolate);
+            Assert.AreEqual(RigidbodyInterpolation.Interpolate, serverPlayer.GetComponent<Rigidbody>().interpolation);
 
             // client rigidbody has no authority and should have a kinematic mode of true
             Assert.True(clientPlayer.GetComponent<Rigidbody>().isKinematic);
-            Assert.True(serverPlayer.GetComponent<Rigidbody>().interpolation == RigidbodyInterpolation.None);
+            Assert.AreEqual(RigidbodyInterpolation.None, clientPlayer.GetComponent<Rigidbody>().interpolation);
 
             // despawn the server player (but keep it around on the server)
             serverPlayer.GetComponent<NetworkObject>().Despawn(false);


### PR DESCRIPTION
Sets the interpolation mode of the rigidbodies to none. The NetworkTransform is responsible for smoothing out bodies visually. Having the mode as something else than none caused minor position changes in the transform of the object which resulted in a log spam on non-authoritative objects.

MTT-1262 , MTT-1255 (might need a PR for NetworkTransform as well)

## Testing and Documentation

* Existing tests modified to unit test that setting the interpolation mode works
* No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->