### PR TITLE
fix: Implement a max number of metric values dispatched per frame

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
@@ -10,7 +10,7 @@ namespace Unity.Netcode
 {
     internal class NetworkMetrics : INetworkMetrics
     {
-        const ulong k_MaxMetricsPerFrame = 1000L;
+        const ulong k_MaxMetricsPerFrame = 999L;
 
         static Dictionary<uint, string> s_SceneEventTypeNames;
 
@@ -406,7 +406,7 @@ namespace Unity.Netcode
         {
             if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
             {
-                Debug.LogError($"Logged more than {k_MaxMetricsPerFrame} network metrics this frame. Not all metrics will be available in the profiler.");
+                Debug.LogError($"Logged more than {k_MaxMetricsPerFrame + 1} network metrics this frame. Not all metrics will be available in the profiler.");
             }
 
             if (m_NumberOfMetricsThisFrame > 0)

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
@@ -406,7 +406,7 @@ namespace Unity.Netcode
         {
             if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
             {
-                Debug.LogError($"Logged more than {k_MaxMetricsPerFrame + 1} network metrics this frame. Not all metrics will be available in the profiler.");
+                Debug.LogWarning($"Logged more than {k_MaxMetricsPerFrame + 1} network metrics this frame. Not all metrics will be available in the profiler.");
             }
 
             if (m_NumberOfMetricsThisFrame > 0)

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
@@ -406,11 +406,6 @@ namespace Unity.Netcode
 
         public void DispatchFrame()
         {
-            if (!CanSendMetrics)
-            {
-                Debug.LogWarning($"Logged more than {k_MaxMetricsPerFrame} network metrics this frame. Not all metrics will be available in the profiler.");
-            }
-
             Dispatcher.Dispatch();
             m_NumberOfMetricsThisFrame = 0;
         }

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
@@ -4,12 +4,15 @@ using System.Collections.Generic;
 using Unity.Multiplayer.Tools;
 using Unity.Multiplayer.Tools.MetricTypes;
 using Unity.Multiplayer.Tools.NetStats;
+using UnityEngine;
 
 namespace Unity.Netcode
 {
     internal class NetworkMetrics : INetworkMetrics
     {
-        private static Dictionary<uint, string> s_SceneEventTypeNames;
+        const ulong k_MaxMetricsPerFrame = 1000L;
+
+        static Dictionary<uint, string> s_SceneEventTypeNames;
 
         static NetworkMetrics()
         {
@@ -59,7 +62,8 @@ namespace Unity.Netcode
         private readonly EventMetric<ServerLogEvent> m_ServerLogReceivedEvent = new EventMetric<ServerLogEvent>(NetworkMetricTypes.ServerLogReceived.Id);
         private readonly EventMetric<SceneEventMetric> m_SceneEventSentEvent = new EventMetric<SceneEventMetric>(NetworkMetricTypes.SceneEventSent.Id);
         private readonly EventMetric<SceneEventMetric> m_SceneEventReceivedEvent = new EventMetric<SceneEventMetric>(NetworkMetricTypes.SceneEventReceived.Id);
-        private bool m_Dirty;
+
+        private ulong m_NumberOfMetricsThisFrame;
 
         public NetworkMetrics()
         {
@@ -99,20 +103,35 @@ namespace Unity.Netcode
 
         public void TrackNetworkMessageSent(ulong receivedClientId, string messageType, long bytesCount)
         {
+            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            {
+                return;
+            }
+
             m_NetworkMessageSentEvent.Mark(new NetworkMessageEvent(new ConnectionInfo(receivedClientId), messageType, bytesCount));
-            MarkDirty();
+            IncrementMetricCount();
         }
 
         public void TrackNetworkMessageReceived(ulong senderClientId, string messageType, long bytesCount)
         {
+            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            {
+                return;
+            }
+
             m_NetworkMessageReceivedEvent.Mark(new NetworkMessageEvent(new ConnectionInfo(senderClientId), messageType, bytesCount));
-            MarkDirty();
+            IncrementMetricCount();
         }
 
         public void TrackNamedMessageSent(ulong receiverClientId, string messageName, long bytesCount)
         {
+            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            {
+                return;
+            }
+
             m_NamedMessageSentEvent.Mark(new NamedMessageEvent(new ConnectionInfo(receiverClientId), messageName, bytesCount));
-            MarkDirty();
+            IncrementMetricCount();
         }
 
         public void TrackNamedMessageSent(IReadOnlyCollection<ulong> receiverClientIds, string messageName, long bytesCount)
@@ -125,14 +144,24 @@ namespace Unity.Netcode
 
         public void TrackNamedMessageReceived(ulong senderClientId, string messageName, long bytesCount)
         {
+            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            {
+                return;
+            }
+
             m_NamedMessageReceivedEvent.Mark(new NamedMessageEvent(new ConnectionInfo(senderClientId), messageName, bytesCount));
-            MarkDirty();
+            IncrementMetricCount();
         }
 
         public void TrackUnnamedMessageSent(ulong receiverClientId, long bytesCount)
         {
+            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            {
+                return;
+            }
+
             m_UnnamedMessageSentEvent.Mark(new UnnamedMessageEvent(new ConnectionInfo(receiverClientId), bytesCount));
-            MarkDirty();
+            IncrementMetricCount();
         }
 
         public void TrackUnnamedMessageSent(IReadOnlyCollection<ulong> receiverClientIds, long bytesCount)
@@ -145,8 +174,13 @@ namespace Unity.Netcode
 
         public void TrackUnnamedMessageReceived(ulong senderClientId, long bytesCount)
         {
+            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            {
+                return;
+            }
+
             m_UnnamedMessageReceivedEvent.Mark(new UnnamedMessageEvent(new ConnectionInfo(senderClientId), bytesCount));
-            MarkDirty();
+            IncrementMetricCount();
         }
 
         public void TrackNetworkVariableDeltaSent(
@@ -156,6 +190,11 @@ namespace Unity.Netcode
             string networkBehaviourName,
             long bytesCount)
         {
+            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            {
+                return;
+            }
+
             m_NetworkVariableDeltaSentEvent.Mark(
                 new NetworkVariableEvent(
                     new ConnectionInfo(receiverClientId),
@@ -163,7 +202,7 @@ namespace Unity.Netcode
                     variableName,
                     networkBehaviourName,
                     bytesCount));
-            MarkDirty();
+            IncrementMetricCount();
         }
 
         public void TrackNetworkVariableDeltaReceived(
@@ -173,6 +212,11 @@ namespace Unity.Netcode
             string networkBehaviourName,
             long bytesCount)
         {
+            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            {
+                return;
+            }
+
             m_NetworkVariableDeltaReceivedEvent.Mark(
                 new NetworkVariableEvent(
                     new ConnectionInfo(senderClientId),
@@ -180,44 +224,74 @@ namespace Unity.Netcode
                     variableName,
                     networkBehaviourName,
                     bytesCount));
-            MarkDirty();
+            IncrementMetricCount();
         }
 
         public void TrackOwnershipChangeSent(ulong receiverClientId, NetworkObject networkObject, long bytesCount)
         {
+            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            {
+                return;
+            }
+
             m_OwnershipChangeSentEvent.Mark(new OwnershipChangeEvent(new ConnectionInfo(receiverClientId), GetObjectIdentifier(networkObject), bytesCount));
-            MarkDirty();
+            IncrementMetricCount();
         }
 
         public void TrackOwnershipChangeReceived(ulong senderClientId, NetworkObject networkObject, long bytesCount)
         {
+            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            {
+                return;
+            }
+
             m_OwnershipChangeReceivedEvent.Mark(new OwnershipChangeEvent(new ConnectionInfo(senderClientId),
                 GetObjectIdentifier(networkObject), bytesCount));
-            MarkDirty();
+            IncrementMetricCount();
         }
 
         public void TrackObjectSpawnSent(ulong receiverClientId, NetworkObject networkObject, long bytesCount)
         {
+            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            {
+                return;
+            }
+
             m_ObjectSpawnSentEvent.Mark(new ObjectSpawnedEvent(new ConnectionInfo(receiverClientId), GetObjectIdentifier(networkObject), bytesCount));
-            MarkDirty();
+            IncrementMetricCount();
         }
 
         public void TrackObjectSpawnReceived(ulong senderClientId, NetworkObject networkObject, long bytesCount)
         {
+            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            {
+                return;
+            }
+
             m_ObjectSpawnReceivedEvent.Mark(new ObjectSpawnedEvent(new ConnectionInfo(senderClientId), GetObjectIdentifier(networkObject), bytesCount));
-            MarkDirty();
+            IncrementMetricCount();
         }
 
         public void TrackObjectDestroySent(ulong receiverClientId, NetworkObject networkObject, long bytesCount)
         {
+            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            {
+                return;
+            }
+
             m_ObjectDestroySentEvent.Mark(new ObjectDestroyedEvent(new ConnectionInfo(receiverClientId), GetObjectIdentifier(networkObject), bytesCount));
-            MarkDirty();
+            IncrementMetricCount();
         }
 
         public void TrackObjectDestroyReceived(ulong senderClientId, NetworkObject networkObject, long bytesCount)
         {
+            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            {
+                return;
+            }
+
             m_ObjectDestroyReceivedEvent.Mark(new ObjectDestroyedEvent(new ConnectionInfo(senderClientId), GetObjectIdentifier(networkObject), bytesCount));
-            MarkDirty();
+            IncrementMetricCount();
         }
 
         public void TrackRpcSent(
@@ -227,6 +301,11 @@ namespace Unity.Netcode
             string networkBehaviourName,
             long bytesCount)
         {
+            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            {
+                return;
+            }
+
             m_RpcSentEvent.Mark(
                 new RpcEvent(
                     new ConnectionInfo(receiverClientId),
@@ -234,7 +313,7 @@ namespace Unity.Netcode
                     rpcName,
                     networkBehaviourName,
                     bytesCount));
-            MarkDirty();
+            IncrementMetricCount();
         }
 
         public void TrackRpcSent(
@@ -257,25 +336,40 @@ namespace Unity.Netcode
             string networkBehaviourName,
             long bytesCount)
         {
+            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            {
+                return;
+            }
+
             m_RpcReceivedEvent.Mark(
                 new RpcEvent(new ConnectionInfo(senderClientId),
                     GetObjectIdentifier(networkObject),
                     rpcName,
                     networkBehaviourName,
                     bytesCount));
-            MarkDirty();
+            IncrementMetricCount();
         }
 
         public void TrackServerLogSent(ulong receiverClientId, uint logType, long bytesCount)
         {
+            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            {
+                return;
+            }
+
             m_ServerLogSentEvent.Mark(new ServerLogEvent(new ConnectionInfo(receiverClientId), (Multiplayer.Tools.MetricTypes.LogLevel)logType, bytesCount));
-            MarkDirty();
+            IncrementMetricCount();
         }
 
         public void TrackServerLogReceived(ulong senderClientId, uint logType, long bytesCount)
         {
+            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            {
+                return;
+            }
+
             m_ServerLogReceivedEvent.Mark(new ServerLogEvent(new ConnectionInfo(senderClientId), (Multiplayer.Tools.MetricTypes.LogLevel)logType, bytesCount));
-            MarkDirty();
+            IncrementMetricCount();
         }
 
         public void TrackSceneEventSent(IReadOnlyList<ulong> receiverClientIds, uint sceneEventType, string sceneName, long bytesCount)
@@ -288,28 +382,43 @@ namespace Unity.Netcode
 
         public void TrackSceneEventSent(ulong receiverClientId, uint sceneEventType, string sceneName, long bytesCount)
         {
+            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            {
+                return;
+            }
+
             m_SceneEventSentEvent.Mark(new SceneEventMetric(new ConnectionInfo(receiverClientId), GetSceneEventTypeName(sceneEventType), sceneName, bytesCount));
-            MarkDirty();
+            IncrementMetricCount();
         }
 
         public void TrackSceneEventReceived(ulong senderClientId, uint sceneEventType, string sceneName, long bytesCount)
         {
+            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            {
+                return;
+            }
+
             m_SceneEventReceivedEvent.Mark(new SceneEventMetric(new ConnectionInfo(senderClientId), GetSceneEventTypeName(sceneEventType), sceneName, bytesCount));
-            MarkDirty();
+            IncrementMetricCount();
         }
 
         public void DispatchFrame()
         {
-            if (m_Dirty)
+            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            {
+                Debug.LogError($"Logged more than {k_MaxMetricsPerFrame} network metrics this frame. Not all metrics will be available in the profiler.");
+            }
+
+            if (m_NumberOfMetricsThisFrame > 0)
             {
                 Dispatcher.Dispatch();
-                m_Dirty = false;
+                m_NumberOfMetricsThisFrame = 0;
             }
         }
 
-        private void MarkDirty()
+        private void IncrementMetricCount()
         {
-            m_Dirty = true;
+            m_NumberOfMetricsThisFrame++;
         }
 
         private static NetworkObjectIdentifier GetObjectIdentifier(NetworkObject networkObject)

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
@@ -411,11 +411,8 @@ namespace Unity.Netcode
                 Debug.LogWarning($"Logged more than {k_MaxMetricsPerFrame} network metrics this frame. Not all metrics will be available in the profiler.");
             }
 
-            if (m_NumberOfMetricsThisFrame > 0)
-            {
-                Dispatcher.Dispatch();
-                m_NumberOfMetricsThisFrame = 0;
-            }
+            Dispatcher.Dispatch();
+            m_NumberOfMetricsThisFrame = 0;
         }
 
         private void IncrementMetricCount()

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
@@ -10,7 +10,7 @@ namespace Unity.Netcode
 {
     internal class NetworkMetrics : INetworkMetrics
     {
-        const ulong k_MaxMetricsPerFrame = 999L;
+        const ulong k_MaxMetricsPerFrame = 1000L;
 
         static Dictionary<uint, string> s_SceneEventTypeNames;
 
@@ -86,7 +86,7 @@ namespace Unity.Netcode
 
         internal IMetricDispatcher Dispatcher { get; }
 
-        private bool CanSendMetrics => m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame;
+        private bool CanSendMetrics => m_NumberOfMetricsThisFrame < k_MaxMetricsPerFrame;
 
         public void SetConnectionId(ulong connectionId)
         {
@@ -408,7 +408,7 @@ namespace Unity.Netcode
         {
             if (!CanSendMetrics)
             {
-                Debug.LogWarning($"Logged more than {k_MaxMetricsPerFrame + 1} network metrics this frame. Not all metrics will be available in the profiler.");
+                Debug.LogWarning($"Logged more than {k_MaxMetricsPerFrame} network metrics this frame. Not all metrics will be available in the profiler.");
             }
 
             if (m_NumberOfMetricsThisFrame > 0)

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
@@ -86,6 +86,8 @@ namespace Unity.Netcode
 
         internal IMetricDispatcher Dispatcher { get; }
 
+        private bool CanSendMetrics => m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame;
+
         public void SetConnectionId(ulong connectionId)
         {
             Dispatcher.SetConnectionId(connectionId);
@@ -103,7 +105,7 @@ namespace Unity.Netcode
 
         public void TrackNetworkMessageSent(ulong receivedClientId, string messageType, long bytesCount)
         {
-            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            if (!CanSendMetrics)
             {
                 return;
             }
@@ -114,7 +116,7 @@ namespace Unity.Netcode
 
         public void TrackNetworkMessageReceived(ulong senderClientId, string messageType, long bytesCount)
         {
-            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            if (!CanSendMetrics)
             {
                 return;
             }
@@ -125,7 +127,7 @@ namespace Unity.Netcode
 
         public void TrackNamedMessageSent(ulong receiverClientId, string messageName, long bytesCount)
         {
-            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            if (!CanSendMetrics)
             {
                 return;
             }
@@ -144,7 +146,7 @@ namespace Unity.Netcode
 
         public void TrackNamedMessageReceived(ulong senderClientId, string messageName, long bytesCount)
         {
-            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            if (!CanSendMetrics)
             {
                 return;
             }
@@ -155,7 +157,7 @@ namespace Unity.Netcode
 
         public void TrackUnnamedMessageSent(ulong receiverClientId, long bytesCount)
         {
-            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            if (!CanSendMetrics)
             {
                 return;
             }
@@ -174,7 +176,7 @@ namespace Unity.Netcode
 
         public void TrackUnnamedMessageReceived(ulong senderClientId, long bytesCount)
         {
-            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            if (!CanSendMetrics)
             {
                 return;
             }
@@ -190,7 +192,7 @@ namespace Unity.Netcode
             string networkBehaviourName,
             long bytesCount)
         {
-            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            if (!CanSendMetrics)
             {
                 return;
             }
@@ -212,7 +214,7 @@ namespace Unity.Netcode
             string networkBehaviourName,
             long bytesCount)
         {
-            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            if (!CanSendMetrics)
             {
                 return;
             }
@@ -229,7 +231,7 @@ namespace Unity.Netcode
 
         public void TrackOwnershipChangeSent(ulong receiverClientId, NetworkObject networkObject, long bytesCount)
         {
-            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            if (!CanSendMetrics)
             {
                 return;
             }
@@ -240,7 +242,7 @@ namespace Unity.Netcode
 
         public void TrackOwnershipChangeReceived(ulong senderClientId, NetworkObject networkObject, long bytesCount)
         {
-            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            if (!CanSendMetrics)
             {
                 return;
             }
@@ -252,7 +254,7 @@ namespace Unity.Netcode
 
         public void TrackObjectSpawnSent(ulong receiverClientId, NetworkObject networkObject, long bytesCount)
         {
-            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            if (!CanSendMetrics)
             {
                 return;
             }
@@ -263,7 +265,7 @@ namespace Unity.Netcode
 
         public void TrackObjectSpawnReceived(ulong senderClientId, NetworkObject networkObject, long bytesCount)
         {
-            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            if (!CanSendMetrics)
             {
                 return;
             }
@@ -274,7 +276,7 @@ namespace Unity.Netcode
 
         public void TrackObjectDestroySent(ulong receiverClientId, NetworkObject networkObject, long bytesCount)
         {
-            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            if (!CanSendMetrics)
             {
                 return;
             }
@@ -285,7 +287,7 @@ namespace Unity.Netcode
 
         public void TrackObjectDestroyReceived(ulong senderClientId, NetworkObject networkObject, long bytesCount)
         {
-            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            if (!CanSendMetrics)
             {
                 return;
             }
@@ -301,7 +303,7 @@ namespace Unity.Netcode
             string networkBehaviourName,
             long bytesCount)
         {
-            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            if (!CanSendMetrics)
             {
                 return;
             }
@@ -336,7 +338,7 @@ namespace Unity.Netcode
             string networkBehaviourName,
             long bytesCount)
         {
-            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            if (!CanSendMetrics)
             {
                 return;
             }
@@ -352,7 +354,7 @@ namespace Unity.Netcode
 
         public void TrackServerLogSent(ulong receiverClientId, uint logType, long bytesCount)
         {
-            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            if (!CanSendMetrics)
             {
                 return;
             }
@@ -363,7 +365,7 @@ namespace Unity.Netcode
 
         public void TrackServerLogReceived(ulong senderClientId, uint logType, long bytesCount)
         {
-            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            if (!CanSendMetrics)
             {
                 return;
             }
@@ -382,7 +384,7 @@ namespace Unity.Netcode
 
         public void TrackSceneEventSent(ulong receiverClientId, uint sceneEventType, string sceneName, long bytesCount)
         {
-            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            if (!CanSendMetrics)
             {
                 return;
             }
@@ -393,7 +395,7 @@ namespace Unity.Netcode
 
         public void TrackSceneEventReceived(ulong senderClientId, uint sceneEventType, string sceneName, long bytesCount)
         {
-            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            if (!CanSendMetrics)
             {
                 return;
             }
@@ -404,7 +406,7 @@ namespace Unity.Netcode
 
         public void DispatchFrame()
         {
-            if (m_NumberOfMetricsThisFrame > k_MaxMetricsPerFrame)
+            if (!CanSendMetrics)
             {
                 Debug.LogWarning($"Logged more than {k_MaxMetricsPerFrame + 1} network metrics this frame. Not all metrics will be available in the profiler.");
             }


### PR DESCRIPTION
Introduces a maximum number of metrics that can be recorded in a given frame. This is to avoid performance issues when a high volume of metrics are tracked. This is a band-aid fix for an issue that was reported in slack.

https://unity.slack.com/archives/C01P4R0S2QH/p1634071340408400?thread_ts=1634052675.376600&cid=C01P4R0S2QH

## Changelog

N/A addresses regression within release

## Testing and Documentation

* Updates existing tests
* No documentation changes or additions were necessary.