### PR TITLE
fix!: NetworkTransform object pool adjustments

### DIFF
--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -692,6 +692,8 @@ namespace Unity.Netcode.Components
             m_ScaleXInterpolator = new BufferedLinearInterpolatorFloat(NetworkManager);
             m_ScaleYInterpolator = new BufferedLinearInterpolatorFloat(NetworkManager);
             m_ScaleZInterpolator = new BufferedLinearInterpolatorFloat(NetworkManager);
+
+            // Register for notifications when spawned
             m_ReplicatedNetworkState.OnValueChanged += OnNetworkStateChanged;
 
             if (m_AllFloatInterpolators.Count == 0)
@@ -711,6 +713,12 @@ namespace Unity.Netcode.Components
             Initialize();
         }
 
+        /// <summary>
+        /// Clean up interpolators in the event the associated
+        /// NetworkObject is part of an object pool and/or
+        /// it is part of an object pool that persists between
+        /// network sessions (i.e. different NetworkManagers)
+        /// </summary>
         public override void OnNetworkDespawn()
         {
             m_AllFloatInterpolators.Clear();

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -680,13 +680,7 @@ namespace Unity.Netcode.Components
         private void Awake()
         {
             m_Transform = transform;
-
-
             // ReplNetworkState.NetworkVariableChannel = NetworkChannel.PositionUpdate; // todo figure this out, talk with Matt/Fatih, this should be unreliable
-
-
-
-            m_ReplicatedNetworkState.OnValueChanged += OnNetworkStateChanged;
         }
 
         public override void OnNetworkSpawn()
@@ -698,6 +692,8 @@ namespace Unity.Netcode.Components
             m_ScaleXInterpolator = new BufferedLinearInterpolatorFloat(NetworkManager);
             m_ScaleYInterpolator = new BufferedLinearInterpolatorFloat(NetworkManager);
             m_ScaleZInterpolator = new BufferedLinearInterpolatorFloat(NetworkManager);
+            m_ReplicatedNetworkState.OnValueChanged += OnNetworkStateChanged;
+
             if (m_AllFloatInterpolators.Count == 0)
             {
                 m_AllFloatInterpolators.Add(m_PositionXInterpolator);
@@ -714,6 +710,21 @@ namespace Unity.Netcode.Components
             m_LocalAuthoritativeNetworkState = m_ReplicatedNetworkState.Value;
             Initialize();
         }
+
+        public override void OnNetworkDespawn()
+        {
+            m_AllFloatInterpolators.Clear();
+            m_PositionXInterpolator = null;
+            m_PositionYInterpolator = null;
+            m_PositionZInterpolator = null;
+            m_RotationInterpolator = null;
+            m_ScaleXInterpolator = null;
+            m_ScaleYInterpolator = null;
+            m_ScaleZInterpolator = null;
+            m_ReplicatedNetworkState.OnValueChanged -= OnNetworkStateChanged;
+            base.OnNetworkDespawn();
+        }
+
 
         public override void OnGainedOwnership()
         {
@@ -737,13 +748,6 @@ namespace Unity.Netcode.Components
             {
                 ApplyInterpolatedNetworkStateToTransform(m_ReplicatedNetworkState.Value, m_Transform);
             }
-        }
-
-        public override void OnDestroy()
-        {
-            m_ReplicatedNetworkState.OnValueChanged -= OnNetworkStateChanged;
-
-            base.OnDestroy();
         }
 
         #region state set


### PR DESCRIPTION
## This Fixes
 Some minor issues for pooled objects with a NetworkTransform component:
- Upon despawning and respawning they just "blink in and out" on the client side.
  - Completely resetting the interpolators upon despawning provides recycled NetworkObjects from a pool with "clean slate" interpolators.
- Don't subscribe to OnValueChanged until spawned
  - NetworkVariables can update prior to the spawn with recent changes, which will throw a null reference exception at line 624 where interpolators have not yet been instantiated.
  - subscribing to OnValueChanged within the OnNetworkSpawn method prevents that from happening.
- Destroying the interpolators when despawned prepares pooled NetworkObjects for their next usage
  - This also prevents "persistent NetworkObject pools" from having interpolators that were created using a previous NetworkManager from a previous session
