### PR TITLE
fix: network transform / interp perf bugs fixes - initialization, time computation

### DIFF
--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -682,14 +682,6 @@ namespace Unity.Netcode.Components
         private void Awake()
         {
             m_Transform = transform;
-            m_ReplicatedNetworkState.OnValueChanged += OnNetworkStateChanged;
-        }
-
-        public override void OnNetworkSpawn()
-        {
-            CanCommitToTransform = IsServer;
-            m_CachedIsServer = IsServer;
-            m_CachedNetworkManager = NetworkManager;
 
             m_PositionXInterpolator = new BufferedLinearInterpolatorFloat();
             m_PositionYInterpolator = new BufferedLinearInterpolatorFloat();
@@ -708,6 +700,21 @@ namespace Unity.Netcode.Components
                 m_AllFloatInterpolators.Add(m_ScaleYInterpolator);
                 m_AllFloatInterpolators.Add(m_ScaleZInterpolator);
             }
+        }
+
+        public override void OnNetworkDespawn()
+        {
+            m_ReplicatedNetworkState.OnValueChanged -= OnNetworkStateChanged;
+        }
+
+        public override void OnNetworkSpawn()
+        {
+            m_ReplicatedNetworkState.OnValueChanged += OnNetworkStateChanged;
+
+            CanCommitToTransform = IsServer;
+            m_CachedIsServer = IsServer;
+            m_CachedNetworkManager = NetworkManager;
+
             if (CanCommitToTransform)
             {
                 TryCommitTransformToServer(m_Transform, m_CachedNetworkManager.LocalTime.Time);

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -747,13 +747,6 @@ namespace Unity.Netcode.Components
             }
         }
 
-        public override void OnDestroy()
-        {
-            m_ReplicatedNetworkState.OnValueChanged -= OnNetworkStateChanged;
-
-            base.OnDestroy();
-        }
-
         #region state set
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -717,6 +717,9 @@ namespace Unity.Netcode.Components
                 TryCommitTransformToServer(m_Transform, m_CachedNetworkManager.LocalTime.Time);
             }
             m_LocalAuthoritativeNetworkState = m_ReplicatedNetworkState.Value;
+
+            // crucial we do this to reset the interpolators so that recycled objects when using a pool will
+            //  not have leftover interpolator state from the previous object
             Initialize();
         }
 

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -683,6 +683,8 @@ namespace Unity.Netcode.Components
         {
             m_Transform = transform;
 
+            // we only want to create our interpolators during Awake so that, when pooled, we do not create tons
+            //  of gc thrash each time objects wink out and are re-used
             m_PositionXInterpolator = new BufferedLinearInterpolatorFloat();
             m_PositionYInterpolator = new BufferedLinearInterpolatorFloat();
             m_PositionZInterpolator = new BufferedLinearInterpolatorFloat();

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -679,12 +679,9 @@ namespace Unity.Netcode.Components
             }
         }
 
-        private void Awake()
+        protected virtual void Awake()
         {
             m_Transform = transform;
-
-            // ReplNetworkState.NetworkVariableChannel = NetworkChannel.PositionUpdate; // todo figure this out, talk with Matt/Fatih, this should be unreliable
-
             m_ReplicatedNetworkState.OnValueChanged += OnNetworkStateChanged;
         }
 

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -679,7 +679,7 @@ namespace Unity.Netcode.Components
             }
         }
 
-        protected virtual void Awake()
+        private void Awake()
         {
             m_Transform = transform;
             m_ReplicatedNetworkState.OnValueChanged += OnNetworkStateChanged;

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -702,11 +702,6 @@ namespace Unity.Netcode.Components
             }
         }
 
-        public override void OnNetworkDespawn()
-        {
-            m_ReplicatedNetworkState.OnValueChanged -= OnNetworkStateChanged;
-        }
-
         public override void OnNetworkSpawn()
         {
             m_ReplicatedNetworkState.OnValueChanged += OnNetworkStateChanged;
@@ -721,6 +716,11 @@ namespace Unity.Netcode.Components
             }
             m_LocalAuthoritativeNetworkState = m_ReplicatedNetworkState.Value;
             Initialize();
+        }
+
+        public override void OnNetworkDespawn()
+        {
+            m_ReplicatedNetworkState.OnValueChanged -= OnNetworkStateChanged;
         }
 
         public override void OnGainedOwnership()

--- a/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTime.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTime.cs
@@ -105,9 +105,9 @@ namespace Unity.Netcode
             return new NetworkTime(m_TickRate, m_CachedTick);
         }
 
-        public NetworkTime TimeTicksAgo(uint ticks)
+        public NetworkTime TimeTicksAgo(int ticks)
         {
-            return this - new NetworkTime(TickRate, (int)ticks);
+            return this - new NetworkTime(TickRate, ticks);
         }
 
         private void UpdateCache()

--- a/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTime.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTime.cs
@@ -107,7 +107,7 @@ namespace Unity.Netcode
 
         public NetworkTime TimeTicksAgo(uint ticks)
         {
-            return this - new NetworkTime(TickRate, ticks);
+            return this - new NetworkTime(TickRate, (int)ticks);
         }
 
         private void UpdateCache()

--- a/com.unity.netcode.gameobjects/Samples/ClientNetworkTransform/Scripts/ClientNetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Samples/ClientNetworkTransform/Scripts/ClientNetworkTransform.cs
@@ -18,8 +18,9 @@ namespace Unity.Netcode.Samples
         /// </summary>
         // This is public to make sure that users don't depend on this IsClient && IsOwner check in their code. If this logic changes in the future, we can make it invisible here
 
-        private void Awake()
+        public override void OnNetworkSpawn()
         {
+            base.OnNetworkSpawn();
             CanCommitToTransform = IsOwner;
         }
 


### PR DESCRIPTION
@VALERE91Unity discovered an initialization issue with ClientNetworkTransform, and this fix (which @MFatihMAR noticed in my previous PR) addresses it (though the problem was the Awake call was stomping the base class' Awake call
