### PR TITLE
fix: networkvariable editor issue

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -91,7 +91,7 @@ namespace Unity.Netcode.Editor
             var behaviour = (NetworkBehaviour)target;
 
             // Only server can MODIFY. So allow modification if network is either not running or we are server
-            if (behaviour.NetworkManager == null || !behaviour.NetworkManager.IsListening || behaviour.NetworkManager.IsServer)
+            if (behaviour.IsBehaviourEditable())
             {
                 if (type == typeof(int))
                 {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -212,6 +212,7 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Gets the NetworkManager that owns this NetworkBehaviour instance
+        ///   See note around `NetworkObject` for how there is a chicken / egg problem when we are not initialized
         /// </summary>
         public NetworkManager NetworkManager => NetworkObject.NetworkManager;
 
@@ -253,8 +254,24 @@ namespace Unity.Netcode
         /// </summary>
         public bool IsSpawned => HasNetworkObject ? NetworkObject.IsSpawned : false;
 
+        internal bool IsBehaviourEditable()
+        {
+            // Only server can MODIFY. So allow modification if network is either not running or we are server
+            return !m_NetworkObject ||
+                   (m_NetworkObject.NetworkManager == null ||
+                    !m_NetworkObject.NetworkManager.IsListening ||
+                    m_NetworkObject.NetworkManager.IsServer);
+        }
+
         /// <summary>
         /// Gets the NetworkObject that owns this NetworkBehaviour instance
+        ///  TODO: this needs an overhaul.  It's expensive, it's ja little naive in how it looks for networkObject in
+        ///   its parent and worst, it creates a puzzle if you are a NetworkBehaviour wanting to see if you're live or not
+        ///   (e.g. editor code).  All you want to do is find out if NetworkManager is null, but to do that you
+        ///   need NetworkObject, but if you try and grab NetworkObject and NetworkManager isn't up you'll get
+        ///   the warning below.  This is why IsBehaviourEditable had to be created.  Matt was going to re-do
+        ///   how NetworkObject works but it was close to the release and too risky to change
+        ///
         /// </summary>
         public NetworkObject NetworkObject
         {


### PR DESCRIPTION
This fixes a bug with network variables in the editor.  There was a chicken/egg problem with trying to find out if the network manager is running.
