### PR TITLE
fix: transform init in OnNetworkSpawn, network transform remove lossy…

### DIFF
--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -864,9 +864,10 @@ namespace Unity.Netcode.Components
                         }
                     }
 #endif
+
+                    // Apply updated interpolated value
+                    ApplyInterpolatedNetworkStateToTransform(m_ReplicatedNetworkState.Value, m_Transform);
                 }
-                // Apply updated interpolated value
-                ApplyInterpolatedNetworkStateToTransform(m_ReplicatedNetworkState.Value, m_Transform);
             }
 
             m_LocalAuthoritativeNetworkState.IsTeleportingNextFrame = false;

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -847,15 +847,14 @@ namespace Unity.Netcode.Components
                         var interpolatedPosition = new Vector3(m_PositionXInterpolator.GetInterpolatedValue(), m_PositionYInterpolator.GetInterpolatedValue(), m_PositionZInterpolator.GetInterpolatedValue());
                         Debug.DrawLine(interpolatedPosition, interpolatedPosition + Vector3.up, Color.magenta, k_DebugDrawLineTime, false);
 
- 
                         // try to update previously consumed NetworkState
                         // if we have any changes, that means made some updates locally
                         // we apply the latest ReplNetworkState again to revert our changes
                         var oldStateDirtyInfo = ApplyTransformToNetworkStateWithInfo(ref m_PrevNetworkState, 0, m_Transform);
 
                         // there are several bugs in this code, as we the message is dumped out under odd circumstances
-						//  For Matt, it would trigger when an object's rotation was perturbed by colliding with another
-                    	//  object vs. explicitly rotating it
+                        //  For Matt, it would trigger when an object's rotation was perturbed by colliding with another
+                        //  object vs. explicitly rotating it
                         if (oldStateDirtyInfo.isPositionDirty || oldStateDirtyInfo.isScaleDirty || (oldStateDirtyInfo.isRotationDirty && SyncRotAngleX && SyncRotAngleY && SyncRotAngleZ))
                         {
                             // ignoring rotation dirty since quaternions will mess with euler angles, making this impossible to determine if the change to a single axis comes
@@ -865,10 +864,9 @@ namespace Unity.Netcode.Components
                         }
                     }
 #endif
-
-                    // Apply updated interpolated value
-                    ApplyInterpolatedNetworkStateToTransform(m_ReplicatedNetworkState.Value, m_Transform);
                 }
+                // Apply updated interpolated value
+                ApplyInterpolatedNetworkStateToTransform(m_ReplicatedNetworkState.Value, m_Transform);
             }
 
             m_LocalAuthoritativeNetworkState.IsTeleportingNextFrame = false;

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -298,7 +298,6 @@ namespace Unity.Netcode.Components
         private int m_LastSentTick;
         private NetworkTransformState m_LastSentState;
 
-
         /// <summary>
         /// Tries updating the server authoritative transform, only if allowed.
         /// If this called server side, this will commit directly.
@@ -396,7 +395,7 @@ namespace Unity.Netcode.Components
         {
             var position = InLocalSpace ? transformToUse.localPosition : transformToUse.position;
             var rotAngles = InLocalSpace ? transformToUse.localEulerAngles : transformToUse.eulerAngles;
-            var scale = InLocalSpace ? transformToUse.localScale : transformToUse.lossyScale;
+            var scale = transformToUse.localScale;
             return ApplyTransformToNetworkStateWithInfo(ref networkState, dirtyTime, position, rotAngles, scale);
         }
 
@@ -510,7 +509,7 @@ namespace Unity.Netcode.Components
 
             // todo: we should store network state w/ quats vs. euler angles
             var interpolatedRotAngles = InLocalSpace ? transformToUpdate.localEulerAngles : transformToUpdate.eulerAngles;
-            var interpolatedScale = InLocalSpace ? transformToUpdate.localScale : transformToUpdate.lossyScale;
+            var interpolatedScale = transformToUpdate.localScale;
 
             // InLocalSpace Read
             InLocalSpace = networkState.InLocalSpace;
@@ -599,18 +598,7 @@ namespace Unity.Netcode.Components
             // Scale Apply
             if (SyncScaleX || SyncScaleY || SyncScaleZ)
             {
-                if (InLocalSpace)
-                {
-                    transformToUpdate.localScale = interpolatedScale;
-                }
-                else
-                {
-                    transformToUpdate.localScale = Vector3.one;
-                    var lossyScale = transformToUpdate.lossyScale;
-                    // todo this conversion is messing with interpolation. local scale interpolates fine, lossy scale is jittery. must investigate. MTT-1208
-                    transformToUpdate.localScale = new Vector3(interpolatedScale.x / lossyScale.x, interpolatedScale.y / lossyScale.y, interpolatedScale.z / lossyScale.z);
-                }
-
+                transformToUpdate.localScale = interpolatedScale;
                 m_PrevNetworkState.Scale = interpolatedScale;
             }
         }
@@ -679,8 +667,6 @@ namespace Unity.Netcode.Components
 
         private void Awake()
         {
-            m_Transform = transform;
-
             // we only want to create our interpolators during Awake so that, when pooled, we do not create tons
             //  of gc thrash each time objects wink out and are re-used
             m_PositionXInterpolator = new BufferedLinearInterpolatorFloat();
@@ -704,6 +690,10 @@ namespace Unity.Netcode.Components
 
         public override void OnNetworkSpawn()
         {
+            // must set up m_Transform in OnNetworkSpawn because it's possible an object spawns but is disabled
+            //  and thus awake won't be called.
+            // TODO: investigate further on not sending data for something that is not enabled
+            m_Transform = transform;
             m_ReplicatedNetworkState.OnValueChanged += OnNetworkStateChanged;
 
             CanCommitToTransform = IsServer;
@@ -857,12 +847,15 @@ namespace Unity.Netcode.Components
                         var interpolatedPosition = new Vector3(m_PositionXInterpolator.GetInterpolatedValue(), m_PositionYInterpolator.GetInterpolatedValue(), m_PositionZInterpolator.GetInterpolatedValue());
                         Debug.DrawLine(interpolatedPosition, interpolatedPosition + Vector3.up, Color.magenta, k_DebugDrawLineTime, false);
 
+ 
                         // try to update previously consumed NetworkState
                         // if we have any changes, that means made some updates locally
                         // we apply the latest ReplNetworkState again to revert our changes
                         var oldStateDirtyInfo = ApplyTransformToNetworkStateWithInfo(ref m_PrevNetworkState, 0, m_Transform);
 
                         // there are several bugs in this code, as we the message is dumped out under odd circumstances
+						//  For Matt, it would trigger when an object's rotation was perturbed by colliding with another
+                    	//  object vs. explicitly rotating it
                         if (oldStateDirtyInfo.isPositionDirty || oldStateDirtyInfo.isScaleDirty || (oldStateDirtyInfo.isRotationDirty && SyncRotAngleX && SyncRotAngleY && SyncRotAngleZ))
                         {
                             // ignoring rotation dirty since quaternions will mess with euler angles, making this impossible to determine if the change to a single axis comes

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -180,7 +180,6 @@ namespace Unity.Netcode.RuntimeTests
             // We are no longer emitting this warning, and we are banishing tests that rely on console output, so
             //  needs re-implementation
             // TODO: This should be a separate test - verify 1 behavior per test
-            // TODO: We are no longer emitting this warning, and we are banishing tests that rely on console output, so
             LogAssert.Expect(LogType.Warning, new Regex(".*without authority detected.*"));
 #endif
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -177,9 +177,10 @@ namespace Unity.Netcode.RuntimeTests
 
             Assert.AreEqual(Vector3.zero, otherSideNetworkTransform.transform.position, "got authority error, but other side still moved!");
 #if NGO_TRANSFORM_DEBUG
-            // TODO: We are no longer emitting this warning, and we are banishing tests that rely on console output, so
+            // We are no longer emitting this warning, and we are banishing tests that rely on console output, so
             //  needs re-implementation
             // TODO: This should be a separate test - verify 1 behavior per test
+            // TODO: We are no longer emitting this warning, and we are banishing tests that rely on console output, so
             LogAssert.Expect(LogType.Warning, new Regex(".*without authority detected.*"));
 #endif
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -177,6 +177,8 @@ namespace Unity.Netcode.RuntimeTests
 
             Assert.AreEqual(Vector3.zero, otherSideNetworkTransform.transform.position, "got authority error, but other side still moved!");
 #if NGO_TRANSFORM_DEBUG
+            // TODO: We are no longer emitting this warning, and we are banishing tests that rely on console output, so
+            //  needs re-implementation
             // TODO: This should be a separate test - verify 1 behavior per test
             LogAssert.Expect(LogType.Warning, new Regex(".*without authority detected.*"));
 #endif


### PR DESCRIPTION
This fixes 3 things:
- removes log spam when NT thinks it detects an authority issue (which gives lots of false alarms)
- moves init of m_Transform to OnNetworkSpawn to address issue @andrews-unity found when disabled objects are spawned
- removes the use of lossyScale

* No tests have been added.
