### PR TITLE
chore: update testproject's packages-lock.json

### DIFF
--- a/testproject/Packages/packages-lock.json
+++ b/testproject/Packages/packages-lock.json
@@ -70,7 +70,7 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.netcode.gameobjects": "0.2.0-preview.1",
+        "com.unity.netcode.gameobjects": "1.0.0-pre.1",
         "com.unity.transport": "1.0.0-pre.5"
       }
     },
@@ -81,12 +81,12 @@
       "dependencies": {
         "com.unity.modules.ai": "1.0.0",
         "com.unity.modules.animation": "1.0.0",
-        "com.unity.nuget.mono-cecil": "1.10.1-preview.1",
+        "com.unity.nuget.mono-cecil": "1.10.1",
         "com.unity.collections": "1.0.0-pre.5"
       }
     },
     "com.unity.nuget.mono-cecil": {
-      "version": "1.10.1-preview.1",
+      "version": "1.10.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {},

--- a/testproject/Packages/packages-lock.json
+++ b/testproject/Packages/packages-lock.json
@@ -70,7 +70,7 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.netcode.gameobjects": "0.0.1-preview.1",
+        "com.unity.netcode.gameobjects": "0.2.0-preview.1",
         "com.unity.transport": "1.0.0-pre.5"
       }
     },


### PR DESCRIPTION
Probably a lingering artifact from #1255

(note: Unity Editor auto-updates this file everytime we open `testproject`)