### PR TITLE
fix!: MTT-1425 Resolving overflow issue with UTP Adapter

### DIFF
--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -80,6 +80,9 @@ namespace Unity.Netcode
         public const int InitialBatchQueueSize = 6 * 1024;
         public const int InitialMaxPacketSize = NetworkParameterConstants.MTU;
 
+        private static ConnectionAddressData s_DefaultConnectionAddressData = new ConnectionAddressData()
+        { Address = "127.0.0.1", Port = 7777 };
+
 #pragma warning disable IDE1006 // Naming Styles
         public static INetworkStreamDriverConstructor s_DriverConstructor;
 #pragma warning restore IDE1006 // Naming Styles
@@ -97,8 +100,20 @@ namespace Unity.Netcode
         [Tooltip("The maximum size in bytes of the send queue for batching Netcode events")]
         [SerializeField] private int m_SendQueueBatchSize = InitialBatchQueueSize;
 
-        [SerializeField]
-        public NetworkEndPoint ConnectionData { get; private set; }
+        [Serializable]
+        public struct ConnectionAddressData
+        {
+            [SerializeField] public string Address;
+            [SerializeField] public int Port;
+
+            public static implicit operator NetworkEndPoint(ConnectionAddressData d) =>
+                NetworkEndPoint.Parse(d.Address, (ushort)d.Port);
+
+            public static implicit operator ConnectionAddressData(NetworkEndPoint d) =>
+                new ConnectionAddressData() { Address = d.Address.Split(':')[0], Port = d.Port };
+        }
+
+        public ConnectionAddressData ConnectionData = s_DefaultConnectionAddressData;
 
         private State m_State = State.Disconnected;
         private NetworkDriver m_Driver;
@@ -321,7 +336,8 @@ namespace Unity.Netcode
         /// </summary>
         public void SetConnectionData(string ipv4Address, ushort port)
         {
-            ConnectionData = NetworkEndPoint.Parse(ipv4Address, port);
+            ConnectionData.Address = ipv4Address;
+            ConnectionData.Port = port;
         }
 
         /// <summary>

--- a/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/DriverClient.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/DriverClient.cs
@@ -35,7 +35,7 @@ namespace Unity.Netcode.UTP.RuntimeTests
 
         private void Awake()
         {
-            var maxCap = UnityTransport.MaximumMessageLength + 128;
+            var maxCap = UnityTransport.InitialBatchQueueSize + 128;
             var fragParams = new FragmentationUtility.Parameters() { PayloadCapacity = maxCap };
 
             m_Driver = NetworkDriver.Create(fragParams);

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -681,7 +681,7 @@ namespace Unity.Netcode.Components
 
         private void Awake()
         {
-            m_Transform = transform;
+           
 
             // ReplNetworkState.NetworkVariableChannel = NetworkChannel.PositionUpdate; // todo figure this out, talk with Matt/Fatih, this should be unreliable
 
@@ -690,6 +690,8 @@ namespace Unity.Netcode.Components
 
         public override void OnNetworkSpawn()
         {
+            m_Transform = transform;
+
             CanCommitToTransform = IsServer;
             m_CachedIsServer = IsServer;
             m_CachedNetworkManager = NetworkManager;


### PR DESCRIPTION
So this is doing some cleanup and fixing several issues the UTP Adapter was having with regards to queued packets, as well as fragmentation. Also cleaned up the public properties to make more sense since what was there before just lead to a lot of confusion. Also we report back a string for an error code now which should make it easier to understand what is going on. 

MTT-1425

## Changelog

### com.unity.adapter.utp
- Fixed: Possible Editor crash when trying to read a batched packet where the size of the packet was larger than the max packet size. 
- Fixed: Removed the requirement that MaxPacketSize needs to be the same size as the batched/fragmentation buffer size. 
- Changed: Consolidated the Send/Recv queue properties as they always needed to be the same. 
- Changed: Consolidated the Fragmentation/Queue size as they always needed to be the same. 
- Added: New `SetConnectionData` function that takes in a NetworkEndpoint
- Removed: Removed `m_MessageBuffer` as it was no longer needed and we just do a temp allocation and copy the packet when we call InvokeOnTransportEvent

## Testing and Documentation

* Testing is already covered by the current transport tests. 
