### PR TITLE
chore: updating versions to pre-release values for APV validation

### DIFF
--- a/com.unity.netcode.adapter.utp/package.json
+++ b/com.unity.netcode.adapter.utp/package.json
@@ -2,10 +2,10 @@
   "name": "com.unity.netcode.adapter.utp",
   "displayName": "Unity Transport for Netcode for GameObjects",
   "description": "This package is plugging Unity Transport into Netcode for GameObjects, which is a network transport layer - the low-level interface for sending UDP data",
-  "version": "0.1.0-preview.1",
+  "version": "1.0.0-pre.1",
   "unity": "2020.3",
   "dependencies": {
-    "com.unity.netcode.gameobjects": "0.2.0-preview.1",
+    "com.unity.netcode.gameobjects": "1.0.0-pre.1",
     "com.unity.transport": "1.0.0-pre.5"
   }
 }

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -2,12 +2,12 @@
     "name": "com.unity.netcode.gameobjects",
     "displayName": "Netcode for GameObjects",
     "description": "Netcode for GameObjects is a high-level netcode SDK that provides networking capabilities to GameObject/MonoBehaviour workflows within Unity and sits on top of underlying transport layer.",
-    "version": "0.2.0-preview.1",
+    "version": "1.0.0-pre.1",
     "unity": "2020.3",
     "dependencies": {
         "com.unity.modules.ai": "1.0.0",
         "com.unity.modules.animation": "1.0.0",
-        "com.unity.nuget.mono-cecil": "1.10.1-preview.1",
+        "com.unity.nuget.mono-cecil": "1.10.1",
         "com.unity.collections": "1.0.0-pre.5"
     }
 }


### PR DESCRIPTION
Updating Package versions to pre.1 values, also updated the com.unity.nuget.mono-cecil package to no longer preview as we can't be in preview. I also did validate this with dry-run internal publishes and they were green. 

## Changelog

### com.unity.netcode.gameobjects
- Changed: Updated version to 1.0.0-pre.1

### com.unity.netcode.adapter.utp
- Changed: Updated version to 1.0.0-pre.1