### PR TITLE
chore: Updating Adapter to using UTP pre.6 and updating Changelog

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -1,17 +1,26 @@
 # Changelog
 All notable changes to this package will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
-## [Unreleased]
+## [1.0.0-pre.1] - 2020-12-20
 
 ### Added
 
-- Support for Relay (#887)
+- Support for Unity Relay (#887)
+- New SetConnectionData function that takes in a NetworkEndpoint
+
+### Changed 
+
+- No longer use courourtines when connecting to relay
+- Consolidated the Send/Recv queue properties as they always needed to be the same.
+- Consolidated the Fragmentation/Queue size as they always needed to be the same.
 
 ### Fixed
 
 - Fixed an issue where OnClientDisconnectCallback was not being called (#1243)
 - Flush the UnityTransport send queue on shutdown (#1234)
 - Exposed a way to set ip and port from code (#1208)
+- Possible Editor crash when trying to read a batched packet where the size of the packet was larger than the max packet size.
+- Removed the requirement that MaxPacketSize needs to be the same size as the batched/fragmentation buffer size.
 
 ## [0.0.1-preview.1] - 2020-12-20
 This is the first release of Unity Transport for Netcode for Gameobjects

--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -10,9 +10,10 @@ All notable changes to this package will be documented in this file. The format 
 
 ### Changed 
 
-- No longer use courourtines when connecting to relay
+- No longer use coroutines when connecting to relay
 - Consolidated the Send/Recv queue properties as they always needed to be the same.
 - Consolidated the Fragmentation/Queue size as they always needed to be the same.
+- Updated Unity Transport package to 1.0.0-pre.6
 
 ### Fixed
 

--- a/com.unity.netcode.adapter.utp/package.json
+++ b/com.unity.netcode.adapter.utp/package.json
@@ -6,6 +6,6 @@
   "unity": "2020.3",
   "dependencies": {
     "com.unity.netcode.gameobjects": "1.0.0-pre.1",
-    "com.unity.transport": "1.0.0-pre.5"
+    "com.unity.transport": "1.0.0-pre.6"
   }
 }


### PR DESCRIPTION
Updated the unity transport package to pre.6 as well as cleaned up the changelog to reflect upcoming release. 

## Changelog

### com.unity.netcode.adapter.utp
- Changed: Updated Unity Transport package to pre.6
