### PR TITLE
chore: update PR template to include checklist and info about backports

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 <!-- Original PR link if this is a backport PR -->
 
-<!-- When backporting is required please add the backport:release-<version> label to this PR. This should include all versions in which this should be backported to. -->
+<!-- When backporting is required please add the type:backport-release-<version> label to this PR. This should include all versions in which this should be backported to. -->
 
 ### PR Checklist
 - [ ] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,15 @@
 
 <!-- Add RFC link here if applicable. -->
 
+<!-- Original PR link if this is a backport PR -->
+
+<!-- When backporting is required please add the backport:release-<version> label to this PR. This should include all versions in which this should be backported to. -->
+
+### PR Checklist
+- [ ] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
+- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
+- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR or a link to the documenation repo PR if this is a manual update. 
+
 ## Changelog
 
 ### com.unity.netcode.gameobjects


### PR DESCRIPTION
This PR updates the PR template to be a little more specific and engaging to the devs it also calls out what one should do if they want something backported. This of course doesn't mean it will actually get backported but it allows us to track backporting.