### PR TITLE
fix: Adding a try/catch around the function call for an RPC

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -15,6 +15,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Fixed 
 
 - Overflow exception when syncing Animator state.
+- Added Try/Catch around RPC calls, preventing exception from causing further RPC calls to fail
 
 ## [1.0.0-pre.2] - 2020-12-20
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -15,7 +15,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Fixed 
 
 - Overflow exception when syncing Animator state.
-- Added Try/Catch around RPC calls, preventing exception from causing further RPC calls to fail
+- Added `try`/`catch` around RPC calls, preventing exception from causing further RPC calls to fail (#1329)
 
 ## [1.0.0-pre.2] - 2020-12-20
 

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -1313,7 +1313,7 @@ namespace Unity.Netcode.Editor.CodeGen
             processor.Emit(OpCodes.Leave, catchEnds);
 
             // Load the Exception onto the stack
-            var catchStarts = processor.Create(OpCodes.Stloc_1);
+            var catchStarts = processor.Create(OpCodes.Stloc_0);
             processor.Append(catchStarts);
 
             // pull in the Exception Module
@@ -1327,12 +1327,17 @@ namespace Unity.Netcode.Editor.CodeGen
 
             // Load string for the error log that will be shown
             processor.Emit(OpCodes.Ldstr, $"You have thrown an exception in an RPC function {methodDefinition.FullName} {{0}}");
-            processor.Emit(OpCodes.Ldloc_1);
+            processor.Emit(OpCodes.Ldloc_0);
             processor.Emit(OpCodes.Callvirt, exp);
             processor.Emit(OpCodes.Call, stringFormat);
 
             // Call Debug.LogError
             processor.Emit(OpCodes.Call, m_Debug_LogError_MethodRef);
+
+            // reset NetworkBehaviour.__rpc_exec_stage = __RpcExecStage.None;
+            processor.Emit(OpCodes.Ldarg_0);
+            processor.Emit(OpCodes.Ldc_I4, (int)NetworkBehaviour.__RpcExecStage.None);
+            processor.Emit(OpCodes.Stfld, m_NetworkBehaviour_rpc_exec_stage_FieldRef);
 
             // catch ends
             processor.Append(catchEnds);

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -1319,14 +1319,14 @@ namespace Unity.Netcode.Editor.CodeGen
             // pull in the Exception Module
             var exception = m_MainModule.ImportReference(typeof(Exception));
 
-            // Get Exception.Message
-            var exp = m_MainModule.ImportReference(typeof(Exception).GetMethod("get_Message", new Type[] { }));
+            // Get Exception.ToString()
+            var exp = m_MainModule.ImportReference(typeof(Exception).GetMethod("ToString", new Type[] { }));
 
             // Get String.Format (This is equivelent to an interpolated string)
             var stringFormat = m_MainModule.ImportReference(typeof(string).GetMethod("Format", new Type[] { typeof(string), typeof(object) }));
 
             // Load string for the error log that will be shown
-            processor.Emit(OpCodes.Ldstr, $"You have thrown an exception in an RPC function {methodDefinition.FullName} {{0}}");
+            processor.Emit(OpCodes.Ldstr, $"Unhandled RPC Exception:\n {{0}}");
             processor.Emit(OpCodes.Ldloc_0);
             processor.Emit(OpCodes.Callvirt, exp);
             processor.Emit(OpCodes.Call, stringFormat);


### PR DESCRIPTION
This PR addresses and issue where if an RPC functions throws an unhandled exception then the entire the rest of the playerloop breaks and the NB that was currently running that RPC is broken forever. 

### PR Checklist
- [X] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [X] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR or a link to the documenation repo PR if this is a manual update. 

## Changelog

### com.unity.netcode.gameobjects
- Fixed: Added a try/catch around RPC calls to catch unhandled exceptions

## Testing and Documentation

* Includes unit tests.
