### PR TITLE
chore: Remove UnityEditor dependency from testproject-tools-integration

### DIFF
--- a/testproject-tools-integration/Assets/Tests/Runtime/testproject.toolsintegration.runtimetests.asmdef
+++ b/testproject-tools-integration/Assets/Tests/Runtime/testproject.toolsintegration.runtimetests.asmdef
@@ -6,8 +6,7 @@
         "Unity.Netcode.RuntimeTests",
         "Unity.Multiplayer.MetricTypes",
         "Unity.Multiplayer.NetStats",
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner"
+        "UnityEngine.TestRunner"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
As a results of this discussion https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/1164#discussion_r720297449 this is a tech debt PR to remove the UnityEditor dependency from the testrpoject-tools-integration project.

MTT-1383