### PR TITLE
fix: Sends failing on UTP adapter when queue is full

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this package will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [1.0.0-pre.3] - TBD
+
+### Fixed
+
+- Fixed sends failing when send queue is filled or close to be filled.
+
 ## [1.0.0-pre.2] - 2020-12-20
 
 ### Changed

--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this package will be documented in this file. The format 
 
 ## [1.0.0-pre.3] - TBD
 
+### Changed
+
+- Updated Unity Transport package to 1.0.0-pre.7
+
 ### Fixed
 
 - Fixed sends failing when send queue is filled or close to be filled.

--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -611,7 +611,7 @@ namespace Unity.Netcode
                 if (!success) // Message is too large to fit in the queue. Shouldn't happen under normal operation.
                 {
                     // If data is too large to be batched, flush it out immediately. This happens with large initial spawn packets from Netcode for Gameobjects.
-                    Debug.LogWarning($"Sent {payload.Count} bytes based on delivery method: {networkDelivery}. Event size exceeds sendQueueBatchSize: ({m_SendQueueBatchSize}). This can be the initial payload!");
+                    Debug.LogWarning($"Event of size {payload.Count} too large to fit in send queue (of size {m_SendQueueBatchSize}). Trying to send directly. This could be the initial payload!");
                     Debug.Assert(networkDelivery == NetworkDelivery.ReliableFragmentedSequenced); // Messages like this, should always be sent via the fragmented pipeline.
                     SendMessageInstantly(sendTarget.ClientId, payload, pipeline);
                 }

--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -566,7 +566,7 @@ namespace Unity.Netcode
             // If we want to be able to actually handle messages MaximumMessageLength bytes in
             // size, we need to allow a bit more than that in FragmentationUtility since this needs
             // to account for headers and such. 128 bytes is plenty enough for such overhead.
-            m_NetworkParameters.Add(new FragmentationUtility.Parameters() { PayloadCapacity = m_SendQueueBatchSize });
+            m_NetworkParameters.Add(new FragmentationUtility.Parameters() { PayloadCapacity = m_SendQueueBatchSize + 128 });
             m_NetworkParameters.Add(new BaselibNetworkParameter()
             {
                 maximumPayloadSize = (uint)m_MaximumPacketSize,
@@ -599,7 +599,8 @@ namespace Unity.Netcode
             if (!success) // This would be false only when the SendQueue is full already or we are sending a super large message at once
             {
                 // If we are in here data exceeded remaining queue size. This should not happen under normal operation.
-                if (payload.Count > queue.Size)
+                // Extra 4 bytes here are to account for the data size that will need to be stored in the queue too.
+                if (payload.Count + 4 > queue.Size)
                 {
                     // If data is too large to be batched, flush it out immediately. This happens with large initial spawn packets from Netcode for Gameobjects.
                     Debug.LogWarning($"Sent {payload.Count} bytes based on delivery method: {networkDelivery}. Event size exceeds sendQueueBatchSize: ({m_SendQueueBatchSize}). This can be the initial payload!");

--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -563,10 +563,13 @@ namespace Unity.Netcode
 
             m_NetworkParameters = new List<INetworkParameter>();
 
-            // If we want to be able to actually handle messages MaximumMessageLength bytes in
-            // size, we need to allow a bit more than that in FragmentationUtility since this needs
-            // to account for headers and such. 128 bytes is plenty enough for such overhead.
-            m_NetworkParameters.Add(new FragmentationUtility.Parameters() { PayloadCapacity = m_SendQueueBatchSize + 128 });
+            // If the user sends a message of exactly m_SendQueueBatchSize length, we'll need an
+            // extra byte to mark it as non-batched and 4 bytes for its length. If the user fills
+            // up the send queue to its capacity (batched messages total m_SendQueueBatchSize), we
+            // still need one extra byte to mark the payload as batched.
+            var fragmentationCapacity = m_SendQueueBatchSize + 1 + 4;
+            m_NetworkParameters.Add(new FragmentationUtility.Parameters() { PayloadCapacity = fragmentationCapacity });
+
             m_NetworkParameters.Add(new BaselibNetworkParameter()
             {
                 maximumPayloadSize = (uint)m_MaximumPacketSize,

--- a/com.unity.netcode.adapter.utp/package.json
+++ b/com.unity.netcode.adapter.utp/package.json
@@ -6,6 +6,6 @@
   "unity": "2020.3",
   "dependencies": {
     "com.unity.netcode.gameobjects": "1.0.0-pre.2",
-    "com.unity.transport": "1.0.0-pre.6"
+    "com.unity.transport": "1.0.0-pre.7"
   }
 }


### PR DESCRIPTION
This is a backport to 1.0.0 of the fix in PR #1317.

Note that tests are failing currently with this PR. Once UTP 1.0.0-pre.7 is released and the adapter is made to depend on it, tests are expected to pass.

## Changelog

### com.unity.netcode.adapter.utp
- Fixed: Sends failing when send queue is full or close to full.

## Testing and Documentation

* Includes unit tests.
* No documentation changes or additions were necessary.