### PR TITLE
chore: Update package versions to 1.0.0-pre.2

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this package will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [1.0.0-pre.2] - 2020-12-20
+
+### Changed
+
+- Updated Netcode for GameObjects dependency to 1.0.0-pre.2
+
 ## [1.0.0-pre.1] - 2020-12-20
 
 ### Added

--- a/com.unity.netcode.adapter.utp/package.json
+++ b/com.unity.netcode.adapter.utp/package.json
@@ -2,10 +2,10 @@
   "name": "com.unity.netcode.adapter.utp",
   "displayName": "Unity Transport for Netcode for GameObjects",
   "description": "This package is plugging Unity Transport into Netcode for GameObjects, which is a network transport layer - the low-level interface for sending UDP data",
-  "version": "1.0.0-pre.1",
+  "version": "1.0.0-pre.2",
   "unity": "2020.3",
   "dependencies": {
-    "com.unity.netcode.gameobjects": "1.0.0-pre.1",
+    "com.unity.netcode.gameobjects": "1.0.0-pre.2",
     "com.unity.transport": "1.0.0-pre.6"
   }
 }

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,7 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
-## [Unreleased]
+## [1.0.0-pre.2] - 2020-12-20
+
+### Added
+
+- Associated Known Issues for the 1.0.0-pre.1 release in the changelog
+
+### Changed
+
+- Updated label for `1.0.0-pre.1` changelog section
+
+## [1.0.0-pre.1] - 2020-12-20
 
 ### Added
 
@@ -101,6 +111,15 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed #915 - clients are receiving data from objects not visible to them (#1099)
 - Fixed `NetworkTransform`'s "late join" issues, `NetworkTransform` now uses `NetworkVariable`s instead of RPCs (#826)
 - Throw an exception for silent failure when a client tries to get another player's `PlayerObject`, it is now only allowed on the server-side (#844)
+
+### Known Issues
+
+- `NetworkVariable` does not serialize `INetworkSerializable` types through their `NetworkSerialize` implementation
+- `NetworkObjects` marked as `DontDestroyOnLoad` are disabled during some network scene transitions
+- `NetworkTransform` interpolates from the origin when switching Local Space synchronization
+- Exceptions thrown in `OnNetworkSpawn` user code for an object will prevent the callback in other objects
+- Cannot send an array of `INetworkSerializable` in RPCs
+- ILPP generation fails with special characters in project path
 
 ## [0.2.0] - 2021-06-03
 

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -2,7 +2,7 @@
     "name": "com.unity.netcode.gameobjects",
     "displayName": "Netcode for GameObjects",
     "description": "Netcode for GameObjects is a high-level netcode SDK that provides networking capabilities to GameObject/MonoBehaviour workflows within Unity and sits on top of underlying transport layer.",
-    "version": "1.0.0-pre.1",
+    "version": "1.0.0-pre.2",
     "unity": "2020.3",
     "dependencies": {
         "com.unity.modules.ai": "1.0.0",


### PR DESCRIPTION
- Fixed changelog header for 1.0.0-pre.1
- Bump package versions
- Bump transport adapter dependency on netcode

https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/1320

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.