### PR TITLE
fix: Resolving issue where IL2CPP would not compile

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -22,6 +22,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 - Overflow exception when syncing Animator state. (#1327)
 - Added `try`/`catch` around RPC calls, preventing exception from causing further RPC calls to fail (#1329)
+- IL2CPP would not properly compile (#1359)
 
 ## [1.0.0-pre.2] - 2021-10-19
 

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -1308,26 +1308,29 @@ namespace Unity.Netcode.Editor.CodeGen
             processor.Emit(OpCodes.Ldc_I4, (int)NetworkBehaviour.__RpcExecStage.None);
             processor.Emit(OpCodes.Stfld, m_NetworkBehaviour_rpc_exec_stage_FieldRef);
 
-            //try ends/catch begins
-            var catchEnds = processor.Create(OpCodes.Nop);
-            processor.Emit(OpCodes.Leave, catchEnds);
-
-            // Load the Exception onto the stack
-            var catchStarts = processor.Create(OpCodes.Stloc_0);
-            processor.Append(catchStarts);
-
             // pull in the Exception Module
             var exception = m_MainModule.ImportReference(typeof(Exception));
 
             // Get Exception.ToString()
             var exp = m_MainModule.ImportReference(typeof(Exception).GetMethod("ToString", new Type[] { }));
 
-            // Get String.Format (This is equivelent to an interpolated string)
+            // Get String.Format (This is equivalent to an interpolated string)
             var stringFormat = m_MainModule.ImportReference(typeof(string).GetMethod("Format", new Type[] { typeof(string), typeof(object) }));
+
+            nhandler.Body.Variables.Add(new VariableDefinition(exception));
+            int exceptionVariableIndex = nhandler.Body.Variables.Count - 1;
+
+            //try ends/catch begins
+            var catchEnds = processor.Create(OpCodes.Nop);
+            processor.Emit(OpCodes.Leave, catchEnds);
+            
+            // Load the Exception onto the stack
+            var catchStarts = processor.Create(OpCodes.Stloc, exceptionVariableIndex);
+            processor.Append(catchStarts);
 
             // Load string for the error log that will be shown
             processor.Emit(OpCodes.Ldstr, $"Unhandled RPC Exception:\n {{0}}");
-            processor.Emit(OpCodes.Ldloc_0);
+            processor.Emit(OpCodes.Ldloc, exceptionVariableIndex);
             processor.Emit(OpCodes.Callvirt, exp);
             processor.Emit(OpCodes.Call, stringFormat);
 

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -1323,7 +1323,7 @@ namespace Unity.Netcode.Editor.CodeGen
             //try ends/catch begins
             var catchEnds = processor.Create(OpCodes.Nop);
             processor.Emit(OpCodes.Leave, catchEnds);
-            
+
             // Load the Exception onto the stack
             var catchStarts = processor.Create(OpCodes.Stloc, exceptionVariableIndex);
             processor.Append(catchStarts);


### PR DESCRIPTION
IL2CPP is very specific about the IL it reads and in this case it could not properly resolve a stack variable with the previous IL so we have to declare a variable explicitly. 

### PR Checklist
- [x] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [X] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR or a link to the documenation repo PR if this is a manual update. 

## Changelog

### com.unity.netcode.gameobjects
- Fixed: IL2CPP would not properly compile

## Testing and Documentation

* No tests have been added.
