### PR TITLE
fix: NetworkList.Contains inverted

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -368,7 +368,7 @@ namespace Unity.Netcode
         public bool Contains(T item)
         {
             int index = NativeArrayExtensions.IndexOf(m_List, item);
-            return index == -1;
+            return index != -1;
         }
 
         /// <inheritdoc />

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -214,8 +214,8 @@ namespace Unity.Netcode.RuntimeTests
                 {
                     return m_Player1OnServer.TheList.Count == 1 &&
                            m_Player1OnClient1.TheList.Count == 1 &&
-                           m_Player1OnServer.TheList.Contains(k_TestKey1) &&
-                           m_Player1OnClient1.TheList.Contains(k_TestKey1);
+                           m_Player1OnServer.TheList.Contains(k_TestVal1) &&
+                           m_Player1OnClient1.TheList.Contains(k_TestVal1);
                 }
             );
         }


### PR DESCRIPTION
This fixes issue #1352 (NetworkList.contains value is inverted).  The logic was flipped AND there was a typo in the test.

type:backport-release-1.0

### PR Checklist

## Changelog

### com.unity.netcode.gameobjects
- Fixed: NetworkList.contains value is inverted (issue #1352)

## Testing and Documentation
* Includes fix to integration tests.
