### PR TITLE
fix: load event completed fires early

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,6 +10,9 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 ### Fixed
+
+- Fixed an issue where if you are running as a server (not host) the LoadEventCompleted and UnloadEventCompleted events would fire early by the NetworkSceneManager.
+
 ### Changed
 
 ## [1.0.0-pre.3] - 2021-10-22

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1028,7 +1028,7 @@ namespace Unity.Netcode
                 // despawned that no longer exists
                 SendSceneEventData(sceneEventId, m_NetworkManager.ConnectedClientsIds.Where(c => c != m_NetworkManager.ServerClientId).ToArray());
 
-                //Second, server sets itself as having finished unloading
+                //Only if we are a host do we want register having loaded for the associated SceneEventProgress
                 if (SceneEventProgressTracking.ContainsKey(sceneEventData.SceneEventProgressId) && m_NetworkManager.IsHost)
                 {
                     SceneEventProgressTracking[sceneEventData.SceneEventProgressId].AddClientAsDone(m_NetworkManager.ServerClientId);
@@ -1344,7 +1344,7 @@ namespace Unity.Netcode
 
             OnLoadComplete?.Invoke(m_NetworkManager.ServerClientId, SceneNameFromHash(sceneEventData.SceneHash), sceneEventData.LoadSceneMode);
 
-            //Second, set the server as having loaded for the associated SceneEventProgress
+            //Second, only if we are a host do we want register having loaded for the associated SceneEventProgress
             if (SceneEventProgressTracking.ContainsKey(sceneEventData.SceneEventProgressId) && m_NetworkManager.IsHost)
             {
                 SceneEventProgressTracking[sceneEventData.SceneEventProgressId].AddClientAsDone(m_NetworkManager.ServerClientId);

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1029,7 +1029,7 @@ namespace Unity.Netcode
                 SendSceneEventData(sceneEventId, m_NetworkManager.ConnectedClientsIds.Where(c => c != m_NetworkManager.ServerClientId).ToArray());
 
                 //Second, server sets itself as having finished unloading
-                if (SceneEventProgressTracking.ContainsKey(sceneEventData.SceneEventProgressId))
+                if (SceneEventProgressTracking.ContainsKey(sceneEventData.SceneEventProgressId) && m_NetworkManager.IsHost)
                 {
                     SceneEventProgressTracking[sceneEventData.SceneEventProgressId].AddClientAsDone(m_NetworkManager.ServerClientId);
                 }
@@ -1345,7 +1345,7 @@ namespace Unity.Netcode
             OnLoadComplete?.Invoke(m_NetworkManager.ServerClientId, SceneNameFromHash(sceneEventData.SceneHash), sceneEventData.LoadSceneMode);
 
             //Second, set the server as having loaded for the associated SceneEventProgress
-            if (SceneEventProgressTracking.ContainsKey(sceneEventData.SceneEventProgressId))
+            if (SceneEventProgressTracking.ContainsKey(sceneEventData.SceneEventProgressId) && m_NetworkManager.IsHost)
             {
                 SceneEventProgressTracking[sceneEventData.SceneEventProgressId].AddClientAsDone(m_NetworkManager.ServerClientId);
             }


### PR DESCRIPTION
[Github Issue #1362](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/1362)
**When starting as server:** If you trigger a scene change, the server keeps a list of clients that have reported that they've completed the load and then fires a LoadEventCompleted event when they all have (or have timed out). However the server also adds itself to the list of completed clients when it finishes loading the scene. The problem is that it doesn't account for this when it checks whether to fire the LoadEventCompleted event.

[MTT-1564](https://jira.unity3d.com/browse/MTT-1564)

### PR Checklist
- [X] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [X] Have you updated the changelog? Each package has a `CHANGELOG.md` file.

## Changelog
### com.unity.netcode.gameobjects
- Fixed an issue where if you are running as a server (not host) the LoadEventCompleted and UnloadEventCompleted events would fire early by the NetworkSceneManager

## Testing and Documentation
* Includes integration tests.
* No documentation changes or additions were necessary.
