### PR TITLE
fix(networkobject): Fixed IsLocalPlayer

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -105,7 +105,7 @@ namespace Unity.Netcode
         /// <summary>
         /// Gets if the object is the the personal clients player object
         /// </summary>
-        public bool IsLocalPlayer => NetworkManager != null && IsPlayerObject && OwnerClientId == NetworkManager.LocalClientId;
+        public bool IsLocalPlayer => NetworkManager != null && IsPlayerObject && NetworkObjectId == NetworkManager.LocalClientId;
 
         /// <summary>
         /// Gets if the object is owned by the local player or if the object is the local player object


### PR DESCRIPTION
In this MR the `IsLocalPlayer`  in the `NetworkObject` gets adjusted, because it only returned true when the owner is the local player and not if the `NetworkObjectID` equals `NetworkManager.Singleton.LocalClientId`. For more information you can read #829.

## Changelog

### com.unity.netcode.gameobjects
- Fixed: Fixed IsLocalPlayer to check for NetworkObjectID instead of OwnerClientId

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.

