### PR TITLE
test: Fix time init tests start waiting period

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeInitializationTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeInitializationTest.cs
@@ -34,9 +34,8 @@ namespace Unity.Netcode.RuntimeTests
             // server time should be 0
             Assert.AreEqual(0, server.NetworkTickSystem.ServerTime.Time);
 
-            // wait 2 frames to ensure network tick is run
-            yield return null;
-            yield return null;
+            // wait until at least 1 server tick passed
+            yield return new WaitUntil(() => server.NetworkTickSystem.ServerTime.Tick > 0);
 
             var serverTimePassed = server.NetworkTickSystem.ServerTime.Time;
             var expectedServerTickCount = Mathf.FloorToInt((float)(serverTimePassed * 30));


### PR DESCRIPTION
Before the tests only passed if the server executed a a NetworkTick in the next 2 frames after starting the server. This would not happen in certain scenarios. Now the test waits until at least 1 tick has passed.

MTT-1556

## Testing and Documentation
* Fixes existing tests
* No documentation changes or additions were necessary.