### PR TITLE
fix: Don't require Linq in adapter tests helper

### DIFF
--- a/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/RuntimeTestsHelpers.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/RuntimeTestsHelpers.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
 using System;
-using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -68,7 +67,9 @@ namespace Unity.Netcode.UTP.RuntimeTests
                 // Copy the data since the backing array will be reused for future messages.
                 if (data != default(ArraySegment<byte>))
                 {
-                    data = new ArraySegment<byte>(data.ToArray());
+                    var dataCopy = new byte[data.Count];
+                    Array.Copy(data.Array, data.Offset, dataCopy, 0, data.Count);
+                    data = new ArraySegment<byte>(dataCopy);
                 }
 
                 m_Events.Add(new TransportEvent


### PR DESCRIPTION
The runtime tests helper for UTP adapter tests was using `ArraySegment<T>.ToArray`. But this is part of .NET Standard 2.1 which we don't support, but by using `System.Linq` it circumvented the issue by executing Linq code instead.

Instead of relying on Linq, perform the same operation more explicitly by using `Array.Copy` instead. It's a tad more verbose, but doesn't require using Linq.

## Changelog

### com.unity.netcode.adapter.utp

N/A

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.