### PR TITLE
fix: Change tools install link URL

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
@@ -363,7 +363,7 @@ namespace Unity.Netcode.Editor
             const string getToolsText = "Access additional tools for multiplayer development by installing the Multiplayer Tools package in the Package Manager.";
             const string openDocsButtonText = "Open Docs";
             const string dismissButtonText = "Dismiss";
-            const string targetUrl = "https://docs-multiplayer.unity3d.com/docs/tutorials/goldenpath_series/goldenpath_foundation_module";
+            const string targetUrl = "https://docs-multiplayer.unity3d.com/docs/tools/install-tools";
             const string infoIconName = "console.infoicon";
 
             if (PlayerPrefs.GetInt(InstallMultiplayerToolsTipDismissedPlayerPrefKey, 0) != 0)


### PR DESCRIPTION
Replace the tools install link with the one provided by the docs team.

MTT-1648

## Changelog

### com.unity.netcode.gameobjects
- Fixed: Change the tools install link so it redirects to the correct documentation page.

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.
