### PR TITLE
fix: using the proper NetworkManagers for the two clients (#1409)

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeMultiInstanceTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeMultiInstanceTest.cs
@@ -56,8 +56,8 @@ namespace Unity.Netcode.RuntimeTests
             var networkManagers = MultiInstanceHelpers.NetworkManagerInstances.ToArray();
 
             var server = networkManagers.First(t => t.IsServer);
-            var firstClient = networkManagers.First(t => t.IsClient);
-            var secondClient = networkManagers.Last(t => t.IsClient);
+            var firstClient = networkManagers.First(t => !t.IsServer);
+            var secondClient = networkManagers.Last(t => !t.IsServer);
 
             Assert.AreNotEqual(firstClient, secondClient);
 


### PR DESCRIPTION
Back-porting 

https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/1409

into 1.1.0. Is this the right process ? It is a bit manual and error-prone.