### PR TITLE
fix: Address packet overflow issues in the UTP adapter (1.1.0)

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 All notable changes to this package will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+
+### Changed
+
+- Removed 'Maximum Packet Size' configuration field in the inspector. This would cause confusion since the maximum packet size is in effect always the MTU (1400 bytes on most platforms).
+
+### Fixed
+
+- Fixed packet overflow errors when sending payloads too close to the MTU (was mostly visible when using Relay).
+
 ## [1.0.0-pre.3] - 2021-10-22
 
 #### Added 

--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -606,7 +606,7 @@ namespace Unity.Netcode
 
             m_NetworkParameters.Add(new BaselibNetworkParameter()
             {
-                maximumPayloadSize = NetworkParameterConstants.MTU,
+                maximumPayloadSize = 2000, // Default value in UTP.
                 receiveQueueCapacity = m_MaxPacketQueueSize,
                 sendQueueCapacity = m_MaxPacketQueueSize
             });

--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -78,7 +78,6 @@ namespace Unity.Netcode
         }
 
         public const int InitialBatchQueueSize = 6 * 1024;
-        public const int InitialMaxPacketSize = NetworkParameterConstants.MTU;
 
         private static ConnectionAddressData s_DefaultConnectionAddressData = new ConnectionAddressData()
         { Address = "127.0.0.1", Port = 7777 };
@@ -90,9 +89,6 @@ namespace Unity.Netcode
 
         [Tooltip("Which protocol should be selected Relay/Non-Relay")]
         [SerializeField] private ProtocolType m_ProtocolType;
-
-        [Tooltip("Maximum size in bytes for a given packet")]
-        [SerializeField] private int m_MaximumPacketSize = InitialMaxPacketSize;
 
         [Tooltip("The maximum amount of packets that can be in the send/recv queues")]
         [SerializeField] private int m_MaxPacketQueueSize = 128;
@@ -607,7 +603,6 @@ namespace Unity.Netcode
         {
             Debug.Assert(sizeof(ulong) == UnsafeUtility.SizeOf<NetworkConnection>(),
                 "Netcode connection id size does not match UTP connection id size");
-            Debug.Assert(m_MaximumPacketSize > 5, "Message buffer size must be greater than 5");
 
             m_NetworkParameters = new List<INetworkParameter>();
 
@@ -620,7 +615,7 @@ namespace Unity.Netcode
 
             m_NetworkParameters.Add(new BaselibNetworkParameter()
             {
-                maximumPayloadSize = (uint)m_MaximumPacketSize,
+                maximumPayloadSize = NetworkParameterConstants.MTU,
                 receiveQueueCapacity = m_MaxPacketQueueSize,
                 sendQueueCapacity = m_MaxPacketQueueSize
             });


### PR DESCRIPTION
This is a backport of PR #1403.

## Changelog

### com.unity.netcode.adapter.utp

* Changed: Removed 'Maximum Packet Size' configuration field in the inspector. This would cause confusion since the maximum packet size is in effect always the MTU (1400 bytes on most platforms).
* Fixed: Packet overflow errors when sending payloads too close to the MTU (was mostly visible when using Relay).

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.