### PR TITLE
fix(scene-management): additional check to see if scene is already loaded

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1496,7 +1496,18 @@ namespace Unity.Netcode
                 // don't try to reload it.
                 shouldPassThrough = true;
             }
-
+            else
+            {
+                // Another check to see if the client already has loaded the scene to be loaded
+                Scene existingScene = SceneManager.GetSceneByName(sceneName);
+                if (existingScene.isLoaded)
+                {
+                    // If the scene is already loaded, then pass through and
+                    // don't try to reload it.
+                    shouldPassThrough = true;
+                }
+            }
+			
 #if UNITY_INCLUDE_TESTS
             if (m_IsRunningUnitTest)
             {

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1496,17 +1496,6 @@ namespace Unity.Netcode
                 // don't try to reload it.
                 shouldPassThrough = true;
             }
-            else
-            {
-                // Another check to see if the client already has loaded the scene to be loaded
-                Scene existingScene = SceneManager.GetSceneByName(sceneName);
-                if (existingScene.isLoaded)
-                {
-                    // If the scene is already loaded, then pass through and
-                    // don't try to reload it.
-                    shouldPassThrough = true;
-                }
-            }
 			
 #if UNITY_INCLUDE_TESTS
             if (m_IsRunningUnitTest)


### PR DESCRIPTION
…and can pass through

The previous implementation only checked if the scene to be loaded is matching the active scene. This caused problems in a multi-scene environment and non-active but already loaded scenes were loaded twice.

## Testing and Documentation
* No tests have been added.
