### PR TITLE
test: yield WaitForTicks instead of WaitForFrames

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbody2DTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbody2DTest.cs
@@ -55,7 +55,7 @@ namespace Unity.Netcode.RuntimeTests.Physics
             Assert.IsNotNull(serverPlayer);
             Assert.IsNotNull(clientPlayer);
 
-            yield return NetworkRigidbodyTestBase.WaitForFrames(5);
+            yield return WaitForTicks(m_ServerNetworkManager, 5);
 
             // server rigidbody has authority and should have a kinematic mode of false
             Assert.True(serverPlayer.GetComponent<Rigidbody2D>().isKinematic == Kinematic);
@@ -68,14 +68,19 @@ namespace Unity.Netcode.RuntimeTests.Physics
             // despawn the server player, (but keep it around on the server)
             serverPlayer.GetComponent<NetworkObject>().Despawn(false);
 
-            yield return NetworkRigidbodyTestBase.WaitForFrames(5);
+            yield return WaitForTicks(m_ServerNetworkManager, 5);
 
             Assert.IsTrue(serverPlayer.GetComponent<Rigidbody2D>().isKinematic == Kinematic);
 
-            yield return NetworkRigidbodyTestBase.WaitForFrames(5);
+            yield return WaitForTicks(m_ServerNetworkManager, 5);
 
             Assert.IsTrue(clientPlayer == null); // safety check that object is actually despawned.
         }
 
+        public IEnumerator WaitForTicks(NetworkManager networkManager, int count)
+        {
+            int nextTick = networkManager.NetworkTickSystem.LocalTime.Tick + count;
+            yield return new WaitUntil(() => networkManager.NetworkTickSystem.LocalTime.Tick >= nextTick);
+        }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbodyTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbodyTest.cs
@@ -42,6 +42,8 @@ namespace Unity.Netcode.RuntimeTests.Physics
         [UnityTest]
         public IEnumerator TestRigidbodyKinematicEnableDisable()
         {
+            Debug.Log("Running version with WaitForSeconds()");
+
             // This is the *SERVER VERSION* of the *CLIENT PLAYER*
             var serverClientPlayerResult = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
             yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId), m_ServerNetworkManager, serverClientPlayerResult));
@@ -55,7 +57,7 @@ namespace Unity.Netcode.RuntimeTests.Physics
             Assert.IsNotNull(serverPlayer, "serverPlayer is not null");
             Assert.IsNotNull(clientPlayer, "clientPlayer is not null");
 
-            yield return WaitForFrames(5);
+            yield return new WaitForSeconds(1.0f);
 
             // server rigidbody has authority and should have a kinematic mode of false
             Assert.True(serverPlayer.GetComponent<Rigidbody>().isKinematic == Kinematic, "serverPlayer kinematic");
@@ -68,11 +70,11 @@ namespace Unity.Netcode.RuntimeTests.Physics
             // despawn the server player (but keep it around on the server)
             serverPlayer.GetComponent<NetworkObject>().Despawn(false);
 
-            yield return WaitForFrames(5);
+            yield return new WaitForSeconds(1.0f);
 
             Assert.IsTrue(serverPlayer.GetComponent<Rigidbody>().isKinematic == Kinematic, "serverPlayer second kinematic");
 
-            yield return WaitForFrames(5);
+            yield return new WaitForSeconds(1.0f);
 
             Assert.IsTrue(clientPlayer == null, "clientPlayer being null"); // safety check that object is actually despawned.
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbodyTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbodyTest.cs
@@ -57,7 +57,7 @@ namespace Unity.Netcode.RuntimeTests.Physics
             Assert.IsNotNull(serverPlayer, "serverPlayer is not null");
             Assert.IsNotNull(clientPlayer, "clientPlayer is not null");
 
-            yield return new WaitForSeconds(1.0f);
+            yield return WaitForTicks(m_ServerNetworkManager, 3);
 
             // server rigidbody has authority and should have a kinematic mode of false
             Assert.True(serverPlayer.GetComponent<Rigidbody>().isKinematic == Kinematic, "serverPlayer kinematic");
@@ -70,19 +70,19 @@ namespace Unity.Netcode.RuntimeTests.Physics
             // despawn the server player (but keep it around on the server)
             serverPlayer.GetComponent<NetworkObject>().Despawn(false);
 
-            yield return new WaitForSeconds(1.0f);
+            yield return WaitForTicks(m_ServerNetworkManager, 3);
 
             Assert.IsTrue(serverPlayer.GetComponent<Rigidbody>().isKinematic == Kinematic, "serverPlayer second kinematic");
 
-            yield return new WaitForSeconds(1.0f);
+            yield return WaitForTicks(m_ServerNetworkManager, 3);
 
             Assert.IsTrue(clientPlayer == null, "clientPlayer being null"); // safety check that object is actually despawned.
         }
 
-        public static IEnumerator WaitForFrames(int count)
+        public IEnumerator WaitForTicks(NetworkManager networkManager, int count)
         {
-            int nextFrameNumber = Time.frameCount + count;
-            yield return new WaitUntil(() => Time.frameCount >= nextFrameNumber);
+            int nextTick = networkManager.NetworkTickSystem.LocalTime.Tick + count;
+            yield return new WaitUntil(() => networkManager.NetworkTickSystem.LocalTime.Tick >= nextTick);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbodyTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbodyTest.cs
@@ -52,29 +52,29 @@ namespace Unity.Netcode.RuntimeTests.Physics
             yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId), m_ClientNetworkManagers[0], clientClientPlayerResult));
             var clientPlayer = clientClientPlayerResult.Result.gameObject;
 
-            Assert.IsNotNull(serverPlayer);
-            Assert.IsNotNull(clientPlayer);
+            Assert.IsNotNull(serverPlayer, "serverPlayer is not null");
+            Assert.IsNotNull(clientPlayer, "clientPlayer is not null");
 
             yield return WaitForFrames(5);
 
             // server rigidbody has authority and should have a kinematic mode of false
-            Assert.True(serverPlayer.GetComponent<Rigidbody>().isKinematic == Kinematic);
-            Assert.AreEqual(RigidbodyInterpolation.Interpolate, serverPlayer.GetComponent<Rigidbody>().interpolation);
+            Assert.True(serverPlayer.GetComponent<Rigidbody>().isKinematic == Kinematic, "serverPlayer kinematic");
+            Assert.AreEqual(RigidbodyInterpolation.Interpolate, serverPlayer.GetComponent<Rigidbody>().interpolation, "server equal interpolate");
 
             // client rigidbody has no authority and should have a kinematic mode of true
-            Assert.True(clientPlayer.GetComponent<Rigidbody>().isKinematic);
-            Assert.AreEqual(RigidbodyInterpolation.None, clientPlayer.GetComponent<Rigidbody>().interpolation);
+            Assert.True(clientPlayer.GetComponent<Rigidbody>().isKinematic, "clientPlayer kinematic");
+            Assert.AreEqual(RigidbodyInterpolation.None, clientPlayer.GetComponent<Rigidbody>().interpolation, "client equal interpolate");
 
             // despawn the server player (but keep it around on the server)
             serverPlayer.GetComponent<NetworkObject>().Despawn(false);
 
             yield return WaitForFrames(5);
 
-            Assert.IsTrue(serverPlayer.GetComponent<Rigidbody>().isKinematic == Kinematic);
+            Assert.IsTrue(serverPlayer.GetComponent<Rigidbody>().isKinematic == Kinematic, "serverPlayer second kinematic");
 
             yield return WaitForFrames(5);
 
-            Assert.IsTrue(clientPlayer == null); // safety check that object is actually despawned.
+            Assert.IsTrue(clientPlayer == null, "clientPlayer being null"); // safety check that object is actually despawned.
         }
 
         public static IEnumerator WaitForFrames(int count)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbodyTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbodyTest.cs
@@ -42,8 +42,6 @@ namespace Unity.Netcode.RuntimeTests.Physics
         [UnityTest]
         public IEnumerator TestRigidbodyKinematicEnableDisable()
         {
-            Debug.Log("Running version with WaitForSeconds()");
-
             // This is the *SERVER VERSION* of the *CLIENT PLAYER*
             var serverClientPlayerResult = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
             yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId), m_ServerNetworkManager, serverClientPlayerResult));

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeMultiInstanceTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeMultiInstanceTest.cs
@@ -143,12 +143,6 @@ namespace Unity.Netcode.RuntimeTests
             yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnectedToServer(server, useHost ? nbClients + 1 : nbClients));
         }
 
-        private IEnumerator WaitForFrames(int count)
-        {
-            int nextFrameNumber = Time.frameCount + count;
-            yield return new WaitUntil(() => Time.frameCount >= nextFrameNumber);
-        }
-
         private readonly struct NetworkTimeState : IEquatable<NetworkTimeState>
         {
             public NetworkTime LocalTime { get; }


### PR DESCRIPTION
Replaces WaitForFrames with WaitForTicks, making the test less susceptible to timing differences

MTT-1555

## Testing and Documentation

This is a test improvement change
