### PR TITLE
fix: Set m_ShuttingDown back to false once shutdown is complete

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1133,6 +1133,7 @@ namespace Unity.Netcode
             m_TransportIdToClientIdMap.Clear();
 
             IsListening = false;
+            m_ShuttingDown = false;
         }
 
         // INetworkUpdateSystem


### PR DESCRIPTION
m_ShuttingDown was not called once shutdown finished, making it so you were unable to StartClient / Host / Server post shutdown (As it would instantly shutdown again)
