### PR TITLE
fix: Set shutdown flags back to false once shutdown is complete

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1134,6 +1134,7 @@ namespace Unity.Netcode
 
             IsListening = false;
             m_ShuttingDown = false;
+            m_StopProcessingMessages = false;
         }
 
         // INetworkUpdateSystem

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1133,6 +1133,7 @@ namespace Unity.Netcode
             m_TransportIdToClientIdMap.Clear();
 
             IsListening = false;
+            m_ShuttingDown = false;
         }
 
         // INetworkUpdateSystem

--- a/com.unity.netcode.gameobjects/Tests/Runtime/StopStartRuntimeTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/StopStartRuntimeTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections;
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    public class StopStartRuntimeTests
+    {
+        [UnityTest]
+        public IEnumerator WhenShuttingDownAndRestarting_SDKRestartsSuccessfullyAndStaysRunning()
+        {            // create server and client instances
+            MultiInstanceHelpers.Create(1, out NetworkManager server, out NetworkManager[] clients);
+
+            try
+            {
+
+                // create prefab
+                var gameObject = new GameObject("PlayerObject");
+                var networkObject = gameObject.AddComponent<NetworkObject>();
+                networkObject.DontDestroyWithOwner = true;
+                MultiInstanceHelpers.MakeNetworkObjectTestPrefab(networkObject);
+
+                server.NetworkConfig.PlayerPrefab = gameObject;
+
+                for (int i = 0; i < clients.Length; i++)
+                {
+                    clients[i].NetworkConfig.PlayerPrefab = gameObject;
+                }
+
+                // start server and connect clients
+                MultiInstanceHelpers.Start(false, server, clients);
+
+                // wait for connection on client side
+                yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(clients));
+
+                // wait for connection on server side
+                yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientConnectedToServer(server));
+
+                // shutdown the server
+                server.Shutdown();
+
+                // wait 1 frame because shutdowns are delayed
+                var nextFrameNumber = Time.frameCount + 1;
+                yield return new WaitUntil(() => Time.frameCount >= nextFrameNumber);
+
+                // Verify the shutdown occurred
+                Assert.IsFalse(server.IsServer);
+                Assert.IsFalse(server.IsListening);
+                Assert.IsFalse(server.IsHost);
+                Assert.IsFalse(server.IsClient);
+
+                server.StartServer();
+                // Verify the server started
+                Assert.IsTrue(server.IsServer);
+                Assert.IsTrue(server.IsListening);
+                
+                // Wait several frames
+                nextFrameNumber = Time.frameCount + 10;
+                yield return new WaitUntil(() => Time.frameCount >= nextFrameNumber);
+                
+                // Verify the server is still running
+                Assert.IsTrue(server.IsServer);
+                Assert.IsTrue(server.IsListening);
+            }
+            finally
+            {
+                // cleanup
+                MultiInstanceHelpers.Destroy();
+            }
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/StopStartRuntimeTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/StopStartRuntimeTests.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections;
-using System.Linq;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -56,11 +54,11 @@ namespace Unity.Netcode.RuntimeTests
                 // Verify the server started
                 Assert.IsTrue(server.IsServer);
                 Assert.IsTrue(server.IsListening);
-                
+
                 // Wait several frames
                 nextFrameNumber = Time.frameCount + 10;
                 yield return new WaitUntil(() => Time.frameCount >= nextFrameNumber);
-                
+
                 // Verify the server is still running
                 Assert.IsTrue(server.IsServer);
                 Assert.IsTrue(server.IsListening);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/StopStartRuntimeTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/StopStartRuntimeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 97a5298e33ee4d32be46ce84fecdcd06
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transport/SIPTransport.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transport/SIPTransport.cs
@@ -112,6 +112,7 @@ namespace Unity.Netcode.RuntimeTests
         {
             s_Server = null;
             m_Peers.Remove(ServerClientId);
+            m_LocalConnection = null;
         }
 
         public override void Shutdown()


### PR DESCRIPTION
The flag remaining set made it impossible to restart NetworkManager after it shuts down.

Credit to @JayPeet, original PR #1423 

MTT-1715
## Changelog

## Testing and Documentation

* Includes integration tests.
* No documentation changes or additions were necessary.
