### PR TITLE
fix: NetworkManager destroys client player object with DontDestroyWithOwner set

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -26,6 +26,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed NetworkVariable not calling NetworkSerialize on INetworkSerializable types (#1383)
 
 - Fixed NetworkObjects not being despawned before they are destroyed during shutdown for client, host, and server instances.
+- Fixed client player object being destroyed on server when the client's player object has DontDestroyWithOwnerSet. (1433)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -26,7 +26,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed NetworkVariable not calling NetworkSerialize on INetworkSerializable types (#1383)
 
 - Fixed NetworkObjects not being despawned before they are destroyed during shutdown for client, host, and server instances.
-- Fixed client player object being destroyed on server when the client's player object has DontDestroyWithOwnerSet. (1433)
+- Fixed client player object being destroyed on server when the client's player object has DontDestroyWithOwner set. (1433)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -26,7 +26,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed NetworkVariable not calling NetworkSerialize on INetworkSerializable types (#1383)
 
 - Fixed NetworkObjects not being despawned before they are destroyed during shutdown for client, host, and server instances.
-- Fixed client player object being destroyed on server when the client's player object has DontDestroyWithOwner set. (1433)
+- Fixed client player object being destroyed on server when the client's player object has DontDestroyWithOwner set. (#1433)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -25,8 +25,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - NetworkConfig will no longer throw an OverflowException in GetConfig() when ForceSamePrefabs is enabled and the number of prefabs causes the config blob size to exceed 1300 bytes. (#1385)
 - Fixed NetworkVariable not calling NetworkSerialize on INetworkSerializable types (#1383)
 
-- Fixed NetworkObjects not being despawned before they are destroyed during shutdown for client, host, and server instances.
-- Fixed client player object being destroyed on server when the client's player object has DontDestroyWithOwner set. (1433)
+- Fixed NetworkObjects not being despawned before they are destroyed during shutdown for client, host, and server instances. (#1390)
+- Fixed client player object being destroyed on server when the client's player object has DontDestroyWithOwner set. (#1433)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1489,6 +1489,7 @@ namespace Unity.Netcode
                     var playerObject = networkClient.PlayerObject;
                     if (playerObject != null)
                     {
+                        // As long as we can destroy the PlayerObject with the owner
                         if (!playerObject.DontDestroyWithOwner)
                         {
                             if (PrefabHandler.ContainsHandler(ConnectedClients[clientId].PlayerObject.GlobalObjectIdHash))
@@ -1500,7 +1501,7 @@ namespace Unity.Netcode
                                 Destroy(playerObject.gameObject);
                             }
                         }
-                        else
+                        else // Otherwise, just remove the ownership
                         {
                             playerObject.RemoveOwnership();
                         }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1489,13 +1489,20 @@ namespace Unity.Netcode
                     var playerObject = networkClient.PlayerObject;
                     if (playerObject != null)
                     {
-                        if (PrefabHandler.ContainsHandler(ConnectedClients[clientId].PlayerObject.GlobalObjectIdHash))
+                        if (!playerObject.DontDestroyWithOwner)
                         {
-                            PrefabHandler.HandleNetworkPrefabDestroy(ConnectedClients[clientId].PlayerObject);
+                            if (PrefabHandler.ContainsHandler(ConnectedClients[clientId].PlayerObject.GlobalObjectIdHash))
+                            {
+                                PrefabHandler.HandleNetworkPrefabDestroy(ConnectedClients[clientId].PlayerObject);
+                            }
+                            else
+                            {
+                                Destroy(playerObject.gameObject);
+                            }
                         }
                         else
                         {
-                            Destroy(playerObject.gameObject);
+                            playerObject.RemoveOwnership();
                         }
                     }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectDestroyTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectDestroyTests.cs
@@ -19,10 +19,7 @@ namespace Unity.Netcode.RuntimeTests
         [UnitySetUp]
         public override IEnumerator Setup()
         {
-            yield return StartSomeClientsAndServerWithPlayers(true, NbClients, playerPrefab =>
-            {
-                // playerPrefab.AddComponent<TestDestroy>();
-            });
+            return base.Setup();
         }
 
         /// <summary>
@@ -64,24 +61,39 @@ namespace Unity.Netcode.RuntimeTests
             Assert.IsTrue(go == null);
         }
 
+        public enum ClientDestroyWithOwner
+        {
+            DestroyWithOwner,
+            DontDestroyWithOwner
+        }
+
         /// <summary>
         /// Tests that a client cannot destroy a spawned networkobject.
         /// </summary>
         /// <returns></returns>
         [UnityTest]
-        public IEnumerator TestNetworkObjectClientDestroy()
+        public IEnumerator TestNetworkObjectClientDestroy([Values(ClientDestroyWithOwner.DestroyWithOwner, ClientDestroyWithOwner.DontDestroyWithOwner)] ClientDestroyWithOwner destroyWithOwner)
         {
-            // This is the *SERVER VERSION* of the *CLIENT PLAYER*
-            var serverClientPlayerResult = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId), m_ServerNetworkManager, serverClientPlayerResult));
+            var clientNetworkManager = m_ClientNetworkManagers[0];
+            clientNetworkManager.LocalClient.PlayerObject.DontDestroyWithOwner = destroyWithOwner != ClientDestroyWithOwner.DestroyWithOwner;
 
-            // This is the *CLIENT VERSION* of the *CLIENT PLAYER*
-            var clientClientPlayerResult = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId), m_ClientNetworkManagers[0], clientClientPlayerResult));
+            if (!clientNetworkManager.LocalClient.PlayerObject.DontDestroyWithOwner)
+            {
+                // destroy the client player, this is not allowed
+                LogAssert.Expect(LogType.Exception, "NotServerException: Destroy a spawned NetworkObject on a non-host client is not valid. Call Destroy or Despawn on the server/host instead.");
+                Object.DestroyImmediate(clientNetworkManager.LocalClient.PlayerObject);
+            }
+            else
+            {
+                Assert.True(m_ServerNetworkManager.ConnectedClients.ContainsKey(clientNetworkManager.LocalClientId));
+                var serverRelativeClientPlayerObject = m_ServerNetworkManager.ConnectedClients[clientNetworkManager.LocalClientId].PlayerObject;
+                serverRelativeClientPlayerObject.DontDestroyWithOwner = true;
+                clientNetworkManager.Shutdown();
+                var waitForFrameCount = Time.frameCount + 2;
+                yield return new WaitUntil(() => Time.frameCount >= waitForFrameCount);
 
-            // destroy the client player, this is not allowed
-            LogAssert.Expect(LogType.Exception, "NotServerException: Destroy a spawned NetworkObject on a non-host client is not valid. Call Destroy or Despawn on the server/host instead.");
-            Object.DestroyImmediate(clientClientPlayerResult.Result.gameObject);
+                Assert.True(serverRelativeClientPlayerObject.gameObject.activeInHierarchy);
+            }
         }
     }
 }


### PR DESCRIPTION
This fixes Github issue #1424 where the server will not destroy the player object if it has DontDestroyWithOwner set.
[MTT-1733](https://jira.unity3d.com/browse/MTT-1733)

### PR Checklist
- [x] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.

## Changelog
### com.unity.netcode.gameobjects
- Fixed client player object being destroyed on server when the client's player object has DontDestroyWithOwner set.

## Testing and Documentation
* Includes integration test