### PR TITLE
fix(fastBufferWriter): allocation and memset size differed

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferWriter.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferWriter.cs
@@ -187,7 +187,7 @@ namespace Unity.Netcode
             }
 
             var newSize = Math.Min(desiredSize, Handle->MaxCapacity);
-            byte* newBuffer = (byte*)UnsafeUtility.Malloc(newSize, UnsafeUtility.AlignOf<byte>(), Handle->Allocator);
+            byte* newBuffer = (byte*)UnsafeUtility.Malloc(sizeof(WriterHandle) + newSize, UnsafeUtility.AlignOf<byte>(), Handle->Allocator);
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
             UnsafeUtility.MemSet(newBuffer, 0, sizeof(WriterHandle) + newSize);
 #endif


### PR DESCRIPTION
Unsafe_Memset corrupted the memory by exceeding the allocated size, which lead to a crash after a few minutes (Development Build).

* No tests have been added.
