### PR TITLE
fix(fastBufferWriter): wrong size passed to unsafe memset

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferWriter.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferWriter.cs
@@ -189,7 +189,7 @@ namespace Unity.Netcode
             var newSize = Math.Min(desiredSize, Handle->MaxCapacity);
             byte* newBuffer = (byte*)UnsafeUtility.Malloc(newSize, UnsafeUtility.AlignOf<byte>(), Handle->Allocator);
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
-            UnsafeUtility.MemSet(newBuffer, 0, sizeof(WriterHandle) + newSize);
+            UnsafeUtility.MemSet(newBuffer, 0, newSize);
 #endif
             UnsafeUtility.MemCpy(newBuffer, Handle->BufferPointer, Length);
             if (Handle->BufferGrew)


### PR DESCRIPTION
Apparently caused no problems in the editor, but produced some random crashes in development build

* No tests have been added.
