### PR TITLE
fix: null reference on client when server disconnects.

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -27,6 +27,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 - Fixed NetworkObjects not being despawned before they are destroyed during shutdown for client, host, and server instances. (#1390)
 - Fixed client player object being destroyed on server when the client's player object has DontDestroyWithOwner set. (#1433)
+- Fixed null reference on client when server disconnects. (#1438)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1176,7 +1176,7 @@ namespace Unity.Netcode
                 // Only do another iteration if: there are no more messages AND (there is no limit to max events or we have processed less than the maximum)
             } while (IsListening && networkEvent != NetworkEvent.Nothing);
 
-            MessagingSystem.ProcessIncomingMessageQueue();
+            MessagingSystem?.ProcessIncomingMessageQueue();
 
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
             s_TransportPoll.End();


### PR DESCRIPTION
This adds a null check to the MessagingSystem during NetworkEarlyUpdate. This is needed because if the server goes down, a connected client will process the disconnect message, which shuts down networking, which deletes the MessagingSystem. This causes a null reference.

### PR Checklist
- [ ] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [*] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR or a link to the documenation repo PR if this is a manual update. 

## Changelog

### com.unity.netcode.gameobjects
- Added: The package whose Changelog should be added to should be in the header. Delete the changelog section entirely if it's not needed.
- Fixed: If you update multiple packages, create a new section with a new header for the other package. 
- Removed/Deprecated/Changed: Each bullet should be prefixed with Added, Fixed, Removed, Deprecated, or Changed to indicate where the entry should go.

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.
