### PR TITLE
MetricsPipeline Stage with dumb data

### DIFF
--- a/com.unity.netcode.adapter.utp/Runtime/MetricsPipelineStage.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/MetricsPipelineStage.cs
@@ -1,0 +1,57 @@
+using AOT;
+using Unity.Burst;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Networking.Transport;
+using UnityEngine;
+
+namespace Unity.Netcode
+{
+    [BurstCompile]
+    public unsafe struct MetricsPipelineStage : INetworkPipelineStage
+    {
+        static TransportFunctionPointer<NetworkPipelineStage.ReceiveDelegate> ReceiveFunctionPointer = new TransportFunctionPointer<NetworkPipelineStage.ReceiveDelegate>(Receive);
+        static TransportFunctionPointer<NetworkPipelineStage.SendDelegate> SendFunctionPointer = new TransportFunctionPointer<NetworkPipelineStage.SendDelegate>(Send);
+        static TransportFunctionPointer<NetworkPipelineStage.InitializeConnectionDelegate> InitializeConnectionFunctionPointer = new TransportFunctionPointer<NetworkPipelineStage.InitializeConnectionDelegate>(InitializeConnection);
+
+        public NetworkPipelineStage StaticInitialize(byte* staticInstanceBuffer, int staticInstanceBufferLength, INetworkParameter[] param)
+        {
+            return new NetworkPipelineStage(
+                Receive: ReceiveFunctionPointer,
+                Send: SendFunctionPointer,
+                InitializeConnection: InitializeConnectionFunctionPointer,
+                ReceiveCapacity: UnsafeUtility.SizeOf<int>(),
+                SendCapacity: UnsafeUtility.SizeOf<int>(),
+                HeaderCapacity: UnsafeUtility.SizeOf<ushort>(),
+                SharedStateCapacity: 0
+            );
+        }
+
+        public int StaticSize => 0;
+
+        [BurstCompile(DisableDirectCall = true)]
+        [MonoPInvokeCallback(typeof(NetworkPipelineStage.ReceiveDelegate))]
+        private static void Receive(ref NetworkPipelineContext pipelineContext, ref InboundRecvBuffer inboundRecvBuffer, ref NetworkPipelineStage.Requests requests, int systemHeaderSize)
+        {
+            Debug.Log("RECEIVING PACKET");
+            UnityTransport.Metrics.TrackPacketReceived(1);
+        }
+
+        [BurstCompile(DisableDirectCall = true)]
+        [MonoPInvokeCallback(typeof(NetworkPipelineStage.SendDelegate))]
+        private static int Send(ref NetworkPipelineContext context, ref InboundSendBuffer inboundBuffer, ref NetworkPipelineStage.Requests requests, int systemHeaderSize)
+        {
+            Debug.Log("SENDING PACKET");
+            UnityTransport.Metrics.TrackPacketSent(1 );
+            return 0;
+        }
+
+        [BurstCompile(DisableDirectCall = true)]
+        [MonoPInvokeCallback(typeof(NetworkPipelineStage.InitializeConnectionDelegate))]
+        private static void InitializeConnection(byte* staticInstanceBuffer, int staticInstanceBufferLength,
+            byte* sendProcessBuffer, int sendProcessBufferLength, byte* recvProcessBuffer, int recvProcessBufferLength,
+            byte* sharedProcessBuffer, int sharedProcessBufferLength)
+        {
+            Debug.Log("CONNECTION INITIALIZE");
+        }
+    }
+}

--- a/com.unity.netcode.adapter.utp/Runtime/MetricsPipelineStage.cs.meta
+++ b/com.unity.netcode.adapter.utp/Runtime/MetricsPipelineStage.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 96e30afc8581457d9394ab639bff9ed7
+timeCreated: 1636558782

--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -1,16 +1,68 @@
 using System;
 using System.Collections.Generic;
+using Unity.Burst;
 using UnityEngine;
 using NetcodeNetworkEvent = Unity.Netcode.NetworkEvent;
 using TransportNetworkEvent = Unity.Networking.Transport.NetworkEvent;
 using Unity.Collections.LowLevel.Unsafe;
 using Unity.Collections;
+using Unity.Multiplayer.Tools;
+using Unity.Multiplayer.Tools.MetricTypes;
+using Unity.Multiplayer.Tools.NetStats;
 using Unity.Networking.Transport;
 using Unity.Networking.Transport.Relay;
 using Unity.Networking.Transport.Utilities;
 
 namespace Unity.Netcode
 {
+    internal interface ITransportNetworkMetrics
+    {
+        void TrackPacketSent(int packetCount);
+        void TrackPacketReceived(int packetCount);
+    }
+
+    [BurstCompile]
+    internal class TransportNetworkMetrics
+    {
+        internal IMetricDispatcher Dispatcher { get; }
+
+        private readonly EventMetric<PacketEvent> m_PacketEventSent = new EventMetric<PacketEvent>(NetworkMetricTypes.PacketEventSent.Id);
+        private readonly EventMetric<PacketEvent> m_PacketEventReceived = new EventMetric<PacketEvent>(NetworkMetricTypes.PacketEventReceived.Id);
+
+        public TransportNetworkMetrics()
+        {
+            Dispatcher = new MetricDispatcherBuilder()
+                .WithMetricEvents(m_PacketEventSent, m_PacketEventReceived)
+                .Build();
+
+            Dispatcher.RegisterObserver(NetcodeObserver.Observer);
+        }
+
+        [BurstCompile]
+        public void TrackPacketSent(int packetCount)
+        {
+            m_PacketEventSent.Mark(new PacketEvent(new ConnectionInfo(100), 1));
+
+        }
+
+        [BurstCompile]
+        public void TrackPacketReceived(int packetCount)
+        {
+            m_PacketEventReceived.Mark(new PacketEvent(new ConnectionInfo(200), 1));
+        }
+
+        public void DispatchFrame()
+        {
+            Dispatcher.Dispatch();
+        }
+
+        internal class NetcodeObserver
+        {
+            public static IMetricObserver Observer { get; } = MetricObserverFactory.Construct();
+        }
+    }
+
+
     /// <summary>
     /// Provides an interface that overrides the ability to create your own drivers and pipelines
     /// </summary>
@@ -191,6 +243,8 @@ namespace Unity.Netcode
         /// SendQueue dictionary is used to batch events instead of sending them immediately.
         /// </summary>
         private readonly Dictionary<SendTarget, SendQueue> m_SendQueue = new Dictionary<SendTarget, SendQueue>();
+
+        internal static TransportNetworkMetrics Metrics = new TransportNetworkMetrics();
 
         private void InitDriver()
         {
@@ -515,6 +569,8 @@ namespace Unity.Netcode
                 {
                     ;
                 }
+
+                Metrics.DispatchFrame();
             }
         }
 
@@ -793,6 +849,7 @@ namespace Unity.Netcode
 
         public void CreateDriver(UnityTransport transport, out NetworkDriver driver, out NetworkPipeline unreliableSequencedPipeline, out NetworkPipeline reliableSequencedFragmentedPipeline)
         {
+            NetworkPipelineStageCollection.RegisterPipelineStage(new MetricsPipelineStage());
             var netParams = new NetworkConfigParameter
             {
                 maxConnectAttempts = transport.m_MaxConnectAttempts,
@@ -824,19 +881,21 @@ namespace Unity.Netcode
                 unreliableSequencedPipeline = driver.CreatePipeline(
                     typeof(UnreliableSequencedPipelineStage),
                     typeof(SimulatorPipelineStage),
-                    typeof(SimulatorPipelineStageInSend));
+                    typeof(SimulatorPipelineStageInSend),
+                    typeof(MetricsPipelineStage));
                 reliableSequencedFragmentedPipeline = driver.CreatePipeline(
                     typeof(FragmentationPipelineStage),
                     typeof(ReliableSequencedPipelineStage),
                     typeof(SimulatorPipelineStage),
-                    typeof(SimulatorPipelineStageInSend));
+                    typeof(SimulatorPipelineStageInSend),
+                    typeof(MetricsPipelineStage));
             }
             else
 #endif
             {
-                unreliableSequencedPipeline = driver.CreatePipeline(typeof(UnreliableSequencedPipelineStage));
+                unreliableSequencedPipeline = driver.CreatePipeline(typeof(UnreliableSequencedPipelineStage), typeof(MetricsPipelineStage));
                 reliableSequencedFragmentedPipeline = driver.CreatePipeline(
-                    typeof(FragmentationPipelineStage), typeof(ReliableSequencedPipelineStage)
+                    typeof(FragmentationPipelineStage), typeof(ReliableSequencedPipelineStage), typeof(MetricsPipelineStage)
                 );
             }
         }

--- a/com.unity.netcode.adapter.utp/Runtime/com.unity.netcode.adapter.utp.asmdef
+++ b/com.unity.netcode.adapter.utp/Runtime/com.unity.netcode.adapter.utp.asmdef
@@ -6,7 +6,11 @@
         "Unity.Jobs",
         "Unity.Burst",
         "Unity.Netcode.Runtime",
-        "Unity.Networking.Transport"
+        "Unity.Networking.Transport",
+        "Unity.Multiplayer.MetricTypes",
+        "Unity.Multiplayer.NetStats",
+        "Unity.Multiplayer.NetStatsReporting",
+        "Unity.Multiplayer.NetworkSolutionInterface"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -15,6 +19,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.multiplayer.tools",
+            "expression": "",
+            "define": "MULTIPLAYER_TOOLS"
+        }
+    ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
<!-- Replace this line with what this PR does and why.  Describe what you'd like reviewers to know, how you applied the Engineering principles, and any interesting tradeoffs made.  Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

<!-- Add JIRA link here. Short version (e.g. MTT-123) also works and gets auto-linked. -->

<!-- Add RFC link here if applicable. -->

<!-- Original PR link if this is a backport PR -->

<!-- When backporting is required please add the type:backport-release-<version> label to this PR. This should include all versions in which this should be backported to. -->

### PR Checklist
- [ ] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR or a link to the documenation repo PR if this is a manual update. 

## Changelog

### com.unity.netcode.gameobjects
- Added: The package whose Changelog should be added to should be in the header. Delete the changelog section entirely if it's not needed.
- Fixed: If you update multiple packages, create a new section with a new header for the other package. 
- Removed/Deprecated/Changed: Each bullet should be prefixed with Added, Fixed, Removed, Deprecated, or Changed to indicate where the entry should go.

## Testing and Documentation

* No tests have been added.
* Includes unit tests.
* Includes integration tests.
* No documentation changes or additions were necessary.
* Includes documentation for previously-undocumented public API entry points.
* Includes edits to existing public API documentation.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
