### PR TITLE
refactor: Improved INetworkMessage interface

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
@@ -95,8 +95,8 @@ namespace Unity.Netcode.Editor.CodeGen
         }
 
 
-        private TypeReference m_FastBufferReader_TypeRef;
-        private TypeReference m_NetworkContext_TypeRef;
+        private MethodReference m_MessagingSystem_ReceiveMessage_MethodRef;
+
         private TypeReference m_MessagingSystem_MessageWithHandler_TypeRef;
         private MethodReference m_MessagingSystem_MessageHandler_Constructor_TypeRef;
         private FieldReference m_ILPPMessageProvider___network_message_types_FieldRef;
@@ -106,10 +106,10 @@ namespace Unity.Netcode.Editor.CodeGen
 
         private MethodReference m_List_Add_MethodRef;
 
+        private const string k_ReceiveMessageName = nameof(MessagingSystem.ReceiveMessage);
+
         private bool ImportReferences(ModuleDefinition moduleDefinition)
         {
-            m_FastBufferReader_TypeRef = moduleDefinition.ImportReference(typeof(FastBufferReader));
-            m_NetworkContext_TypeRef = moduleDefinition.ImportReference(typeof(NetworkContext));
             m_MessagingSystem_MessageHandler_Constructor_TypeRef =
                 moduleDefinition.ImportReference(typeof(MessagingSystem.MessageHandler).GetConstructors()[0]);
 
@@ -162,38 +162,19 @@ namespace Unity.Netcode.Editor.CodeGen
                 }
             }
 
-
-            return true;
-        }
-
-        private MethodReference GetNetworkMessageRecieveHandler(TypeDefinition typeDefinition)
-        {
-            SequencePoint typeSequence = null;
-            foreach (var method in typeDefinition.Methods)
+            var messagingSystemType = typeof(MessagingSystem);
+            foreach (var methodInfo in messagingSystemType.GetMethods(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public))
             {
-                var resolved = method.Resolve();
-                var methodSequence = resolved.DebugInformation.SequencePoints.FirstOrDefault();
-                if (typeSequence == null || methodSequence.StartLine < typeSequence.StartLine)
+                switch (methodInfo.Name)
                 {
-                    typeSequence = methodSequence;
-                }
-
-                if (resolved.IsStatic && resolved.IsPublic && resolved.Name == "Receive" && resolved.Parameters.Count == 2
-                    && !resolved.Parameters[0].IsIn
-                    && !resolved.Parameters[0].ParameterType.IsByReference
-                    && resolved.Parameters[0].ParameterType.Resolve() ==
-                        m_FastBufferReader_TypeRef.Resolve()
-                    && resolved.Parameters[1].IsIn
-                    && resolved.Parameters[1].ParameterType.IsByReference
-                    && resolved.Parameters[1].ParameterType.GetElementType().Resolve() == m_NetworkContext_TypeRef.Resolve()
-                    && resolved.ReturnType == resolved.Module.TypeSystem.Void)
-                {
-                    return method;
+                    case k_ReceiveMessageName:
+                        m_MessagingSystem_ReceiveMessage_MethodRef = moduleDefinition.ImportReference(methodInfo);
+                        break;
                 }
             }
 
-            m_Diagnostics.AddError(typeSequence, $"Class {typeDefinition.FullName} does not implement required method: `public static void Receive(FastBufferReader, in NetworkContext)`");
-            return null;
+
+            return true;
         }
 
         private MethodDefinition GetOrCreateStaticConstructor(TypeDefinition typeDefinition)
@@ -264,11 +245,8 @@ namespace Unity.Netcode.Editor.CodeGen
 
                     foreach (var type in networkMessageTypes)
                     {
-                        var receiveMethod = GetNetworkMessageRecieveHandler(type);
-                        if (receiveMethod == null)
-                        {
-                            continue;
-                        }
+                        var receiveMethod = new GenericInstanceMethod(m_MessagingSystem_ReceiveMessage_MethodRef);
+                        receiveMethod.GenericArguments.Add(type);
                         CreateInstructionsToRegisterType(processor, instructions, type, receiveMethod);
                     }
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -89,7 +89,7 @@ namespace Unity.Netcode
                 message.RpcReadData = tempBuffer;
                 message.ReceivingNetworkObject = NetworkObject;
                 message.ReceivingNetworkBehaviour = this;
-                message.Handle(context);
+                message.Handle(ref context);
                 rpcMessageSize = tempBuffer.Length;
             }
             else
@@ -200,7 +200,7 @@ namespace Unity.Netcode
                 message.RpcReadData = tempBuffer;
                 message.ReceivingNetworkObject = NetworkObject;
                 message.ReceivingNetworkBehaviour = this;
-                message.Handle(context);
+                message.Handle(ref context);
                 messageSize = tempBuffer.Length;
             }
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -141,11 +141,11 @@ namespace Unity.Netcode
                 return !m_NetworkManager.m_StopProcessingMessages;
             }
 
-            public void OnBeforeHandleMessage<T>(ref T message, in NetworkContext context) where T : INetworkMessage
+            public void OnBeforeHandleMessage<T>(ref T message, ref NetworkContext context) where T : INetworkMessage
             {
             }
 
-            public void OnAfterHandleMessage<T>(ref T message, in NetworkContext context) where T : INetworkMessage
+            public void OnAfterHandleMessage<T>(ref T message, ref NetworkContext context) where T : INetworkMessage
             {
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -86,11 +86,11 @@ namespace Unity.Netcode
                 m_NetworkManager = manager;
             }
 
-            public void OnBeforeSendMessage(ulong clientId, Type messageType, NetworkDelivery delivery)
+            public void OnBeforeSendMessage<T>(ulong clientId, ref T message, NetworkDelivery delivery) where T : INetworkMessage
             {
             }
 
-            public void OnAfterSendMessage(ulong clientId, Type messageType, NetworkDelivery delivery, int messageSizeBytes)
+            public void OnAfterSendMessage<T>(ulong clientId, ref T message, NetworkDelivery delivery, int messageSizeBytes) where T : INetworkMessage
             {
             }
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -140,6 +140,14 @@ namespace Unity.Netcode
 
                 return !m_NetworkManager.m_StopProcessingMessages;
             }
+
+            public void OnBeforeHandleMessage<T>(ref T message, in NetworkContext context) where T : INetworkMessage
+            {
+            }
+
+            public void OnAfterHandleMessage<T>(ref T message, in NetworkContext context) where T : INetworkMessage
+            {
+            }
         }
 
         private class NetworkManagerMessageSender : IMessageSender
@@ -1253,7 +1261,7 @@ namespace Unity.Netcode
                 ShouldSendConnectionData = NetworkConfig.ConnectionApproval,
                 ConnectionData = NetworkConfig.ConnectionData
             };
-            SendMessage(message, NetworkDelivery.ReliableSequenced, ServerClientId);
+            SendMessage(ref message, NetworkDelivery.ReliableSequenced, ServerClientId);
         }
 
         private IEnumerator ApprovalTimeout(ulong clientId)
@@ -1376,7 +1384,7 @@ namespace Unity.Netcode
             }
         }
 
-        internal unsafe int SendMessage<TMessageType, TClientIdListType>(in TMessageType message, NetworkDelivery delivery, in TClientIdListType clientIds)
+        internal unsafe int SendMessage<TMessageType, TClientIdListType>(ref TMessageType message, NetworkDelivery delivery, in TClientIdListType clientIds)
             where TMessageType : INetworkMessage
             where TClientIdListType : IReadOnlyList<ulong>
         {
@@ -1399,12 +1407,12 @@ namespace Unity.Netcode
                 {
                     return 0;
                 }
-                return MessagingSystem.SendMessage(message, delivery, nonServerIds, newIdx);
+                return MessagingSystem.SendMessage(ref message, delivery, nonServerIds, newIdx);
             }
-            return MessagingSystem.SendMessage(message, delivery, clientIds);
+            return MessagingSystem.SendMessage(ref message, delivery, clientIds);
         }
 
-        internal unsafe int SendMessage<T>(in T message, NetworkDelivery delivery,
+        internal unsafe int SendMessage<T>(ref T message, NetworkDelivery delivery,
             ulong* clientIds, int numClientIds)
             where T : INetworkMessage
         {
@@ -1427,19 +1435,19 @@ namespace Unity.Netcode
                 {
                     return 0;
                 }
-                return MessagingSystem.SendMessage(message, delivery, nonServerIds, newIdx);
+                return MessagingSystem.SendMessage(ref message, delivery, nonServerIds, newIdx);
             }
 
-            return MessagingSystem.SendMessage(message, delivery, clientIds, numClientIds);
+            return MessagingSystem.SendMessage(ref message, delivery, clientIds, numClientIds);
         }
 
-        internal unsafe int SendMessage<T>(in T message, NetworkDelivery delivery, in NativeArray<ulong> clientIds)
+        internal unsafe int SendMessage<T>(ref T message, NetworkDelivery delivery, in NativeArray<ulong> clientIds)
             where T : INetworkMessage
         {
-            return SendMessage(message, delivery, (ulong*)clientIds.GetUnsafePtr(), clientIds.Length);
+            return SendMessage(ref message, delivery, (ulong*)clientIds.GetUnsafePtr(), clientIds.Length);
         }
 
-        internal int SendMessage<T>(in T message, NetworkDelivery delivery, ulong clientId)
+        internal int SendMessage<T>(ref T message, NetworkDelivery delivery, ulong clientId)
             where T : INetworkMessage
         {
             // Prevent server sending to itself
@@ -1447,7 +1455,7 @@ namespace Unity.Netcode
             {
                 return 0;
             }
-            return MessagingSystem.SendMessage(message, delivery, clientId);
+            return MessagingSystem.SendMessage(ref message, delivery, clientId);
         }
 
         internal void HandleIncomingData(ulong clientId, ArraySegment<byte> payload, float receiveTime)
@@ -1576,7 +1584,7 @@ namespace Unity.Netcode
             {
                 Tick = NetworkTickSystem.ServerTime.Tick
             };
-            SendMessage(message, NetworkDelivery.Unreliable, ConnectedClientsIds);
+            SendMessage(ref message, NetworkDelivery.Unreliable, ConnectedClientsIds);
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
             s_SyncTime.End();
 #endif
@@ -1628,7 +1636,7 @@ namespace Unity.Netcode
                         }
                     }
 
-                    SendMessage(message, NetworkDelivery.ReliableFragmentedSequenced, ownerClientId);
+                    SendMessage(ref message, NetworkDelivery.ReliableFragmentedSequenced, ownerClientId);
 
                     // If scene management is enabled, then let NetworkSceneManager handle the initial scene and NetworkObject synchronization
                     if (!NetworkConfig.EnableSceneManagement)
@@ -1687,7 +1695,7 @@ namespace Unity.Netcode
                 message.ObjectInfo.Header.HasParent = false;
                 message.ObjectInfo.Header.IsPlayerObject = true;
                 message.ObjectInfo.Header.OwnerClientId = clientId;
-                var size = SendMessage(message, NetworkDelivery.ReliableFragmentedSequenced, clientPair.Key);
+                var size = SendMessage(ref message, NetworkDelivery.ReliableFragmentedSequenced, clientPair.Key);
                 NetworkMetrics.TrackObjectSpawnSent(clientPair.Key, ConnectedClients[clientId].PlayerObject, size);
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -328,7 +328,7 @@ namespace Unity.Netcode
                     NetworkObjectId = NetworkObjectId
                 };
                 // Send destroy call
-                var size = NetworkManager.SendMessage(message, NetworkDelivery.ReliableSequenced, clientId);
+                var size = NetworkManager.SendMessage(ref message, NetworkDelivery.ReliableSequenced, clientId);
                 NetworkManager.NetworkMetrics.TrackObjectDestroySent(clientId, this, size);
             }
         }
@@ -718,7 +718,7 @@ namespace Unity.Netcode
                     }
                 }
 
-                NetworkManager.SendMessage(message, NetworkDelivery.ReliableSequenced, clientIds, idx);
+                NetworkManager.SendMessage(ref message, NetworkDelivery.ReliableSequenced, clientIds, idx);
             }
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
@@ -93,7 +93,7 @@ namespace Unity.Netcode
         internal List<SentSpawn> SentSpawns = new List<SentSpawn>();
     }
 
-    internal delegate int MockSendMessage(in SnapshotDataMessage message, NetworkDelivery delivery, ulong clientId);
+    internal delegate int MockSendMessage(ref SnapshotDataMessage message, NetworkDelivery delivery, ulong clientId);
     internal delegate int MockSpawnObject(SnapshotSpawnCommand spawnCommand);
     internal delegate int MockDespawnObject(SnapshotDespawnCommand despawnCommand);
 
@@ -837,11 +837,11 @@ namespace Unity.Netcode
 
             if (m_NetworkManager)
             {
-                m_NetworkManager.SendMessage(message, NetworkDelivery.Unreliable, clientId);
+                m_NetworkManager.SendMessage(ref message, NetworkDelivery.Unreliable, clientId);
             }
             else
             {
-                MockSendMessage(message, NetworkDelivery.Unreliable, clientId);
+                MockSendMessage(ref message, NetworkDelivery.Unreliable, clientId);
             }
 
             m_ClientData[clientId].LastReceivedSequence = 0;

--- a/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
@@ -835,13 +835,22 @@ namespace Unity.Netcode
             WriteIndex(ref message);
             WriteSpawns(ref message, clientId);
 
-            if (m_NetworkManager)
+            try
             {
-                m_NetworkManager.SendMessage(ref message, NetworkDelivery.Unreliable, clientId);
+                if (m_NetworkManager)
+                {
+                    m_NetworkManager.SendMessage(ref message, NetworkDelivery.Unreliable, clientId);
+                }
+                else
+                {
+                    MockSendMessage(ref message, NetworkDelivery.Unreliable, clientId);
+                }
             }
-            else
+            finally
             {
-                MockSendMessage(ref message, NetworkDelivery.Unreliable, clientId);
+                message.Entries.Dispose();
+                message.Spawns.Dispose();
+                message.Despawns.Dispose();
             }
 
             m_ClientData[clientId].LastReceivedSequence = 0;

--- a/com.unity.netcode.gameobjects/Runtime/Logging/NetworkLog.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Logging/NetworkLog.cs
@@ -62,7 +62,7 @@ namespace Unity.Netcode
                     LogType = logType,
                     Message = message
                 };
-                var size = NetworkManager.Singleton.SendMessage(networkMessage, NetworkDelivery.ReliableFragmentedSequenced,
+                var size = NetworkManager.Singleton.SendMessage(ref networkMessage, NetworkDelivery.ReliableFragmentedSequenced,
                     NetworkManager.Singleton.ServerClientId);
 
                 NetworkManager.Singleton.NetworkMetrics.TrackServerLogSent(NetworkManager.Singleton.ServerClientId, (uint)logType, size);

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/CustomMessageManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/CustomMessageManager.cs
@@ -73,9 +73,9 @@ namespace Unity.Netcode
 
             var message = new UnnamedMessage
             {
-                Data = messageBuffer
+                SendData = messageBuffer
             };
-            var size = m_NetworkManager.SendMessage(message, networkDelivery, clientIds);
+            var size = m_NetworkManager.SendMessage(ref message, networkDelivery, clientIds);
 
             // Size is zero if we were only sending the message to ourself in which case it isn't sent.
             if (size != 0)
@@ -94,9 +94,9 @@ namespace Unity.Netcode
         {
             var message = new UnnamedMessage
             {
-                Data = messageBuffer
+                SendData = messageBuffer
             };
-            var size = m_NetworkManager.SendMessage(message, networkDelivery, clientId);
+            var size = m_NetworkManager.SendMessage(ref message, networkDelivery, clientId);
             // Size is zero if we were only sending the message to ourself in which case it isn't sent.
             if (size != 0)
             {
@@ -223,9 +223,9 @@ namespace Unity.Netcode
             var message = new NamedMessage
             {
                 Hash = hash,
-                Data = messageStream
+                SendData = messageStream
             };
-            var size = m_NetworkManager.SendMessage(message, networkDelivery, clientId);
+            var size = m_NetworkManager.SendMessage(ref message, networkDelivery, clientId);
 
             // Size is zero if we were only sending the message to ourself in which case it isn't sent.
             if (size != 0)
@@ -266,9 +266,9 @@ namespace Unity.Netcode
             var message = new NamedMessage
             {
                 Hash = hash,
-                Data = messageStream
+                SendData = messageStream
             };
-            var size = m_NetworkManager.SendMessage(message, networkDelivery, clientIds);
+            var size = m_NetworkManager.SendMessage(ref message, networkDelivery, clientIds);
 
             // Size is zero if we were only sending the message to ourself in which case it isn't sent.
             if (size != 0)

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/INetworkHooks.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/INetworkHooks.cs
@@ -13,18 +13,18 @@ namespace Unity.Netcode
         /// Called before an individual message is sent.
         /// </summary>
         /// <param name="clientId">The destination clientId</param>
-        /// <param name="messageType">The type of the message being sent</param>
+        /// <param name="message">The message being sent</param>
         /// <param name="delivery"></param>
-        void OnBeforeSendMessage(ulong clientId, Type messageType, NetworkDelivery delivery);
+        void OnBeforeSendMessage<T>(ulong clientId, ref T message, NetworkDelivery delivery) where T : INetworkMessage;
 
         /// <summary>
         /// Called after an individual message is sent.
         /// </summary>
         /// <param name="clientId">The destination clientId</param>
-        /// <param name="messageType">The type of the message being sent</param>
+        /// <param name="message">The message being sent</param>
         /// <param name="delivery"></param>
         /// <param name="messageSizeBytes">Number of bytes in the message, not including the message header</param>
-        void OnAfterSendMessage(ulong clientId, Type messageType, NetworkDelivery delivery, int messageSizeBytes);
+        void OnAfterSendMessage<T>(ulong clientId, ref T message, NetworkDelivery delivery, int messageSizeBytes) where T : INetworkMessage;
 
         /// <summary>
         /// Called before an individual message is received.

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/INetworkHooks.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/INetworkHooks.cs
@@ -94,8 +94,22 @@ namespace Unity.Netcode
         /// <returns></returns>
         bool OnVerifyCanReceive(ulong senderId, Type messageType);
 
+        /// <summary>
+        /// Called after a message is serialized, but before it's handled.
+        /// Differs from OnBeforeReceiveMessage in that the actual message object is passed and can be inspected.
+        /// </summary>
+        /// <param name="message">The message object</param>
+        /// <param name="context">The network context the message is being ahandled in</param>
+        /// <typeparam name="T"></typeparam>
         void OnBeforeHandleMessage<T>(ref T message, ref NetworkContext context) where T : INetworkMessage;
 
+        /// <summary>
+        /// Called after a message is serialized and handled.
+        /// Differs from OnAfterReceiveMessage in that the actual message object is passed and can be inspected.
+        /// </summary>
+        /// <param name="message">The message object</param>
+        /// <param name="context">The network context the message is being ahandled in</param>
+        /// <typeparam name="T"></typeparam>
         void OnAfterHandleMessage<T>(ref T message, ref NetworkContext context) where T : INetworkMessage;
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/INetworkHooks.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/INetworkHooks.cs
@@ -93,5 +93,9 @@ namespace Unity.Netcode
         /// <param name="messageType">The type of the message</param>
         /// <returns></returns>
         bool OnVerifyCanReceive(ulong senderId, Type messageType);
+
+        void OnBeforeHandleMessage<T>(ref T message, in NetworkContext context) where T : INetworkMessage;
+
+        void OnAfterHandleMessage<T>(ref T message, in NetworkContext context) where T : INetworkMessage;
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/INetworkHooks.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/INetworkHooks.cs
@@ -94,8 +94,8 @@ namespace Unity.Netcode
         /// <returns></returns>
         bool OnVerifyCanReceive(ulong senderId, Type messageType);
 
-        void OnBeforeHandleMessage<T>(ref T message, in NetworkContext context) where T : INetworkMessage;
+        void OnBeforeHandleMessage<T>(ref T message, ref NetworkContext context) where T : INetworkMessage;
 
-        void OnAfterHandleMessage<T>(ref T message, in NetworkContext context) where T : INetworkMessage;
+        void OnAfterHandleMessage<T>(ref T message, ref NetworkContext context) where T : INetworkMessage;
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/INetworkMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/INetworkMessage.cs
@@ -45,5 +45,7 @@ namespace Unity.Netcode
         /// </summary>
         /// <param name="writer"></param>
         void Serialize(FastBufferWriter writer);
+        bool Deserialize(FastBufferReader reader, in NetworkContext context);
+        void Handle(in NetworkContext context);
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/INetworkMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/INetworkMessage.cs
@@ -15,7 +15,7 @@ namespace Unity.Netcode
     /// static message handler for receiving messages of the following name and signature:
     ///
     /// <code>
-    /// public static void Receive(FastBufferReader reader, in NetworkContext context)
+    /// public static void Receive(FastBufferReader reader, ref NetworkContext context)
     /// </code>
     ///
     /// It is the responsibility of the Serialize and Receive methods to ensure there is enough buffer space
@@ -45,7 +45,7 @@ namespace Unity.Netcode
         /// </summary>
         /// <param name="writer"></param>
         void Serialize(FastBufferWriter writer);
-        bool Deserialize(FastBufferReader reader, in NetworkContext context);
-        void Handle(in NetworkContext context);
+        bool Deserialize(FastBufferReader reader, ref NetworkContext context);
+        void Handle(ref NetworkContext context);
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ChangeOwnershipMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ChangeOwnershipMessage.cs
@@ -9,7 +9,7 @@ namespace Unity.Netcode
         {
             writer.WriteValueSafe(this);
         }
-        public bool Deserialize(FastBufferReader reader, in NetworkContext context)
+        public bool Deserialize(FastBufferReader reader, ref NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
             if (!networkManager.IsClient)
@@ -19,14 +19,14 @@ namespace Unity.Netcode
             reader.ReadValueSafe(out this);
             if (!networkManager.SpawnManager.SpawnedObjects.ContainsKey(NetworkObjectId))
             {
-                networkManager.SpawnManager.TriggerOnSpawn(NetworkObjectId, reader, context);
+                networkManager.SpawnManager.TriggerOnSpawn(NetworkObjectId, reader, ref context);
                 return false;
             }
 
             return true;
         }
 
-        public void Handle(in NetworkContext context)
+        public void Handle(ref NetworkContext context)
         {
 
             var networkManager = (NetworkManager)context.SystemOwner;

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
@@ -40,7 +40,7 @@ namespace Unity.Netcode
             }
         }
 
-        public bool Deserialize(FastBufferReader reader, in NetworkContext context)
+        public bool Deserialize(FastBufferReader reader, ref NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
             if (!networkManager.IsClient)
@@ -61,7 +61,7 @@ namespace Unity.Netcode
             return true;
         }
 
-        public void Handle(in NetworkContext context)
+        public void Handle(ref NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
             networkManager.LocalClientId = OwnerClientId;

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionRequestMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionRequestMessage.cs
@@ -21,7 +21,7 @@ namespace Unity.Netcode
             }
         }
 
-        public bool Deserialize(FastBufferReader reader, in NetworkContext context)
+        public bool Deserialize(FastBufferReader reader, ref NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
             if (!networkManager.IsServer)
@@ -85,7 +85,7 @@ namespace Unity.Netcode
             return true;
         }
 
-        public void Handle(in NetworkContext context)
+        public void Handle(ref NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
             var senderId = context.SenderId;

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/CreateObjectMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/CreateObjectMessage.cs
@@ -10,7 +10,7 @@ namespace Unity.Netcode
             ObjectInfo.Serialize(writer);
         }
 
-        public bool Deserialize(FastBufferReader reader, in NetworkContext context)
+        public bool Deserialize(FastBufferReader reader, ref NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
             if (!networkManager.IsClient)
@@ -22,7 +22,7 @@ namespace Unity.Netcode
             return true;
         }
 
-        public void Handle(in NetworkContext context)
+        public void Handle(ref NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
             var networkObject = NetworkObject.AddSceneObject(ObjectInfo, m_ReceivedNetworkVariableData, networkManager);

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/DestroyObjectMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/DestroyObjectMessage.cs
@@ -9,19 +9,20 @@ namespace Unity.Netcode
             writer.WriteValueSafe(this);
         }
 
-        public static void Receive(FastBufferReader reader, in NetworkContext context)
+        public bool Deserialize(FastBufferReader reader, in NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
             if (!networkManager.IsClient)
             {
-                return;
+                return false;
             }
-            reader.ReadValueSafe(out DestroyObjectMessage message);
-            message.Handle(context.SenderId, networkManager, reader.Length);
+            reader.ReadValueSafe(out this);
+            return true;
         }
 
-        public void Handle(ulong senderId, NetworkManager networkManager, int messageSize)
+        public void Handle(in NetworkContext context)
         {
+            var networkManager = (NetworkManager)context.SystemOwner;
             if (!networkManager.SpawnManager.SpawnedObjects.TryGetValue(NetworkObjectId, out var networkObject))
             {
                 // This is the same check and log message that happens inside OnDespawnObject, but we have to do it here
@@ -34,7 +35,7 @@ namespace Unity.Netcode
                 return;
             }
 
-            networkManager.NetworkMetrics.TrackObjectDestroyReceived(senderId, networkObject, messageSize);
+            networkManager.NetworkMetrics.TrackObjectDestroyReceived(context.SenderId, networkObject, context.MessageSize);
             networkManager.SpawnManager.OnDespawnObject(networkObject, true);
         }
     }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/DestroyObjectMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/DestroyObjectMessage.cs
@@ -9,7 +9,7 @@ namespace Unity.Netcode
             writer.WriteValueSafe(this);
         }
 
-        public bool Deserialize(FastBufferReader reader, in NetworkContext context)
+        public bool Deserialize(FastBufferReader reader, ref NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
             if (!networkManager.IsClient)
@@ -20,7 +20,7 @@ namespace Unity.Netcode
             return true;
         }
 
-        public void Handle(in NetworkContext context)
+        public void Handle(ref NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
             if (!networkManager.SpawnManager.SpawnedObjects.TryGetValue(NetworkObjectId, out var networkObject))

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NamedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NamedMessage.cs
@@ -13,14 +13,14 @@ namespace Unity.Netcode
             writer.WriteBytesSafe(SendData.GetUnsafePtr(), SendData.Length);
         }
 
-        public bool Deserialize(FastBufferReader reader, in NetworkContext context)
+        public bool Deserialize(FastBufferReader reader, ref NetworkContext context)
         {
             reader.ReadValueSafe(out Hash);
             m_ReceiveData = reader;
             return true;
         }
 
-        public void Handle(in NetworkContext context)
+        public void Handle(ref NetworkContext context)
         {
             ((NetworkManager)context.SystemOwner).CustomMessagingManager.InvokeNamedMessage(Hash, context.SenderId, m_ReceiveData, context.SerializedHeaderSize);
         }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkVariableDeltaMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkVariableDeltaMessage.cs
@@ -95,7 +95,7 @@ namespace Unity.Netcode
             }
         }
 
-        public bool Deserialize(FastBufferReader reader, in NetworkContext context)
+        public bool Deserialize(FastBufferReader reader, ref NetworkContext context)
         {
             if (!reader.TryBeginRead(FastBufferWriter.GetWriteSize(NetworkObjectId) +
                                       FastBufferWriter.GetWriteSize(NetworkBehaviourIndex)))
@@ -109,7 +109,7 @@ namespace Unity.Netcode
             return true;
         }
 
-        public void Handle(in NetworkContext context)
+        public void Handle(ref NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
 
@@ -218,7 +218,7 @@ namespace Unity.Netcode
             }
             else
             {
-                networkManager.SpawnManager.TriggerOnSpawn(NetworkObjectId, m_ReceivedNetworkVariableData, context);
+                networkManager.SpawnManager.TriggerOnSpawn(NetworkObjectId, m_ReceivedNetworkVariableData, ref context);
             }
         }
     }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ParentSyncMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ParentSyncMessage.cs
@@ -26,7 +26,7 @@ namespace Unity.Netcode
             }
         }
 
-        public bool Deserialize(FastBufferReader reader, in NetworkContext context)
+        public bool Deserialize(FastBufferReader reader, ref NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
             if (!networkManager.IsClient)
@@ -48,14 +48,14 @@ namespace Unity.Netcode
 
             if (!networkManager.SpawnManager.SpawnedObjects.ContainsKey(NetworkObjectId))
             {
-                networkManager.SpawnManager.TriggerOnSpawn(NetworkObjectId, reader, context);
+                networkManager.SpawnManager.TriggerOnSpawn(NetworkObjectId, reader, ref context);
                 return false;
             }
 
             return true;
         }
 
-        public void Handle(in NetworkContext context)
+        public void Handle(ref NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
             var networkObject = networkManager.SpawnManager.SpawnedObjects[NetworkObjectId];

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ParentSyncMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ParentSyncMessage.cs
@@ -26,42 +26,41 @@ namespace Unity.Netcode
             }
         }
 
-        public static void Receive(FastBufferReader reader, in NetworkContext context)
+        public bool Deserialize(FastBufferReader reader, in NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
             if (!networkManager.IsClient)
             {
-                return;
+                return false;
             }
 
-            var message = new ParentSyncMessage();
-            reader.ReadValueSafe(out message.NetworkObjectId);
-            reader.ReadValueSafe(out message.IsReparented);
-            if (message.IsReparented)
+            reader.ReadValueSafe(out NetworkObjectId);
+            reader.ReadValueSafe(out IsReparented);
+            if (IsReparented)
             {
-                reader.ReadValueSafe(out message.IsLatestParentSet);
-                if (message.IsLatestParentSet)
+                reader.ReadValueSafe(out IsLatestParentSet);
+                if (IsLatestParentSet)
                 {
                     reader.ReadValueSafe(out ulong latestParent);
-                    message.LatestParent = latestParent;
+                    LatestParent = latestParent;
                 }
             }
 
-            message.Handle(reader, context, networkManager);
-        }
-
-        public void Handle(FastBufferReader reader, in NetworkContext context, NetworkManager networkManager)
-        {
-            if (networkManager.SpawnManager.SpawnedObjects.ContainsKey(NetworkObjectId))
-            {
-                var networkObject = networkManager.SpawnManager.SpawnedObjects[NetworkObjectId];
-                networkObject.SetNetworkParenting(IsReparented, LatestParent);
-                networkObject.ApplyNetworkParenting();
-            }
-            else
+            if (!networkManager.SpawnManager.SpawnedObjects.ContainsKey(NetworkObjectId))
             {
                 networkManager.SpawnManager.TriggerOnSpawn(NetworkObjectId, reader, context);
+                return false;
             }
+
+            return true;
+        }
+
+        public void Handle(in NetworkContext context)
+        {
+            var networkManager = (NetworkManager)context.SystemOwner;
+            var networkObject = networkManager.SpawnManager.SpawnedObjects[NetworkObjectId];
+            networkObject.SetNetworkParenting(IsReparented, LatestParent);
+            networkObject.ApplyNetworkParenting();
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/RpcMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/RpcMessage.cs
@@ -35,7 +35,7 @@ namespace Unity.Netcode
             writer.WriteBytes(RpcWriteData.GetUnsafePtr(), RpcWriteData.Length);
         }
 
-        public bool Deserialize(FastBufferReader reader, in NetworkContext context)
+        public bool Deserialize(FastBufferReader reader, ref NetworkContext context)
         {
             if (!reader.TryBeginRead(FastBufferWriter.GetWriteSize(Header)))
             {
@@ -46,7 +46,7 @@ namespace Unity.Netcode
             var networkManager = (NetworkManager)context.SystemOwner;
             if (!networkManager.SpawnManager.SpawnedObjects.ContainsKey(Header.NetworkObjectId))
             {
-                networkManager.SpawnManager.TriggerOnSpawn(Header.NetworkObjectId, reader, context);
+                networkManager.SpawnManager.TriggerOnSpawn(Header.NetworkObjectId, reader, ref context);
                 return false;
             }
 
@@ -61,7 +61,7 @@ namespace Unity.Netcode
             return true;
         }
 
-        public void Handle(in NetworkContext context)
+        public void Handle(ref NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
             var senderId = context.SenderId;

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/SceneEventMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/SceneEventMessage.cs
@@ -13,13 +13,13 @@ namespace Unity.Netcode
             EventData.Serialize(writer);
         }
 
-        public bool Deserialize(FastBufferReader reader, in NetworkContext context)
+        public bool Deserialize(FastBufferReader reader, ref NetworkContext context)
         {
             m_ReceivedData = reader;
             return true;
         }
 
-        public void Handle(in NetworkContext context)
+        public void Handle(ref NetworkContext context)
         {
             ((NetworkManager)context.SystemOwner).SceneManager.HandleSceneEvent(context.SenderId, m_ReceivedData);
         }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/SceneEventMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/SceneEventMessage.cs
@@ -6,14 +6,22 @@ namespace Unity.Netcode
     {
         public SceneEventData EventData;
 
+        private FastBufferReader m_ReceivedData;
+
         public void Serialize(FastBufferWriter writer)
         {
             EventData.Serialize(writer);
         }
 
-        public static void Receive(FastBufferReader reader, in NetworkContext context)
+        public bool Deserialize(FastBufferReader reader, in NetworkContext context)
         {
-            ((NetworkManager)context.SystemOwner).SceneManager.HandleSceneEvent(context.SenderId, reader);
+            m_ReceivedData = reader;
+            return true;
+        }
+
+        public void Handle(in NetworkContext context)
+        {
+            ((NetworkManager)context.SystemOwner).SceneManager.HandleSceneEvent(context.SenderId, m_ReceivedData);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ServerLogMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ServerLogMessage.cs
@@ -17,7 +17,7 @@ namespace Unity.Netcode
             BytePacker.WriteValuePacked(writer, Message);
         }
 
-        public bool Deserialize(FastBufferReader reader, in NetworkContext context)
+        public bool Deserialize(FastBufferReader reader, ref NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
             if (networkManager.IsServer && networkManager.NetworkConfig.EnableNetworkLogs)
@@ -30,7 +30,7 @@ namespace Unity.Netcode
             return false;
         }
 
-        public void Handle(in NetworkContext context)
+        public void Handle(ref NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
             var senderId = context.SenderId;

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/SnapshotDataMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/SnapshotDataMessage.cs
@@ -95,7 +95,7 @@ namespace Unity.Netcode
             writer.WriteBytes((byte*)Despawns.GetUnsafePtr(), Despawns.Length * sizeof(DespawnData));
         }
 
-        public unsafe bool Deserialize(FastBufferReader reader, in NetworkContext context)
+        public unsafe bool Deserialize(FastBufferReader reader, ref NetworkContext context)
         {
             if (!reader.TryBeginRead(
                 FastBufferWriter.GetWriteSize(CurrentTick) +
@@ -131,7 +131,7 @@ namespace Unity.Netcode
             return true;
         }
 
-        public void Handle(in NetworkContext context)
+        public void Handle(ref NetworkContext context)
         {
 
             using (ReceiveMainBuffer)

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/SnapshotDataMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/SnapshotDataMessage.cs
@@ -76,9 +76,6 @@ namespace Unity.Netcode
                 Despawns.Length * sizeof(DespawnData)
             ))
             {
-                Entries.Dispose();
-                Spawns.Dispose();
-                Despawns.Dispose();
                 throw new OverflowException($"Not enough space to serialize {nameof(SnapshotDataMessage)}");
             }
             writer.WriteValue(CurrentTick);
@@ -96,10 +93,6 @@ namespace Unity.Netcode
 
             writer.WriteValue((ushort)Despawns.Length);
             writer.WriteBytes((byte*)Despawns.GetUnsafePtr(), Despawns.Length * sizeof(DespawnData));
-
-            Entries.Dispose();
-            Spawns.Dispose();
-            Despawns.Dispose();
         }
 
         public unsafe bool Deserialize(FastBufferReader reader, in NetworkContext context)

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/TimeSyncMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/TimeSyncMessage.cs
@@ -9,7 +9,7 @@ namespace Unity.Netcode
             writer.WriteValueSafe(this);
         }
 
-        public bool Deserialize(FastBufferReader reader, in NetworkContext context)
+        public bool Deserialize(FastBufferReader reader, ref NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
             if (!networkManager.IsClient)
@@ -20,7 +20,7 @@ namespace Unity.Netcode
             return true;
         }
 
-        public void Handle(in NetworkContext context)
+        public void Handle(ref NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
             var time = new NetworkTime(networkManager.NetworkTickSystem.TickRate, Tick);

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/TimeSyncMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/TimeSyncMessage.cs
@@ -9,21 +9,22 @@ namespace Unity.Netcode
             writer.WriteValueSafe(this);
         }
 
-        public static void Receive(FastBufferReader reader, in NetworkContext context)
+        public bool Deserialize(FastBufferReader reader, in NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
             if (!networkManager.IsClient)
             {
-                return;
+                return false;
             }
-            reader.ReadValueSafe(out TimeSyncMessage message);
-            message.Handle(context.SenderId, networkManager);
+            reader.ReadValueSafe(out this);
+            return true;
         }
 
-        public void Handle(ulong senderId, NetworkManager networkManager)
+        public void Handle(in NetworkContext context)
         {
+            var networkManager = (NetworkManager)context.SystemOwner;
             var time = new NetworkTime(networkManager.NetworkTickSystem.TickRate, Tick);
-            networkManager.NetworkTimeSystem.Sync(time.Time, networkManager.NetworkConfig.NetworkTransport.GetCurrentRtt(senderId) / 1000d);
+            networkManager.NetworkTimeSystem.Sync(time.Time, networkManager.NetworkConfig.NetworkTransport.GetCurrentRtt(context.SenderId) / 1000d);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/UnnamedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/UnnamedMessage.cs
@@ -2,16 +2,23 @@ namespace Unity.Netcode
 {
     internal struct UnnamedMessage : INetworkMessage
     {
-        public FastBufferWriter Data;
+        public FastBufferWriter SendData;
+        private FastBufferReader m_ReceivedData;
 
         public unsafe void Serialize(FastBufferWriter writer)
         {
-            writer.WriteBytesSafe(Data.GetUnsafePtr(), Data.Length);
+            writer.WriteBytesSafe(SendData.GetUnsafePtr(), SendData.Length);
         }
 
-        public static void Receive(FastBufferReader reader, in NetworkContext context)
+        public bool Deserialize(FastBufferReader reader, in NetworkContext context)
         {
-            ((NetworkManager)context.SystemOwner).CustomMessagingManager.InvokeUnnamedMessage(context.SenderId, reader, context.SerializedHeaderSize);
+            m_ReceivedData = reader;
+            return true;
+        }
+
+        public void Handle(in NetworkContext context)
+        {
+            ((NetworkManager)context.SystemOwner).CustomMessagingManager.InvokeUnnamedMessage(context.SenderId, m_ReceivedData, context.SerializedHeaderSize);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/UnnamedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/UnnamedMessage.cs
@@ -10,13 +10,13 @@ namespace Unity.Netcode
             writer.WriteBytesSafe(SendData.GetUnsafePtr(), SendData.Length);
         }
 
-        public bool Deserialize(FastBufferReader reader, in NetworkContext context)
+        public bool Deserialize(FastBufferReader reader, ref NetworkContext context)
         {
             m_ReceivedData = reader;
             return true;
         }
 
-        public void Handle(in NetworkContext context)
+        public void Handle(ref NetworkContext context)
         {
             ((NetworkManager)context.SystemOwner).CustomMessagingManager.InvokeUnnamedMessage(context.SenderId, m_ReceivedData, context.SerializedHeaderSize);
         }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
@@ -40,7 +40,7 @@ namespace Unity.Netcode
             }
         }
 
-        internal delegate void MessageHandler(FastBufferReader reader, in NetworkContext context, MessagingSystem system);
+        internal delegate void MessageHandler(FastBufferReader reader, ref NetworkContext context, MessagingSystem system);
 
         private NativeList<ReceiveQueueItem> m_IncomingMessageQueue = new NativeList<ReceiveQueueItem>(16, Allocator.Persistent);
 
@@ -261,7 +261,7 @@ namespace Unity.Netcode
                 // for some dynamic-length value.
                 try
                 {
-                    handler.Invoke(reader, context, this);
+                    handler.Invoke(reader, ref context, this);
                 }
                 catch (Exception e)
                 {
@@ -320,21 +320,21 @@ namespace Unity.Netcode
             queue.Dispose();
         }
 
-        public static void ReceiveMessage<T>(FastBufferReader reader, in NetworkContext context, MessagingSystem system) where T : INetworkMessage, new()
+        public static void ReceiveMessage<T>(FastBufferReader reader, ref NetworkContext context, MessagingSystem system) where T : INetworkMessage, new()
         {
             var message = new T();
-            if (message.Deserialize(reader, context))
+            if (message.Deserialize(reader, ref context))
             {
                 for (var hookIdx = 0; hookIdx < system.m_Hooks.Count; ++hookIdx)
                 {
-                    system.m_Hooks[hookIdx].OnBeforeHandleMessage(ref message, context);
+                    system.m_Hooks[hookIdx].OnBeforeHandleMessage(ref message, ref context);
                 }
 
-                message.Handle(context);
+                message.Handle(ref context);
 
                 for (var hookIdx = 0; hookIdx < system.m_Hooks.Count; ++hookIdx)
                 {
-                    system.m_Hooks[hookIdx].OnBeforeHandleMessage(ref message, context);
+                    system.m_Hooks[hookIdx].OnBeforeHandleMessage(ref message, ref context);
                 }
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
@@ -40,7 +40,7 @@ namespace Unity.Netcode
             }
         }
 
-        internal delegate void MessageHandler(FastBufferReader reader, in NetworkContext context);
+        internal delegate void MessageHandler(FastBufferReader reader, in NetworkContext context, MessagingSystem system);
 
         private NativeList<ReceiveQueueItem> m_IncomingMessageQueue = new NativeList<ReceiveQueueItem>(16, Allocator.Persistent);
 
@@ -236,6 +236,7 @@ namespace Unity.Netcode
                 Timestamp = timestamp,
                 Header = header,
                 SerializedHeaderSize = serializedHeaderSize,
+                MessageSize = header.MessageSize
             };
 
             var type = m_ReverseTypeMap[header.MessageType];
@@ -260,7 +261,7 @@ namespace Unity.Netcode
                 // for some dynamic-length value.
                 try
                 {
-                    handler.Invoke(reader, context);
+                    handler.Invoke(reader, context, this);
                 }
                 catch (Exception e)
                 {
@@ -319,6 +320,25 @@ namespace Unity.Netcode
             queue.Dispose();
         }
 
+        public static void ReceiveMessage<T>(FastBufferReader reader, in NetworkContext context, MessagingSystem system) where T : INetworkMessage, new()
+        {
+            var message = new T();
+            if (message.Deserialize(reader, context))
+            {
+                for (var hookIdx = 0; hookIdx < system.m_Hooks.Count; ++hookIdx)
+                {
+                    system.m_Hooks[hookIdx].OnBeforeHandleMessage(ref message, context);
+                }
+
+                message.Handle(context);
+
+                for (var hookIdx = 0; hookIdx < system.m_Hooks.Count; ++hookIdx)
+                {
+                    system.m_Hooks[hookIdx].OnBeforeHandleMessage(ref message, context);
+                }
+            }
+        }
+
         private bool CanSend(ulong clientId, Type messageType, NetworkDelivery delivery)
         {
             for (var hookIdx = 0; hookIdx < m_Hooks.Count; ++hookIdx)
@@ -332,7 +352,7 @@ namespace Unity.Netcode
             return true;
         }
 
-        internal unsafe int SendMessage<TMessageType, TClientIdListType>(in TMessageType message, NetworkDelivery delivery, in TClientIdListType clientIds)
+        internal unsafe int SendMessage<TMessageType, TClientIdListType>(ref TMessageType message, NetworkDelivery delivery, in TClientIdListType clientIds)
             where TMessageType : INetworkMessage
             where TClientIdListType : IReadOnlyList<ulong>
         {
@@ -441,24 +461,24 @@ namespace Unity.Netcode
             }
         }
 
-        internal unsafe int SendMessage<T>(in T message, NetworkDelivery delivery,
+        internal unsafe int SendMessage<T>(ref T message, NetworkDelivery delivery,
             ulong* clientIds, int numClientIds)
             where T : INetworkMessage
         {
-            return SendMessage(message, delivery, new PointerListWrapper<ulong>(clientIds, numClientIds));
+            return SendMessage(ref message, delivery, new PointerListWrapper<ulong>(clientIds, numClientIds));
         }
 
-        internal unsafe int SendMessage<T>(in T message, NetworkDelivery delivery, ulong clientId)
+        internal unsafe int SendMessage<T>(ref T message, NetworkDelivery delivery, ulong clientId)
             where T : INetworkMessage
         {
             ulong* clientIds = stackalloc ulong[] { clientId };
-            return SendMessage(message, delivery, new PointerListWrapper<ulong>(clientIds, 1));
+            return SendMessage(ref message, delivery, new PointerListWrapper<ulong>(clientIds, 1));
         }
 
-        internal unsafe int SendMessage<T>(in T message, NetworkDelivery delivery, in NativeArray<ulong> clientIds)
+        internal unsafe int SendMessage<T>(ref T message, NetworkDelivery delivery, in NativeArray<ulong> clientIds)
             where T : INetworkMessage
         {
-            return SendMessage(message, delivery, new PointerListWrapper<ulong>((ulong*)clientIds.GetUnsafePtr(), clientIds.Length));
+            return SendMessage(ref message, delivery, new PointerListWrapper<ulong>((ulong*)clientIds.GetUnsafePtr(), clientIds.Length));
         }
 
         internal unsafe void ProcessSendQueues()

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
@@ -334,7 +334,7 @@ namespace Unity.Netcode
 
                 for (var hookIdx = 0; hookIdx < system.m_Hooks.Count; ++hookIdx)
                 {
-                    system.m_Hooks[hookIdx].OnBeforeHandleMessage(ref message, ref context);
+                    system.m_Hooks[hookIdx].OnAfterHandleMessage(ref message, ref context);
                 }
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
@@ -388,7 +388,7 @@ namespace Unity.Netcode
 
                 for (var hookIdx = 0; hookIdx < m_Hooks.Count; ++hookIdx)
                 {
-                    m_Hooks[hookIdx].OnBeforeSendMessage(clientId, typeof(TMessageType), delivery);
+                    m_Hooks[hookIdx].OnBeforeSendMessage(clientId, ref message, delivery);
                 }
 
                 var sendQueueItem = m_SendQueues[clientId];
@@ -419,7 +419,7 @@ namespace Unity.Netcode
                 writeQueueItem.BatchHeader.BatchSize++;
                 for (var hookIdx = 0; hookIdx < m_Hooks.Count; ++hookIdx)
                 {
-                    m_Hooks[hookIdx].OnAfterSendMessage(clientId, typeof(TMessageType), delivery, tmpSerializer.Length + headerSerializer.Length);
+                    m_Hooks[hookIdx].OnAfterSendMessage(clientId, ref message, delivery, tmpSerializer.Length + headerSerializer.Length);
                 }
             }
 

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/NetworkContext.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/NetworkContext.cs
@@ -30,5 +30,10 @@ namespace Unity.Netcode
         /// The actual serialized size of the header when packed into the buffer
         /// </summary>
         public int SerializedHeaderSize;
+
+        /// <summary>
+        /// The size of the message in the buffer, header excluded
+        /// </summary>
+        public uint MessageSize;
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/MetricHooks.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/MetricHooks.cs
@@ -12,13 +12,13 @@ namespace Unity.Netcode
         }
 
 
-        public void OnBeforeSendMessage(ulong clientId, Type messageType, NetworkDelivery delivery)
+        public void OnBeforeSendMessage<T>(ulong clientId, ref T message, NetworkDelivery delivery) where T : INetworkMessage
         {
         }
 
-        public void OnAfterSendMessage(ulong clientId, Type messageType, NetworkDelivery delivery, int messageSizeBytes)
+        public void OnAfterSendMessage<T>(ulong clientId, ref T message, NetworkDelivery delivery, int messageSizeBytes) where T : INetworkMessage
         {
-            m_NetworkManager.NetworkMetrics.TrackNetworkMessageSent(clientId, messageType.Name, messageSizeBytes);
+            m_NetworkManager.NetworkMetrics.TrackNetworkMessageSent(clientId, nameof(T), messageSizeBytes);
         }
 
         public void OnBeforeReceiveMessage(ulong senderId, Type messageType, int messageSizeBytes)

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/MetricHooks.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/MetricHooks.cs
@@ -57,5 +57,15 @@ namespace Unity.Netcode
         {
             return true;
         }
+
+        public void OnBeforeHandleMessage<T>(ref T message, in NetworkContext context) where T : INetworkMessage
+        {
+            // TODO: Per-message metrics recording moved here
+        }
+
+        public void OnAfterHandleMessage<T>(ref T message, in NetworkContext context) where T : INetworkMessage
+        {
+            // TODO: Per-message metrics recording moved here
+        }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/MetricHooks.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/MetricHooks.cs
@@ -18,7 +18,7 @@ namespace Unity.Netcode
 
         public void OnAfterSendMessage<T>(ulong clientId, ref T message, NetworkDelivery delivery, int messageSizeBytes) where T : INetworkMessage
         {
-            m_NetworkManager.NetworkMetrics.TrackNetworkMessageSent(clientId, nameof(T), messageSizeBytes);
+            m_NetworkManager.NetworkMetrics.TrackNetworkMessageSent(clientId, typeof(T).Name, messageSizeBytes);
         }
 
         public void OnBeforeReceiveMessage(ulong senderId, Type messageType, int messageSizeBytes)
@@ -58,12 +58,12 @@ namespace Unity.Netcode
             return true;
         }
 
-        public void OnBeforeHandleMessage<T>(ref T message, in NetworkContext context) where T : INetworkMessage
+        public void OnBeforeHandleMessage<T>(ref T message, ref NetworkContext context) where T : INetworkMessage
         {
             // TODO: Per-message metrics recording moved here
         }
 
-        public void OnAfterHandleMessage<T>(ref T message, in NetworkContext context) where T : INetworkMessage
+        public void OnAfterHandleMessage<T>(ref T message, ref NetworkContext context) where T : INetworkMessage
         {
             // TODO: Per-message metrics recording moved here
         }

--- a/com.unity.netcode.gameobjects/Runtime/Profiling/ProfilingHooks.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Profiling/ProfilingHooks.cs
@@ -86,5 +86,15 @@ namespace Unity.Netcode
         {
             return true;
         }
+
+        public void OnBeforeHandleMessage<T>(ref T message, in NetworkContext context) where T : INetworkMessage
+        {
+            // nop
+        }
+
+        public void OnAfterHandleMessage<T>(ref T message, in NetworkContext context) where T : INetworkMessage
+        {
+            // nop
+        }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Profiling/ProfilingHooks.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Profiling/ProfilingHooks.cs
@@ -87,12 +87,12 @@ namespace Unity.Netcode
             return true;
         }
 
-        public void OnBeforeHandleMessage<T>(ref T message, in NetworkContext context) where T : INetworkMessage
+        public void OnBeforeHandleMessage<T>(ref T message, ref NetworkContext context) where T : INetworkMessage
         {
             // nop
         }
 
-        public void OnAfterHandleMessage<T>(ref T message, in NetworkContext context) where T : INetworkMessage
+        public void OnAfterHandleMessage<T>(ref T message, ref NetworkContext context) where T : INetworkMessage
         {
             // nop
         }

--- a/com.unity.netcode.gameobjects/Runtime/Profiling/ProfilingHooks.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Profiling/ProfilingHooks.cs
@@ -37,14 +37,14 @@ namespace Unity.Netcode
             return marker;
         }
 
-        public void OnBeforeSendMessage(ulong clientId, Type messageType, NetworkDelivery delivery)
+        public void OnBeforeSendMessage<T>(ulong clientId, ref T message, NetworkDelivery delivery) where T : INetworkMessage
         {
-            GetSenderProfilerMarker(messageType).Begin();
+            GetSenderProfilerMarker(typeof(T)).Begin();
         }
 
-        public void OnAfterSendMessage(ulong clientId, Type messageType, NetworkDelivery delivery, int messageSizeBytes)
+        public void OnAfterSendMessage<T>(ulong clientId, ref T message, NetworkDelivery delivery, int messageSizeBytes) where T : INetworkMessage
         {
-            GetSenderProfilerMarker(messageType).End();
+            GetSenderProfilerMarker(typeof(T)).End();
         }
 
         public void OnBeforeReceiveMessage(ulong senderId, Type messageType, int messageSizeBytes)

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -735,7 +735,7 @@ namespace Unity.Netcode
             {
                 EventData = SceneEventDataStore[sceneEventId]
             };
-            var size = m_NetworkManager.SendMessage(message, k_DeliveryType, targetClientIds);
+            var size = m_NetworkManager.SendMessage(ref message, k_DeliveryType, targetClientIds);
 
             m_NetworkManager.NetworkMetrics.TrackSceneEventSent(
                 targetClientIds, (uint)SceneEventDataStore[sceneEventId].SceneEventType, SceneNameFromHash(SceneEventDataStore[sceneEventId].SceneHash), size);
@@ -857,7 +857,7 @@ namespace Unity.Netcode
             {
                 EventData = sceneEventData
             };
-            var size = m_NetworkManager.SendMessage(message, k_DeliveryType, m_NetworkManager.ConnectedClientsIds);
+            var size = m_NetworkManager.SendMessage(ref message, k_DeliveryType, m_NetworkManager.ConnectedClientsIds);
 
             m_NetworkManager.NetworkMetrics.TrackSceneEventSent(
                 m_NetworkManager.ConnectedClientsIds,
@@ -1326,7 +1326,7 @@ namespace Unity.Netcode
                     {
                         EventData = sceneEventData
                     };
-                    var size = m_NetworkManager.SendMessage(message, k_DeliveryType, clientId);
+                    var size = m_NetworkManager.SendMessage(ref message, k_DeliveryType, clientId);
                     m_NetworkManager.NetworkMetrics.TrackSceneEventSent(clientId, (uint)sceneEventData.SceneEventType, scene.name, size);
                 }
             }
@@ -1433,7 +1433,7 @@ namespace Unity.Netcode
             {
                 EventData = sceneEventData
             };
-            var size = m_NetworkManager.SendMessage(message, k_DeliveryType, clientId);
+            var size = m_NetworkManager.SendMessage(ref message, k_DeliveryType, clientId);
             m_NetworkManager.NetworkMetrics.TrackSceneEventSent(
                 clientId, (uint)sceneEventData.SceneEventType, "", size);
 
@@ -1580,7 +1580,7 @@ namespace Unity.Netcode
             {
                 EventData = responseSceneEventData
             };
-            var size = m_NetworkManager.SendMessage(message, k_DeliveryType, m_NetworkManager.ServerClientId);
+            var size = m_NetworkManager.SendMessage(ref message, k_DeliveryType, m_NetworkManager.ServerClientId);
 
             m_NetworkManager.NetworkMetrics.TrackSceneEventSent(m_NetworkManager.ServerClientId, (uint)responseSceneEventData.SceneEventType, sceneName, size);
 

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -102,7 +102,7 @@ namespace Unity.Netcode
         /// There is a one second maximum lifetime of triggers to avoid memory leaks. After one second has passed
         /// without the requested object ID being spawned, the triggers for it are automatically deleted.
         /// </summary>
-        internal unsafe void TriggerOnSpawn(ulong networkObjectId, FastBufferReader reader, in NetworkContext context)
+        internal unsafe void TriggerOnSpawn(ulong networkObjectId, FastBufferReader reader, ref NetworkContext context)
         {
             if (!m_Triggers.ContainsKey(networkObjectId))
             {

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -204,7 +204,7 @@ namespace Unity.Netcode
                 NetworkObjectId = networkObject.NetworkObjectId,
                 OwnerClientId = networkObject.OwnerClientId
             };
-            var size = NetworkManager.SendMessage(message, NetworkDelivery.ReliableSequenced, NetworkManager.ConnectedClientsIds);
+            var size = NetworkManager.SendMessage(ref message, NetworkDelivery.ReliableSequenced, NetworkManager.ConnectedClientsIds);
 
             foreach (var client in NetworkManager.ConnectedClients)
             {
@@ -270,7 +270,7 @@ namespace Unity.Netcode
                 NetworkObjectId = networkObject.NetworkObjectId,
                 OwnerClientId = networkObject.OwnerClientId
             };
-            var size = NetworkManager.SendMessage(message, NetworkDelivery.ReliableSequenced, NetworkManager.ConnectedClientsIds);
+            var size = NetworkManager.SendMessage(ref message, NetworkDelivery.ReliableSequenced, NetworkManager.ConnectedClientsIds);
 
             foreach (var client in NetworkManager.ConnectedClients)
             {
@@ -527,7 +527,7 @@ namespace Unity.Netcode
                 {
                     ObjectInfo = networkObject.GetMessageSceneObject(clientId)
                 };
-                var size = NetworkManager.SendMessage(message, NetworkDelivery.ReliableFragmentedSequenced, clientId);
+                var size = NetworkManager.SendMessage(ref message, NetworkDelivery.ReliableFragmentedSequenced, clientId);
                 NetworkManager.NetworkMetrics.TrackObjectSpawnSent(clientId, networkObject, size);
 
                 networkObject.MarkVariablesDirty();
@@ -767,7 +767,7 @@ namespace Unity.Netcode
                             {
                                 NetworkObjectId = networkObject.NetworkObjectId
                             };
-                            var size = NetworkManager.SendMessage(message, NetworkDelivery.ReliableSequenced, m_TargetClientIds);
+                            var size = NetworkManager.SendMessage(ref message, NetworkDelivery.ReliableSequenced, m_TargetClientIds);
                             foreach (var targetClientId in m_TargetClientIds)
                             {
                                 NetworkManager.NetworkMetrics.TrackObjectDestroySent(targetClientId, networkObject, size);

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageReceivingTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageReceivingTests.cs
@@ -23,14 +23,14 @@ namespace Unity.Netcode.EditorTests
                 writer.WriteValueSafe(this);
             }
 
-            public bool Deserialize(FastBufferReader reader, in NetworkContext context)
+            public bool Deserialize(FastBufferReader reader, ref NetworkContext context)
             {
                 Deserialized = true;
                 reader.ReadValueSafe(out this);
                 return true;
             }
 
-            public void Handle(in NetworkContext context)
+            public void Handle(ref NetworkContext context)
             {
                 Handled = true;
                 DeserializedValues.Add(this);

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageReceivingTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageReceivingTests.cs
@@ -15,6 +15,7 @@ namespace Unity.Netcode.EditorTests
             public int B;
             public int C;
             public static bool Deserialized;
+            public static bool Handled;
             public static List<TestMessage> DeserializedValues = new List<TestMessage>();
 
             public void Serialize(FastBufferWriter writer)
@@ -22,11 +23,17 @@ namespace Unity.Netcode.EditorTests
                 writer.WriteValueSafe(this);
             }
 
-            public static void Receive(FastBufferReader reader, in NetworkContext context)
+            public bool Deserialize(FastBufferReader reader, in NetworkContext context)
             {
                 Deserialized = true;
-                reader.ReadValueSafe(out TestMessage value);
-                DeserializedValues.Add(value);
+                reader.ReadValueSafe(out this);
+                return true;
+            }
+
+            public void Handle(in NetworkContext context)
+            {
+                Handled = true;
+                DeserializedValues.Add(this);
             }
         }
 
@@ -39,7 +46,7 @@ namespace Unity.Netcode.EditorTests
                     new MessagingSystem.MessageWithHandler
                     {
                         MessageType = typeof(TestMessage),
-                        Handler = TestMessage.Receive
+                        Handler = MessagingSystem.ReceiveMessage<TestMessage>
                     }
                 };
             }
@@ -51,6 +58,7 @@ namespace Unity.Netcode.EditorTests
         public void SetUp()
         {
             TestMessage.Deserialized = false;
+            TestMessage.Handled = false;
             TestMessage.DeserializedValues.Clear();
 
             m_MessagingSystem = new MessagingSystem(new NopMessageSender(), this, new TestMessageProvider());
@@ -94,6 +102,7 @@ namespace Unity.Netcode.EditorTests
                 {
                     m_MessagingSystem.HandleMessage(messageHeader, reader, 0, 0, 0);
                     Assert.IsTrue(TestMessage.Deserialized);
+                    Assert.IsTrue(TestMessage.Handled);
                     Assert.AreEqual(1, TestMessage.DeserializedValues.Count);
                     Assert.AreEqual(message, TestMessage.DeserializedValues[0]);
                 }
@@ -129,6 +138,7 @@ namespace Unity.Netcode.EditorTests
                 {
                     m_MessagingSystem.HandleIncomingData(0, new ArraySegment<byte>(writer.ToArray()), 0);
                     Assert.IsFalse(TestMessage.Deserialized);
+                    Assert.IsFalse(TestMessage.Handled);
                     Assert.IsEmpty(TestMessage.DeserializedValues); ;
                 }
             }
@@ -162,6 +172,7 @@ namespace Unity.Netcode.EditorTests
                     m_MessagingSystem.HandleIncomingData(0, new ArraySegment<byte>(writer.ToArray()), 0);
                     m_MessagingSystem.ProcessIncomingMessageQueue();
                     Assert.IsTrue(TestMessage.Deserialized);
+                    Assert.IsTrue(TestMessage.Handled);
                     Assert.AreEqual(1, TestMessage.DeserializedValues.Count);
                     Assert.AreEqual(message, TestMessage.DeserializedValues[0]);
                 }
@@ -199,10 +210,12 @@ namespace Unity.Netcode.EditorTests
                 {
                     m_MessagingSystem.HandleIncomingData(0, new ArraySegment<byte>(writer.ToArray()), 0);
                     Assert.IsFalse(TestMessage.Deserialized);
+                    Assert.IsFalse(TestMessage.Handled);
                     Assert.IsEmpty(TestMessage.DeserializedValues);
 
                     m_MessagingSystem.ProcessIncomingMessageQueue();
                     Assert.IsTrue(TestMessage.Deserialized);
+                    Assert.IsTrue(TestMessage.Handled);
                     Assert.AreEqual(2, TestMessage.DeserializedValues.Count);
                     Assert.AreEqual(message, TestMessage.DeserializedValues[0]);
                     Assert.AreEqual(message2, TestMessage.DeserializedValues[1]);

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageRegistrationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageRegistrationTests.cs
@@ -17,12 +17,12 @@ namespace Unity.Netcode.EditorTests
                 writer.WriteValue(this);
             }
 
-            public bool Deserialize(FastBufferReader reader, in NetworkContext context)
+            public bool Deserialize(FastBufferReader reader, ref NetworkContext context)
             {
                 return true;
             }
 
-            public void Handle(in NetworkContext context)
+            public void Handle(ref NetworkContext context)
             {
             }
         }
@@ -38,12 +38,12 @@ namespace Unity.Netcode.EditorTests
                 writer.WriteValue(this);
             }
 
-            public bool Deserialize(FastBufferReader reader, in NetworkContext context)
+            public bool Deserialize(FastBufferReader reader, ref NetworkContext context)
             {
                 return true;
             }
 
-            public void Handle(in NetworkContext context)
+            public void Handle(ref NetworkContext context)
             {
             }
         }
@@ -78,12 +78,12 @@ namespace Unity.Netcode.EditorTests
                 writer.WriteValue(this);
             }
 
-            public bool Deserialize(FastBufferReader reader, in NetworkContext context)
+            public bool Deserialize(FastBufferReader reader, ref NetworkContext context)
             {
                 return true;
             }
 
-            public void Handle(in NetworkContext context)
+            public void Handle(ref NetworkContext context)
             {
             }
         }
@@ -113,12 +113,12 @@ namespace Unity.Netcode.EditorTests
                 writer.WriteValue(this);
             }
 
-            public bool Deserialize(FastBufferReader reader, in NetworkContext context)
+            public bool Deserialize(FastBufferReader reader, ref NetworkContext context)
             {
                 return true;
             }
 
-            public void Handle(in NetworkContext context)
+            public void Handle(ref NetworkContext context)
             {
             }
         }

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageRegistrationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageRegistrationTests.cs
@@ -17,9 +17,13 @@ namespace Unity.Netcode.EditorTests
                 writer.WriteValue(this);
             }
 
-            public static void Receive(FastBufferReader reader, in NetworkContext context)
+            public bool Deserialize(FastBufferReader reader, in NetworkContext context)
             {
+                return true;
+            }
 
+            public void Handle(in NetworkContext context)
+            {
             }
         }
 
@@ -34,9 +38,13 @@ namespace Unity.Netcode.EditorTests
                 writer.WriteValue(this);
             }
 
-            public static void Receive(FastBufferReader reader, in NetworkContext context)
+            public bool Deserialize(FastBufferReader reader, in NetworkContext context)
             {
+                return true;
+            }
 
+            public void Handle(in NetworkContext context)
+            {
             }
         }
         private class TestMessageProviderOne : IMessageProvider
@@ -48,12 +56,12 @@ namespace Unity.Netcode.EditorTests
                     new MessagingSystem.MessageWithHandler
                     {
                         MessageType = typeof(TestMessageOne),
-                        Handler = TestMessageOne.Receive
+                        Handler = MessagingSystem.ReceiveMessage<TestMessageOne>
                     },
                     new MessagingSystem.MessageWithHandler
                     {
                         MessageType = typeof(TestMessageTwo),
-                        Handler = TestMessageTwo.Receive
+                        Handler = MessagingSystem.ReceiveMessage<TestMessageTwo>
                     }
                 };
             }
@@ -70,9 +78,13 @@ namespace Unity.Netcode.EditorTests
                 writer.WriteValue(this);
             }
 
-            public static void Receive(FastBufferReader reader, in NetworkContext context)
+            public bool Deserialize(FastBufferReader reader, in NetworkContext context)
             {
+                return true;
+            }
 
+            public void Handle(in NetworkContext context)
+            {
             }
         }
         private class TestMessageProviderTwo : IMessageProvider
@@ -84,7 +96,7 @@ namespace Unity.Netcode.EditorTests
                     new MessagingSystem.MessageWithHandler
                     {
                         MessageType = typeof(TestMessageThree),
-                        Handler = TestMessageThree.Receive
+                        Handler = MessagingSystem.ReceiveMessage<TestMessageThree>
                     }
                 };
             }
@@ -101,9 +113,13 @@ namespace Unity.Netcode.EditorTests
                 writer.WriteValue(this);
             }
 
-            public static void Receive(FastBufferReader reader, in NetworkContext context)
+            public bool Deserialize(FastBufferReader reader, in NetworkContext context)
             {
+                return true;
+            }
 
+            public void Handle(in NetworkContext context)
+            {
             }
         }
         private class TestMessageProviderThree : IMessageProvider
@@ -115,7 +131,7 @@ namespace Unity.Netcode.EditorTests
                     new MessagingSystem.MessageWithHandler
                     {
                         MessageType = typeof(TestMessageFour),
-                        Handler = TestMessageFour.Receive
+                        Handler = MessagingSystem.ReceiveMessage<TestMessageFour>
                     }
                 };
             }
@@ -158,10 +174,10 @@ namespace Unity.Netcode.EditorTests
             using (systemTwo)
             using (systemThree)
             {
-                MessagingSystem.MessageHandler handlerOne = TestMessageOne.Receive;
-                MessagingSystem.MessageHandler handlerTwo = TestMessageTwo.Receive;
-                MessagingSystem.MessageHandler handlerThree = TestMessageThree.Receive;
-                MessagingSystem.MessageHandler handlerFour = TestMessageFour.Receive;
+                MessagingSystem.MessageHandler handlerOne = MessagingSystem.ReceiveMessage<TestMessageOne>;
+                MessagingSystem.MessageHandler handlerTwo = MessagingSystem.ReceiveMessage<TestMessageTwo>;
+                MessagingSystem.MessageHandler handlerThree = MessagingSystem.ReceiveMessage<TestMessageThree>;
+                MessagingSystem.MessageHandler handlerFour = MessagingSystem.ReceiveMessage<TestMessageFour>;
 
                 var foundHandlerOne = systemOne.MessageHandlers[systemOne.GetMessageType(typeof(TestMessageOne))];
 

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageSendingTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageSendingTests.cs
@@ -21,7 +21,12 @@ namespace Unity.Netcode.EditorTests
                 writer.WriteValueSafe(this);
             }
 
-            public static void Receive(FastBufferReader reader, in NetworkContext context)
+            public bool Deserialize(FastBufferReader reader, in NetworkContext context)
+            {
+                return true;
+            }
+
+            public void Handle(in NetworkContext context)
             {
             }
         }
@@ -45,7 +50,7 @@ namespace Unity.Netcode.EditorTests
                     new MessagingSystem.MessageWithHandler
                     {
                         MessageType = typeof(TestMessage),
-                        Handler = TestMessage.Receive
+                        Handler = MessagingSystem.ReceiveMessage<TestMessage>
                     }
                 };
             }
@@ -86,7 +91,7 @@ namespace Unity.Netcode.EditorTests
         public void WhenSendingMessage_SerializeIsCalled()
         {
             var message = GetMessage();
-            m_MessagingSystem.SendMessage(message, NetworkDelivery.Reliable, m_Clients);
+            m_MessagingSystem.SendMessage(ref message, NetworkDelivery.Reliable, m_Clients);
             Assert.IsTrue(TestMessage.Serialized);
         }
 
@@ -94,7 +99,7 @@ namespace Unity.Netcode.EditorTests
         public void WhenSendingMessage_NothingIsSentBeforeProcessingSendQueue()
         {
             var message = GetMessage();
-            m_MessagingSystem.SendMessage(message, NetworkDelivery.Reliable, m_Clients);
+            m_MessagingSystem.SendMessage(ref message, NetworkDelivery.Reliable, m_Clients);
             Assert.IsEmpty(m_MessageSender.MessageQueue);
         }
 
@@ -102,7 +107,7 @@ namespace Unity.Netcode.EditorTests
         public void WhenProcessingSendQueue_MessageIsSent()
         {
             var message = GetMessage();
-            m_MessagingSystem.SendMessage(message, NetworkDelivery.Reliable, m_Clients);
+            m_MessagingSystem.SendMessage(ref message, NetworkDelivery.Reliable, m_Clients);
 
             m_MessagingSystem.ProcessSendQueues();
             Assert.AreEqual(1, m_MessageSender.MessageQueue.Count);
@@ -112,9 +117,9 @@ namespace Unity.Netcode.EditorTests
         public void WhenSendingMultipleMessages_MessagesAreBatched()
         {
             var message = GetMessage();
-            m_MessagingSystem.SendMessage(message, NetworkDelivery.Reliable, m_Clients);
-            m_MessagingSystem.SendMessage(message, NetworkDelivery.Reliable, m_Clients);
-            m_MessagingSystem.SendMessage(message, NetworkDelivery.Reliable, m_Clients);
+            m_MessagingSystem.SendMessage(ref message, NetworkDelivery.Reliable, m_Clients);
+            m_MessagingSystem.SendMessage(ref message, NetworkDelivery.Reliable, m_Clients);
+            m_MessagingSystem.SendMessage(ref message, NetworkDelivery.Reliable, m_Clients);
 
             m_MessagingSystem.ProcessSendQueues();
             Assert.AreEqual(1, m_MessageSender.MessageQueue.Count);
@@ -127,7 +132,7 @@ namespace Unity.Netcode.EditorTests
             var size = UnsafeUtility.SizeOf<TestMessage>() + 2; // MessageHeader packed with this message will be 2 bytes
             for (var i = 0; i < 1300 / size; ++i)
             {
-                m_MessagingSystem.SendMessage(message, NetworkDelivery.Reliable, m_Clients);
+                m_MessagingSystem.SendMessage(ref message, NetworkDelivery.Reliable, m_Clients);
             }
 
             m_MessagingSystem.ProcessSendQueues();
@@ -141,7 +146,7 @@ namespace Unity.Netcode.EditorTests
             var size = UnsafeUtility.SizeOf<TestMessage>() + 2; // MessageHeader packed with this message will be 2 bytes
             for (var i = 0; i < (1300 / size) + 1; ++i)
             {
-                m_MessagingSystem.SendMessage(message, NetworkDelivery.Reliable, m_Clients);
+                m_MessagingSystem.SendMessage(ref message, NetworkDelivery.Reliable, m_Clients);
             }
 
             m_MessagingSystem.ProcessSendQueues();
@@ -155,7 +160,7 @@ namespace Unity.Netcode.EditorTests
             var size = UnsafeUtility.SizeOf<TestMessage>() + 2; // MessageHeader packed with this message will be 2 bytes
             for (var i = 0; i < (1300 / size) + 1; ++i)
             {
-                m_MessagingSystem.SendMessage(message, NetworkDelivery.ReliableFragmentedSequenced, m_Clients);
+                m_MessagingSystem.SendMessage(ref message, NetworkDelivery.ReliableFragmentedSequenced, m_Clients);
             }
 
             m_MessagingSystem.ProcessSendQueues();
@@ -166,9 +171,9 @@ namespace Unity.Netcode.EditorTests
         public void WhenSwitchingDelivery_NewBatchesAreCreated()
         {
             var message = GetMessage();
-            m_MessagingSystem.SendMessage(message, NetworkDelivery.Reliable, m_Clients);
-            m_MessagingSystem.SendMessage(message, NetworkDelivery.Reliable, m_Clients);
-            m_MessagingSystem.SendMessage(message, NetworkDelivery.Unreliable, m_Clients);
+            m_MessagingSystem.SendMessage(ref message, NetworkDelivery.Reliable, m_Clients);
+            m_MessagingSystem.SendMessage(ref message, NetworkDelivery.Reliable, m_Clients);
+            m_MessagingSystem.SendMessage(ref message, NetworkDelivery.Unreliable, m_Clients);
 
             m_MessagingSystem.ProcessSendQueues();
             Assert.AreEqual(2, m_MessageSender.MessageQueue.Count);
@@ -178,9 +183,9 @@ namespace Unity.Netcode.EditorTests
         public void WhenSwitchingChannel_NewBatchesAreNotCreated()
         {
             var message = GetMessage();
-            m_MessagingSystem.SendMessage(message, NetworkDelivery.Reliable, m_Clients);
-            m_MessagingSystem.SendMessage(message, NetworkDelivery.Reliable, m_Clients);
-            m_MessagingSystem.SendMessage(message, NetworkDelivery.Reliable, m_Clients);
+            m_MessagingSystem.SendMessage(ref message, NetworkDelivery.Reliable, m_Clients);
+            m_MessagingSystem.SendMessage(ref message, NetworkDelivery.Reliable, m_Clients);
+            m_MessagingSystem.SendMessage(ref message, NetworkDelivery.Reliable, m_Clients);
 
             m_MessagingSystem.ProcessSendQueues();
             Assert.AreEqual(1, m_MessageSender.MessageQueue.Count);
@@ -191,8 +196,8 @@ namespace Unity.Netcode.EditorTests
         {
             var message = GetMessage();
             var message2 = GetMessage();
-            m_MessagingSystem.SendMessage(message, NetworkDelivery.Reliable, m_Clients);
-            m_MessagingSystem.SendMessage(message2, NetworkDelivery.Reliable, m_Clients);
+            m_MessagingSystem.SendMessage(ref message, NetworkDelivery.Reliable, m_Clients);
+            m_MessagingSystem.SendMessage(ref message2, NetworkDelivery.Reliable, m_Clients);
 
             m_MessagingSystem.ProcessSendQueues();
             var reader = new FastBufferReader(m_MessageSender.MessageQueue[0], Allocator.Temp);

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageSendingTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageSendingTests.cs
@@ -21,12 +21,12 @@ namespace Unity.Netcode.EditorTests
                 writer.WriteValueSafe(this);
             }
 
-            public bool Deserialize(FastBufferReader reader, in NetworkContext context)
+            public bool Deserialize(FastBufferReader reader, ref NetworkContext context)
             {
                 return true;
             }
 
-            public void Handle(in NetworkContext context)
+            public void Handle(ref NetworkContext context)
             {
             }
         }

--- a/com.unity.netcode.gameobjects/Tests/Editor/SnapshotTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/SnapshotTests.cs
@@ -106,14 +106,9 @@ namespace Unity.Netcode.EditorTests
                 message.Serialize(writer);
                 using var reader = new FastBufferReader(writer, Allocator.Temp);
                 var context = new NetworkContext { SenderId = 0, Timestamp = 0.0f, SystemOwner = new Tuple<SnapshotSystem, ulong>(m_RecvSnapshot, 0) };
-                message.Deserialize(reader, ref context);
-                message.Handle(ref context);
-            }
-            else
-            {
-                message.Spawns.Dispose();
-                message.Despawns.Dispose();
-                message.Entries.Dispose();
+                var newMessage = new SnapshotDataMessage();
+                newMessage.Deserialize(reader, ref context);
+                newMessage.Handle(ref context);
             }
 
             return 0;
@@ -127,14 +122,9 @@ namespace Unity.Netcode.EditorTests
                 message.Serialize(writer);
                 using var reader = new FastBufferReader(writer, Allocator.Temp);
                 var context = new NetworkContext { SenderId = 0, Timestamp = 0.0f, SystemOwner = new Tuple<SnapshotSystem, ulong>(m_SendSnapshot, 1) };
-                message.Deserialize(reader, ref context);
-                message.Handle(ref context);
-            }
-            else
-            {
-                message.Spawns.Dispose();
-                message.Despawns.Dispose();
-                message.Entries.Dispose();
+                var newMessage = new SnapshotDataMessage();
+                newMessage.Deserialize(reader, ref context);
+                newMessage.Handle(ref context);
             }
 
             return 0;

--- a/com.unity.netcode.gameobjects/Tests/Editor/SnapshotTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/SnapshotTests.cs
@@ -67,7 +67,7 @@ namespace Unity.Netcode.EditorTests
             return 0;
         }
 
-        internal int SendMessage(in SnapshotDataMessage message, NetworkDelivery delivery, ulong clientId)
+        internal int SendMessage(ref SnapshotDataMessage message, NetworkDelivery delivery, ulong clientId)
         {
             if (!m_PassBackResponses)
             {
@@ -106,7 +106,8 @@ namespace Unity.Netcode.EditorTests
                 message.Serialize(writer);
                 using var reader = new FastBufferReader(writer, Allocator.Temp);
                 var context = new NetworkContext { SenderId = 0, Timestamp = 0.0f, SystemOwner = new Tuple<SnapshotSystem, ulong>(m_RecvSnapshot, 0) };
-                SnapshotDataMessage.Receive(reader, context);
+                message.Deserialize(reader, context);
+                message.Handle(context);
             }
             else
             {
@@ -118,7 +119,7 @@ namespace Unity.Netcode.EditorTests
             return 0;
         }
 
-        internal int SendMessageRecvSide(in SnapshotDataMessage message, NetworkDelivery delivery, ulong clientId)
+        internal int SendMessageRecvSide(ref SnapshotDataMessage message, NetworkDelivery delivery, ulong clientId)
         {
             if (m_PassBackResponses)
             {
@@ -126,7 +127,8 @@ namespace Unity.Netcode.EditorTests
                 message.Serialize(writer);
                 using var reader = new FastBufferReader(writer, Allocator.Temp);
                 var context = new NetworkContext { SenderId = 0, Timestamp = 0.0f, SystemOwner = new Tuple<SnapshotSystem, ulong>(m_SendSnapshot, 1) };
-                SnapshotDataMessage.Receive(reader, context);
+                message.Deserialize(reader, context);
+                message.Handle(context);
             }
             else
             {

--- a/com.unity.netcode.gameobjects/Tests/Editor/SnapshotTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/SnapshotTests.cs
@@ -106,8 +106,8 @@ namespace Unity.Netcode.EditorTests
                 message.Serialize(writer);
                 using var reader = new FastBufferReader(writer, Allocator.Temp);
                 var context = new NetworkContext { SenderId = 0, Timestamp = 0.0f, SystemOwner = new Tuple<SnapshotSystem, ulong>(m_RecvSnapshot, 0) };
-                message.Deserialize(reader, context);
-                message.Handle(context);
+                message.Deserialize(reader, ref context);
+                message.Handle(ref context);
             }
             else
             {
@@ -127,8 +127,8 @@ namespace Unity.Netcode.EditorTests
                 message.Serialize(writer);
                 using var reader = new FastBufferReader(writer, Allocator.Temp);
                 var context = new NetworkContext { SenderId = 0, Timestamp = 0.0f, SystemOwner = new Tuple<SnapshotSystem, ulong>(m_SendSnapshot, 1) };
-                message.Deserialize(reader, context);
-                message.Handle(context);
+                message.Deserialize(reader, ref context);
+                message.Handle(ref context);
             }
             else
             {


### PR DESCRIPTION
Improved INetworkMessage interface so that all required methods are non-static, refactored how messages are handled in MessagingSystem to allow for another hook that takes the message object as a parameter so that we can move metrics boilerplate code from message handlers into MetricsHooks (to be done in a separate PR)

MTT-1478

## Jira Description
There are a few things we can do to make INetworkMessage a little easier to use, which will also support some other architectural improvements, particularly in being able to decouple some of the tools code from the SDK code.

The list of changes is:

- Interface changes to look like this:
  ```c#
   internal interface INetworkMessage
   {
       void Serialize(FastBufferWriter writer);
       void Deserialize(FastBufferReader reader, ref NetworkContext context);
       void Handle(ref NetworkContext context);
   }
   ```
- static `Receive()` on each message type goes away, replaced with that `Deserialize()` method that's actually part of the interface (so no more unused method issues)
- The `Handle()` method that currently exists in all message types by convention becomes a required member of the interface
`MessagingSystem`  gets a new `MessagingSystem.ReceiveMessage<T>() where T: new(), INetworkMessage`, which is responsible for calling the other two methods (separated so that a hook can be added in between them)
- ILPP changes to register that as the delegate for each message, which will work the same way `Receive()` currently works.

That change has two big advantages: 

- It gets rid of the requirement to have ILPP check for that static method and lets the interface properly communicate everything needed for it
- It allows INetworkHooks to accept the message object itself into its OnAfterReceiveMessage(), which allows all the metric tracking functions to be called from MetricHook in a generic way instead of having boilerplate for tracking messages in every "send a message" and "receive a message" location... and in the process, also removes the strong coupling/dependencies between SDK code and tools code, and ensures that tracking doesn't run in release builds since we don't register MetricHooks in release builds.

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.