### PR TITLE
fix: Prevent an exception in UTP when host disconnects

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this package will be documented in this file. The format 
 ### Fixed
 
 - Fixed packet overflow errors when sending payloads too close to the MTU (was mostly visible when using Relay).
+- Don't throw an exception when the host disconnects (issue 1439 on GitHub).
 
 ## [1.0.0-pre.3] - 2021-10-22
 

--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -435,19 +435,21 @@ namespace Unity.Netcode
                     }
                 case TransportNetworkEvent.Type.Disconnect:
                     {
-                        InvokeOnTransportEvent(NetcodeNetworkEvent.Disconnect,
-                            ParseClientId(networkConnection),
-                            default(ArraySegment<byte>),
-                            Time.realtimeSinceStartup);
-
                         if (m_ServerConnection.IsCreated)
                         {
                             m_ServerConnection = default;
-                            if (m_Driver.GetConnectionState(m_ServerConnection) == NetworkConnection.State.Connecting)
+
+                            var reason = reader.ReadByte();
+                            if (reason == (byte)Networking.Transport.Error.DisconnectReason.MaxConnectionAttempts)
                             {
                                 Debug.LogError("Client failed to connect to server");
                             }
                         }
+
+                        InvokeOnTransportEvent(NetcodeNetworkEvent.Disconnect,
+                            ParseClientId(networkConnection),
+                            default(ArraySegment<byte>),
+                            Time.realtimeSinceStartup);
 
                         m_State = State.Disconnected;
                         return true;


### PR DESCRIPTION
This is a backport to `release/1.0.0` of PR #1441.

## Changelog

### com.unity.netcode.adapter.utp
- Fixed: Don't throw an exception when the host disconnects.

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.