### PR TITLE
fix: Increase adapter tests timeout threshold for PS4/Switch

### DIFF
--- a/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/RuntimeTestsHelpers.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/RuntimeTestsHelpers.cs
@@ -10,8 +10,13 @@ namespace Unity.Netcode.UTP.RuntimeTests
     {
         // Half a second might seem like a very long time to wait for a network event, but in CI
         // many of the machines are underpowered (e.g. old Android devices or Macs) and there are
-        // sometimes lag spikes that cause can cause delays upwards of 300ms.
+        // sometimes very high lag spikes. PS4 and Switch are particularly sensitive in this regard
+        // so we allow even more time for these platforms.
+#if UNITY_PS4 || UNITY_SWITCH
+        public const float MaxNetworkEventWaitTime = 2.0f;
+#else
         public const float MaxNetworkEventWaitTime = 0.5f;
+#endif
 
         // Wait for an event to appear in the given event list (must be the very next event).
         public static IEnumerator WaitForNetworkEvent(NetworkEvent type, List<TransportEvent> events)


### PR DESCRIPTION
PS4 and Switch appear to be particularly sensitive to timing issues in our tests, so increase the timeout threshold to 2 seconds.

This addresses MTT-1552.

## Changelog

### com.unity.netcode.adapter.utp
N/A

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.