### PR TITLE
Fix for #1440: Connection IDs not matching Disconnection IDs

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1343,12 +1343,12 @@ namespace Unity.Netcode
                     break;
                 case NetworkEvent.Data:
                     {
+                        clientId = TransportIdToClientId(clientId);
+
                         if (NetworkLog.CurrentLogLevel <= LogLevel.Developer)
                         {
                             NetworkLog.LogInfo($"Incoming Data From {clientId}: {payload.Count} bytes");
                         }
-
-                        clientId = TransportIdToClientId(clientId);
 
                         HandleIncomingData(clientId, payload, receiveTime);
                         break;
@@ -1357,9 +1357,9 @@ namespace Unity.Netcode
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
                     s_TransportDisconnect.Begin();
 #endif
-                    OnClientDisconnectCallback?.Invoke(clientId);
-
                     clientId = TransportIdToClientId(clientId);
+
+                    OnClientDisconnectCallback?.Invoke(clientId);
 
                     m_TransportIdToClientIdMap.Remove(transportId);
                     m_ClientIdToTransportIdMap.Remove(clientId);


### PR DESCRIPTION
Fix for https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/1440. TransportIdToClientId  seems to be called in the wrong place which is causing the clientID passed into the connection callback to be incorrect during the disconnection callback (Except for where the clientID and transportID are the same)

Also moved a call of TransportIdToClientId to before a debug log which printed the client ID, as it would be printing the transport ID and not the client ID, which could end up as being confusing.

Tested locally and with a remote server, which fixed issues I was having relating to this bug
