### PR TITLE
ci: standards.py assert on minimum python version

### DIFF
--- a/.yamato/project-standards.yml
+++ b/.yamato/project-standards.yml
@@ -10,7 +10,7 @@ standards_{{ projects.first.name }}:
     - dotnet --version
     - dotnet format --version
     - curl https://pyenv.run | bash
-    - exec $SHELL
+    - exec "$SHELL"
     - pyenv install 3.7.12 -f
     - pyenv global 3.7.12
     - export PATH=$(pyenv root)/shims:$PATH

--- a/.yamato/project-standards.yml
+++ b/.yamato/project-standards.yml
@@ -9,12 +9,10 @@ standards_{{ projects.first.name }}:
   commands:
     - dotnet --version
     - dotnet format --version
-    - curl https://pyenv.run | bash
-    - exec "$SHELL"
-    - pyenv install 3.7.12 -f
-    - pyenv global 3.7.12
-    - export PATH=$(pyenv root)/shims:$PATH
+    - sudo apt-get install python3.7 -y
     - python --version
+    - python3 --version
+    - python3.7 --version
     - pip install unity-downloader-cli --upgrade --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - unity-downloader-cli -u {{ projects.first.test_editors.first }} -c editor --wait --fast
     - .Editor/Unity -batchmode -nographics -logFile - -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -projectPath {{ projects.first.path }} -quit

--- a/.yamato/project-standards.yml
+++ b/.yamato/project-standards.yml
@@ -10,6 +10,7 @@ standards_{{ projects.first.name }}:
     - dotnet --version
     - dotnet format --version
     - curl https://pyenv.run | bash
+    - eval "$(pyenv virtualenv-init -)"
     - pyenv install 3.7.12 -f
     - pyenv global 3.7.12
     - export PATH=$(pyenv root)/shims:$PATH

--- a/.yamato/project-standards.yml
+++ b/.yamato/project-standards.yml
@@ -9,10 +9,7 @@ standards_{{ projects.first.name }}:
   commands:
     - dotnet --version
     - dotnet format --version
-    - sudo apt-get install python3.7 -y
     - python --version
-    - python3 --version
-    - python3.7 --version
     - pip install unity-downloader-cli --upgrade --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - unity-downloader-cli -u {{ projects.first.test_editors.first }} -c editor --wait --fast
     - .Editor/Unity -batchmode -nographics -logFile - -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -projectPath {{ projects.first.path }} -quit

--- a/.yamato/project-standards.yml
+++ b/.yamato/project-standards.yml
@@ -9,7 +9,11 @@ standards_{{ projects.first.name }}:
   commands:
     - dotnet --version
     - dotnet format --version
-    - python3.9 --version
+    - curl https://pyenv.run | bash
+    - pyenv install 3.7.12 -f
+    - pyenv global 3.7.12
+    - export PATH=$(pyenv root)/shims:$PATH
+    - python --version
     - pip install unity-downloader-cli --upgrade --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - unity-downloader-cli -u {{ projects.first.test_editors.first }} -c editor --wait --fast
     - .Editor/Unity -batchmode -nographics -logFile - -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -projectPath {{ projects.first.path }} -quit

--- a/.yamato/project-standards.yml
+++ b/.yamato/project-standards.yml
@@ -10,7 +10,7 @@ standards_{{ projects.first.name }}:
     - dotnet --version
     - dotnet format --version
     - curl https://pyenv.run | bash
-    - eval "$(pyenv virtualenv-init -)"
+    - exec $SHELL
     - pyenv install 3.7.12 -f
     - pyenv global 3.7.12
     - export PATH=$(pyenv root)/shims:$PATH

--- a/standards.py
+++ b/standards.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import os
 import sys

--- a/standards.py
+++ b/standards.py
@@ -7,7 +7,8 @@ import argparse
 import datetime
 import subprocess
 
-assert sys.version_info >= (3, 7)
+print(sys.version_info)
+assert sys.version_info >= (3, 9)
 
 parser = argparse.ArgumentParser()
 

--- a/standards.py
+++ b/standards.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.9
+#!/usr/bin/env python3
 
 import os
 import sys
@@ -7,6 +7,7 @@ import argparse
 import datetime
 import subprocess
 
+assert sys.version_info >= (3, 7)
 
 parser = argparse.ArgumentParser()
 

--- a/standards.py
+++ b/standards.py
@@ -7,8 +7,8 @@ import argparse
 import datetime
 import subprocess
 
-print(sys.version_info)
-assert sys.version_info >= (3, 9)
+assert sys.version_info >= (3, 6)
+
 
 parser = argparse.ArgumentParser()
 
@@ -83,7 +83,9 @@ if args.check:
             any_error = True
 
         print("check: code style")
-        cs_run = subprocess.run(["dotnet", "format", project_file, "style", "--severity", "error", "--no-restore", "--verify-no-changes", "--verbosity", args.verbosity])
+        cs_run = subprocess.run(
+            ["dotnet", "format", project_file, "style", "--severity", "error", "--no-restore", "--verify-no-changes", "--verbosity", args.verbosity]
+        )
         if cs_run.returncode != 0:
             print("check: code style failed")
             any_error = True

--- a/standards.py
+++ b/standards.py
@@ -7,7 +7,7 @@ import argparse
 import datetime
 import subprocess
 
-assert sys.version_info >= (3, 6)
+assert sys.version_info >= (3, 7)
 
 
 parser = argparse.ArgumentParser()


### PR DESCRIPTION
Fixing standards.py to not call a specific Python version and checking in code that it is at least 3.7

No need for backport, test, documentation or changelog. 