### PR TITLE
feat: Exposition of INetworkMetrics to UTP Adapter

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/AssemblyInfo.cs
+++ b/com.unity.netcode.gameobjects/Runtime/AssemblyInfo.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Unity.Netcode.EditorTests")]
 [assembly: InternalsVisibleTo("Unity.Netcode.Editor.CodeGen")]
 [assembly: InternalsVisibleTo("Unity.Netcode.Editor")]
+[assembly: InternalsVisibleTo("Unity.Netcode.Adapter.UTP")]
 [assembly: InternalsVisibleTo("TestProject.EditorTests")]
 [assembly: InternalsVisibleTo("TestProject.RuntimeTests")]
 [assembly: InternalsVisibleTo("TestProject.ToolsIntegration.RuntimeTests")]

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -562,6 +562,8 @@ namespace Unity.Netcode
                 return;
             }
 
+            NetworkConfig.NetworkTransport.NetworkMetrics = NetworkMetrics;
+
             //This 'if' should never enter
             if (SnapshotSystem != null)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Transports/NetworkTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/NetworkTransport.cs
@@ -18,6 +18,8 @@ namespace Unity.Netcode
         /// <value><c>true</c> if is supported; otherwise, <c>false</c>.</value>
         public virtual bool IsSupported => true;
 
+        internal INetworkMetrics NetworkMetrics;
+
         /// <summary>
         /// Delegate for transport network events
         /// </summary>


### PR DESCRIPTION
This code expose the INetworkMetric to the UTP Adapter and adds it to the NetworkTransport to be accessible within the UTP Adapter. This will be required to track metrics from transport (at least until UTP Adapter is port directly into NGO)

MTT-1659

## Testing and Documentation

* No tests have been added.
* No documentation have been 
