### PR TITLE
fix: moved node management from NetworkObject to InterestManager

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -13,36 +13,11 @@ namespace Unity.Netcode
     [AddComponentMenu("Netcode/" + nameof(NetworkObject), -99)]
     [DisallowMultipleComponent]
 
-    public sealed class NetworkObject : MonoBehaviour, IInterestObject<NetworkObject>
+    public sealed class NetworkObject : MonoBehaviour
     {
         [HideInInspector]
         [SerializeField]
         internal uint GlobalObjectIdHash;
-
-        private List<IInterestNode<NetworkObject>> m_InterestNodes = new List<IInterestNode<NetworkObject>>();
-
-        public void AddInterestNode(IInterestNode<NetworkObject> node)
-        {
-            if (!m_InterestNodes.Contains(node))
-            {
-                node.AddObject(this);
-                m_InterestNodes.Add(node);
-            }
-        }
-
-        public void RemoveInterestNode(IInterestNode<NetworkObject> node)
-        {
-            if (m_InterestNodes.Contains(node))
-            {
-                node.RemoveObject(this);
-                m_InterestNodes.Remove(node);
-            }
-        }
-
-        public List<IInterestNode<NetworkObject>> GetInterestNodes()
-        {
-            return m_InterestNodes;
-        }
 
 #if UNITY_EDITOR
         private void OnValidate()

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using Unity.Netcode.Interest;
 
 using UnityEngine;
 

--- a/com.unity.netcode.gameobjects/Runtime/Interest/InterestManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Interest/InterestManager.cs
@@ -1,26 +1,24 @@
+using System;
 using System.Collections.Generic;
+using UnityEditor;
+
 namespace Unity.Netcode.Interest
 {
-    internal interface IInterestObject<TObject>
-    {
-        public void AddInterestNode(IInterestNode<TObject> obj);
-        public void RemoveInterestNode(IInterestNode<TObject> obj);
-        public List<IInterestNode<TObject>> GetInterestNodes();
-    }
-
     // interest *system* instead of interest node ?
-    internal class InterestManager<TObject> where TObject : IInterestObject<TObject>
+    internal class InterestManager<TObject>
     {
-        private readonly InterestNodeStatic<TObject> m_DefaultInterestNode = new InterestNodeStatic<TObject>();
+        private InterestNodeStatic<TObject> m_DefaultInterestNode = new InterestNodeStatic<TObject>();
 
         // Trigger the Interest system to do an update sweep on any Interest nodes
         //  I am associated with
         public void UpdateObject(ref TObject obj)
         {
-            List<IInterestNode<TObject>> nodes = obj.GetInterestNodes();
-            foreach (var node in nodes)
+            if (m_InterestNodesMap.TryGetValue(obj, out var nodes))
             {
-                node.UpdateObject(obj);
+                foreach (var node in nodes)
+                {
+                    node.UpdateObject(obj);
+                }
             }
         }
 
@@ -39,9 +37,7 @@ namespace Unity.Netcode.Interest
             // That is, if you don't opt into the system behavior is the same as before
             //  the Interest system was added
 
-            List<IInterestNode<TObject>> nodes = obj.GetInterestNodes();
-
-            if (nodes.Count > 0)
+            if (m_InterestNodesMap.TryGetValue(obj, out var nodes))
             {
                 // I am walking through each of the interest nodes that this object has
                 foreach (var node in nodes)
@@ -60,19 +56,24 @@ namespace Unity.Netcode.Interest
 
         public void AddDefaultInterestNode(TObject obj)
         {
-            obj.AddInterestNode(m_DefaultInterestNode);
+            AddInterestNode(ref obj, m_DefaultInterestNode);
         }
 
         public void RemoveObject(ref TObject obj)
         {
-            List<IInterestNode<TObject>> nodes = obj.GetInterestNodes();
-            foreach (var node in nodes)
+            if (m_InterestNodesMap.TryGetValue(obj, out var nodes))
             {
-                if (node == null)
+                foreach (var node in nodes)
                 {
-                    continue;
+                    if (node == null)
+                    {
+                        continue;
+                    }
+
+                    node.RemoveObject(obj);
                 }
-                node.RemoveObject(obj);
+
+                m_InterestNodesMap.Remove(obj);
             }
         }
 
@@ -84,6 +85,39 @@ namespace Unity.Netcode.Interest
             }
         }
 
+        public void AddInterestNode(ref TObject obj, IInterestNode<TObject> node)
+        {
+            node.AddObject(obj);
+
+            if (!m_InterestNodesMap.TryGetValue(obj, out var nodes))
+            {
+                m_InterestNodesMap[obj] = new List<IInterestNode<TObject>>();
+                m_InterestNodesMap[obj].Add(node);
+            }
+            else
+            {
+                if (!nodes.Contains(node))
+                {
+                    nodes.Add(node);
+                }
+            }
+        }
+
+        public void RemoveInterestNode(ref TObject obj, IInterestNode<TObject> node)
+        {
+            node.RemoveObject(obj);
+            if (m_InterestNodesMap.TryGetValue(obj, out var nodes))
+            {
+                if (nodes.Contains(node))
+                {
+                    nodes.Remove(node);
+                }
+            }
+        }
+
         private HashSet<IInterestNode<TObject>> m_ChildNodes;
+
+        private Dictionary<TObject, List<IInterestNode<TObject>>> m_InterestNodesMap =
+            new Dictionary<TObject, List<IInterestNode<TObject>>>();
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Interest/InterestManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Interest/InterestManager.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using UnityEditor;
 
 namespace Unity.Netcode.Interest
 {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/InterestTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/InterestTests.cs
@@ -189,22 +189,22 @@ namespace Unity.Netcode.RuntimeTests
 
             m_PlayerNetworkObject.gameObject.AddComponent<CloakedBehaviour>();
             m_PlayerNetworkObject.gameObject.transform.position = new Vector3(0.0f, 0.0f, 0.0f);
-            m_PlayerNetworkObject.AddInterestNode(theNode);
+            m_InterestManager.AddInterestNode(ref m_PlayerNetworkObject, theNode);
 
             var (ok1Obj, ok1Guid) = MakeInterestGameObjectHelper(new Vector3(0.5f, 0.0f, 0.0f));
             ok1Obj.gameObject.AddComponent<CloakedBehaviour>();
-            ok1Obj.AddInterestNode(theNode);
+            m_InterestManager.AddInterestNode(ref ok1Obj, theNode);
             NetworkManagerHelper.SpawnNetworkObject(ok1Guid);
 
             var (closeButCloaked, closeButCloakedGuid) = MakeInterestGameObjectHelper(new Vector3(1.0f, 0.0f, 0.0f));
             closeButCloaked.gameObject.AddComponent<CloakedBehaviour>();
             closeButCloaked.gameObject.GetComponent<CloakedBehaviour>().IsCloaked = true;
-            closeButCloaked.AddInterestNode(theNode);
+            m_InterestManager.AddInterestNode(ref closeButCloaked, theNode);
             NetworkManagerHelper.SpawnNetworkObject(closeButCloakedGuid);
 
             var (tooFarObj, tooFarGuid) = MakeInterestGameObjectHelper(new Vector3(3.0f, 0.0f, 0.0f));
             tooFarObj.gameObject.AddComponent<CloakedBehaviour>();
-            tooFarObj.AddInterestNode(theNode);
+            m_InterestManager.AddInterestNode(ref tooFarObj, theNode);
             NetworkManagerHelper.SpawnNetworkObject(tooFarGuid);
 
             m_InterestManager.QueryFor(ref m_PlayerNetworkObject, ref results);
@@ -236,22 +236,22 @@ namespace Unity.Netcode.RuntimeTests
 
             m_PlayerNetworkObject.gameObject.AddComponent<CloakedBehaviour>();
             m_PlayerNetworkObject.gameObject.transform.position = new Vector3(0.0f, 0.0f, 0.0f);
-            m_PlayerNetworkObject.AddInterestNode(theNode);
+            m_InterestManager.AddInterestNode(ref m_PlayerNetworkObject, theNode);
 
             var (ok1Obj, ok1Guid) = MakeInterestGameObjectHelper(new Vector3(0.5f, 0.0f, 0.0f));
             ok1Obj.gameObject.AddComponent<CloakedBehaviour>();
-            ok1Obj.AddInterestNode(theNode);
+            m_InterestManager.AddInterestNode(ref ok1Obj, theNode);
             NetworkManagerHelper.SpawnNetworkObject(ok1Guid);
 
             var (closeButCloaked, closeButCloakedGuid) = MakeInterestGameObjectHelper(new Vector3(1.0f, 0.0f, 0.0f));
             closeButCloaked.gameObject.AddComponent<CloakedBehaviour>();
             closeButCloaked.gameObject.GetComponent<CloakedBehaviour>().IsCloaked = true;
-            closeButCloaked.AddInterestNode(theNode);
+            m_InterestManager.AddInterestNode(ref closeButCloaked, theNode);
             NetworkManagerHelper.SpawnNetworkObject(closeButCloakedGuid);
 
             var (tooFarObj, tooFarGuid) = MakeInterestGameObjectHelper(new Vector3(3.0f, 0.0f, 0.0f));
             tooFarObj.gameObject.AddComponent<CloakedBehaviour>();
-            tooFarObj.AddInterestNode(theNode);
+            m_InterestManager.AddInterestNode(ref tooFarObj, theNode);
             NetworkManagerHelper.SpawnNetworkObject(tooFarGuid);
 
             m_InterestManager.QueryFor(ref m_PlayerNetworkObject, ref results);
@@ -276,7 +276,7 @@ namespace Unity.Netcode.RuntimeTests
 
             var (objA, objAGuid) = MakeInterestGameObjectHelper();
             objA.gameObject.AddComponent<CloakedBehaviour>();
-            objA.AddInterestNode(nodeA);
+            m_InterestManager.AddInterestNode(ref objA, nodeA);
             NetworkManagerHelper.SpawnNetworkObject(objAGuid);
 
             results.Clear();
@@ -296,7 +296,7 @@ namespace Unity.Netcode.RuntimeTests
             Assert.True(results.Count - objectsBeforeAdd == 1);
 
             // remove nodeA from objA. now it shouldn't show up; it's orphaned
-            objA.RemoveInterestNode(nodeA);
+            m_InterestManager.RemoveInterestNode(ref objA, nodeA);
             results.Clear();
             m_InterestManager.QueryFor(ref m_PlayerNetworkObject, ref results);
             Assert.True(results.Count - objectsBeforeAdd == 0);
@@ -324,7 +324,7 @@ namespace Unity.Netcode.RuntimeTests
             {
                 var (thisObj, thisGuid) = MakeInterestGameObjectHelper();
                 thisObj.NetworkObjectId = (ulong)(i + 100);
-                thisObj.AddInterestNode(oddsEvensNode);
+                m_InterestManager.AddInterestNode(ref thisObj, oddsEvensNode);
                 objs[i] = thisObj;
                 NetworkManagerHelper.SpawnNetworkObject(thisGuid);
             }
@@ -395,18 +395,18 @@ namespace Unity.Netcode.RuntimeTests
             int objectsBeforeAdd = results.Count - 1; // -1 because we want to count m_PlayerNetworkObject
 
             m_PlayerNetworkObject.gameObject.transform.position = new Vector3(0.0f, 0.0f, 0.0f);
-            m_PlayerNetworkObject.AddInterestNode(naiveRadiusNode);
+            m_InterestManager.AddInterestNode(ref m_PlayerNetworkObject, naiveRadiusNode);
 
             var (ok1Obj, ok1Guid) = MakeInterestGameObjectHelper(new Vector3(0.5f, 0.0f, 0.0f));
-            ok1Obj.AddInterestNode(naiveRadiusNode);
+            m_InterestManager.AddInterestNode(ref ok1Obj, naiveRadiusNode);
             NetworkManagerHelper.SpawnNetworkObject(ok1Guid);
 
             var (ok2Obj, ok2Guid) = MakeInterestGameObjectHelper(new Vector3(1.0f, 0.0f, 0.0f));
-            ok2Obj.AddInterestNode(naiveRadiusNode);
+            m_InterestManager.AddInterestNode(ref ok2Obj, naiveRadiusNode);
             NetworkManagerHelper.SpawnNetworkObject(ok2Guid);
 
             var (tooFarObj, tooFarGuid) = MakeInterestGameObjectHelper(new Vector3(3.0f, 0.0f, 0.0f));
-            tooFarObj.AddInterestNode(naiveRadiusNode);
+            m_InterestManager.AddInterestNode(ref tooFarObj, naiveRadiusNode);
             NetworkManagerHelper.SpawnNetworkObject(tooFarGuid);
 
             var (alwaysObj, alwaysGuid) = MakeInterestGameObjectHelper(new Vector3(99.0f, 99.0f, 99.0f));
@@ -506,7 +506,7 @@ namespace Unity.Netcode.RuntimeTests
                 for (var j = 0; j < objsToMakePerNode; j++)
                 {
                     var (obj, guid) = MakeInterestGameObjectHelper();
-                    obj.AddInterestNode(thisNode);
+                    m_InterestManager.AddInterestNode(ref obj, thisNode);
                     NetworkManagerHelper.SpawnNetworkObject(guid);
                 }
             }


### PR DESCRIPTION
Why?
1. We found a bug where when NetworkObjects are pooled, that we don't purge out "m_InterestNodes" causes issues
2. @NoelStephensUnity had a suggestion on doing a cleanup step, and as we iterated over it the abstraction of having the NetworkObject keep track of its own InterestNodes seemed more and more awkward
3. This actually will make making InterestManager detached from the GameObject / NetworkObject easier later (aligned with our arch plans)

No backporting required, this is a new feature for 1.1

### PR Checklist
- [x] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR or a link to the documenation repo PR if this is a manual update. 

## Changelog

## Testing and Documentation

* No tests have been added.  @jeffreyrainy has a commit right after this one that has a unit test that will fail CI without this change
