### PR TITLE
fix: clear override to network prefab

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -29,6 +29,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed NetworkObjects not being despawned before they are destroyed during shutdown for client, host, and server instances. (#1390)
 - Fixed client player object being destroyed on server when the client's player object has DontDestroyWithOwner set. (#1433)
 - Fixed: NetworkVariables containing more than 1300 bytes of data (such as large NetworkLists) no longer cause an OverflowException (the limit on data size is now whatever limit the chosen transport imposes on fragmented NetworkDelivery mechanisms) (#1481)
+- Fixed issue with NetworkConfig.OverrideToNetworkPrefab not being cleared when NetworkManager is initialized. (#1508)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -607,8 +607,9 @@ namespace Unity.Netcode
             // This is used to remove entries not needed or invalid
             var removeEmptyPrefabs = new List<int>();
 
-            // Always clear our prefab override links before building
+            // Always clear our prefab override links before initializing
             NetworkConfig.NetworkPrefabOverrideLinks.Clear();
+            // Always clear our override to NetworkPrefab links before initializing
             NetworkConfig.OverrideToNetworkPrefab.Clear();
 
             // Build the NetworkPrefabOverrideLinks dictionary

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -609,6 +609,7 @@ namespace Unity.Netcode
 
             // Always clear our prefab override links before building
             NetworkConfig.NetworkPrefabOverrideLinks.Clear();
+            NetworkConfig.OverrideToNetworkPrefab.Clear();
 
             // Build the NetworkPrefabOverrideLinks dictionary
             for (int i = 0; i < NetworkConfig.NetworkPrefabs.Count; i++)


### PR DESCRIPTION
Based on the [user submitted PR-1419
](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/1419)
Need to clear NetworkConfig.OverrideToNetworkPrefab during NetworkManager.Initialize
[MTT-1911
](https://jira.unity3d.com/browse/MTT-1911)


### PR Checklist
- [X] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [X] Have you updated the changelog? Each package has a `CHANGELOG.md` file.

## Changelog
### com.unity.netcode.gameobjects
Fixed issue with NetworkConfig.OverrideToNetworkPrefab not being cleared when NetworkManager is initialized.

## Testing and Documentation
* No tests have been added.
* No documentation changes or additions were necessary.
