### PR TITLE
fix: error when serializing ConnectionApprovalMessage with scene management disabled when one or more objects is hidden via the CheckObjectVisibility delegate

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -29,6 +29,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed NetworkObjects not being despawned before they are destroyed during shutdown for client, host, and server instances. (#1390)
 - Fixed client player object being destroyed on server when the client's player object has DontDestroyWithOwner set. (#1433)
 - Fixed: NetworkVariables containing more than 1300 bytes of data (such as large NetworkLists) no longer cause an OverflowException (the limit on data size is now whatever limit the chosen transport imposes on fragmented NetworkDelivery mechanisms) (#1481)
+- Fixed: Fixed: Fixed error when serializing ConnectionApprovalMessage with scene management disabled when one or more objects is hidden via the CheckObjectVisibility delegate (#1509)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -29,7 +29,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed NetworkObjects not being despawned before they are destroyed during shutdown for client, host, and server instances. (#1390)
 - Fixed client player object being destroyed on server when the client's player object has DontDestroyWithOwner set. (#1433)
 - Fixed: NetworkVariables containing more than 1300 bytes of data (such as large NetworkLists) no longer cause an OverflowException (the limit on data size is now whatever limit the chosen transport imposes on fragmented NetworkDelivery mechanisms) (#1481)
-- Fixed: Fixed: Fixed error when serializing ConnectionApprovalMessage with scene management disabled when one or more objects is hidden via the CheckObjectVisibility delegate (#1509)
+- Fixed: Fixed error when serializing ConnectionApprovalMessage with scene management disabled when one or more objects is hidden via the CheckObjectVisibility delegate (#1509)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1655,7 +1655,6 @@ namespace Unity.Netcode
                     {
                         if (SpawnManager.SpawnedObjectsList.Count != 0)
                         {
-                            message.SceneObjectCount = SpawnManager.SpawnedObjectsList.Count;
                             message.SpawnedObjectsList = SpawnManager.SpawnedObjectsList;
                         }
                     }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
@@ -7,7 +7,6 @@ namespace Unity.Netcode
     {
         public ulong OwnerClientId;
         public int NetworkTick;
-        public int SceneObjectCount;
 
         // Not serialized, held as references to serialize NetworkVariable data
         public HashSet<NetworkObject> SpawnedObjectsList;
@@ -23,10 +22,13 @@ namespace Unity.Netcode
             }
             writer.WriteValue(OwnerClientId);
             writer.WriteValue(NetworkTick);
-            writer.WriteValue(SceneObjectCount);
 
-            if (SceneObjectCount != 0)
+            uint sceneObjectCount = 0;
+            if (SpawnedObjectsList != null)
             {
+                var pos = writer.Position;
+                writer.Seek(writer.Position + FastBufferWriter.GetWriteSize(sceneObjectCount));
+
                 // Serialize NetworkVariable data
                 foreach (var sobj in SpawnedObjectsList)
                 {
@@ -35,8 +37,16 @@ namespace Unity.Netcode
                         sobj.Observers.Add(OwnerClientId);
                         var sceneObject = sobj.GetMessageSceneObject(OwnerClientId);
                         sceneObject.Serialize(writer);
+                        ++sceneObjectCount;
                     }
                 }
+                writer.Seek(pos);
+                writer.WriteValue(sceneObjectCount);
+                writer.Seek(writer.Length);
+            }
+            else
+            {
+                writer.WriteValue(sceneObjectCount);
             }
         }
 
@@ -56,7 +66,6 @@ namespace Unity.Netcode
 
             reader.ReadValue(out OwnerClientId);
             reader.ReadValue(out NetworkTick);
-            reader.ReadValue(out SceneObjectCount);
             m_ReceivedSceneObjectData = reader;
             return true;
         }
@@ -77,10 +86,11 @@ namespace Unity.Netcode
             if (!networkManager.NetworkConfig.EnableSceneManagement)
             {
                 networkManager.SpawnManager.DestroySceneObjects();
+                m_ReceivedSceneObjectData.ReadValue(out uint sceneObjectCount);
 
                 // Deserializing NetworkVariable data is deferred from Receive() to Handle to avoid needing
                 // to create a list to hold the data. This is a breach of convention for performance reasons.
-                for (ushort i = 0; i < SceneObjectCount; i++)
+                for (ushort i = 0; i < sceneObjectCount; i++)
                 {
                     var sceneObject = new NetworkObject.SceneObject();
                     sceneObject.Deserialize(m_ReceivedSceneObjectData);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Components/NetworkVisibilityComponent.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Components/NetworkVisibilityComponent.cs
@@ -1,0 +1,13 @@
+namespace Unity.Netcode.RuntimeTests
+{
+    public class NetworkVisibilityComponent : NetworkBehaviour
+    {
+        public void Hide()
+        {
+            GetComponent<NetworkObject>().CheckObjectVisibility += HandleCheckObjectVisibility;
+        }
+
+        protected virtual bool HandleCheckObjectVisibility(ulong clientId) => false;
+
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Components/NetworkVisibilityComponent.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Components/NetworkVisibilityComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c84178a212f3cf4a8818bfbcbc92eef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/MultiInstanceHelpers.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/MultiInstanceHelpers.cs
@@ -230,15 +230,17 @@ namespace Unity.Netcode.RuntimeTests
             }
         }
 
+        public delegate void BeforeClientStartCallback();
+
         /// <summary>
         /// Starts NetworkManager instances created by the Create method.
         /// </summary>
         /// <param name="host">Whether or not to create a Host instead of Server</param>
         /// <param name="server">The Server NetworkManager</param>
         /// <param name="clients">The Clients NetworkManager</param>
-        /// <param name="startInitializationCallback">called immediately after server and client(s) are started</param>
+        /// <param name="callback">called immediately after server is started and before client(s) are started</param>
         /// <returns></returns>
-        public static bool Start(bool host, NetworkManager server, NetworkManager[] clients)
+        public static bool Start(bool host, NetworkManager server, NetworkManager[] clients, BeforeClientStartCallback callback = null)
         {
             if (s_IsStarted)
             {
@@ -259,6 +261,8 @@ namespace Unity.Netcode.RuntimeTests
 
             // if set, then invoke this for the server
             RegisterHandlers(server);
+
+            callback?.Invoke();
 
             if (ClientSceneHandler != null)
             {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVisibilityTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVisibilityTests.cs
@@ -16,7 +16,7 @@ namespace Unity.Netcode.RuntimeTests
             MultiInstanceHelpers.Destroy();
             if (m_TestNetworkPrefab)
             {
-                GameObject.Destroy(m_TestNetworkPrefab);
+                Object.Destroy(m_TestNetworkPrefab);
                 m_TestNetworkPrefab = null;
             }
         }
@@ -65,7 +65,7 @@ namespace Unity.Netcode.RuntimeTests
             yield return MultiInstanceHelpers.Run(
                 MultiInstanceHelpers.WaitForClientsConnectedToServer(server, clients.Length + 1, null, 512));
 
-            Assert.AreEqual(2, GameObject.FindObjectsOfType<NetworkVisibilityComponent>().Length);
+            Assert.AreEqual(2, Object.FindObjectsOfType<NetworkVisibilityComponent>().Length);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVisibilityTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVisibilityTests.cs
@@ -1,0 +1,72 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    public class NetworkVisibilityTests
+    {
+        private NetworkObject m_NetSpawnedObject;
+        private GameObject m_TestNetworkPrefab;
+
+        [TearDown]
+        public void TearDown()
+        {
+            MultiInstanceHelpers.Destroy();
+            if (m_TestNetworkPrefab)
+            {
+                GameObject.Destroy(m_TestNetworkPrefab);
+                m_TestNetworkPrefab = null;
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator HiddenObjectsTest()
+        {
+
+            const int numClients = 1;
+            Assert.True(MultiInstanceHelpers.Create(numClients, out NetworkManager server, out NetworkManager[] clients));
+            m_TestNetworkPrefab = new GameObject("Object");
+            var networkObject = m_TestNetworkPrefab.AddComponent<NetworkObject>();
+            m_TestNetworkPrefab.AddComponent<NetworkVisibilityComponent>();
+
+            // Make it a prefab
+            MultiInstanceHelpers.MakeNetworkObjectTestPrefab(networkObject);
+
+            var validNetworkPrefab = new NetworkPrefab();
+            validNetworkPrefab.Prefab = m_TestNetworkPrefab;
+            server.NetworkConfig.NetworkPrefabs.Add(validNetworkPrefab);
+            server.NetworkConfig.EnableSceneManagement = false;
+            foreach (var client in clients)
+            {
+                client.NetworkConfig.NetworkPrefabs.Add(validNetworkPrefab);
+                client.NetworkConfig.EnableSceneManagement = false;
+            }
+
+            // Start the instances
+            if (!MultiInstanceHelpers.Start(true, server, clients, () =>
+            {
+                var serverObject = Object.Instantiate(m_TestNetworkPrefab, Vector3.zero, Quaternion.identity);
+                NetworkObject serverNetworkObject = serverObject.GetComponent<NetworkObject>();
+                serverNetworkObject.NetworkManagerOwner = server;
+                serverNetworkObject.Spawn();
+                serverObject.GetComponent<NetworkVisibilityComponent>().Hide();
+            }))
+            {
+                Debug.LogError("Failed to start instances");
+                Assert.Fail("Failed to start instances");
+            }
+
+            // [Client-Side] Wait for a connection to the server
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(clients, null, 512));
+
+            // [Host-Side] Check to make sure all clients are connected
+            yield return MultiInstanceHelpers.Run(
+                MultiInstanceHelpers.WaitForClientsConnectedToServer(server, clients.Length + 1, null, 512));
+
+            Assert.AreEqual(2, GameObject.FindObjectsOfType<NetworkVisibilityComponent>().Length);
+        }
+    }
+}
+

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVisibilityTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVisibilityTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e053d627444648908b32a1bc22778d37
+timeCreated: 1638402116


### PR DESCRIPTION
MTT-1847
fixes #1445 

## Changelog

### com.unity.netcode.gameobjects
- Fixed: Fixed error when serializing ConnectionApprovalMessage with scene management disabled when one or more objects is hidden via the CheckObjectVisibility delegate

## Testing and Documentation

* Includes integration tests.
* No documentation changes or additions were necessary.
