### PR TITLE
fix: host NetworkManager.LocalClient not being set

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -32,6 +32,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed an exception being thrown during NetworkVariableDeltaMessage serialization when EnsureNetworkVariableLengthSafety is enabled (#1487)
 - Fixed: NetworkVariables containing more than 1300 bytes of data (such as large NetworkLists) no longer cause an OverflowException (the limit on data size is now whatever limit the chosen transport imposes on fragmented NetworkDelivery mechanisms) (#1481)
 - Fixed KeyNotFound exception when removing ownership of a newly spawned NetworkObject that is already owned by the server. (#1500)
+- Fixed NetworkManager.LocalClient not being set when starting as a host. (#1511)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1674,6 +1674,7 @@ namespace Unity.Netcode
                 }
                 else // Server just adds itself as an observer to all spawned NetworkObjects
                 {
+                    LocalClient = client;
                     SpawnManager.UpdateObservedNetworkObjects(ownerClientId);
                     InvokeOnClientConnectedCallback(ownerClientId);
                 }

--- a/testproject/Assets/Tests/Runtime/NetworkManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkManagerTests.cs
@@ -1,0 +1,16 @@
+using NUnit.Framework;
+using Unity.Netcode.RuntimeTests;
+
+namespace TestProject.RuntimeTests
+{
+    public class NetworkManagerTests : BaseMultiInstanceTest
+    {
+        protected override int NbClients => 1;
+
+        [Test]
+        public void ValidateHostLocalClient()
+        {
+            Assert.IsTrue(m_ServerNetworkManager.LocalClient != null);
+        }
+    }
+}

--- a/testproject/Assets/Tests/Runtime/NetworkManagerTests.cs.meta
+++ b/testproject/Assets/Tests/Runtime/NetworkManagerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2642ec8067a2f5b4e8133eaab43e4b7a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
When starting as a host, the NetworkManager.LocalClient was never being set.
[MTT-1914](https://jira.unity3d.com/browse/MTT-1914)

### PR Checklist
- [X] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [X] Have you updated the changelog? Each package has a `CHANGELOG.md` file.

## Changelog

### com.unity.netcode.gameobjects
Fixed NetworkManager.LocalClient not being set when starting as a host.

## Testing and Documentation
* Includes integration tests.
