### PR TITLE
feat: Enable fragmentation for unreliable delivery (UTP) (1.0.0)

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this package will be documented in this file. The format 
 
 - Removed 'Maximum Packet Size' configuration field in the inspector. This would cause confusion since the maximum packet size is in effect always the MTU (1400 bytes on most platforms).
 - Updated com.unity.transport to 1.0.0-pre.8
+- All delivery methods now support fragmentation, meaning the 'Send Queue Batch Size' setting (which controls the maximum payload size) now applies to all delivery methods, not just reliable ones.
 
 
 ### Fixed

--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -819,6 +819,7 @@ namespace Unity.Netcode
             {
                 unreliableSequencedPipeline = driver.CreatePipeline(
                     typeof(UnreliableSequencedPipelineStage),
+                    typeof(FragmentationPipelineStage),
                     typeof(SimulatorPipelineStage),
                     typeof(SimulatorPipelineStageInSend));
                 reliableSequencedFragmentedPipeline = driver.CreatePipeline(
@@ -830,7 +831,8 @@ namespace Unity.Netcode
             else
 #endif
             {
-                unreliableSequencedPipeline = driver.CreatePipeline(typeof(UnreliableSequencedPipelineStage));
+                unreliableSequencedPipeline = driver.CreatePipeline(
+                    typeof(UnreliableSequencedPipelineStage), typeof(FragmentationPipelineStage));
                 reliableSequencedFragmentedPipeline = driver.CreatePipeline(
                     typeof(FragmentationPipelineStage), typeof(ReliableSequencedPipelineStage)
                 );

--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -16,7 +16,12 @@ namespace Unity.Netcode
     /// </summary>
     public interface INetworkStreamDriverConstructor
     {
-        void CreateDriver(UnityTransport transport, out NetworkDriver driver, out NetworkPipeline unreliableSequencedPipeline, out NetworkPipeline reliableSequencedFragmentedPipeline);
+        void CreateDriver(
+            UnityTransport transport,
+            out NetworkDriver driver,
+            out NetworkPipeline unreliableFragmentedPipeline,
+            out NetworkPipeline unreliableSequencedFragmentedPipeline,
+            out NetworkPipeline reliableSequencedFragmentedPipeline);
     }
 
     public static class ErrorUtilities
@@ -141,7 +146,8 @@ namespace Unity.Netcode
         private NetworkConnection m_ServerConnection;
         private ulong m_ServerClientId;
 
-        private NetworkPipeline m_UnreliableSequencedPipeline;
+        private NetworkPipeline m_UnreliableFragmentedPipeline;
+        private NetworkPipeline m_UnreliableSequencedFragmentedPipeline;
         private NetworkPipeline m_ReliableSequencedFragmentedPipeline;
 
         public override ulong ServerClientId => m_ServerClientId;
@@ -194,7 +200,12 @@ namespace Unity.Netcode
 
         private void InitDriver()
         {
-            DriverConstructor.CreateDriver(this, out m_Driver, out m_UnreliableSequencedPipeline, out m_ReliableSequencedFragmentedPipeline);
+            DriverConstructor.CreateDriver(
+                this,
+                out m_Driver,
+                out m_UnreliableFragmentedPipeline,
+                out m_UnreliableSequencedFragmentedPipeline,
+                out m_ReliableSequencedFragmentedPipeline);
         }
 
         private void DisposeDriver()
@@ -210,10 +221,10 @@ namespace Unity.Netcode
             switch (delivery)
             {
                 case NetworkDelivery.Unreliable:
-                    return NetworkPipeline.Null;
+                    return m_UnreliableFragmentedPipeline;
 
                 case NetworkDelivery.UnreliableSequenced:
-                    return m_UnreliableSequencedPipeline;
+                    return m_UnreliableSequencedFragmentedPipeline;
 
                 case NetworkDelivery.Reliable:
                 case NetworkDelivery.ReliableSequenced:
@@ -647,7 +658,6 @@ namespace Unity.Netcode
                 {
                     // If data is too large to be batched, flush it out immediately. This happens with large initial spawn packets from Netcode for Gameobjects.
                     Debug.LogWarning($"Event of size {payload.Count} too large to fit in send queue (of size {m_SendQueueBatchSize}). Trying to send directly. This could be the initial payload!");
-                    Debug.Assert(networkDelivery == NetworkDelivery.ReliableFragmentedSequenced); // Messages like this, should always be sent via the fragmented pipeline.
                     SendMessageInstantly(sendTarget.ClientId, payload, pipeline);
                 }
             }
@@ -728,10 +738,6 @@ namespace Unity.Netcode
         {
             NetworkPipeline pipeline = sendTarget.NetworkPipeline;
             var payloadSize = sendQueue.Count + 1; // 1 extra byte to tell whether the message is batched or not
-            if (payloadSize > NetworkParameterConstants.MTU) // If this is bigger than MTU then force it to be sent via the FragmentedReliableSequencedPipeline
-            {
-                pipeline = m_ReliableSequencedFragmentedPipeline;
-            }
 
             var sendBuffer = sendQueue.GetData();
             SendBatchedMessage(sendTarget.ClientId, ref sendBuffer, pipeline);
@@ -795,7 +801,10 @@ namespace Unity.Netcode
             m_ServerClientId = 0;
         }
 
-        public void CreateDriver(UnityTransport transport, out NetworkDriver driver, out NetworkPipeline unreliableSequencedPipeline, out NetworkPipeline reliableSequencedFragmentedPipeline)
+        public void CreateDriver(UnityTransport transport, out NetworkDriver driver,
+            out NetworkPipeline unreliableFragmentedPipeline,
+            out NetworkPipeline unreliableSequencedFragmentedPipeline,
+            out NetworkPipeline reliableSequencedFragmentedPipeline)
         {
             var maxFrameTimeMS = 0;
 
@@ -817,9 +826,13 @@ namespace Unity.Netcode
 #if UNITY_EDITOR || DEVELOPMENT_BUILD
             if (simulatorParams.PacketDelayMs > 0 || simulatorParams.PacketDropInterval > 0)
             {
-                unreliableSequencedPipeline = driver.CreatePipeline(
-                    typeof(UnreliableSequencedPipelineStage),
+                unreliableFragmentedPipeline = driver.CreatePipeline(
                     typeof(FragmentationPipelineStage),
+                    typeof(SimulatorPipelineStage),
+                    typeof(SimulatorPipelineStageInSend));
+                unreliableSequencedFragmentedPipeline = driver.CreatePipeline(
+                    typeof(FragmentationPipelineStage),
+                    typeof(UnreliableSequencedPipelineStage),
                     typeof(SimulatorPipelineStage),
                     typeof(SimulatorPipelineStageInSend));
                 reliableSequencedFragmentedPipeline = driver.CreatePipeline(
@@ -831,8 +844,10 @@ namespace Unity.Netcode
             else
 #endif
             {
-                unreliableSequencedPipeline = driver.CreatePipeline(
-                    typeof(UnreliableSequencedPipelineStage), typeof(FragmentationPipelineStage));
+                unreliableFragmentedPipeline = driver.CreatePipeline(
+                    typeof(FragmentationPipelineStage));
+                unreliableSequencedFragmentedPipeline = driver.CreatePipeline(
+                    typeof(FragmentationPipelineStage), typeof(UnreliableSequencedPipelineStage));
                 reliableSequencedFragmentedPipeline = driver.CreatePipeline(
                     typeof(FragmentationPipelineStage), typeof(ReliableSequencedPipelineStage)
                 );

--- a/com.unity.netcode.adapter.utp/Tests/Runtime/TransportTests.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/TransportTests.cs
@@ -13,7 +13,7 @@ namespace Unity.Netcode.UTP.RuntimeTests
     public class TransportTests
     {
         // No need to test all reliable delivery methods since they all map to the same pipeline.
-        private static readonly NetworkDelivery[] s_DeliveryParameters =
+        private static readonly NetworkDelivery[] k_DeliveryParameters =
         {
             NetworkDelivery.Unreliable,
             NetworkDelivery.UnreliableSequenced,
@@ -54,7 +54,7 @@ namespace Unity.Netcode.UTP.RuntimeTests
 
         // Check if can make a simple data exchange.
         [UnityTest]
-        public IEnumerator PingPong([ValueSource("s_DeliveryParameters")] NetworkDelivery delivery)
+        public IEnumerator PingPong([ValueSource("k_DeliveryParameters")] NetworkDelivery delivery)
         {
             InitializeTransport(out m_Server, out m_ServerEvents);
             InitializeTransport(out m_Client1, out m_Client1Events);
@@ -83,7 +83,7 @@ namespace Unity.Netcode.UTP.RuntimeTests
 
         // Check if can make a simple data exchange (both ways at a time).
         [UnityTest]
-        public IEnumerator PingPongSimultaneous([ValueSource("s_DeliveryParameters")] NetworkDelivery delivery)
+        public IEnumerator PingPongSimultaneous([ValueSource("k_DeliveryParameters")] NetworkDelivery delivery)
         {
             InitializeTransport(out m_Server, out m_ServerEvents);
             InitializeTransport(out m_Client1, out m_Client1Events);
@@ -117,7 +117,7 @@ namespace Unity.Netcode.UTP.RuntimeTests
         }
 
         [UnityTest]
-        public IEnumerator FilledSendQueueSingleSend([ValueSource("s_DeliveryParameters")] NetworkDelivery delivery)
+        public IEnumerator FilledSendQueueSingleSend([ValueSource("k_DeliveryParameters")] NetworkDelivery delivery)
         {
             InitializeTransport(out m_Server, out m_ServerEvents);
             InitializeTransport(out m_Client1, out m_Client1Events);
@@ -136,7 +136,7 @@ namespace Unity.Netcode.UTP.RuntimeTests
         }
 
         [UnityTest]
-        public IEnumerator FilledSendQueueMultipleSends([ValueSource("s_DeliveryParameters")] NetworkDelivery delivery)
+        public IEnumerator FilledSendQueueMultipleSends([ValueSource("k_DeliveryParameters")] NetworkDelivery delivery)
         {
             InitializeTransport(out m_Server, out m_ServerEvents);
             InitializeTransport(out m_Client1, out m_Client1Events);
@@ -167,7 +167,7 @@ namespace Unity.Netcode.UTP.RuntimeTests
 
         // Check making multiple sends to a client in a single frame.
         [UnityTest]
-        public IEnumerator MultipleSendsSingleFrame([ValueSource("s_DeliveryParameters")] NetworkDelivery delivery)
+        public IEnumerator MultipleSendsSingleFrame([ValueSource("k_DeliveryParameters")] NetworkDelivery delivery)
         {
             InitializeTransport(out m_Server, out m_ServerEvents);
             InitializeTransport(out m_Client1, out m_Client1Events);
@@ -196,7 +196,7 @@ namespace Unity.Netcode.UTP.RuntimeTests
 
         // Check sending data to multiple clients.
         [UnityTest]
-        public IEnumerator SendMultipleClients([ValueSource("s_DeliveryParameters")] NetworkDelivery delivery)
+        public IEnumerator SendMultipleClients([ValueSource("k_DeliveryParameters")] NetworkDelivery delivery)
         {
             InitializeTransport(out m_Server, out m_ServerEvents);
             InitializeTransport(out m_Client1, out m_Client1Events);
@@ -233,7 +233,7 @@ namespace Unity.Netcode.UTP.RuntimeTests
 
         // Check receiving data from multiple clients.
         [UnityTest]
-        public IEnumerator ReceiveMultipleClients([ValueSource("s_DeliveryParameters")] NetworkDelivery delivery)
+        public IEnumerator ReceiveMultipleClients([ValueSource("k_DeliveryParameters")] NetworkDelivery delivery)
         {
             InitializeTransport(out m_Server, out m_ServerEvents);
             InitializeTransport(out m_Client1, out m_Client1Events);


### PR DESCRIPTION
This is a backport of PR #1512.

## Changelog

### com.unity.netcode.adapter.utp
- Changed: All delivery methods now support fragmentation, meaning the 'Send Queue Batch Size' setting (which controls the maximum payload size) now applies to all delivery methods, not just reliable ones.

## Testing and Documentation

* Includes unit/integration tests.
* No documentation changes or additions were necessary.