### PR TITLE
fix: network transform respawn tests fail on mac

### DIFF
--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -713,6 +713,7 @@ namespace Unity.Netcode.Components
                 m_AllFloatInterpolators.Add(m_ScaleYInterpolator);
                 m_AllFloatInterpolators.Add(m_ScaleZInterpolator);
             }
+            m_ReplicatedNetworkState.OnValueChanged += OnNetworkStateChanged;
         }
 
         private bool m_InitializeClient = true;
@@ -729,7 +730,7 @@ namespace Unity.Netcode.Components
             //  and thus awake won't be called.
             // TODO: investigate further on not sending data for something that is not enabled
             m_Transform = transform;
-            m_ReplicatedNetworkState.OnValueChanged += OnNetworkStateChanged;
+            //m_ReplicatedNetworkState.OnValueChanged += OnNetworkStateChanged;
 
             CanCommitToTransform = IsServer;
             m_CachedIsServer = IsServer;
@@ -767,7 +768,7 @@ namespace Unity.Netcode.Components
                 }
             }
 
-            m_ReplicatedNetworkState.OnValueChanged -= OnNetworkStateChanged;
+            //m_ReplicatedNetworkState.OnValueChanged -= OnNetworkStateChanged;
         }
 
         public override void OnGainedOwnership()

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -756,13 +756,17 @@ namespace Unity.Netcode.Components
 
         public override void OnNetworkDespawn()
         {
-            // Server resets both its m_LocalAuthoritativeNetworkState and the m_ReplicatedNetworkState upon despawn
-            if (IsServer && EnableDeferredClientInit)
+            if (EnableDeferredClientInit)
             {
                 // Reset the network state once despawned -- helps prevent pooled objects from interpolating from the last state
                 m_LocalAuthoritativeNetworkState.Reset();
-                m_ReplicatedNetworkState.Value = m_LocalAuthoritativeNetworkState;
+                // Server resets both its m_LocalAuthoritativeNetworkState and the m_ReplicatedNetworkState upon despawn
+                if (IsServer)
+                {
+                    m_ReplicatedNetworkState.Value = m_LocalAuthoritativeNetworkState;
+                }
             }
+
             m_ReplicatedNetworkState.OnValueChanged -= OnNetworkStateChanged;
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -249,6 +249,8 @@ namespace Unity.Netcode.RuntimeTests
 
         public NetworkObject Instantiate(ulong ownerClientId, Vector3 position, Quaternion rotation)
         {
+            m_ClientSideObject.transform.position = position;
+            m_ClientSideObject.transform.rotation = rotation;
             m_ClientSideSpawned = true;
             m_ClientSideObject.SetActive(true);
             return m_ClientSideObject.GetComponent<NetworkObject>();
@@ -313,13 +315,15 @@ namespace Unity.Netcode.RuntimeTests
             yield return new WaitUntil(() => m_ClientSideSpawned);
 
             // Let the object move a bit
-            yield return new WaitForSeconds(0.5f);
+            yield return WaitForFrames(100);
 
             // Make sure it moved on the client side
             Assert.IsTrue(m_ClientSideObject.transform.position != Vector3.zero);
 
             m_ServerNetworkManager.SpawnManager.DespawnObject(m_DefaultNetworkObject);
             yield return new WaitUntil(() => !m_ClientSideSpawned);
+
+            yield return WaitForFrames(30);
 
             // Re-spawn the same NetworkObject
             m_DefaultNetworkObject.Spawn();
@@ -337,6 +341,13 @@ namespace Unity.Netcode.RuntimeTests
 
             // Done
             m_DefaultNetworkObject.Despawn();
+        }
+
+
+        private IEnumerator WaitForFrames(int framesToWait)
+        {
+            var frameCountToWaitFor = Time.frameCount + framesToWait;
+            yield return new WaitUntil(() => frameCountToWaitFor <= Time.frameCount);
         }
 
         public override IEnumerator Teardown()

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -247,7 +247,7 @@ namespace Unity.Netcode.RuntimeTests
             }
 
 
-            private void FixedUpdate()
+            private void Update()
             {
                 if (!IsSpawned || !IsServer)
                 {
@@ -262,7 +262,7 @@ namespace Unity.Netcode.RuntimeTests
                 {
                     // This is only for testing purposes where I should be able to
                     // achieve a "close to" specific distance over (n) frames
-                    transform.position += m_Speed * Time.deltaTime;
+                    transform.position += m_Speed;
                     //m_Rigidbody.MovePosition(transform.position + m_Speed);
                 }
             }
@@ -323,9 +323,9 @@ namespace Unity.Netcode.RuntimeTests
 
 
         private int m_MovementFrames = 20;
-        private int m_SpawnWaitTime = 2;
+        //private int m_SpawnWaitTime = 1;
         private float m_Speed => 100.0f / m_MovementFrames;
-        private float m_FirstInterpMag => (float)(m_Speed * m_MovementFrames * 0.02f);
+        private float m_FirstInterpMag => 2.0f;
 
 
         [UnityTest]
@@ -349,7 +349,7 @@ namespace Unity.Netcode.RuntimeTests
 #if RESPAWNPOSITION_STRESS_TEST
             m_MovementFrames = 10;
 
-            for (int i = 0; i < 100; i++)
+            for (int i = 0; i < 10; i++)
             {
 #endif
             clientDynamicObjectMover.SetSpeed(m_Speed);
@@ -378,7 +378,7 @@ namespace Unity.Netcode.RuntimeTests
 
 
             yield return new WaitUntil(() => m_ClientSideSpawned);
-            yield return WaitForFrames(m_SpawnWaitTime);
+            yield return new WaitForEndOfFrame();
 
             var firstClientInterpolatedPosition = clientDynamicObjectMover.GetFirstInterpolatedPosition();
             Assert.IsFalse(firstClientInterpolatedPosition.magnitude > m_FirstInterpMag);
@@ -403,7 +403,7 @@ namespace Unity.Netcode.RuntimeTests
             m_DefaultNetworkObject.Spawn();
 
             yield return new WaitUntil(() => m_ClientSideSpawned);
-            yield return WaitForFrames(m_SpawnWaitTime);
+            yield return new WaitForEndOfFrame();
             firstClientInterpolatedPosition = clientDynamicObjectMover.GetFirstInterpolatedPosition();
             Debug.Log($"[Without Fix] First client interpolated position: {firstClientInterpolatedPosition}");
             // At this point (*** the bug ***) the client should have close to the previous frame's position plus any delta sent from the server.

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -325,8 +325,6 @@ namespace Unity.Netcode.RuntimeTests
         private int m_MovementFrames = 20;
         //private int m_SpawnWaitTime = 1;
         private float m_Speed => 100.0f / m_MovementFrames;
-        private float m_FirstInterpMag => 2.0f;
-
 
         [UnityTest]
         public IEnumerator RespawnedPositionTest()
@@ -376,12 +374,12 @@ namespace Unity.Netcode.RuntimeTests
             m_DefaultNetworkObject.gameObject.SetActive(true);
             m_DefaultNetworkObject.Spawn();
 
-
             yield return new WaitUntil(() => m_ClientSideSpawned);
             yield return new WaitForEndOfFrame();
 
             var firstClientInterpolatedPosition = clientDynamicObjectMover.GetFirstInterpolatedPosition();
-            Assert.IsFalse(firstClientInterpolatedPosition.magnitude > m_FirstInterpMag);
+            Debug.Log($"Pre-[Verify With Fix] Magnitude: {firstClientInterpolatedPosition} vs m_Speed: {m_Speed}");
+            Assert.IsFalse(firstClientInterpolatedPosition.magnitude > m_Speed);
             Debug.Log($"[Verify With Fix] First client interpolated position: {firstClientInterpolatedPosition}");
 
             yield return WaitForFrames(m_MovementFrames);


### PR DESCRIPTION
Determined there were timing issues between MAC and other platforms.
Also determined that MultiInstance timing varies from actual runtime local testing (manual testing).
Fixed the issue by refactoring the original fix to handle recycled (pooled) NetworkObjects.

### PR Checklist
- [X] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.

## Testing and Documentation
* Includes refactoring of integration test .
* No documentation changes or additions were necessary.