### PR TITLE
fix: Better error message when calling RPCs on objects that haven't been spawned.

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/RpcMessages.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/RpcMessages.cs
@@ -66,11 +66,9 @@ namespace Unity.Netcode
         public static void Handle(ref NetworkContext context, ref RpcMetadata metadata, ref FastBufferReader payload, ref __RpcParams rpcParams)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
-
-            var objectExists = networkManager.SpawnManager.SpawnedObjects.TryGetValue(metadata.NetworkObjectId, out var networkObject);
-            if (!objectExists)
+            if (!networkManager.SpawnManager.SpawnedObjects.TryGetValue(metadata.NetworkObjectId, out var networkObject))
             {
-                throw new Exception("RPC called on an object that isn't in the spawned objects list - please make sure an object is spawned before calling RPCs.");
+                throw new Exception($"RPC called on a {nameof(NetworkObject)} that is not in the spawned objects list - please make sure the {nameof(NetworkObject)} is spawned before calling RPCs.");
             }
             var networkBehaviour = networkObject.GetNetworkBehaviourAtOrderIndex(metadata.NetworkBehaviourId);
 

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/RpcMessages.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/RpcMessages.cs
@@ -66,7 +66,12 @@ namespace Unity.Netcode
         public static void Handle(ref NetworkContext context, ref RpcMetadata metadata, ref FastBufferReader payload, ref __RpcParams rpcParams)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
-            var networkObject = networkManager.SpawnManager.SpawnedObjects[metadata.NetworkObjectId];
+
+            var objectExists = networkManager.SpawnManager.SpawnedObjects.TryGetValue(metadata.NetworkObjectId, out var networkObject);
+            if (!objectExists)
+            {
+                throw new Exception("RPC called on an object that isn't in the spawned objects list - please make sure an object is spawned before calling RPCs.");
+            }
             var networkBehaviour = networkObject.GetNetworkBehaviourAtOrderIndex(metadata.NetworkBehaviourId);
 
             try


### PR DESCRIPTION
MTT-1705
#1369 

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.