### PR TITLE
chore: Update UTP to pre.10 in the adapter (1.0.0)

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this package will be documented in this file. The format 
 ### Changed
 
 - Removed 'Maximum Packet Size' configuration field in the inspector. This would cause confusion since the maximum packet size is in effect always the MTU (1400 bytes on most platforms).
-- Updated com.unity.transport to 1.0.0-pre.8
+- Updated com.unity.transport to 1.0.0-pre.10.
 - All delivery methods now support fragmentation, meaning the 'Send Queue Batch Size' setting (which controls the maximum payload size) now applies to all delivery methods, not just reliable ones.
 
 

--- a/com.unity.netcode.adapter.utp/package.json
+++ b/com.unity.netcode.adapter.utp/package.json
@@ -6,6 +6,6 @@
   "unity": "2020.3",
   "dependencies": {
     "com.unity.netcode.gameobjects": "1.0.0-pre.3",
-    "com.unity.transport": "1.0.0-pre.8"
+    "com.unity.transport": "1.0.0-pre.10"
   }
 }


### PR DESCRIPTION
This is a backport of PR #1501 to `release/1.0.0`.

[Changelog for release 1.0.0-pre.10 of UTP](https://github.cds.internal.unity3d.com/unity/com.unity.transport/blob/release/1.0.0/CHANGELOG.md#100-pre10---2021-12-02), for those interested.

## Changelog

### com.unity.netcode.adapter.utp

- Changed: Updated `com.unity.transport` to 1.0.0-pre.10.

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.