### PR TITLE
feat: Adding "previousValue" in NetworkListEvent

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -9,6 +9,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ## [Unreleased]
 
 ### Added
+- Adding `PreviousValue` in NetworkListEvent, when `Value` has changed
 
 ### Removed
 

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -272,10 +272,13 @@ namespace Unity.Netcode
                         {
                             reader.ReadValueSafe(out int index);
                             reader.ReadValueSafe(out T value);
-                            if (index < m_List.Length)
+                            if (index >= m_List.Length)
                             {
-                                m_List[index] = value;
+                                throw new Exception("Shouldn't be here, index is higher than list length");
                             }
+
+                            var previousValue = m_List[index];
+                            m_List[index] = value;
 
                             if (OnListChanged != null)
                             {
@@ -283,7 +286,8 @@ namespace Unity.Netcode
                                 {
                                     Type = eventType,
                                     Index = index,
-                                    Value = value
+                                    Value = value,
+                                    PreviousValue = previousValue
                                 });
                             }
 
@@ -293,7 +297,8 @@ namespace Unity.Netcode
                                 {
                                     Type = eventType,
                                     Index = index,
-                                    Value = value
+                                    Value = value,
+                                    PreviousValue = previousValue
                                 });
                             }
                         }
@@ -527,6 +532,11 @@ namespace Unity.Netcode
         /// The value changed, added or removed if available.
         /// </summary>
         public T Value;
+
+        /// <summary>
+        /// The previous value when "Value" has changed, if available.
+        /// </summary>
+        public T PreviousValue;
 
         /// <summary>
         /// the index changed, added or removed if available


### PR DESCRIPTION
This way, instead of users having to maintain a local value themselves, we just add it when individual values changes. It'll stay to default with other event types (just like "index" stays to default when the event type doesn't have an index)

No Jira

### PR Checklist
- [ ] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [x] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR or a link to the documenation repo PR if this is a manual update. 

## Changelog

### com.unity.netcode.gameobjects
- Added: - Adding `PreviousValue` in NetworkListEvent, when `Value` has changed

## Testing and Documentation

* Includes integration tests.
* Includes edits to existing public API documentation.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
