### PR TITLE
fix(networktransfrom): Reset interpolation buffers when InLocalSpace changes

### DIFF
--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -655,6 +655,16 @@ namespace Unity.Netcode.Components
                 return;
             }
 
+            //If InLocalSpace has changed, all interpolation buffers values are wrong, so we reset it
+            if (oldState.InLocalSpace != newState.InLocalSpace)
+            {
+                // NOTE: Maybe a better solution could be implemented where we cache the time which InLocalSpace changed (newState.ServerTime)
+                // and correctly choose the space to interpolate in based on the interpolation time
+                // this would also have to handle the "transition" scenario where A is in local space and B is in world space, and vice-versa
+                m_LocalAuthoritativeNetworkState = newState;
+                ResetInterpolatedStateToCurrentAuthoritativeState();
+            }
+
             AddInterpolatedState(newState);
 
 #if NGO_TRANSFORM_DEBUG


### PR DESCRIPTION
**Reason for this PR:**

Currently, changing `NetworkTransform.InLocalSpace` in runtime breaks interpolation (this can be verified in the [ClientDriven sample project](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.bitesize/tree/main/Basic/ClientDriven), steps below).

The reason is that previous values in the interpolation buffers are in the wrong space (relative to the current value of `InLocalSpace`) which causes the object to interpolate from a non-sense world position until buffer values older than the server time which InLocalSpace changed are consumed (for any connected client).

This PR implements a lowest effort solution to this problem, which simply resets the buffer and snaps the object to the most up to date position received. I've added a comment suggesting what _I think might_ be a better solution to the problem (didn't test it). Please let me know if this is something that makes sense at all.

**Reproducing the issue ([Unity's ClientDriven sample](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.bitesize/tree/main/Basic/ClientDriven)):**

1 - Clone and make a windowed local build of the ClientDriven project, inside Unity's bitesize sample project.
2 - Start one instance of ClientDriven as `Host`, and another instance as `Client`
3 - On the `Host` instance find and grab an ingredient. Note that the ingredient interpolation breaks in the `Client` view
4 - Throw the ingredient in the `Host` instance. Note interpolation breaks again in the `Client` view.