### PR TITLE
fix: Fix a bug where NetworkTime initialized with wrong tick

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -20,6 +20,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed NetworkVariables containing more than 1300 bytes of data (such as large NetworkLists) no longer cause an OverflowException (the limit on data size is now whatever limit the chosen transport imposes on fragmented NetworkDelivery mechanisms) (#1481)
 - Fixed error when serializing ConnectionApprovalMessage with scene management disabled when one or more objects is hidden via the CheckObjectVisibility delegate (#1509)
 - Fixed The NetworkConfig's checksum hash includes the NetworkTick so that clients with a different tickrate than the server are identified and not allowed to connect. (#1513)
+- Fixed a bug where when constructing a NetworkTime from a tick the resulting instance sometimes had a different tick value due to floating point math imprecision.(#1561)
 
 ### Changed
 
@@ -50,7 +51,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed NetworkObjects not being despawned before they are destroyed during shutdown for client, host, and server instances. (#1390)
 - Fixed KeyNotFound exception when removing ownership of a newly spawned NetworkObject that is already owned by the server. (#1500)
 - Fixed NetworkManager.LocalClient not being set when starting as a host. (#1511)
-- Fixed a bug where when constructing a NetworkTime from a tick the resulting instance sometimes had a different tick value due to floating point math imprecision.
 - Fixed a few memory leak cases when shutting down NetworkManager during Incoming Message Queue processing. (#1323)
 
 ### Changed

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -35,6 +35,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed KeyNotFoundException when removing ownership of a newly spawned NetworkObject that is already owned by the server. (#1500)
 - Fixed The NetworkConfig's checksum hash includes the NetworkTick so that clients with a different tickrate than the server are identified and not allowed to connect. (#1513)
 - Fixed NetworkManager.LocalClient not being set when starting as a host. (#1511)
+- Fixed a bug where when constructing a NetworkTime from a tick the resulting instance sometimes had a different tick value due to floating point math imprecision.
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTime.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTime.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Assertions;
 
@@ -115,7 +114,6 @@ namespace Unity.Netcode
         /// <summary>
         /// Converts excess tick offset into ticks and recalculates the cached time value.
         /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void Recalculate()
         {
             if (m_TickOffset >= m_TickInterval || m_TickOffset <= m_TickInterval)

--- a/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTime.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTime.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Assertions;
 
@@ -11,33 +12,32 @@ namespace Unity.Netcode
     /// </summary>
     public struct NetworkTime
     {
-        private double m_TimeSec;
+        private double m_TickOffset;
+        private int m_Tick;
+        private double m_CachedTime;
 
         private uint m_TickRate;
         private double m_TickInterval;
 
-        private int m_CachedTick;
-        private double m_CachedTickOffset;
-
         /// <summary>
         /// Gets the amount of time which has passed since the last network tick.
         /// </summary>
-        public double TickOffset => m_CachedTickOffset;
+        public double TickOffset => m_TickOffset;
 
         /// <summary>
         /// Gets the current time. This is a non fixed time value and similar to <see cref="Time.time"/>
         /// </summary>
-        public double Time => m_TimeSec;
+        public double Time => m_CachedTime;
 
         /// <summary>
         /// Gets the current time as a float.
         /// </summary>
-        public float TimeAsFloat => (float)m_TimeSec;
+        public float TimeAsFloat => (float)m_CachedTime;
 
         /// <summary>
         /// Gets he current fixed network time. This is the time value of the last network tick. Similar to <see cref="Time.fixedTime"/>
         /// </summary>
-        public double FixedTime => m_CachedTick * m_TickInterval;
+        public double FixedTime => m_Tick * m_TickInterval;
 
         /// <summary>
         /// Gets the fixed delta time. This value is based on the <see cref="TickRate"/> and stays constant.
@@ -48,7 +48,7 @@ namespace Unity.Netcode
         /// <summary>
         /// Gets the amount of network ticks which have passed until reaching the current time value.
         /// </summary>
-        public int Tick => m_CachedTick;
+        public int Tick => m_Tick;
 
         /// <summary>
         /// Gets the tickrate of the system of this <see cref="NetworkTime"/>.
@@ -64,11 +64,12 @@ namespace Unity.Netcode
         {
             Assert.IsTrue(tickRate > 0, "Tickrate must be a positive value.");
 
+            m_CachedTime = 0;
+            m_Tick = 0;
+            m_TickOffset = 0;
+
             m_TickRate = tickRate;
             m_TickInterval = 1f / m_TickRate; // potential floating point precision issue, could result in different interval on different machines
-            m_CachedTickOffset = 0;
-            m_CachedTick = 0;
-            m_TimeSec = 0;
         }
 
         /// <summary>
@@ -80,8 +81,9 @@ namespace Unity.Netcode
         public NetworkTime(uint tickRate, int tick, double tickOffset = 0d)
             : this(tickRate)
         {
-            Assert.IsTrue(tickOffset < 1d / tickRate);
-            this += tick * m_TickInterval + tickOffset;
+            m_Tick = tick;
+            m_TickOffset = tickOffset;
+            Recalculate();
         }
 
         /// <summary>
@@ -102,7 +104,7 @@ namespace Unity.Netcode
         /// <returns>A <see cref="NetworkTime"/> where Time is the FixedTime value of this instance.</returns>
         public NetworkTime ToFixedTime()
         {
-            return new NetworkTime(m_TickRate, m_CachedTick);
+            return new NetworkTime(m_TickRate, m_Tick);
         }
 
         public NetworkTime TimeTicksAgo(int ticks)
@@ -110,34 +112,46 @@ namespace Unity.Netcode
             return this - new NetworkTime(TickRate, ticks);
         }
 
-        private void UpdateCache()
+        /// <summary>
+        /// Converts excess tick offset into ticks and recalculates the cached time value.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void Recalculate()
         {
-            double d = m_TimeSec / m_TickInterval;
-            m_CachedTick = (int)d;
-            m_CachedTickOffset = ((d - Math.Truncate(d)) * m_TickInterval);
-
-            // This handles negative time, decreases tick by 1 and makes offset positive.
-            if (m_CachedTick < 0 && m_CachedTickOffset != 0d)
+            if (m_TickOffset >= m_TickInterval || m_TickOffset <= m_TickInterval)
             {
-                m_CachedTick--;
-                m_CachedTickOffset = m_TickInterval + m_CachedTickOffset;
+                double d = m_TickOffset / m_TickInterval;
+                m_Tick += (int)d;
+                m_TickOffset = ((d - Math.Truncate(d)) * m_TickInterval);
             }
+
+            // This handles negative time offset, decreases tick by 1 and makes offset positive.
+            if (m_TickOffset < 0d)
+            {
+                m_Tick--;
+                m_TickOffset += m_TickInterval;
+                Assert.IsTrue(m_TickOffset < m_TickInterval);
+            }
+
+            m_CachedTime = m_Tick * m_TickInterval + m_TickOffset;
         }
 
         public static NetworkTime operator -(NetworkTime a, NetworkTime b)
         {
-            return new NetworkTime(a.TickRate, a.Time - b.Time);
+            Assert.AreEqual(a.TickRate, b.TickRate, $"Can only subtract two {nameof(NetworkTime)} with equal {nameof(TickRate)}");
+            return new NetworkTime(a.TickRate, a.Tick - b.Tick, a.TickOffset - b.TickOffset);
         }
 
         public static NetworkTime operator +(NetworkTime a, NetworkTime b)
         {
-            return new NetworkTime(a.TickRate, a.Time + b.Time);
+            Assert.AreEqual(a.TickRate, b.TickRate, $"Can only add two {nameof(NetworkTime)} with equal {nameof(TickRate)}");
+            return new NetworkTime(a.TickRate, a.Tick + b.Tick, a.TickOffset + b.TickOffset);
         }
 
         public static NetworkTime operator +(NetworkTime a, double b)
         {
-            a.m_TimeSec += b;
-            a.UpdateCache();
+            a.m_TickOffset += b;
+            a.Recalculate();
             return a;
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Editor/Timing/NetworkTimeTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Timing/NetworkTimeTests.cs
@@ -142,7 +142,7 @@ namespace Unity.Netcode.EditorTests
         }
 
         [Test]
-        public void NetworkTimeCorrectTick([Values(30u, 60u, 1u, 100u)]uint tickRate)
+        public void NetworkTimeCorrectTick([Values(30u, 60u, 1u, 100u)] uint tickRate)
         {
             for (int i = 0; i < 10000; i++)
             {

--- a/com.unity.netcode.gameobjects/Tests/Editor/Timing/NetworkTimeTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Timing/NetworkTimeTests.cs
@@ -28,9 +28,9 @@ namespace Unity.Netcode.EditorTests
         [TestCase(-4301d, -4301f, 20u)]
         [TestCase(-4301d, -4301f, 30u)]
         [TestCase(-4301d, -4301f, 60u)]
-        [TestCase(float.MaxValue, float.MaxValue, 20u)]
-        [TestCase(float.MaxValue, float.MaxValue, 30u)]
-        [TestCase(float.MaxValue, float.MaxValue, 60u)]
+        [TestCase(int.MaxValue / 21d, int.MaxValue / 21f, 20u)]
+        [TestCase(int.MaxValue / 31d, int.MaxValue / 31f, 30u)]
+        [TestCase(int.MaxValue / 61d, int.MaxValue / 61f, 60u)]
         public void TestTimeAsFloat(double d, float f, uint tickRate)
         {
             var networkTime = new NetworkTime(tickRate, d);
@@ -139,6 +139,16 @@ namespace Unity.Netcode.EditorTests
             var timeA = new NetworkTime(60, a);
             NetworkTime timeB = timeA - new NetworkTime(60, time);
             Assert.IsTrue(Approximately(floatResultB, timeB.Time));
+        }
+
+        [Test]
+        public void NetworkTimeCorrectTick([Values(30u, 60u, 1u, 100u)]uint tickRate)
+        {
+            for (int i = 0; i < 10000; i++)
+            {
+                var time = new NetworkTime(tickRate, i);
+                Assert.AreEqual(i, time.Tick);
+            }
         }
 
         [Test]

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Timing/NetworkTimeSystemTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Timing/NetworkTimeSystemTests.cs
@@ -51,6 +51,30 @@ namespace Unity.Netcode.RuntimeTests
                 Assert.AreEqual(Math.Floor((tickSystem.ServerTime.Time / delta)), NetworkManager.Singleton.ServerTime.Tick);
                 Assert.True(Mathf.Approximately((float)NetworkManager.Singleton.LocalTime.Time, (float)NetworkManager.Singleton.ServerTime.Time));
             }
+
+            Assert.AreNotEqual(0, tickSystem.LocalTime.Tick);
+        }
+
+        /// <summary>
+        /// Tests whether the ticks invoked by the time system consistently increments it's tick value by 1 during each invocation of the tick event.
+        /// </summary>
+        /// <returns></returns>
+        [UnityTest]
+        public IEnumerator CorrectTickIncrementationTest()
+        {
+            var tickSystem = NetworkManager.Singleton.NetworkTickSystem;
+
+            var ticks = tickSystem.LocalTime.Tick;
+            tickSystem.Tick += () =>
+            {
+                ticks++;
+                Assert.AreEqual(ticks, tickSystem.LocalTime.Tick);
+            };
+
+            while (tickSystem.LocalTime.Time < 3f)
+            {
+                yield return null;
+            }
         }
 
         [TearDown]


### PR DESCRIPTION
Due to floating point math imprecision NetworkTime was sometimes initialized with a different tick value than the one passed from the constructor. Fixes #1495 

[MTT-2063](https://jira.unity3d.com/browse/MTT-2063)

<!-- Replace this line with what this PR does and why.  Describe what you'd like reviewers to know, how you applied the Engineering principles, and any interesting tradeoffs made.  Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

<!-- Add JIRA link here. Short version (e.g. MTT-123) also works and gets auto-linked. -->

<!-- Add RFC link here if applicable. -->

<!-- Original PR link if this is a backport PR -->

<!-- When backporting is required please add the type:backport-release-<version> label to this PR. This should include all versions in which this should be backported to. -->

### PR Checklist
- [x] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [x] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR or a link to the documenation repo PR if this is a manual update. 

## Changelog

### com.unity.netcode.gameobjects
- Fixed: Fixed a bug where when constructing a NetworkTime from a tick the resulting instance sometimes had a different tick value due to floating point math imprecision.

## Testing and Documentation

* Includes unit tests for NetworkTime and NetworkTickSystem.
* No documentation changes or additions were necessary.