### PR TITLE
chore: Increment package versions for NGO 1.0.0-pre.4 and update changelogs

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this package will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]

--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -5,19 +5,28 @@ All notable changes to this package will be documented in this file. The format 
 
 ### Added
 
-- Added new 'Max Send Queue Size' configuration field in the inspector. This controls the size of the send queue that is used to accumulate small sends together and also acts as an overflow queue when there are too many in-flight packets or when other internal queues are full.
-
 ### Changed
-
-- Removed 'Maximum Packet Size' configuration field in the inspector. This would cause confusion since the maximum packet size is in effect always the MTU (1400 bytes on most platforms).
-- Updated com.unity.transport to 1.0.0-pre.10
-- All delivery methods now support fragmentation, meaning the 'Send Queue Batch Size' setting (which controls the maximum payload size) now applies to all delivery methods, not just reliable ones.
 
 ### Fixed
 
-- Fixed packet overflow errors when sending payloads too close to the MTU (was mostly visible when using Relay).
-- Don't throw an exception when the host disconnects (issue 1439 on GitHub).
-- Avoid "too many inflight packets" errors by queueing packets in a queue when the limit of inflight packets is reached in UTP. The size of this queue can be controlled with the 'Max Send Queue Size' configuration field.
+## [1.0.0-pre.4] - 2022-01-04
+
+### Added
+
+- Added new 'Max Send Queue Size' configuration field in the inspector. This controls the size of the send queue that is used to accumulate small sends together and also acts as an overflow queue when there are too many in-flight packets or when other internal queues are full. (#1491)
+
+### Changed
+
+- Updated Netcode for GameObjects dependency to 1.0.0-pre.4 (#1562)
+- Removed 'Maximum Packet Size' configuration field in the inspector. This would cause confusion since the maximum packet size is in effect always the MTU (1400 bytes on most platforms). (#1403)
+- Updated com.unity.transport to 1.0.0-pre.10 (#1501)
+- All delivery methods now support fragmentation, meaning the 'Send Queue Batch Size' setting (which controls the maximum payload size) now applies to all delivery methods, not just reliable ones. (#1512)
+
+### Fixed
+
+- Fixed packet overflow errors when sending payloads too close to the MTU (was mostly visible when using Relay). (#1403)
+- Don't throw an exception when the host disconnects (issue 1439 on GitHub). (#1441)
+- Avoid "too many inflight packets" errors by queueing packets in a queue when the limit of inflight packets is reached in UTP. The size of this queue can be controlled with the 'Max Send Queue Size' configuration field. (#1491)
 
 ## [1.0.0-pre.3] - 2021-10-22
 
@@ -35,13 +44,13 @@ All notable changes to this package will be documented in this file. The format 
 - Fixed sends failing when send queue is filled or close to be filled. (#1317)
 - Heartbeats API not working for Unity Transport when running in the editor or development builds. (#1314)
 
-## [1.0.0-pre.2] - 2020-12-20
+## [1.0.0-pre.2] - 2021-10-19
 
 ### Changed
 
 - Updated Netcode for GameObjects dependency to 1.0.0-pre.2
 
-## [1.0.0-pre.1] - 2020-12-20
+## [1.0.0-pre.1] - 2021-10-19
 
 ### Added
 

--- a/com.unity.netcode.adapter.utp/package.json
+++ b/com.unity.netcode.adapter.utp/package.json
@@ -2,11 +2,11 @@
   "name": "com.unity.netcode.adapter.utp",
   "displayName": "Unity Transport for Netcode for GameObjects",
   "description": "This package is plugging Unity Transport into Netcode for GameObjects, which is a network transport layer - the low-level interface for sending UDP data",
-  "version": "1.0.0-pre.3",
+  "version": "1.0.0-pre.4",
   "unity": "2020.3",
   "dependencies": {
     "com.unity.burst": "1.6.2",
-    "com.unity.netcode.gameobjects": "1.0.0-pre.3",
+    "com.unity.netcode.gameobjects": "1.0.0-pre.4",
     "com.unity.transport": "1.0.0-pre.10"
   }
 }

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,38 +12,49 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 - Added `PreviousValue` in `NetworkListEvent`, when `Value` has changed (#1528)
 
-### Removed
-
-- Removed `FixedQueue` (#1398)
-- Removed `StreamExtensions` (#1398)
-- Removed `TypeExtensions` (#1398)
-
 ### Fixed
 
-- Fixed in-scene NetworkObjects that are moved into the DDOL scene not getting restored to their original active state (enabled/disabled) after a full scene transition (#1354)
-- Fixed invalid IL code being generated when using `this` instead of `this ref` for the FastBufferReader/FastBufferWriter parameter of an extension method. (#1393)
-- Fixed an issue where if you are running as a server (not host) the LoadEventCompleted and UnloadEventCompleted events would fire early by the NetworkSceneManager (#1379)
-- Fixed a runtime error when sending an array of an INetworkSerializable type that's implemented as a struct (#1402)
-- Fixed NetworkConfig to no longer throw an OverflowException in GetConfig() when ForceSamePrefabs is enabled and the number of prefabs causes the config blob size to exceed 1300 bytes. (#1385)
-- Fixed NetworkVariable not calling NetworkSerialize on INetworkSerializable types (#1383)
-- Fixed NullReferenceException on ImportReferences call in NetworkBehaviourILPP (#1434)
-- Fixed NetworkObjects not being despawned before they are destroyed during shutdown for client, host, and server instances. (#1390)
 - Fixed client player object being destroyed on server when the client's player object has DontDestroyWithOwner set. (#1433)
 - Fixed FastBufferReader being created with a length of 1 if provided an input of length 0. (#1480)
 - Fixed an exception being thrown during NetworkVariableDeltaMessage serialization when EnsureNetworkVariableLengthSafety is enabled (#1487)
 - Fixed NetworkVariables containing more than 1300 bytes of data (such as large NetworkLists) no longer cause an OverflowException (the limit on data size is now whatever limit the chosen transport imposes on fragmented NetworkDelivery mechanisms) (#1481)
 - Fixed error when serializing ConnectionApprovalMessage with scene management disabled when one or more objects is hidden via the CheckObjectVisibility delegate (#1509)
-- Fixed KeyNotFoundException when removing ownership of a newly spawned NetworkObject that is already owned by the server. (#1500)
 - Fixed The NetworkConfig's checksum hash includes the NetworkTick so that clients with a different tickrate than the server are identified and not allowed to connect. (#1513)
-- Fixed NetworkManager.LocalClient not being set when starting as a host. (#1511)
 
 ### Changed
 
 - ServerRpcParams and ClientRpcParams must be the last parameter of an RPC in order to function properly. Added a compile-time check to ensure this is the case and trigger an error if they're placed elsewhere. (#1318)
-- The SDK no longer limits message size to 64k. (The transport may still impose its own limits, but the SDK no longer does.) (#1384)
-- Updated com.unity.collections to 1.1.0
 - NetworkManager's GameObject is no longer allowed to be nested under one or more GameObject(s).(#1484)
 - NetworkManager DontDestroy property was removed and now NetworkManager always is migrated into the DontDestroyOnLoad scene. (#1484)
+
+## [1.0.0-pre.4] - 2021-01-04
+
+### Added
+
+### Removed
+
+- Removed FixedQueue (#1398)
+- Removed StreamExtensions (#1398)
+- Removed TypeExtensions (#1398)
+
+### Fixed
+
+- Fixed in-scene NetworkObjects that are moved into the DDOL scene not getting restored to their original active state (enabled/disabled) after a full scene transition (#1354)
+- Fixed invalid IL code being generated when using this instead of this ref for the FastBufferReader/FastBufferWriter parameter of an extension method. (#1393)
+- Fixed an issue where if you are running as a server (not host) the LoadEventCompleted and UnloadEventCompleted events would fire early by the NetworkSceneManager (#1379)
+- Fixed a runtime error when sending an array of an INetworkSerializable type that's implemented as a struct (#1402)
+- NetworkConfig will no longer throw an OverflowException in GetConfig() when ForceSamePrefabs is enabled and the number of prefabs causes the config blob size to exceed 1300 bytes. (#1385)
+- Fixed NetworkVariable not calling NetworkSerialize on INetworkSerializable types (#1383)
+- Fixed NullReferenceException on ImportReferences call in NetworkBehaviourILPP (#1434)
+- Fixed NetworkObjects not being despawned before they are destroyed during shutdown for client, host, and server instances. (#1390)
+- Fixed KeyNotFound exception when removing ownership of a newly spawned NetworkObject that is already owned by the server. (#1500)
+- Fixed NetworkManager.LocalClient not being set when starting as a host. (#1511)
+- Fixed a few memory leak cases when shutting down NetworkManager during Incoming Message Queue processing. (#1323)
+
+### Changed
+
+- The SDK no longer limits message size to 64k. (The transport may still impose its own limits, but the SDK no longer does.) (#1384)
+- Updated com.unity.collections to 1.1.0 (#1451)
 
 ## [1.0.0-pre.3] - 2021-10-22
 

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -2,7 +2,7 @@
     "name": "com.unity.netcode.gameobjects",
     "displayName": "Netcode for GameObjects",
     "description": "Netcode for GameObjects is a high-level netcode SDK that provides networking capabilities to GameObject/MonoBehaviour workflows within Unity and sits on top of underlying transport layer.",
-    "version": "1.0.0-pre.3",
+    "version": "1.0.0-pre.4",
     "unity": "2020.3",
     "dependencies": {
         "com.unity.modules.ai": "1.0.0",


### PR DESCRIPTION
<!-- Replace this line with what this PR does and why.  Describe what you'd like reviewers to know, how you applied the Engineering principles, and any interesting tradeoffs made.  Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

<!-- Add JIRA link here. Short version (e.g. MTT-123) also works and gets auto-linked. -->

<!-- Add RFC link here if applicable. -->

<!-- Original PR link if this is a backport PR -->

<!-- When backporting is required please add the type:backport-release-<version> label to this PR. This should include all versions in which this should be backported to. -->

### PR Checklist
- [x] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR or a link to the documenation repo PR if this is a manual update. 

## Changelog

### com.unity.netcode.gameobjects
- Changed: Updated Netcode for GameObjects dependency to 1.0.0-pre.4

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
