### PR TITLE
chore: Increment package versions for NGO 1.0.0-pre.4 and update changelogs

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -5,21 +5,28 @@ All notable changes to this package will be documented in this file. The format 
 
 ### Added
 
-- Added new 'Max Send Queue Size' configuration field in the inspector. This controls the size of the send queue that is used to accumulate small sends together and also acts as an overflow queue when there are too many in-flight packets or when other internal queues are full.
-
 ### Changed
-
-- Removed 'Maximum Packet Size' configuration field in the inspector. This would cause confusion since the maximum packet size is in effect always the MTU (1400 bytes on most platforms).
-- Updated com.unity.transport to 1.0.0-pre.10.
-- The 'Send Queue Batch Size' configuration field now controls the size of the send queue, rather than the size of a single batch of messages. Consequently, it should be set much higher than it was previously.
-- All delivery methods now support fragmentation, meaning the 'Send Queue Batch Size' setting (which controls the maximum payload size) now applies to all delivery methods, not just reliable ones.
-
 
 ### Fixed
 
-- Fixed packet overflow errors when sending payloads too close to the MTU (was mostly visible when using Relay).
-- Don't throw an exception when the host disconnects (issue 1439 on GitHub).
-- Avoid "too many inflight packets" errors by queueing packets in a queue when the limit of inflight packets is reached in UTP. The size of this queue can be controlled with the 'Max Send Queue Size' configuration field.
+## [1.0.0-pre.4] - 2022-01-04
+
+### Added
+
+- Added new 'Max Send Queue Size' configuration field in the inspector. This controls the size of the send queue that is used to accumulate small sends together and also acts as an overflow queue when there are too many in-flight packets or when other internal queues are full. (#1491)
+
+### Changed
+
+- Updated Netcode for GameObjects dependency to 1.0.0-pre.4 (#1562)
+- Removed 'Maximum Packet Size' configuration field in the inspector. This would cause confusion since the maximum packet size is in effect always the MTU (1400 bytes on most platforms). (#1403)
+- Updated com.unity.transport to 1.0.0-pre.10 (#1501)
+- All delivery methods now support fragmentation, meaning the 'Send Queue Batch Size' setting (which controls the maximum payload size) now applies to all delivery methods, not just reliable ones. (#1512)
+
+### Fixed
+
+- Fixed packet overflow errors when sending payloads too close to the MTU (was mostly visible when using Relay). (#1403)
+- Don't throw an exception when the host disconnects (issue 1439 on GitHub). (#1441)
+- Avoid "too many inflight packets" errors by queueing packets in a queue when the limit of inflight packets is reached in UTP. The size of this queue can be controlled with the 'Max Send Queue Size' configuration field. (#1491)
 
 ## [1.0.0-pre.3] - 2021-10-22
 
@@ -37,13 +44,13 @@ All notable changes to this package will be documented in this file. The format 
 - Fixed sends failing when send queue is filled or close to be filled. (#1317)
 - Heartbeats API not working for Unity Transport when running in the editor or development builds. (#1314)
 
-## [1.0.0-pre.2] - 2020-12-20
+## [1.0.0-pre.2] - 2021-10-19
 
 ### Changed
 
 - Updated Netcode for GameObjects dependency to 1.0.0-pre.2
 
-## [1.0.0-pre.1] - 2020-12-20
+## [1.0.0-pre.1] - 2021-10-19
 
 ### Added
 

--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -1,13 +1,6 @@
 # Changelog
+
 All notable changes to this package will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-
-## [Unreleased]
-
-### Added
-
-### Changed
-
-### Fixed
 
 ## [1.0.0-pre.4] - 2022-01-04
 

--- a/com.unity.netcode.adapter.utp/package.json
+++ b/com.unity.netcode.adapter.utp/package.json
@@ -2,10 +2,10 @@
   "name": "com.unity.netcode.adapter.utp",
   "displayName": "Unity Transport for Netcode for GameObjects",
   "description": "This package is plugging Unity Transport into Netcode for GameObjects, which is a network transport layer - the low-level interface for sending UDP data",
-  "version": "1.0.0-pre.3",
+  "version": "1.0.0-pre.4",
   "unity": "2020.3",
   "dependencies": {
-    "com.unity.netcode.gameobjects": "1.0.0-pre.3",
+    "com.unity.netcode.gameobjects": "1.0.0-pre.4",
     "com.unity.transport": "1.0.0-pre.10"
   }
 }

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,14 +10,20 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
-### Removed
-
-- Removed `FixedQueue` (#1398)
-- Removed `StreamExtensions` (#1398)
-- Removed `TypeExtensions` (#1398)
-
 ### Fixed
 
+### Changed
+
+## [1.0.0-pre.4] - 2021-01-04
+
+### Added
+
+### Removed
+- Removed FixedQueue (#1398)
+- Removed StreamExtensions (#1398)
+- Removed TypeExtensions (#1398)
+
+### Fixed
 - Fixed in-scene NetworkObjects that are moved into the DDOL scene not getting restored to their original active state (enabled/disabled) after a full scene transition (#1354)
 - Fixed invalid IL code being generated when using `this` instead of `this ref` for the FastBufferReader/FastBufferWriter parameter of an extension method. (#1393)
 - Fixed an issue where if you are running as a server (not host) the LoadEventCompleted and UnloadEventCompleted events would fire early by the NetworkSceneManager (#1379)
@@ -28,12 +34,11 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed NetworkObjects not being despawned before they are destroyed during shutdown for client, host, and server instances. (#1390)
 - Fixed KeyNotFound exception when removing ownership of a newly spawned NetworkObject that is already owned by the server. (#1500)
 - Fixed NetworkManager.LocalClient not being set when starting as a host. (#1511)
+- Fixed a few memory leak cases when shutting down NetworkManager during Incoming Message Queue processing. (#1323)
 
 ### Changed
-
 - The SDK no longer limits message size to 64k. (The transport may still impose its own limits, but the SDK no longer does.) (#1384)
 - Updated com.unity.collections to 1.1.0 (#1451)
-
 
 ## [1.0.0-pre.3] - 2021-10-22
 

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -2,7 +2,7 @@
     "name": "com.unity.netcode.gameobjects",
     "displayName": "Netcode for GameObjects",
     "description": "Netcode for GameObjects is a high-level netcode SDK that provides networking capabilities to GameObject/MonoBehaviour workflows within Unity and sits on top of underlying transport layer.",
-    "version": "1.0.0-pre.3",
+    "version": "1.0.0-pre.4",
     "unity": "2020.3",
     "dependencies": {
         "com.unity.modules.ai": "1.0.0",


### PR DESCRIPTION
This is a backport of https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/1562

## Changelog

### com.unity.netcode.gameobjects
- Changed: Updated Netcode for GameObjects dependency to 1.0.0-pre.4
