### PR TITLE
chore: update sdk package dependencies

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,14 +10,13 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
-- Added `com.unity.modules.physics` and `com.unity.modules.physics2d` dependencies (#1565)
+- Added `com.unity.modules.physics` and `com.unity.modules.physics2d` package dependencies (#1565)
 - Added `PreviousValue` in `NetworkListEvent`, when `Value` has changed (#1528)
 
 ### Removed
 
-- Removed `FixedQueue` (#1398)
-- Removed `StreamExtensions` (#1398)
-- Removed `TypeExtensions` (#1398)
+- Removed `com.unity.modules.ai` package dependency
+- Removed `FixedQueue`, `StreamExtensions`, `TypeExtensions` (#1398)
 
 ### Fixed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -9,6 +9,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ## [Unreleased]
 
 ### Added
+
+- Added `com.unity.modules.physics` and `com.unity.modules.physics2d` dependencies (#1565)
 - Adding `PreviousValue` in NetworkListEvent, when `Value` has changed
 
 ### Removed

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -7,6 +7,8 @@
     "dependencies": {
         "com.unity.modules.ai": "1.0.0",
         "com.unity.modules.animation": "1.0.0",
+        "com.unity.modules.physics": "1.0.0",
+        "com.unity.modules.physics2d": "1.0.0",
         "com.unity.nuget.mono-cecil": "1.10.1",
         "com.unity.collections": "1.1.0",
         "com.unity.test-framework.performance": "2.8.0-preview"

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -5,7 +5,6 @@
     "version": "1.0.0-pre.3",
     "unity": "2020.3",
     "dependencies": {
-        "com.unity.modules.ai": "1.0.0",
         "com.unity.modules.animation": "1.0.0",
         "com.unity.modules.physics": "1.0.0",
         "com.unity.modules.physics2d": "1.0.0",


### PR DESCRIPTION
A user discovered (#1558) that we don't depend on physics and physics2d packages from the SDK package atm.
We have `NetworkRigidbody` and `NetworkRigidbody2D` components in the SDK which have deps to those packages.
Even though we might move high-level components into a separate package later, currently we should add those deps to make them explicit and clear to avoid confusion.

JIRA: MTT-2033

<!-- Add JIRA link here. Short version (e.g. MTT-123) also works and gets auto-linked. -->

<!-- Add RFC link here if applicable. -->

<!-- Original PR link if this is a backport PR -->

<!-- When backporting is required please add the type:backport-release-<version> label to this PR. This should include all versions in which this should be backported to. -->

### PR Checklist
- [x] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] ~Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR or a link to the documenation repo PR if this is a manual update.~

## Changelog

### com.unity.netcode.gameobjects

- Added physics & physics2d dependencies

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
