### PR TITLE
fix: interest manager must not be internal, add disable mode

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,6 +10,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 - Adding `PreviousValue` in NetworkListEvent, when `Value` has changed
+- InterestManager now has a `Disable` setting to allow the user to bypass its function for debugging 
 
 ### Removed
 
@@ -35,6 +36,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed KeyNotFoundException when removing ownership of a newly spawned NetworkObject that is already owned by the server. (#1500)
 - Fixed The NetworkConfig's checksum hash includes the NetworkTick so that clients with a different tickrate than the server are identified and not allowed to connect. (#1513)
 - Fixed NetworkManager.LocalClient not being set when starting as a host. (#1511)
+- Fixed InterestManager was declared internal / inaccessible outside tests
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
@@ -32,7 +32,6 @@ namespace Unity.Netcode
                         m_InterestUpdateThisFrame.Clear();
                         networkManager.InterestManager.QueryFor(ref client.PlayerObject, ref m_InterestUpdateThisFrame);
                         foreach (var sobj in m_InterestUpdateThisFrame)
-
                         {
                             if (sobj.IsNetworkVisibleTo(client.ClientId))
                             {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -58,7 +58,7 @@ namespace Unity.Netcode
 
         // For unit (vs. integration) testing and for better decoupling, we don't want to have to require Initialize()
         //  to use the InterestManager
-        internal InterestManager<NetworkObject> InterestManager
+        public InterestManager<NetworkObject> InterestManager
         {
             get
             {

--- a/com.unity.netcode.gameobjects/Runtime/Interest/InterestManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Interest/InterestManager.cs
@@ -3,9 +3,18 @@ using System.Collections.Generic;
 namespace Unity.Netcode.Interest
 {
     // interest *system* instead of interest node ?
-    internal class InterestManager<TObject>
+    public class InterestManager<TObject>
     {
         private InterestNodeStatic<TObject> m_DefaultInterestNode = new InterestNodeStatic<TObject>();
+
+        public bool Disable;
+
+        public InterestManager()
+        {
+            // This is the node objects will be added to if no replication group is
+            //  specified, which means they always get replicated
+            m_ChildNodes = new HashSet<IInterestNode<TObject>> { m_DefaultInterestNode };
+        }
 
         // Trigger the Interest system to do an update sweep on any Interest nodes
         //  I am associated with
@@ -18,13 +27,6 @@ namespace Unity.Netcode.Interest
                     node.UpdateObject(obj);
                 }
             }
-        }
-
-        public InterestManager()
-        {
-            // This is the node objects will be added to if no replication group is
-            //  specified, which means they always get replicated
-            m_ChildNodes = new HashSet<IInterestNode<TObject>> { m_DefaultInterestNode };
         }
 
         public void AddObject(ref TObject obj)
@@ -77,9 +79,16 @@ namespace Unity.Netcode.Interest
 
         public void QueryFor(ref TObject client, ref HashSet<TObject> results)
         {
-            foreach (var c in m_ChildNodes)
+            if (!Disable)
             {
-                c.QueryFor(client, results);
+                foreach (var c in m_ChildNodes)
+                {
+                    c.QueryFor(client, results);
+                }
+            }
+            else
+            {
+                results.UnionWith(m_InterestNodesMap.Keys);
             }
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Interest/RadiusInterestKernel.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Interest/RadiusInterestKernel.cs
@@ -7,6 +7,11 @@ namespace Unity.Netcode
     {
         public float Radius = 0.0f;
 
+        public RadiusInterestKernel(float radius)
+        {
+            Radius = radius;
+        }
+
         public bool QueryFor(NetworkObject clientNetworkObject, NetworkObject obj)
         {
             return Vector3.Distance(obj.transform.position, clientNetworkObject.gameObject.transform.position) <= Radius;

--- a/com.unity.netcode.gameobjects/Runtime/Interest/RadiusInterestKernel.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Interest/RadiusInterestKernel.cs
@@ -7,6 +7,10 @@ namespace Unity.Netcode
     {
         public float Radius = 0.0f;
 
+        public RadiusInterestKernel()
+        {
+        }
+
         public RadiusInterestKernel(float radius)
         {
             Radius = radius;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/InterestTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/InterestTests.cs
@@ -606,7 +606,7 @@ namespace Unity.Netcode.RuntimeTests
             results.Clear();
             m_InterestManager.QueryFor(ref m_PlayerNetworkObject, ref results);
             var hits = results.Count;
-//??            Assert.True(hits == (2 + objectsBeforeAdd));
+            Assert.True(hits == (2 + objectsBeforeAdd));
             Assert.True(results.Contains(object1));
             Assert.False(results.Contains(object2));
             Assert.True(results.Contains(nc.PlayerObject));
@@ -616,7 +616,7 @@ namespace Unity.Netcode.RuntimeTests
             results.Clear();
             m_InterestManager.QueryFor(ref m_PlayerNetworkObject, ref results);
             hits = results.Count;
-//??            Assert.True(hits == (3 + objectsBeforeAdd));
+            Assert.True(hits == (3 + objectsBeforeAdd));
             Assert.True(results.Contains(object1));
             Assert.True(results.Contains(object2));
             Assert.True(results.Contains(nc.PlayerObject));


### PR DESCRIPTION
The InterestManager mistakenly was declared 'internal' which prevented anyone outside the SDK (and tests...) from adding nodes, etc.

Also, while I was in here I added a convenience to allow users to disable the interest manager for debugging purposes per ideation with @SamuelBellomo 

MTT-2041

### PR Checklist
- No backport needed, this was not avail in 1.0.  This will go into 1.1.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- InterestManager documentation hasn't been written yet

## Testing and Documentation
* Includes new integration test.