### PR TITLE
fix: Add metrics pipeline stage to unreliable pipeline

### DIFF
--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -772,7 +772,11 @@ namespace Unity.Netcode
                 unreliableFragmentedPipeline = driver.CreatePipeline(
                     typeof(FragmentationPipelineStage),
                     typeof(SimulatorPipelineStage),
-                    typeof(SimulatorPipelineStageInSend));
+                    typeof(SimulatorPipelineStageInSend)
+#if MULTIPLAYER_TOOLS
+                    ,typeof(NetworkMetricsPipelineStage)
+#endif
+                    );
                 unreliableSequencedFragmentedPipeline = driver.CreatePipeline(
                     typeof(FragmentationPipelineStage),
                     typeof(UnreliableSequencedPipelineStage),


### PR DESCRIPTION
PR #1512 added a new pipeline for unreliable traffic in the UTP adapter and I forgot to add `NetworkMetricsPipelineStage` to this new pipeline in development builds. Oops.

No JIRA item since this is just a minor fix of a previous change and there's no functional impact (the metrics pipeline stage doesn't do anything at the moment).

## Changelog

### com.unity.netcode.adapter.utp

N/A

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.