### PR TITLE
fix: Fix OwnedObjects not being added to when using ChangeOwnership

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -21,7 +21,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed NetworkVariables containing more than 1300 bytes of data (such as large NetworkLists) no longer cause an OverflowException (the limit on data size is now whatever limit the chosen transport imposes on fragmented NetworkDelivery mechanisms) (#1481)
 - Fixed error when serializing ConnectionApprovalMessage with scene management disabled when one or more objects is hidden via the CheckObjectVisibility delegate (#1509)
 - Fixed The NetworkConfig's checksum hash includes the NetworkTick so that clients with a different tickrate than the server are identified and not allowed to connect. (#1513)
-- Fixed: OwnedObjects not being properly modified when using ChangeOwnership. (#1572)
+- Fixed OwnedObjects not being properly modified when using ChangeOwnership. (#1572)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -20,6 +20,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed NetworkVariables containing more than 1300 bytes of data (such as large NetworkLists) no longer cause an OverflowException (the limit on data size is now whatever limit the chosen transport imposes on fragmented NetworkDelivery mechanisms) (#1481)
 - Fixed error when serializing ConnectionApprovalMessage with scene management disabled when one or more objects is hidden via the CheckObjectVisibility delegate (#1509)
 - Fixed The NetworkConfig's checksum hash includes the NetworkTick so that clients with a different tickrate than the server are identified and not allowed to connect. (#1513)
+- Fixed: OwnedObjects not being properly modified when using ChangeOwnership. (#1572)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -280,6 +280,10 @@ namespace Unity.Netcode
 
             networkObject.OwnerClientId = clientId;
 
+            if (TryGetNetworkClient(clientId, out NetworkClient newNetworkClient))
+            {
+                newNetworkClient.OwnedObjects.Add(networkObject);
+            }
 
             var message = new ChangeOwnershipMessage
             {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectNetworkClientOwnedObjectsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectNetworkClientOwnedObjectsTests.cs
@@ -1,0 +1,60 @@
+using System.Collections;
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    public class NetworkObjectNetworkClientOwnedObjectsTests
+    {
+        [UnityTest]
+        public IEnumerator ChangeOwnershipOwnedObjectsAddTest()
+        {
+            // create server and client instances
+            MultiInstanceHelpers.Create(1, out NetworkManager server, out NetworkManager[] clients);
+
+            // create prefab
+            var gameObject = new GameObject("ClientOwnedObject");
+            var networkObject = gameObject.AddComponent<NetworkObject>();
+            MultiInstanceHelpers.MakeNetworkObjectTestPrefab(networkObject);
+
+            server.NetworkConfig.NetworkPrefabs.Add(new NetworkPrefab()
+            {
+                Prefab = gameObject
+            });
+
+            for (int i = 0; i < clients.Length; i++)
+            {
+                clients[i].NetworkConfig.NetworkPrefabs.Add(new NetworkPrefab()
+                {
+                    Prefab = gameObject
+                });
+            }
+
+            // start server and connect clients
+            MultiInstanceHelpers.Start(false, server, clients);
+
+            // wait for connection on client side
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(clients));
+
+            // wait for connection on server side
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientConnectedToServer(server));
+
+            NetworkObject serverObject = Object.Instantiate(gameObject).GetComponent<NetworkObject>();
+            serverObject.NetworkManagerOwner = server;
+            serverObject.Spawn();
+
+            // The object is owned by server
+            Assert.False(server.ConnectedClients[clients[0].LocalClientId].OwnedObjects.Any(x => x.NetworkObjectId == serverObject.NetworkObjectId));
+
+            // Change the ownership
+            serverObject.ChangeOwnership(clients[0].LocalClientId);
+
+            // Ensure it's now added to the list
+            Assert.True(server.ConnectedClients[clients[0].LocalClientId].OwnedObjects.Any(x => x.NetworkObjectId == serverObject.NetworkObjectId));
+
+            MultiInstanceHelpers.Destroy();
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectNetworkClientOwnedObjectsTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectNetworkClientOwnedObjectsTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f9f4a54dbedb4473a2d5b3475d960826
+timeCreated: 1641832591


### PR DESCRIPTION
Fixes: #1525

Previously, an object was not added to a clients OwnedObjects list when the ChangeOwnership API was used.
MTT-1975

### PR Checklist
- [ ] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR or a link to the documenation repo PR if this is a manual update. 

## Changelog

### com.unity.netcode.gameobjects
- Fixed OwnedObjects not being properly modified when using ChangeOwnership.

## Testing and Documentation
* Includes unit tests.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
