### PR TITLE
feat: Adding "previousValue" in NetworkListEvent (#1528)

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -9,6 +9,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ## [1.0.0-pre.4] - 2021-01-04
 
 ### Added
+- Adding `PreviousValue` in NetworkListEvent, when `Value` has changed
 
 - Added `com.unity.modules.physics` and `com.unity.modules.physics2d` package dependencies (#1565)
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,10 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
+## [Unreleased]
+
+### Added
+
+- Added `PreviousValue` in NetworkListEvent, when `Value` has changed
+
 ## [1.0.0-pre.4] - 2021-01-04
 
 ### Added
-- Adding `PreviousValue` in NetworkListEvent, when `Value` has changed
 
 - Added `com.unity.modules.physics` and `com.unity.modules.physics2d` package dependencies (#1565)
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,7 +10,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
-- Added `PreviousValue` in NetworkListEvent, when `Value` has changed
+- Added `PreviousValue` in NetworkListEvent, when `Value` has changed (#1528)
 
 ## [1.0.0-pre.4] - 2021-01-04
 

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -272,10 +272,13 @@ namespace Unity.Netcode
                         {
                             reader.ReadValueSafe(out int index);
                             reader.ReadValueSafe(out T value);
-                            if (index < m_List.Length)
+                            if (index >= m_List.Length)
                             {
-                                m_List[index] = value;
+                                throw new Exception("Shouldn't be here, index is higher than list length");
                             }
+
+                            var previousValue = m_List[index];
+                            m_List[index] = value;
 
                             if (OnListChanged != null)
                             {
@@ -283,7 +286,8 @@ namespace Unity.Netcode
                                 {
                                     Type = eventType,
                                     Index = index,
-                                    Value = value
+                                    Value = value,
+                                    PreviousValue = previousValue
                                 });
                             }
 
@@ -293,7 +297,8 @@ namespace Unity.Netcode
                                 {
                                     Type = eventType,
                                     Index = index,
-                                    Value = value
+                                    Value = value,
+                                    PreviousValue = previousValue
                                 });
                             }
                         }
@@ -527,6 +532,11 @@ namespace Unity.Netcode
         /// The value changed, added or removed if available.
         /// </summary>
         public T Value;
+
+        /// <summary>
+        /// The previous value when "Value" has changed, if available.
+        /// </summary>
+        public T PreviousValue;
 
         /// <summary>
         /// the index changed, added or removed if available

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -328,6 +328,58 @@ namespace Unity.Netcode.RuntimeTests
             );
         }
 
+
+        [UnityTest]
+        public IEnumerator NetworkListValueUpdate([Values(true, false)] bool useHost)
+        {
+            m_TestWithHost = useHost;
+            yield return MultiInstanceHelpers.RunAndWaitForCondition(
+                () =>
+                {
+                    m_Player1OnServer.TheList.Add(k_TestVal1);
+                },
+                () =>
+                {
+                    return m_Player1OnServer.TheList.Count == 1 &&
+                           m_Player1OnClient1.TheList.Count == 1 &&
+                           m_Player1OnServer.TheList[0] == k_TestVal1 &&
+                           m_Player1OnClient1.TheList[0] == k_TestVal1;
+                }
+            );
+
+            var testSucceeded = false;
+
+            void TestValueUpdatedCallback(NetworkListEvent<int> changedEvent)
+            {
+                testSucceeded = changedEvent.PreviousValue == k_TestVal1 &&
+                                changedEvent.Value == k_TestVal3;
+            }
+
+            try
+            {
+                yield return MultiInstanceHelpers.RunAndWaitForCondition(
+                    () =>
+                    {
+                        m_Player1OnServer.TheList[0] = k_TestVal3;
+                        m_Player1OnClient1.TheList.OnListChanged += TestValueUpdatedCallback;
+                    },
+                    () =>
+                    {
+                        return m_Player1OnServer.TheList.Count == 1 &&
+                               m_Player1OnClient1.TheList.Count == 1 &&
+                               m_Player1OnServer.TheList[0] == k_TestVal3 &&
+                               m_Player1OnClient1.TheList[0] == k_TestVal3;
+                    }
+                );
+            }
+            finally
+            {
+                m_Player1OnClient1.TheList.OnListChanged -= TestValueUpdatedCallback;
+            }
+
+            Assert.That(testSucceeded);
+        }
+
         [Test]
         public void NetworkListIEnumerator([Values(true, false)] bool useHost)
         {


### PR DESCRIPTION
Backport of #1528 to release
(cherry picked from commit 27423461792fa75b6d2f1c6ea968e3a86070a927)

<!-- Replace this line with what this PR does and why.  Describe what you'd like reviewers to know, how you applied the Engineering principles, and any interesting tradeoffs made.  Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

<!-- Add JIRA link here. Short version (e.g. MTT-123) also works and gets auto-linked. -->

<!-- Add RFC link here if applicable. -->

<!-- Original PR link if this is a backport PR -->

<!-- When backporting is required please add the type:backport-release-<version> label to this PR. This should include all versions in which this should be backported to. -->

### PR Checklist
- [x] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [x] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR or a link to the documenation repo PR if this is a manual update. 

