### PR TITLE
fix: snapshot spawn with proper NetworkVariable Values 

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -765,11 +765,17 @@ namespace Unity.Netcode
             }
         }
 
-        internal void InvokeBehaviourNetworkSpawn()
+        internal void InvokeBehaviourPreNetworkSpawn()
         {
             for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
             {
                 ChildNetworkBehaviours[i].InternalOnNetworkSpawn();
+            }
+        }
+        internal void InvokeBehaviourPostNetworkSpawn()
+        {
+            for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
+            {
                 ChildNetworkBehaviours[i].OnNetworkSpawn();
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
@@ -286,7 +286,7 @@ namespace Unity.Netcode
                     spawnCommand.ObjectRotation);
             }
 
-            m_NetworkManager.SpawnManager.SpawnNetworkObjectLocallyCommon(networkObject, spawnCommand.NetworkObjectId,
+            m_NetworkManager.SpawnManager.PreSpawnNetworkObjectLocallyCommon(networkObject, spawnCommand.NetworkObjectId,
                 true, spawnCommand.IsPlayerObject, spawnCommand.OwnerClientId, false);
 
             //todo: discuss with tools how to report shared bytes
@@ -298,7 +298,7 @@ namespace Unity.Netcode
             if (m_NetworkManager.SpawnManager.SpawnedObjects.TryGetValue(spawnCommand.NetworkObjectId,
                 out NetworkObject networkObject))
             {
-                m_NetworkManager.SpawnManager.SpawnNetworkObjectLocallyCommon2(networkObject, spawnCommand.NetworkObjectId,
+                m_NetworkManager.SpawnManager.PostSpawnNetworkObjectLocallyCommon(networkObject, spawnCommand.NetworkObjectId,
                     true, spawnCommand.IsPlayerObject, spawnCommand.OwnerClientId, false);
             }
             else

--- a/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
@@ -701,7 +701,7 @@ namespace Unity.Netcode
             }
             else
             {
-                Debug.Log("Error reading header");
+                Debug.LogError("Error reading header");
                 return;
             }
 
@@ -857,13 +857,6 @@ namespace Unity.Netcode
                 behaviour = networkObject.GetNetworkBehaviourAtOrderIndex(updateCommand.BehaviourIndex);
 
                 Debug.Assert(networkObject != null);
-
-                if (updateCommand.VariableIndex >= behaviour.NetworkVariableFields.Count)
-                {
-                    Debug.Log(updateCommand.VariableIndex);
-                    Debug.Log(behaviour.NetworkVariableFields.Count);
-                    //todo: fix this, next line with throw an exception
-                }
 
                 variable = behaviour.NetworkVariableFields[updateCommand.VariableIndex];
             }

--- a/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
@@ -538,11 +538,11 @@ namespace Unity.Netcode
                 // When we spawn an object we need to include its initial value.
                 // This scans the NetworkVariable of the spawn object and store its NetworkVariables
 
-                UpdateCommand updateCommand = new UpdateCommand();
-                for(ushort childIndex = 0; childIndex < networkObject.ChildNetworkBehaviours.Count; childIndex++)
+                var updateCommand = new UpdateCommand();
+                for (ushort childIndex = 0; childIndex < networkObject.ChildNetworkBehaviours.Count; childIndex++)
                 {
                     var behaviour = networkObject.ChildNetworkBehaviours[childIndex];
-                    for(var variableIndex = 0; variableIndex < behaviour.NetworkVariableFields.Count; variableIndex++)
+                    for (var variableIndex = 0; variableIndex < behaviour.NetworkVariableFields.Count; variableIndex++)
                     {
                         updateCommand.NetworkObjectId = command.NetworkObjectId;
                         updateCommand.BehaviourIndex = childIndex;

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -427,6 +427,7 @@ namespace Unity.Netcode
             }
 
             SpawnNetworkObjectLocallyCommon(networkObject, networkId, sceneObject, playerObject, ownerClientId, destroyWithScene);
+            SpawnNetworkObjectLocallyCommon2(networkObject, networkId, sceneObject, playerObject, ownerClientId, destroyWithScene);
         }
 
         // Ran on both server and client
@@ -449,9 +450,10 @@ namespace Unity.Netcode
             }
 
             SpawnNetworkObjectLocallyCommon(networkObject, sceneObject.Header.NetworkObjectId, sceneObject.Header.IsSceneObject, sceneObject.Header.IsPlayerObject, sceneObject.Header.OwnerClientId, destroyWithScene);
+            SpawnNetworkObjectLocallyCommon2(networkObject, sceneObject.Header.NetworkObjectId, sceneObject.Header.IsSceneObject, sceneObject.Header.IsPlayerObject, sceneObject.Header.OwnerClientId, destroyWithScene);
         }
 
-        private void SpawnNetworkObjectLocallyCommon(NetworkObject networkObject, ulong networkId, bool sceneObject, bool playerObject, ulong? ownerClientId, bool destroyWithScene)
+        internal void SpawnNetworkObjectLocallyCommon(NetworkObject networkObject, ulong networkId, bool sceneObject, bool playerObject, ulong? ownerClientId, bool destroyWithScene)
         {
             if (SpawnedObjects.ContainsKey(networkId))
             {
@@ -512,7 +514,10 @@ namespace Unity.Netcode
             networkObject.SetCachedParent(networkObject.transform.parent);
             networkObject.ApplyNetworkParenting();
             NetworkObject.CheckOrphanChildren();
+        }
 
+        internal void SpawnNetworkObjectLocallyCommon2(NetworkObject networkObject, ulong networkId, bool sceneObject, bool playerObject, ulong? ownerClientId, bool destroyWithScene)
+        {
             networkObject.InvokeBehaviourNetworkSpawn();
 
             NetworkManager.InterestManager.AddObject(ref networkObject);

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -426,8 +426,8 @@ namespace Unity.Netcode
                 throw new SpawnStateException("Object is already spawned");
             }
 
-            SpawnNetworkObjectLocallyCommon(networkObject, networkId, sceneObject, playerObject, ownerClientId, destroyWithScene);
-            SpawnNetworkObjectLocallyCommon2(networkObject, networkId, sceneObject, playerObject, ownerClientId, destroyWithScene);
+            PreSpawnNetworkObjectLocallyCommon(networkObject, networkId, sceneObject, playerObject, ownerClientId, destroyWithScene);
+            PostSpawnNetworkObjectLocallyCommon(networkObject, networkId, sceneObject, playerObject, ownerClientId, destroyWithScene);
         }
 
         // Ran on both server and client
@@ -449,11 +449,11 @@ namespace Unity.Netcode
                 networkObject.SetNetworkVariableData(variableData);
             }
 
-            SpawnNetworkObjectLocallyCommon(networkObject, sceneObject.Header.NetworkObjectId, sceneObject.Header.IsSceneObject, sceneObject.Header.IsPlayerObject, sceneObject.Header.OwnerClientId, destroyWithScene);
-            SpawnNetworkObjectLocallyCommon2(networkObject, sceneObject.Header.NetworkObjectId, sceneObject.Header.IsSceneObject, sceneObject.Header.IsPlayerObject, sceneObject.Header.OwnerClientId, destroyWithScene);
+            PreSpawnNetworkObjectLocallyCommon(networkObject, sceneObject.Header.NetworkObjectId, sceneObject.Header.IsSceneObject, sceneObject.Header.IsPlayerObject, sceneObject.Header.OwnerClientId, destroyWithScene);
+            PostSpawnNetworkObjectLocallyCommon(networkObject, sceneObject.Header.NetworkObjectId, sceneObject.Header.IsSceneObject, sceneObject.Header.IsPlayerObject, sceneObject.Header.OwnerClientId, destroyWithScene);
         }
 
-        internal void SpawnNetworkObjectLocallyCommon(NetworkObject networkObject, ulong networkId, bool sceneObject, bool playerObject, ulong? ownerClientId, bool destroyWithScene)
+        internal void PreSpawnNetworkObjectLocallyCommon(NetworkObject networkObject, ulong networkId, bool sceneObject, bool playerObject, ulong? ownerClientId, bool destroyWithScene)
         {
             if (SpawnedObjects.ContainsKey(networkId))
             {
@@ -517,7 +517,7 @@ namespace Unity.Netcode
             networkObject.InvokeBehaviourPreNetworkSpawn();
         }
 
-        internal void SpawnNetworkObjectLocallyCommon2(NetworkObject networkObject, ulong networkId, bool sceneObject, bool playerObject, ulong? ownerClientId, bool destroyWithScene)
+        internal void PostSpawnNetworkObjectLocallyCommon(NetworkObject networkObject, ulong networkId, bool sceneObject, bool playerObject, ulong? ownerClientId, bool destroyWithScene)
         {
             networkObject.InvokeBehaviourPostNetworkSpawn();
 

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -514,11 +514,12 @@ namespace Unity.Netcode
             networkObject.SetCachedParent(networkObject.transform.parent);
             networkObject.ApplyNetworkParenting();
             NetworkObject.CheckOrphanChildren();
+            networkObject.InvokeBehaviourPreNetworkSpawn();
         }
 
         internal void SpawnNetworkObjectLocallyCommon2(NetworkObject networkObject, ulong networkId, bool sceneObject, bool playerObject, ulong? ownerClientId, bool destroyWithScene)
         {
-            networkObject.InvokeBehaviourNetworkSpawn();
+            networkObject.InvokeBehaviourPostNetworkSpawn();
 
             NetworkManager.InterestManager.AddObject(ref networkObject);
 

--- a/com.unity.netcode.gameobjects/Tests/Editor/SnapshotTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/SnapshotTests.cs
@@ -54,9 +54,14 @@ namespace Unity.Netcode.EditorTests
             AdvanceOneTickRecvSide();
         }
 
-        internal void SpawnObject(SnapshotSpawnCommand command, ulong srcClientId)
+        internal void PreSpawnObject(SnapshotSpawnCommand command, ulong srcClientId)
         {
             m_SpawnedObjectCount++;
+        }
+
+        internal void PostSpawnObject(SnapshotSpawnCommand command, ulong srcClientId)
+        {
+
         }
 
         internal void DespawnObject(SnapshotDespawnCommand command, ulong srcClientId)
@@ -116,7 +121,8 @@ namespace Unity.Netcode.EditorTests
             m_SendSnapshot.ConnectedClientsId.Add(0);
             m_SendSnapshot.ConnectedClientsId.Add(1);
             m_SendSnapshot.SendMessage = SendMessage;
-            m_SendSnapshot.SpawnObject = SpawnObject;
+            m_SendSnapshot.PreSpawnObject = PreSpawnObject;
+            m_SendSnapshot.PostSpawnObject = PostSpawnObject;
             m_SendSnapshot.DespawnObject = DespawnObject;
         }
 
@@ -139,7 +145,8 @@ namespace Unity.Netcode.EditorTests
             m_SendSnapshot.ConnectedClientsId.Add(0);
             m_SendSnapshot.ConnectedClientsId.Add(1);
             m_RecvSnapshot.SendMessage = SendMessageRecvSide;
-            m_RecvSnapshot.SpawnObject = SpawnObject;
+            m_RecvSnapshot.PreSpawnObject = PreSpawnObject;
+            m_RecvSnapshot.PostSpawnObject = PostSpawnObject;
             m_RecvSnapshot.DespawnObject = DespawnObject;
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Editor/SnapshotTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/SnapshotTests.cs
@@ -92,6 +92,8 @@ namespace Unity.Netcode.EditorTests
 
         internal int SendMessageRecvSide(SnapshotDataMessage message, ulong clientId)
         {
+            SimulateTransport(ref message);
+
             if (m_PassBackResponses)
             {
                 // todo: pass back to sending Snapshot

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOnSpawnTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOnSpawnTests.cs
@@ -77,7 +77,6 @@ namespace Unity.Netcode.RuntimeTests
         /// </summary>
         /// <returns></returns>
         [UnityTest]
-        [Ignore("Snapshot transition")]
         public IEnumerator TestOnNetworkSpawnCallbacks()
         {
             // [Host-Side] Get the Host owned instance


### PR DESCRIPTION
This PR makes it so that NetworkObject are spawned with their correct NetworkVariable values. Upon spawning, the values are stored in the same snapshot message.

On the receive side, the spawn notification code is split in two parts. One part (pre) is done as the spawns are read from the snapshot. The values are then read from the snapshot. The second part (post) of spawn notification is then done, so the client see the NetworkVariables spawned with proper values. 
