### PR TITLE
fix: Rename 'Send Queue Batch Size' field in adapter

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this package will be documented in this file. The format 
 
 ### Changed
 
+- Rename the 'Send Queue Batch Size' property to 'Max Payload Size' to better reflect its usage.
+
 ### Fixed
 
 ## [1.0.0-pre.4] - 2022-01-04

--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this package will be documented in this file. The format 
 
 ### Changed
 
-- Rename the 'Send Queue Batch Size' property to 'Max Payload Size' to better reflect its usage.
+- Rename the 'Send Queue Batch Size' property to 'Max Payload Size' to better reflect its usage (#1584)
 
 ### Fixed
 

--- a/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/DriverClient.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/DriverClient.cs
@@ -36,7 +36,7 @@ namespace Unity.Netcode.UTP.RuntimeTests
         private void Awake()
         {
 
-            var maxCap = UnityTransport.InitialBatchQueueSize + 128;
+            var maxCap = UnityTransport.InitialMaxPayloadSize + 128;
 
             var settings = new NetworkSettings();
             settings.WithFragmentationStageParameters(payloadCapacity: maxCap);

--- a/com.unity.netcode.adapter.utp/Tests/Runtime/TransportTests.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/TransportTests.cs
@@ -136,7 +136,7 @@ namespace Unity.Netcode.UTP.RuntimeTests
 
             yield return WaitForNetworkEvent(NetworkEvent.Connect, m_Client1Events);
 
-            var payload = new ArraySegment<byte>(new byte[UnityTransport.InitialBatchQueueSize]);
+            var payload = new ArraySegment<byte>(new byte[UnityTransport.InitialMaxPayloadSize]);
             m_Client1.Send(m_Client1.ServerClientId, payload, delivery);
 
             yield return WaitForNetworkEvent(NetworkEvent.Data, m_ServerEvents);
@@ -171,7 +171,7 @@ namespace Unity.Netcode.UTP.RuntimeTests
             yield return new WaitForSeconds(numSends * 0.02f);
 
             // Extra event is the connect event.
-            Assert.AreEqual(m_ServerEvents.Count, numSends + 1);
+            Assert.AreEqual(numSends + 1, m_ServerEvents.Count);
 
             for (int i = 1; i <= numSends; i++)
             {


### PR DESCRIPTION
Its actual meaning is to be the maximum payload size. The name is not entirely wrong, since this also happens to be the batch size for the send queue, but the field would still have a utility if we removed batching from the adapter, so 'Max Payload Size' is a more accurate name.

We had not renamed it before because we didn't want to break compatibility, but I just learned of `FormerlySerializedAs` which allows renaming inspector fields while retaining the value assigned to their previous name. Using that to rename the field, we avoid a breaking change.

This addresses MTT-2175.

## Changelog

### com.unity.netcode.adapter.utp
- Changed: Rename the 'Send Queue Batch Size' property to 'Max Payload Size' to better reflect its usage.

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.