### PR TITLE
fix: Rename 'Send Queue Batch Size' field in adapter (1.0.0)

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this package will be documented in this file. The format 
 
 ### Changed
 
-- Rename the 'Send Queue Batch Size' property to 'Max Payload Size' to better reflect its usage.
+- Rename the 'Send Queue Batch Size' property to 'Max Payload Size' to better reflect its usage. (#1585)
 
 ### Fixed
 

--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this package will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+- Rename the 'Send Queue Batch Size' property to 'Max Payload Size' to better reflect its usage.
+
+### Fixed
+
 ## [1.0.0-pre.4] - 2022-01-04
 
 ### Added

--- a/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/DriverClient.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/DriverClient.cs
@@ -36,7 +36,7 @@ namespace Unity.Netcode.UTP.RuntimeTests
         private void Awake()
         {
 
-            var maxCap = UnityTransport.InitialBatchQueueSize + 128;
+            var maxCap = UnityTransport.InitialMaxPayloadSize + 128;
 
             var settings = new NetworkSettings();
             settings.WithFragmentationStageParameters(payloadCapacity: maxCap);

--- a/com.unity.netcode.adapter.utp/Tests/Runtime/TransportTests.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/TransportTests.cs
@@ -128,7 +128,7 @@ namespace Unity.Netcode.UTP.RuntimeTests
 
             yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ServerEvents);
 
-            var payload = new ArraySegment<byte>(new byte[UnityTransport.InitialBatchQueueSize]);
+            var payload = new ArraySegment<byte>(new byte[UnityTransport.InitialMaxPayloadSize]);
             m_Client1.Send(m_Client1.ServerClientId, payload, delivery);
 
             yield return WaitForNetworkEvent(NetworkEvent.Data, m_ServerEvents);


### PR DESCRIPTION
This is a backport of PR #1584.

## Changelog

### com.unity.netcode.adapter.utp

* Changed: Rename the 'Send Queue Batch Size' property to 'Max Payload Size' to better reflect its usage.

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.