### PR TITLE
fix: NetworkList now properly calls INetworkSerializable's NetworkSerialize() method

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -23,6 +23,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed error when serializing ConnectionApprovalMessage with scene management disabled when one or more objects is hidden via the CheckObjectVisibility delegate (#1509)
 - Fixed The NetworkConfig's checksum hash includes the NetworkTick so that clients with a different tickrate than the server are identified and not allowed to connect. (#1513)
 - Fixed OwnedObjects not being properly modified when using ChangeOwnership. (#1572)
+- Fixed: NetworkList now properly calls INetworkSerializable's NetworkSerialize() method (#1586)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -90,18 +90,18 @@ namespace Unity.Netcode
                 {
                     case NetworkListEvent<T>.EventType.Add:
                         {
-                            writer.WriteValueSafe(m_DirtyEvents[i].Value);
+                            NetworkVariable<T>.Write(writer, m_DirtyEvents[i].Value);
                         }
                         break;
                     case NetworkListEvent<T>.EventType.Insert:
                         {
                             writer.WriteValueSafe(m_DirtyEvents[i].Index);
-                            writer.WriteValueSafe(m_DirtyEvents[i].Value);
+                            NetworkVariable<T>.Write(writer, m_DirtyEvents[i].Value);
                         }
                         break;
                     case NetworkListEvent<T>.EventType.Remove:
                         {
-                            writer.WriteValueSafe(m_DirtyEvents[i].Value);
+                            NetworkVariable<T>.Write(writer, m_DirtyEvents[i].Value);
                         }
                         break;
                     case NetworkListEvent<T>.EventType.RemoveAt:
@@ -112,7 +112,7 @@ namespace Unity.Netcode
                     case NetworkListEvent<T>.EventType.Value:
                         {
                             writer.WriteValueSafe(m_DirtyEvents[i].Index);
-                            writer.WriteValueSafe(m_DirtyEvents[i].Value);
+                            NetworkVariable<T>.Write(writer, m_DirtyEvents[i].Value);
                         }
                         break;
                     case NetworkListEvent<T>.EventType.Clear:
@@ -130,7 +130,7 @@ namespace Unity.Netcode
             writer.WriteValueSafe((ushort)m_List.Length);
             for (int i = 0; i < m_List.Length; i++)
             {
-                writer.WriteValueSafe(m_List[i]);
+                NetworkVariable<T>.Write(writer, m_List[i]);
             }
         }
 
@@ -141,7 +141,7 @@ namespace Unity.Netcode
             reader.ReadValueSafe(out ushort count);
             for (int i = 0; i < count; i++)
             {
-                reader.ReadValueSafe(out T value);
+                NetworkVariable<T>.Read(reader, out T value);
                 m_List.Add(value);
             }
         }
@@ -157,7 +157,7 @@ namespace Unity.Netcode
                 {
                     case NetworkListEvent<T>.EventType.Add:
                         {
-                            reader.ReadValueSafe(out T value);
+                            NetworkVariable<T>.Read(reader, out T value);
                             m_List.Add(value);
 
                             if (OnListChanged != null)
@@ -184,7 +184,7 @@ namespace Unity.Netcode
                     case NetworkListEvent<T>.EventType.Insert:
                         {
                             reader.ReadValueSafe(out int index);
-                            reader.ReadValueSafe(out T value);
+                            NetworkVariable<T>.Read(reader, out T value);
                             m_List.InsertRangeWithBeginEnd(index, index + 1);
                             m_List[index] = value;
 
@@ -211,7 +211,7 @@ namespace Unity.Netcode
                         break;
                     case NetworkListEvent<T>.EventType.Remove:
                         {
-                            reader.ReadValueSafe(out T value);
+                            NetworkVariable<T>.Read(reader, out T value);
                             int index = m_List.IndexOf(value);
                             if (index == -1)
                             {
@@ -271,7 +271,7 @@ namespace Unity.Netcode
                     case NetworkListEvent<T>.EventType.Value:
                         {
                             reader.ReadValueSafe(out int index);
-                            reader.ReadValueSafe(out T value);
+                            NetworkVariable<T>.Read(reader, out T value);
                             if (index >= m_List.Length)
                             {
                                 throw new Exception("Shouldn't be here, index is higher than list length");

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -10,7 +10,7 @@ namespace Unity.Netcode
     public class NetworkVariable<T> : NetworkVariableBase where T : unmanaged
     {
         // Functions that know how to serialize INetworkSerializable
-        internal static void WriteNetworkSerializable<TForMethod>(FastBufferWriter writer, ref TForMethod value)
+        internal static void WriteNetworkSerializable<TForMethod>(FastBufferWriter writer, in TForMethod value)
             where TForMethod : INetworkSerializable, new()
         {
             writer.WriteNetworkSerializable(value);
@@ -22,7 +22,7 @@ namespace Unity.Netcode
         }
 
         // Functions that serialize other types
-        private static void WriteValue<TForMethod>(FastBufferWriter writer, ref TForMethod value) where TForMethod : unmanaged
+        private static void WriteValue<TForMethod>(FastBufferWriter writer, in TForMethod value) where TForMethod : unmanaged
         {
             writer.WriteValueSafe(value);
         }
@@ -33,7 +33,7 @@ namespace Unity.Netcode
             reader.ReadValueSafe(out value);
         }
 
-        internal delegate void WriteDelegate<TForMethod>(FastBufferWriter writer, ref TForMethod value);
+        internal delegate void WriteDelegate<TForMethod>(FastBufferWriter writer, in TForMethod value);
 
         internal delegate void ReadDelegate<TForMethod>(FastBufferReader reader, out TForMethod value);
 
@@ -174,7 +174,7 @@ namespace Unity.Netcode
         /// <inheritdoc />
         public override void WriteField(FastBufferWriter writer)
         {
-            Write(writer, ref m_InternalValue);
+            Write(writer, m_InternalValue);
         }
     }
 }


### PR DESCRIPTION
MTT-1687
#1396 

## Changelog

### com.unity.netcode.gameobjects
- Fixed: NetworkList now properly calls INetworkSerializable's NetworkSerialize() method

## Testing and Documentation

* Includes integration tests.
* No documentation changes or additions were necessary.