### PR TITLE
fix: Disallowed async keyword in RPCs

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -23,6 +23,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed error when serializing ConnectionApprovalMessage with scene management disabled when one or more objects is hidden via the CheckObjectVisibility delegate (#1509)
 - Fixed The NetworkConfig's checksum hash includes the NetworkTick so that clients with a different tickrate than the server are identified and not allowed to connect. (#1513)
 - Fixed OwnedObjects not being properly modified when using ChangeOwnership. (#1572)
+- Disallowed async keyword in RPCs (1587)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -382,7 +382,6 @@ namespace Unity.Netcode.Editor.CodeGen
 
             foreach (var methodDefinition in typeDefinition.Methods)
             {
-                m_Diagnostics.AddWarning($"{methodDefinition.FullName} {methodDefinition.DebugInformation.SequencePoints.Count}");
                 var rpcAttribute = CheckAndGetRpcAttribute(methodDefinition);
                 if (rpcAttribute == null)
                 {


### PR DESCRIPTION
MTT-1588
fixes #570

## Changelog

### com.unity.netcode.gameobjects
- Fixed: Disallowed async keyword in RPCs

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.