### PR TITLE
Fix/cast messagesize as uint

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -23,6 +23,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed error when serializing ConnectionApprovalMessage with scene management disabled when one or more objects is hidden via the CheckObjectVisibility delegate (#1509)
 - Fixed The NetworkConfig's checksum hash includes the NetworkTick so that clients with a different tickrate than the server are identified and not allowed to connect. (#1513)
 - Fixed OwnedObjects not being properly modified when using ChangeOwnership. (#1572)
+- Fixed messages larger than 64k being written with incorrectly truncated message size in header (#1591)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
@@ -371,7 +371,7 @@ namespace Unity.Netcode
 
             var header = new MessageHeader
             {
-                MessageSize = (ushort)tmpSerializer.Length,
+                MessageSize = (uint)tmpSerializer.Length,
                 MessageType = m_MessageTypes[typeof(TMessageType)],
             };
             BytePacker.WriteValueBitPacked(headerSerializer, header.MessageType);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectSpawnManyObjectsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectSpawnManyObjectsTests.cs
@@ -1,0 +1,59 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    public class NetworkObjectSpawnManyObjectsTests
+    {
+        // "many" in this case means enough to exceed a ushort_max message size written in the header
+        // 1500 is not a magic number except that it's big enough to trigger a failure
+        private const int k_SpawnedObjects = 1500;
+
+        [UnityTest]
+        // When this test fails it does so without an exception and will wait the default ~6 minutes
+        [Timeout(10000)]
+        public IEnumerator WhenManyObjectsAreSpawnedAtOnce_AllAreReceived()
+        {
+            MultiInstanceHelpers.Create(1, out NetworkManager server, out NetworkManager[] clients);
+
+            // create prefab
+            var gameObject = new GameObject("TestObject");
+            var networkObject = gameObject.AddComponent<NetworkObject>();
+            MultiInstanceHelpers.MakeNetworkObjectTestPrefab(networkObject);
+
+            server.NetworkConfig.NetworkPrefabs.Add(new NetworkPrefab()
+            {
+                Prefab = gameObject
+            });
+
+            for (int i = 0; i < clients.Length; i++)
+            {
+                clients[i].NetworkConfig.NetworkPrefabs.Add(new NetworkPrefab()
+                {
+                    Prefab = gameObject
+                });
+            }
+
+            MultiInstanceHelpers.Start(false, server, clients);
+
+            for (int i = 0; i < k_SpawnedObjects; i++)
+            {
+                NetworkObject serverObject = Object.Instantiate(gameObject).GetComponent<NetworkObject>();
+                serverObject.NetworkManagerOwner = server;
+                serverObject.Spawn();
+            }
+
+            // wait for connection on client side
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(clients, null, 10f));
+
+            // wait for connection on server side
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientConnectedToServer(server, null, 10f));
+
+            // ensure all objects are replicated
+            Assert.AreEqual(k_SpawnedObjects, clients[0].SpawnManager.SpawnedObjectsList.Count);
+            MultiInstanceHelpers.Destroy();
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectSpawnManyObjectsTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectSpawnManyObjectsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4e0439aa2d2a72e4aa42b051d26af366
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Casts MessageSize as `uint` instead of `ushort` when writing the message header. See the associated issue (https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/1591) for how this causes failures. In short, if we send `0x10001` bytes of data here the message size gets clipped to `ushort` making it `0x0001`. The full data is actually still written without issue. Just the size reported in the header is wrong.

On the receiving end, this value is used to allocate a buffer for reading the data. In the scenario above we get a one-byte buffer to hold our 64k of data. The actual read logic is scattered all over the place, in my case it was failing in NetworkVariable deserialize, but it will fail just about anywhere there's a buffer read. Those things don't actually check the message header's reported size, they just assume the data is there and attempt to read past the buffer.

Everywhere else in this file message size is semantically treated as `int` and cast to `int`. I don't think a negative message size has any sensible meaning and the cast on this line is currently unsigned, so I chose unsigned int.

In any case, it's not the outgoing MessagingSystem's job to silently clip the logical data size that gets written, especially when writing it out. It's the transport's job to complain if it can't serialize it, and it's the clients job to not read UINT_MAX bytes from a socket. The ByteWriter thing has its own check that the size value itself can be serialized (capped to 30 bits). And pretty much everything else down stream is responsible for what goes into the buffer and over the wire.

If MessagingSystem actually *does* care it needs to fail loudly and with an explicit check. Obviously, with the silent truncation this was sort of a debugging nightmare.

### PR Checklist
- [x] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [x] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR or a link to the documenation repo PR if this is a manual update. 

## Changelog

### com.unity.netcode.gameobjects
- Fixed: Messages larger than 64k being written with incorrectly truncated message size in header

## Testing and Documentation
* Includes unit tests.