### PR TITLE
fix: Server was able to be mapped as both ID 0 and ID 1

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -23,6 +23,9 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed error when serializing ConnectionApprovalMessage with scene management disabled when one or more objects is hidden via the CheckObjectVisibility delegate (#1509)
 - Fixed The NetworkConfig's checksum hash includes the NetworkTick so that clients with a different tickrate than the server are identified and not allowed to connect. (#1513)
 - Fixed OwnedObjects not being properly modified when using ChangeOwnership. (#1572)
+- Fixed an issue where sometimes the first client to connect to the server could see messages from the server as coming from itself. (#1597)
+- Fixed an issue where clients seemed to be able to send messages to ClientId 1, but these messages would actually still go to the server (id 0) instead of that client. (#1597)
+- Improved clarity of error messaging when a client attempts to send a message to a destination other than the server, which isn't allowed. (#1597)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1336,7 +1336,20 @@ namespace Unity.Netcode
                     s_TransportConnect.Begin();
 #endif
 
-                    clientId = m_NextClientId++;
+                    // Assumptions:
+                    // - When server receives a connection, it *must be* a client
+                    // - When client receives one, it *must be* the server
+                    // Client's can't connect to or talk to other clients.
+                    // Server is a sentinel so only one exists, if we are server, we can't be
+                    // connecting to it.
+                    if (IsServer)
+                    {
+                        clientId = m_NextClientId++;
+                    }
+                    else
+                    {
+                        clientId = ServerClientId;
+                    }
                     m_ClientIdToTransportIdMap[clientId] = transportId;
                     m_TransportIdToClientIdMap[transportId] = clientId;
 
@@ -1439,6 +1452,12 @@ namespace Unity.Netcode
                 }
                 return MessagingSystem.SendMessage(ref message, delivery, nonServerIds, newIdx);
             }
+            // else
+            if(clientIds.Count != 1 || clientIds[0] != ServerClientId)
+            {
+                throw new ArgumentException($"Clients may only send messages to {nameof(ServerClientId)}");
+            }
+
             return MessagingSystem.SendMessage(ref message, delivery, clientIds);
         }
 
@@ -1467,6 +1486,11 @@ namespace Unity.Netcode
                 }
                 return MessagingSystem.SendMessage(ref message, delivery, nonServerIds, newIdx);
             }
+            // else
+            if(numClientIds != 1 || clientIds[0] != ServerClientId)
+            {
+                throw new ArgumentException($"Clients may only send messages to {nameof(ServerClientId)}");
+            }
 
             return MessagingSystem.SendMessage(ref message, delivery, clientIds, numClientIds);
         }
@@ -1484,6 +1508,11 @@ namespace Unity.Netcode
             if (IsServer && clientId == ServerClientId)
             {
                 return 0;
+            }
+
+            if (!IsServer && clientId != ServerClientId)
+            {
+                throw new ArgumentException($"Clients may only send messages to {nameof(ServerClientId)}");
             }
             return MessagingSystem.SendMessage(ref message, delivery, clientId);
         }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1453,7 +1453,7 @@ namespace Unity.Netcode
                 return MessagingSystem.SendMessage(ref message, delivery, nonServerIds, newIdx);
             }
             // else
-            if(clientIds.Count != 1 || clientIds[0] != ServerClientId)
+            if (clientIds.Count != 1 || clientIds[0] != ServerClientId)
             {
                 throw new ArgumentException($"Clients may only send messages to {nameof(ServerClientId)}");
             }
@@ -1487,7 +1487,7 @@ namespace Unity.Netcode
                 return MessagingSystem.SendMessage(ref message, delivery, nonServerIds, newIdx);
             }
             // else
-            if(numClientIds != 1 || clientIds[0] != ServerClientId)
+            if (numClientIds != 1 || clientIds[0] != ServerClientId)
             {
                 throw new ArgumentException($"Clients may only send messages to {nameof(ServerClientId)}");
             }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
@@ -118,7 +118,7 @@ namespace Unity.Netcode
             for (var queueIndex = 0; queueIndex < m_IncomingMessageQueue.Length; ++queueIndex)
             {
                 // Avoid copies...
-                ref var item = ref m_IncomingMessageQueue.GetUnsafeList()->ElementAt(queueIndex);
+                ref var item = ref m_IncomingMessageQueue.ElementAt(queueIndex);
                 item.Reader.Dispose();
             }
 
@@ -279,7 +279,7 @@ namespace Unity.Netcode
             for (var index = 0; index < m_IncomingMessageQueue.Length; ++index)
             {
                 // Avoid copies...
-                ref var item = ref m_IncomingMessageQueue.GetUnsafeList()->ElementAt(index);
+                ref var item = ref m_IncomingMessageQueue.ElementAt(index);
                 HandleMessage(item.Header, item.Reader, item.SenderId, item.Timestamp, item.MessageHeaderSerializedSize);
                 if (m_Disposed)
                 {
@@ -314,7 +314,7 @@ namespace Unity.Netcode
             var queue = m_SendQueues[clientId];
             for (var i = 0; i < queue.Length; ++i)
             {
-                queue.GetUnsafeList()->ElementAt(i).Writer.Dispose();
+                queue.ElementAt(i).Writer.Dispose();
             }
 
             queue.Dispose();
@@ -396,22 +396,22 @@ namespace Unity.Netcode
                 {
                     sendQueueItem.Add(new SendQueueItem(delivery, NON_FRAGMENTED_MESSAGE_MAX_SIZE, Allocator.TempJob,
                         maxSize));
-                    sendQueueItem.GetUnsafeList()->ElementAt(0).Writer.Seek(sizeof(BatchHeader));
+                    sendQueueItem.ElementAt(0).Writer.Seek(sizeof(BatchHeader));
                 }
                 else
                 {
-                    ref var lastQueueItem = ref sendQueueItem.GetUnsafeList()->ElementAt(sendQueueItem.Length - 1);
+                    ref var lastQueueItem = ref sendQueueItem.ElementAt(sendQueueItem.Length - 1);
                     if (lastQueueItem.NetworkDelivery != delivery ||
                         lastQueueItem.Writer.MaxCapacity - lastQueueItem.Writer.Position
                         < tmpSerializer.Length + headerSerializer.Length)
                     {
                         sendQueueItem.Add(new SendQueueItem(delivery, NON_FRAGMENTED_MESSAGE_MAX_SIZE, Allocator.TempJob,
                             maxSize));
-                        sendQueueItem.GetUnsafeList()->ElementAt(sendQueueItem.Length - 1).Writer.Seek(sizeof(BatchHeader));
+                        sendQueueItem.ElementAt(sendQueueItem.Length - 1).Writer.Seek(sizeof(BatchHeader));
                     }
                 }
 
-                ref var writeQueueItem = ref sendQueueItem.GetUnsafeList()->ElementAt(sendQueueItem.Length - 1);
+                ref var writeQueueItem = ref sendQueueItem.ElementAt(sendQueueItem.Length - 1);
                 writeQueueItem.Writer.TryBeginWrite(tmpSerializer.Length + headerSerializer.Length);
 
                 writeQueueItem.Writer.WriteBytes(headerSerializer.GetUnsafePtr(), headerSerializer.Length);
@@ -489,7 +489,7 @@ namespace Unity.Netcode
                 var sendQueueItem = kvp.Value;
                 for (var i = 0; i < sendQueueItem.Length; ++i)
                 {
-                    ref var queueItem = ref sendQueueItem.GetUnsafeList()->ElementAt(i);
+                    ref var queueItem = ref sendQueueItem.ElementAt(i);
                     if (queueItem.BatchHeader.BatchSize == 0)
                     {
                         queueItem.Writer.Dispose();


### PR DESCRIPTION
This meant the first client to connect could sometimes see messages from the server as coming from itself, and could successfully send to its own LocalClientId (even though the message would go to the server). Other clients would be able to send and receive from id 1, but that would also be the server.

MTT-1536
MTT-1691
## Changelog

### com.unity.netcode.gameobjects
- Fixed: Fixed an issue where sometimes the first client to connect to the server could see messages from the server as coming from itself.
- Fixed: Fixed an issue where clients seemed to be able to send messages to ClientId 1, but these messages would actually still go to the server (id 0) instead of that client.
- Fixed: Improved clarity of error messaging when a client attempts to send a message to a destination other than the server, which isn't allowed.

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.
