### PR TITLE
fix: refresh cancommit value of ClientNetworkTransform

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -16,6 +16,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed The ClientNetworkTransform sample script to allow for owner changes at runtime. (#1606)
 - Fixed client player object being destroyed on server when the client's player object has DontDestroyWithOwner set. (#1433)
 - Fixed FastBufferReader being created with a length of 1 if provided an input of length 0. (#1480)
 - Fixed an exception being thrown during NetworkVariableDeltaMessage serialization when EnsureNetworkVariableLengthSafety is enabled (#1487)

--- a/com.unity.netcode.gameobjects/Samples/ClientNetworkTransform/Scripts/ClientNetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Samples/ClientNetworkTransform/Scripts/ClientNetworkTransform.cs
@@ -26,6 +26,7 @@ namespace Unity.Netcode.Samples
 
         protected override void Update()
         {
+            CanCommitToTransform = IsOwner;
             base.Update();
             if (NetworkManager.Singleton != null && (NetworkManager.Singleton.IsConnectedClient || NetworkManager.Singleton.IsListening))
             {


### PR DESCRIPTION
ClientNetworkTransform does not update the CanCommitTransform value when changing the ownership value at runtime.

### PR Checklist
- [x] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [x] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR or a link to the documenation repo PR if this is a manual update. 

## Changelog

### com.unity.netcode.gameobjects
- Fixed: The ClientNetworkTransform sample script allows for owner changes at runtime now.

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
