### PR TITLE
feat: Allow specifying a different listen address in the adapter (1.0.0)

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -6,9 +6,12 @@ All notable changes to this package will be documented in this file. The format 
 
 ### Added
 
+- A new 'Listen Address' field under 'Connection Data' in the inspector has been added to specify the address a server should listen to, in case it differs from the main 'Address' field. The `SetConnectionData` method has been updated accordingly to take an optional parameter to specify that listen address.
+
 ### Changed
 
 - Rename the 'Send Queue Batch Size' property to 'Max Payload Size' to better reflect its usage. (#1585)
+- Implicit conversions between `ConnectionAddressData` and `NetworkEndPoint` are now deprecated, since their semantics are no longer clear with the introduction of the new `ListenAddress` field (see above).
 
 ### Fixed
 

--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -6,12 +6,12 @@ All notable changes to this package will be documented in this file. The format 
 
 ### Added
 
-- A new 'Server Listen Address' field under 'Connection Data' in the inspector has been added to specify the address a server should listen to, in case it differs from the main 'Address' field. The `SetConnectionData` method has been updated accordingly to take an optional parameter to specify that listen address. (#1607)
+- A new 'Server Listen Address' field under 'Connection Data' in the inspector has been added to specify the address a server should listen to, in case it differs from the main 'Address' field. The `SetConnectionData` method has been updated accordingly to take an optional parameter to specify that listen address. (#1605)
 
 ### Changed
 
-- Rename the 'Send Queue Batch Size' property to 'Max Payload Size' to better reflect its usage. (#1585)
-- Implicit conversions between `ConnectionAddressData` and `NetworkEndPoint` are now deprecated, since their semantics are no longer clear with the introduction of the new `ServerListenAddress` field (see above). (#1607)
+- Rename the 'Send Queue Batch Size' property to 'Max Payload Size' to better reflect its usage. (#1584)
+- Implicit conversions between `ConnectionAddressData` and `NetworkEndPoint` are now deprecated, since their semantics are no longer clear with the introduction of the new `ServerListenAddress` field (see above). (#1605)
 
 ### Fixed
 

--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -6,12 +6,12 @@ All notable changes to this package will be documented in this file. The format 
 
 ### Added
 
-- A new 'Listen Address' field under 'Connection Data' in the inspector has been added to specify the address a server should listen to, in case it differs from the main 'Address' field. The `SetConnectionData` method has been updated accordingly to take an optional parameter to specify that listen address.
+- A new 'Server Listen Address' field under 'Connection Data' in the inspector has been added to specify the address a server should listen to, in case it differs from the main 'Address' field. The `SetConnectionData` method has been updated accordingly to take an optional parameter to specify that listen address.
 
 ### Changed
 
 - Rename the 'Send Queue Batch Size' property to 'Max Payload Size' to better reflect its usage. (#1585)
-- Implicit conversions between `ConnectionAddressData` and `NetworkEndPoint` are now deprecated, since their semantics are no longer clear with the introduction of the new `ListenAddress` field (see above).
+- Implicit conversions between `ConnectionAddressData` and `NetworkEndPoint` are now deprecated, since their semantics are no longer clear with the introduction of the new `ServerListenAddress` field (see above).
 
 ### Fixed
 

--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -6,12 +6,12 @@ All notable changes to this package will be documented in this file. The format 
 
 ### Added
 
-- A new 'Server Listen Address' field under 'Connection Data' in the inspector has been added to specify the address a server should listen to, in case it differs from the main 'Address' field. The `SetConnectionData` method has been updated accordingly to take an optional parameter to specify that listen address.
+- A new 'Server Listen Address' field under 'Connection Data' in the inspector has been added to specify the address a server should listen to, in case it differs from the main 'Address' field. The `SetConnectionData` method has been updated accordingly to take an optional parameter to specify that listen address. (#1607)
 
 ### Changed
 
 - Rename the 'Send Queue Batch Size' property to 'Max Payload Size' to better reflect its usage. (#1585)
-- Implicit conversions between `ConnectionAddressData` and `NetworkEndPoint` are now deprecated, since their semantics are no longer clear with the introduction of the new `ServerListenAddress` field (see above).
+- Implicit conversions between `ConnectionAddressData` and `NetworkEndPoint` are now deprecated, since their semantics are no longer clear with the introduction of the new `ServerListenAddress` field (see above). (#1607)
 
 ### Fixed
 

--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -90,7 +90,7 @@ namespace Unity.Netcode
         public const int InitialMaxSendQueueSize = 16 * InitialMaxPayloadSize;
 
         private static ConnectionAddressData s_DefaultConnectionAddressData = new ConnectionAddressData()
-        { Address = "127.0.0.1", Port = 7777, ListenAddress = null };
+        { Address = "127.0.0.1", Port = 7777, ServerListenAddress = null };
 
 #pragma warning disable IDE1006 // Naming Styles
         public static INetworkStreamDriverConstructor s_DriverConstructor;
@@ -138,7 +138,7 @@ namespace Unity.Netcode
             [SerializeField] public ushort Port;
 
             [Tooltip("IP address the server will listen on. If not provided, will use 'Address'.")]
-            [SerializeField] public string ListenAddress;
+            [SerializeField] public string ServerListenAddress;
 
             private static NetworkEndPoint ParseNetworkEndpoint(string ip, ushort port)
             {
@@ -153,7 +153,7 @@ namespace Unity.Netcode
 
             public NetworkEndPoint ServerEndPoint => ParseNetworkEndpoint(Address, Port);
 
-            public NetworkEndPoint ListenEndPoint => ParseNetworkEndpoint(ListenAddress ?? Address, Port);
+            public NetworkEndPoint ListenEndPoint => ParseNetworkEndpoint(ServerListenAddress ?? Address, Port);
 
             [Obsolete("Use ServerEndPoint or ListenEndPoint properties instead.")]
             public static implicit operator NetworkEndPoint(ConnectionAddressData d) =>
@@ -161,7 +161,7 @@ namespace Unity.Netcode
 
             [Obsolete("Construct manually from NetworkEndPoint.Address and NetworkEndPoint.Port instead.")]
             public static implicit operator ConnectionAddressData(NetworkEndPoint d) =>
-                new ConnectionAddressData() { Address = d.Address.Split(':')[0], Port = d.Port, ListenAddress = null };
+                new ConnectionAddressData() { Address = d.Address.Split(':')[0], Port = d.Port, ServerListenAddress = null };
         }
 
         public ConnectionAddressData ConnectionData = s_DefaultConnectionAddressData;
@@ -405,7 +405,7 @@ namespace Unity.Netcode
             {
                 Address = ipv4Address,
                 Port = port,
-                ListenAddress = listenAddress
+                ServerListenAddress = listenAddress
             };
 
             SetProtocol(ProtocolType.UnityTransport);

--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -90,7 +90,7 @@ namespace Unity.Netcode
         public const int InitialMaxSendQueueSize = 16 * InitialMaxPayloadSize;
 
         private static ConnectionAddressData s_DefaultConnectionAddressData = new ConnectionAddressData()
-        { Address = "127.0.0.1", Port = 7777 };
+        { Address = "127.0.0.1", Port = 7777, ListenAddress = null };
 
 #pragma warning disable IDE1006 // Naming Styles
         public static INetworkStreamDriverConstructor s_DriverConstructor;
@@ -131,22 +131,37 @@ namespace Unity.Netcode
         [Serializable]
         public struct ConnectionAddressData
         {
+            [Tooltip("IP address of the server (address to which clients will connect to).")]
             [SerializeField] public string Address;
-            [SerializeField] public int Port;
 
-            public static implicit operator NetworkEndPoint(ConnectionAddressData d)
+            [Tooltip("UDP port of the server.")]
+            [SerializeField] public ushort Port;
+
+            [Tooltip("IP address the server will listen on. If not provided, will use 'Address'.")]
+            [SerializeField] public string ListenAddress;
+
+            private static NetworkEndPoint ParseNetworkEndpoint(string ip, ushort port)
             {
-                if (!NetworkEndPoint.TryParse(d.Address, (ushort)d.Port, out var networkEndPoint))
+                if (!NetworkEndPoint.TryParse(ip, port, out var endpoint))
                 {
-                    Debug.LogError($"Invalid address {d.Address}:{d.Port}");
+                    Debug.LogError($"Invalid network endpoint: {ip}:{port}.");
                     return default;
                 }
 
-                return networkEndPoint;
+                return endpoint;
             }
 
+            public NetworkEndPoint ServerEndPoint => ParseNetworkEndpoint(Address, Port);
+
+            public NetworkEndPoint ListenEndPoint => ParseNetworkEndpoint(ListenAddress ?? Address, Port);
+
+            [Obsolete("Use ServerEndPoint or ListenEndPoint properties instead.")]
+            public static implicit operator NetworkEndPoint(ConnectionAddressData d) =>
+                ParseNetworkEndpoint(d.Address, d.Port);
+
+            [Obsolete("Construct manually from NetworkEndPoint.Address and NetworkEndPoint.Port instead.")]
             public static implicit operator ConnectionAddressData(NetworkEndPoint d) =>
-                new ConnectionAddressData() { Address = d.Address.Split(':')[0], Port = d.Port };
+                new ConnectionAddressData() { Address = d.Address.Split(':')[0], Port = d.Port, ListenAddress = null };
         }
 
         public ConnectionAddressData ConnectionData = s_DefaultConnectionAddressData;
@@ -267,7 +282,7 @@ namespace Unity.Netcode
             }
             else
             {
-                serverEndpoint = ConnectionData;
+                serverEndpoint = ConnectionData.ServerEndPoint;
             }
 
             InitDriver();
@@ -384,26 +399,36 @@ namespace Unity.Netcode
         /// <summary>
         /// Sets IP and Port information. This will be ignored if using the Unity Relay and you should call <see cref="SetRelayServerData"/>
         /// </summary>
-        public void SetConnectionData(string ipv4Address, ushort port)
+        public void SetConnectionData(string ipv4Address, ushort port, string listenAddress = null)
         {
-            if (!NetworkEndPoint.TryParse(ipv4Address, port, out var endPoint))
+            ConnectionData = new ConnectionAddressData
             {
-                Debug.LogError($"Invalid address {ipv4Address}:{port}");
-                ConnectionData = default;
+                Address = ipv4Address,
+                Port = port,
+                ListenAddress = listenAddress
+            };
 
-                return;
-            }
-
-            SetConnectionData(endPoint);
+            SetProtocol(ProtocolType.UnityTransport);
         }
 
         /// <summary>
         /// Sets IP and Port information. This will be ignored if using the Unity Relay and you should call <see cref="SetRelayServerData"/>
         /// </summary>
-        public void SetConnectionData(NetworkEndPoint endPoint)
+        public void SetConnectionData(NetworkEndPoint endPoint, NetworkEndPoint listenEndPoint = default)
         {
-            ConnectionData = endPoint;
-            SetProtocol(ProtocolType.UnityTransport);
+            string serverAddress = endPoint.Address.Split(':')[0];
+
+            string listenAddress = null;
+            if (listenEndPoint != default)
+            {
+                listenAddress = listenEndPoint.Address.Split(':')[0];
+                if (endPoint.Port != listenEndPoint.Port)
+                {
+                    Debug.LogError($"Port mismatch between server and listen endpoints ({endPoint.Port} vs {listenEndPoint.Port}).");
+                }
+            }
+
+            SetConnectionData(serverAddress, endPoint.Port, listenAddress);
         }
 
         private bool StartRelayServer()
@@ -704,7 +729,7 @@ namespace Unity.Netcode
             switch (m_ProtocolType)
             {
                 case ProtocolType.UnityTransport:
-                    return ServerBindAndListen(ConnectionData);
+                    return ServerBindAndListen(ConnectionData.ListenEndPoint);
                 case ProtocolType.RelayUnityTransport:
                     return StartRelayServer();
                 default:

--- a/com.unity.netcode.adapter.utp/Tests/Runtime/ConnectionTests.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/ConnectionTests.cs
@@ -49,7 +49,6 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator ConnectSingleClient()
         {
-
             InitializeTransport(out m_Server, out m_ServerEvents);
             InitializeTransport(out m_Clients[0], out m_ClientsEvents[0]);
 
@@ -69,7 +68,6 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator ConnectMultipleClients()
         {
-
             InitializeTransport(out m_Server, out m_ServerEvents);
             m_Server.StartServer();
 
@@ -234,7 +232,6 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator RepeatedClientDisconnectsNoop()
         {
-
             InitializeTransport(out m_Server, out m_ServerEvents);
             InitializeTransport(out m_Clients[0], out m_ClientsEvents[0]);
 
@@ -258,6 +255,28 @@ namespace Unity.Netcode.RuntimeTests
             // Check we haven't received anything else on the client or server.
             Assert.AreEqual(m_ServerEvents.Count, previousServerEventsCount);
             Assert.AreEqual(m_ClientsEvents[0].Count, previousClientEventsCount);
+
+            yield return null;
+        }
+
+        // Check connection with different server/listen addresses.
+        [UnityTest]
+        public IEnumerator DifferentServerAndListenAddresses()
+        {
+            InitializeTransport(out m_Server, out m_ServerEvents);
+            InitializeTransport(out m_Clients[0], out m_ClientsEvents[0]);
+
+            m_Server.SetConnectionData("127.0.0.1", 10042, "0.0.0.0");
+            m_Clients[0].SetConnectionData("127.0.0.1", 10042);
+
+            m_Server.StartServer();
+            m_Clients[0].StartClient();
+
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[0]);
+
+            // Check we've received Connect event on server too.
+            Assert.AreEqual(1, m_ServerEvents.Count);
+            Assert.AreEqual(NetworkEvent.Connect, m_ServerEvents[0].Type);
 
             yield return null;
         }


### PR DESCRIPTION
MTT-1902

This is a backport of PR #1605 to `release/1.0.0`.

## Changelog

### com.unity.netcode.adapter.utp

- Added: A new 'Server Listen Address' field under 'Connection Data' in the inspector has been added to specify the address a server should listen to, in case it differs from the main 'Address' field. The `SetConnectionData` method has been updated accordingly to take an optional parameter to specify that listen address.
- Changed: Implicit conversions between `ConnectionAddressData` and `NetworkEndPoint` are now deprecated, since their semantics are no longer clear with the introduction of the new `ServerListenAddress` field (see above).

(A note on the deprecation above: I would be exceedingly surprised if these were actually used by any user. They were only used to convert to/from the UTP `NetworkEndPoint` type internally to make the code "cleaner". Unfortunately they are public, so proper deprecation is in order.)

## Testing and Documentation

* Includes integration tests.
* AFAIK, no documentation changes or additions are necessary.