### PR TITLE
feat: Lift ~44KB limit for reliable payloads in the adapter (1.0.0)

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -8,9 +8,11 @@ All notable changes to this package will be documented in this file. The format 
 
 ### Changed
 
-- Rename the 'Send Queue Batch Size' property to 'Max Payload Size' to better reflect its usage. (#1585)
+- Rename the 'Send Queue Batch Size' property to 'Max Payload Size' to better reflect its usage. (#1584)
 
 ### Fixed
+
+- Lifted the limit of ~44KB for reliable payloads. Before the fix, attempting to send a payload larger than that with reliable delivery would silently fail. Note that it is still not recommended to send such large reliable payloads, since their delivery could take a few network round-trips. (#1596)
 
 ## [1.0.0-pre.4] - 2022-01-04
 

--- a/com.unity.netcode.adapter.utp/Runtime/BatchedSendQueue.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/BatchedSendQueue.cs
@@ -134,10 +134,13 @@ namespace Unity.Netcode.UTP.Utilities
         /// does not reduce the length of the queue. Callers are expected to call
         /// <see cref="Consume"/> with the value returned by this method afterwards if the data can
         /// be safely removed from the queue (e.g. if it was sent successfully).
+        ///
+        /// This method should not be used together with <see cref="FillWriterWithBytes"> since this
+        /// could lead to a corrupted queue.
         /// </remarks>
         /// <param name="writer">The <see cref="DataStreamWriter"/> to write to.</param>
         /// <returns>How many bytes were written to the writer.</returns>
-        public int FillWriter(ref DataStreamWriter writer)
+        public int FillWriterWithMessages(ref DataStreamWriter writer)
         {
             if (!IsCreated || Length == 0)
             {
@@ -174,6 +177,38 @@ namespace Unity.Netcode.UTP.Utilities
 
                 return writer.Capacity - writerAvailable;
             }
+        }
+
+        /// <summary>
+        /// Fill the given <see cref="DataStreamWriter"/> with as many bytes from the queue as
+        /// possible, disregarding message boundaries.
+        /// </summary>
+        ///<remarks>
+        /// This does NOT actually consume anything from the queue. That is, calling this method
+        /// does not reduce the length of the queue. Callers are expected to call
+        /// <see cref="Consume"/> with the value returned by this method afterwards if the data can
+        /// be safely removed from the queue (e.g. if it was sent successfully).
+        ///
+        /// This method should not be used together with <see cref="FillWriterWithMessages"/> since
+        /// this could lead to reading messages from a corrupted queue.
+        /// </remarks>
+        /// <param name="writer">The <see cref="DataStreamWriter"/> to write to.</param>
+        /// <returns>How many bytes were written to the writer.</returns>
+        public int FillWriterWithBytes(ref DataStreamWriter writer)
+        {
+            if (!IsCreated || Length == 0)
+            {
+                return 0;
+            }
+
+            var copyLength = Math.Min(writer.Capacity, Length);
+
+            unsafe
+            {
+                writer.WriteBytes((byte*)m_Data.GetUnsafePtr() + HeadIndex, copyLength);
+            }
+
+            return copyLength;
         }
 
         /// <summary>Consume a number of bytes from the head of the queue.</summary>

--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -347,7 +347,7 @@ namespace Unity.Netcode
 
         internal void SetMaxPayloadSize(int maxPayloadSize)
         {
-            m_SendQueueBatchSize = maxPayloadSize;
+            m_MaxPayloadSize = maxPayloadSize;
         }
 
         private void SetProtocol(ProtocolType inProtocol)

--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -23,7 +23,7 @@ namespace Unity.Netcode
             out NetworkDriver driver,
             out NetworkPipeline unreliableFragmentedPipeline,
             out NetworkPipeline unreliableSequencedFragmentedPipeline,
-            out NetworkPipeline reliableSequencedFragmentedPipeline);
+            out NetworkPipeline reliableSequencedPipeline);
     }
 
     public static class ErrorUtilities
@@ -160,7 +160,7 @@ namespace Unity.Netcode
 
         private NetworkPipeline m_UnreliableFragmentedPipeline;
         private NetworkPipeline m_UnreliableSequencedFragmentedPipeline;
-        private NetworkPipeline m_ReliableSequencedFragmentedPipeline;
+        private NetworkPipeline m_ReliableSequencedPipeline;
 
         public override ulong ServerClientId => m_ServerClientId;
 
@@ -210,6 +210,11 @@ namespace Unity.Netcode
         /// </summary>
         private readonly Dictionary<SendTarget, BatchedSendQueue> m_SendQueue = new Dictionary<SendTarget, BatchedSendQueue>();
 
+        // Since reliable messages may be spread out over multiple transport payloads, it's possible
+        // to receive only parts of a message in an update. We thus keep the reliable receive queues
+        // around to avoid losing partial messages.
+        private readonly Dictionary<ulong, BatchedReceiveQueue> m_ReliableReceiveQueues = new Dictionary<ulong, BatchedReceiveQueue>();
+
         private void InitDriver()
         {
             DriverConstructor.CreateDriver(
@@ -217,7 +222,7 @@ namespace Unity.Netcode
                 out m_Driver,
                 out m_UnreliableFragmentedPipeline,
                 out m_UnreliableSequencedFragmentedPipeline,
-                out m_ReliableSequencedFragmentedPipeline);
+                out m_ReliableSequencedPipeline);
         }
 
         private void DisposeDriver()
@@ -241,7 +246,7 @@ namespace Unity.Netcode
                 case NetworkDelivery.Reliable:
                 case NetworkDelivery.ReliableSequenced:
                 case NetworkDelivery.ReliableFragmentedSequenced:
-                    return m_ReliableSequencedFragmentedPipeline;
+                    return m_ReliableSequencedPipeline;
 
                 default:
                     Debug.LogError($"Unknown {nameof(NetworkDelivery)} value: {delivery}");
@@ -338,6 +343,11 @@ namespace Unity.Netcode
                     return RelayConnectionData.FromBytePointer(ptr, RelayConnectionData.k_Length);
                 }
             }
+        }
+
+        internal void SetMaxPayloadSize(int maxPayloadSize)
+        {
+            m_SendQueueBatchSize = maxPayloadSize;
         }
 
         private void SetProtocol(ProtocolType inProtocol)
@@ -439,7 +449,14 @@ namespace Unity.Netcode
                     return;
                 }
 
-                var written = queue.FillWriter(ref writer);
+                // We don't attempt to send entire payloads over the reliable pipeline. Instead we
+                // fragment it manually. This is safe and easy to do since the reliable pipeline
+                // basically implements a stream, so as long as we separate the different messages
+                // in the stream (the send queue does that automatically) we are sure they'll be
+                // reassembled properly at the other end. This allows us to lift the limit of ~44KB
+                // on reliable payloads (because of the reliable window size).
+                var written = pipeline == m_ReliableSequencedPipeline
+                    ? queue.FillWriterWithBytes(ref writer) : queue.FillWriterWithMessages(ref writer);
 
                 result = m_Driver.EndSend(writer);
                 if (result == written)
@@ -481,9 +498,42 @@ namespace Unity.Netcode
 
         }
 
+        private void ReceiveMessages(ulong clientId, NetworkPipeline pipeline, DataStreamReader dataReader)
+        {
+            BatchedReceiveQueue queue;
+            if (pipeline == m_ReliableSequencedPipeline)
+            {
+                if (m_ReliableReceiveQueues.TryGetValue(clientId, out queue))
+                {
+                    queue.PushReader(dataReader);
+                }
+                else
+                {
+                    queue = new BatchedReceiveQueue(dataReader);
+                    m_ReliableReceiveQueues[clientId] = queue;
+                }
+            }
+            else
+            {
+                queue = new BatchedReceiveQueue(dataReader);
+            }
+
+            while (!queue.IsEmpty)
+            {
+                var message = queue.PopMessage();
+                if (message == default)
+                {
+                    // Only happens if there's only a partial message in the queue (rare).
+                    break;
+                }
+
+                InvokeOnTransportEvent(NetcodeNetworkEvent.Data, clientId, message, Time.realtimeSinceStartup);
+            }
+        }
+
         private bool ProcessEvent()
         {
-            var eventType = m_Driver.PopEvent(out var networkConnection, out var reader);
+            var eventType = m_Driver.PopEvent(out var networkConnection, out var reader, out var pipeline);
 
             switch (eventType)
             {
@@ -510,6 +560,8 @@ namespace Unity.Netcode
                             }
                         }
 
+                        m_ReliableReceiveQueues.Remove(ParseClientId(networkConnection));
+
                         InvokeOnTransportEvent(NetcodeNetworkEvent.Disconnect,
                             ParseClientId(networkConnection),
                             default(ArraySegment<byte>),
@@ -520,17 +572,7 @@ namespace Unity.Netcode
                     }
                 case TransportNetworkEvent.Type.Data:
                     {
-                        var queue = new BatchedReceiveQueue(reader);
-
-                        while (!queue.IsEmpty)
-                        {
-                            InvokeOnTransportEvent(NetcodeNetworkEvent.Data,
-                                ParseClientId(networkConnection),
-                                queue.PopMessage(),
-                                Time.realtimeSinceStartup
-                            );
-                        }
-
+                        ReceiveMessages(ParseClientId(networkConnection), pipeline, reader);
                         return true;
                     }
             }
@@ -744,7 +786,7 @@ namespace Unity.Netcode
         public void CreateDriver(UnityTransport transport, out NetworkDriver driver,
             out NetworkPipeline unreliableFragmentedPipeline,
             out NetworkPipeline unreliableSequencedFragmentedPipeline,
-            out NetworkPipeline reliableSequencedFragmentedPipeline)
+            out NetworkPipeline reliableSequencedPipeline)
         {
             var maxFrameTimeMS = 0;
 
@@ -775,8 +817,7 @@ namespace Unity.Netcode
                     typeof(UnreliableSequencedPipelineStage),
                     typeof(SimulatorPipelineStage),
                     typeof(SimulatorPipelineStageInSend));
-                reliableSequencedFragmentedPipeline = driver.CreatePipeline(
-                    typeof(FragmentationPipelineStage),
+                reliableSequencedPipeline = driver.CreatePipeline(
                     typeof(ReliableSequencedPipelineStage),
                     typeof(SimulatorPipelineStage),
                     typeof(SimulatorPipelineStageInSend));
@@ -788,8 +829,8 @@ namespace Unity.Netcode
                     typeof(FragmentationPipelineStage));
                 unreliableSequencedFragmentedPipeline = driver.CreatePipeline(
                     typeof(FragmentationPipelineStage), typeof(UnreliableSequencedPipelineStage));
-                reliableSequencedFragmentedPipeline = driver.CreatePipeline(
-                    typeof(FragmentationPipelineStage), typeof(ReliableSequencedPipelineStage)
+                reliableSequencedPipeline = driver.CreatePipeline(
+                    typeof(ReliableSequencedPipelineStage)
                 );
             }
         }

--- a/com.unity.netcode.adapter.utp/Tests/Editor/BatchedReceiveQueueTests.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Editor/BatchedReceiveQueueTests.cs
@@ -72,5 +72,122 @@ namespace Unity.Netcode.UTP.EditorTests
             Assert.AreEqual(default(ArraySegment<byte>), q.PopMessage());
             Assert.True(q.IsEmpty);
         }
+
+        [Test]
+        public void BatchedReceiveQueue_PartialMessage()
+        {
+            var dataLength = sizeof(int);
+
+            var data = new NativeArray<byte>(dataLength, Allocator.Temp);
+
+            var writer = new DataStreamWriter(data);
+            writer.WriteInt(42);
+
+            var reader = new DataStreamReader(data);
+            var q = new BatchedReceiveQueue(reader);
+
+            Assert.False(q.IsEmpty);
+            Assert.AreEqual(default(ArraySegment<byte>), q.PopMessage());
+        }
+
+        [Test]
+        public void BatchedReceiveQueue_PushReader_ToFilledQueue()
+        {
+            var data1Length = sizeof(int);
+            var data2Length = sizeof(byte);
+
+            var data1 = new NativeArray<byte>(data1Length, Allocator.Temp);
+            var data2 = new NativeArray<byte>(data2Length, Allocator.Temp);
+
+            var writer1 = new DataStreamWriter(data1);
+            writer1.WriteInt(1);
+            var writer2 = new DataStreamWriter(data2);
+            writer2.WriteByte(42);
+
+            var reader1 = new DataStreamReader(data1);
+            var reader2 = new DataStreamReader(data2);
+
+            var q = new BatchedReceiveQueue(reader1);
+
+            Assert.False(q.IsEmpty);
+
+            q.PushReader(reader2);
+
+            Assert.False(q.IsEmpty);
+
+            var message = q.PopMessage();
+            Assert.AreEqual(1, message.Count);
+            Assert.AreEqual((byte)42, message.Array[message.Offset]);
+
+            Assert.AreEqual(default(ArraySegment<byte>), q.PopMessage());
+            Assert.True(q.IsEmpty);
+        }
+
+        [Test]
+        public void BatchedReceiveQueue_PushReader_ToPartiallyFilledQueue()
+        {
+            var dataLength = sizeof(int) + 1;
+
+            var data = new NativeArray<byte>(dataLength, Allocator.Temp);
+
+            var writer = new DataStreamWriter(data);
+            writer.WriteInt(1);
+            writer.WriteByte((byte)42);
+
+            var reader = new DataStreamReader(data);
+            var q = new BatchedReceiveQueue(reader);
+
+            reader = new DataStreamReader(data);
+            q.PushReader(reader);
+
+            var message = q.PopMessage();
+            Assert.AreEqual(1, message.Count);
+            Assert.AreEqual((byte)42, message.Array[message.Offset]);
+
+            reader = new DataStreamReader(data);
+            q.PushReader(reader);
+
+            message = q.PopMessage();
+            Assert.AreEqual(1, message.Count);
+            Assert.AreEqual((byte)42, message.Array[message.Offset]);
+
+            message = q.PopMessage();
+            Assert.AreEqual(1, message.Count);
+            Assert.AreEqual((byte)42, message.Array[message.Offset]);
+
+            Assert.AreEqual(default(ArraySegment<byte>), q.PopMessage());
+            Assert.True(q.IsEmpty);
+        }
+
+        [Test]
+        public void BatchedReceiveQueue_PushReader_ToEmptyQueue()
+        {
+            var dataLength = sizeof(int) + 1;
+
+            var data = new NativeArray<byte>(dataLength, Allocator.Temp);
+
+            var writer = new DataStreamWriter(data);
+            writer.WriteInt(1);
+            writer.WriteByte((byte)42);
+
+            var reader = new DataStreamReader(data);
+            var q = new BatchedReceiveQueue(reader);
+
+            Assert.False(q.IsEmpty);
+
+            q.PopMessage();
+
+            Assert.True(q.IsEmpty);
+
+            reader = new DataStreamReader(data);
+            q.PushReader(reader);
+
+            var message = q.PopMessage();
+            Assert.AreEqual(1, message.Count);
+            Assert.AreEqual((byte)42, message.Array[message.Offset]);
+
+            Assert.AreEqual(default(ArraySegment<byte>), q.PopMessage());
+            Assert.True(q.IsEmpty);
+        }
     }
 }

--- a/com.unity.netcode.adapter.utp/Tests/Runtime/ConnectionTests.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/ConnectionTests.cs
@@ -20,8 +20,6 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTearDown]
         public IEnumerator Cleanup()
         {
-            Debug.Log("Calling Cleanup");
-
             if (m_Server)
             {
                 m_Server.Shutdown();

--- a/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/RuntimeTestsHelpers.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/RuntimeTestsHelpers.cs
@@ -36,7 +36,7 @@ namespace Unity.Netcode.UTP.RuntimeTests
 
         // Common code to initialize a UnityTransport that logs its events.
         public static void InitializeTransport(out UnityTransport transport, out List<TransportEvent> events,
-            int maxPayloadSize = UnityTransport.InitialBatchQueueSize)
+            int maxPayloadSize = UnityTransport.InitialMaxPayloadSize)
         {
             var logger = new TransportEventLogger();
             events = logger.Events;

--- a/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/RuntimeTestsHelpers.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/RuntimeTestsHelpers.cs
@@ -35,13 +35,15 @@ namespace Unity.Netcode.UTP.RuntimeTests
         }
 
         // Common code to initialize a UnityTransport that logs its events.
-        public static void InitializeTransport(out UnityTransport transport, out List<TransportEvent> events)
+        public static void InitializeTransport(out UnityTransport transport, out List<TransportEvent> events,
+            int maxPayloadSize = UnityTransport.InitialBatchQueueSize)
         {
             var logger = new TransportEventLogger();
             events = logger.Events;
 
             transport = new GameObject().AddComponent<UnityTransport>();
             transport.OnTransportEvent += logger.HandleEvent;
+            transport.SetMaxPayloadSize(maxPayloadSize);
             transport.Initialize();
         }
 

--- a/com.unity.netcode.adapter.utp/Tests/Runtime/TransportTests.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/TransportTests.cs
@@ -27,7 +27,6 @@ namespace Unity.Netcode.UTP.RuntimeTests
         [UnityTearDown]
         public IEnumerator Cleanup()
         {
-            Debug.Log("Calling Cleanup");
             if (m_Server)
             {
                 m_Server.Shutdown();
@@ -120,18 +119,36 @@ namespace Unity.Netcode.UTP.RuntimeTests
         [UnityTest]
         public IEnumerator SendMaximumPayloadSize([ValueSource("k_DeliveryParameters")] NetworkDelivery delivery)
         {
-            InitializeTransport(out m_Server, out m_ServerEvents);
-            InitializeTransport(out m_Client1, out m_Client1Events);
+            // We want something that's over the old limit of ~44KB for reliable payloads.
+            var payloadSize = 64 * 1024;
+
+            InitializeTransport(out m_Server, out m_ServerEvents, payloadSize);
+            InitializeTransport(out m_Client1, out m_Client1Events, payloadSize);
 
             m_Server.StartServer();
             m_Client1.StartClient();
 
             yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ServerEvents);
 
-            var payload = new ArraySegment<byte>(new byte[UnityTransport.InitialMaxPayloadSize]);
+            var payloadData = new byte[payloadSize];
+            for (int i = 0; i < payloadData.Length; i++)
+            {
+                payloadData[i] = (byte)i;
+            }
+
+            var payload = new ArraySegment<byte>(payloadData);
             m_Client1.Send(m_Client1.ServerClientId, payload, delivery);
 
             yield return WaitForNetworkEvent(NetworkEvent.Data, m_ServerEvents);
+
+            Assert.AreEqual(payloadSize, m_ServerEvents[1].Data.Count);
+
+            var receivedArray = m_ServerEvents[1].Data.Array;
+            var receivedArrayOffset = m_ServerEvents[1].Data.Offset;
+            for (int i = 0; i < payloadSize; i++)
+            {
+                Assert.AreEqual(payloadData[i], receivedArray[receivedArrayOffset + i]);
+            }
 
             yield return null;
         }


### PR DESCRIPTION
MTT-2176

This is backport of PR #1596 to `release/1.0.0`.

## Changelog

### com.unity.netcode.adapter.utp

* Fixed: Lifted the limit of ~44KB for reliable payloads. Before the fix, attempting to send a payload larger than that with reliable delivery would silently fail. Note that it is still not recommended to send such large reliable payloads, since their delivery could take a few network round-trips.

## Testing and Documentation

* Includes unit tests.
* Includes integration tests.
* No documentation changes or additions were necessary.