### PR TITLE
chore: Update UTP adapter dependencies

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -11,8 +11,8 @@ All notable changes to this package will be documented in this file. The format 
 ### Changed
 
 - Rename the 'Send Queue Batch Size' property to 'Max Payload Size' to better reflect its usage (#1584)
-- Updated Unity Transport package to 1.0.0-pre.12.
-- Updated Burst package to 1.6.4.
+- Updated Unity Transport package to 1.0.0-pre.12. (#1615)
+- Updated Burst package to 1.6.4. (#1615)
 
 ### Fixed
 

--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this package will be documented in this file. The format 
 ### Changed
 
 - Rename the 'Send Queue Batch Size' property to 'Max Payload Size' to better reflect its usage (#1584)
+- Updated Unity Transport package to 1.0.0-pre.12.
+- Updated Burst package to 1.6.4.
 
 ### Fixed
 

--- a/com.unity.netcode.adapter.utp/package.json
+++ b/com.unity.netcode.adapter.utp/package.json
@@ -5,8 +5,8 @@
   "version": "1.0.0-pre.4",
   "unity": "2020.3",
   "dependencies": {
-    "com.unity.burst": "1.6.2",
+    "com.unity.burst": "1.6.4",
     "com.unity.netcode.gameobjects": "1.0.0-pre.4",
-    "com.unity.transport": "1.0.0-pre.10"
+    "com.unity.transport": "1.0.0-pre.12"
   }
 }


### PR DESCRIPTION
Update the adapter dependencies on UTP and Burst to point to their latest version.

## Changelog

### com.unity.netcode.adapter.utp

* Changed: Updated Unity Transport package to 1.0.0-pre.12.
* Changed: Updated Burst package to 1.6.4.

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.