### PR TITLE
chore: Update UTP adapter dependencies (1.0.0)

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this package will be documented in this file. The format 
 ### Changed
 
 - Rename the 'Send Queue Batch Size' property to 'Max Payload Size' to better reflect its usage. (#1584)
+- Updated Unity Transport package to 1.0.0-pre.12. (#1615)
 
 ### Fixed
 

--- a/com.unity.netcode.adapter.utp/package.json
+++ b/com.unity.netcode.adapter.utp/package.json
@@ -6,6 +6,6 @@
   "unity": "2020.3",
   "dependencies": {
     "com.unity.netcode.gameobjects": "1.0.0-pre.4",
-    "com.unity.transport": "1.0.0-pre.10"
+    "com.unity.transport": "1.0.0-pre.12"
   }
 }


### PR DESCRIPTION
Backport of PR #1615 to `release/1.0.0`.

## Changelog

### com.unity.netcode.adapter.utp

* Changed: Updated Unity Transport package to 1.0.0-pre.12.

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.