### PR TITLE
fix: rounding issue with tick calculation - release 1.0.0 backport

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -35,6 +35,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed KeyNotFound exception when removing ownership of a newly spawned NetworkObject that is already owned by the server. (#1500)
 - Fixed NetworkManager.LocalClient not being set when starting as a host. (#1511)
 - Fixed a few memory leak cases when shutting down NetworkManager during Incoming Message Queue processing. (#1323)
+- Fixed network tick value sometimes being duplicated or skipped. (#1614)
 
 ### Changed
 - The SDK no longer limits message size to 64k. (The transport may still impose its own limits, but the SDK no longer does.) (#1384)

--- a/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTime.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTime.cs
@@ -114,6 +114,11 @@ namespace Unity.Netcode
         {
             double d = m_TimeSec / m_TickInterval;
             m_CachedTick = (int)d;
+            // This check is needed due to double division imprecision of large numbers
+            if ((d - m_CachedTick) >= 0.999999999999)
+            {
+                m_CachedTick++;
+            }
             m_CachedTickOffset = ((d - Math.Truncate(d)) * m_TickInterval);
 
             // This handles negative time, decreases tick by 1 and makes offset positive.


### PR DESCRIPTION
Fixing rounding issue with tick calculation.

[MTT-2063](https://jira.unity3d.com/browse/MTT-2063)

This is a backport of [PR-1614](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/1614)

### PR Checklist
- [x] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [X] Have you updated the changelog? Each package has a `CHANGELOG.md` file.

## Changelog

### com.unity.netcode.gameobjects
Fixed network tick value sometimes being duplicated or skipped. (#1614)

## Testing and Documentation
* Includes unit test: NetworkTickAdvanceTest
* No documentation changes or additions were necessary.


