### PR TITLE
fix: refresh cancommit value of ClientNetworkTransform - release 1.0.0 backport

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,9 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 - Added `PreviousValue` in NetworkListEvent, when `Value` has changed (#1528)
 
+### Fixed
+- Fixed The ClientNetworkTransform sample script to allow for owner changes at runtime. (#1606)
+
 ## [1.0.0-pre.4] - 2021-01-04
 
 ### Added

--- a/com.unity.netcode.gameobjects/Samples/ClientNetworkTransform/Scripts/ClientNetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Samples/ClientNetworkTransform/Scripts/ClientNetworkTransform.cs
@@ -26,6 +26,7 @@ namespace Unity.Netcode.Samples
 
         protected override void Update()
         {
+            CanCommitToTransform = IsOwner;
             base.Update();
             if (NetworkManager.Singleton != null && (NetworkManager.Singleton.IsConnectedClient || NetworkManager.Singleton.IsListening))
             {


### PR DESCRIPTION
This is a backport of #1606 
