### PR TITLE
fix: snapshot to use ReadField and ReadDelta appropriately

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
@@ -330,6 +330,11 @@ namespace Unity.Netcode
         {
             m_NetworkManager.SpawnManager.SpawnedObjects.TryGetValue(despawnCommand.NetworkObjectId, out NetworkObject networkObject);
 
+            if (networkObject == null)
+            {
+                return;
+            }
+
             m_NetworkManager.SpawnManager.OnDespawnObject(networkObject, true);
             //todo: discuss with tools how to report shared bytes
             m_NetworkManager.NetworkMetrics.TrackObjectDestroyReceived(srcClientId, networkObject, 8);

--- a/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
@@ -574,7 +574,8 @@ namespace Unity.Netcode
                         updateCommand.BehaviourIndex = childIndex;
                         updateCommand.VariableIndex = variableIndex;
 
-                        Store(updateCommand, behaviour.NetworkVariableFields[variableIndex], false);
+                        // because this is a spawn, we specify that this isn't a delta update
+                        Store(updateCommand, behaviour.NetworkVariableFields[variableIndex], /* IsDelta = */ false);
                     }
                 }
             }
@@ -781,7 +782,9 @@ namespace Unity.Netcode
                     variable.TickRead = updateCommand.TickWritten;
                     if (updateCommand.IsDelta)
                     {
-                        variable.ReadDelta(message.ReadBuffer, false); // todo: pass something for keep dirty delta
+                        // todo: revisit if we need to pass something for keepDirtyDelta
+                        // since we currently only have server-authoritative changes, this makes no difference
+                        variable.ReadDelta(message.ReadBuffer, /* keepDirtyDelta = */false);
                     }
                     else
                     {

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -144,6 +144,14 @@ namespace Unity.Netcode
                 reader.ReadValueSafe(out T value);
                 m_List.Add(value);
             }
+
+            if (OnListChanged != null)
+            {
+                OnListChanged(new NetworkListEvent<T>
+                {
+                    Type = NetworkListEvent<T>.EventType.Full
+                });
+            }
         }
 
         /// <inheritdoc />

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -168,7 +168,10 @@ namespace Unity.Netcode
         /// <inheritdoc />
         public override void ReadField(FastBufferReader reader)
         {
+            T previousValue = m_InternalValue;
             Read(reader, out m_InternalValue);
+
+            OnValueChanged?.Invoke(previousValue, m_InternalValue);
         }
 
         /// <inheritdoc />

--- a/com.unity.netcode.gameobjects/Tests/Runtime/HiddenVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/HiddenVariableTests.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/HiddenVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/HiddenVariableTests.cs
@@ -173,7 +173,7 @@ namespace Unity.Netcode.RuntimeTests
             Debug.Log("Objects spawned");
 
             // ==== Set the NetworkVariable value to 2
-            HiddenVariableObject.ExpectedSize = 1;
+            HiddenVariableObject.ExpectedSize = 1; // list will only contain {2}
             HiddenVariableObject.SpawnCount = 0;
 
             m_NetSpawnedObject.GetComponent<HiddenVariableObject>().MyNetworkVariable.Value = 2;
@@ -191,7 +191,7 @@ namespace Unity.Netcode.RuntimeTests
             Debug.Log("Value changed");
 
             // ==== Hide our object to a different client
-            HiddenVariableObject.ExpectedSize = 2;
+            HiddenVariableObject.ExpectedSize = 2; // list will contain {2, 3}
             m_NetSpawnedObject.NetworkHide(otherClient.ClientId);
 
             // ==== Change the NetworkVariable value
@@ -212,7 +212,7 @@ namespace Unity.Netcode.RuntimeTests
             Debug.Log("Values changed");
 
             // ==== Show our object again to this client
-            HiddenVariableObject.ExpectedSize = 2;
+            HiddenVariableObject.ExpectedSize = 2; // list will contain {2, 3} upon spawn, that happens first
             m_NetSpawnedObject.NetworkShow(otherClient.ClientId);
 
             // ==== Wait for object to be spawned
@@ -223,7 +223,7 @@ namespace Unity.Netcode.RuntimeTests
             // ==== We need a refresh for the newly re-spawned object
             yield return RefreshGameObects();
 
-            HiddenVariableObject.ExpectedSize = 3;
+            HiddenVariableObject.ExpectedSize = 3; // list will then contain {2, 3, 4} after Add()
 
             // ==== Change the NetworkVariable value
             // we should get all notifications of value changing and no errors or exception

--- a/com.unity.netcode.gameobjects/Tests/Runtime/HiddenVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/HiddenVariableTests.cs
@@ -27,6 +27,8 @@ namespace Unity.Netcode.RuntimeTests
             MyNetworkList.OnListChanged += ListChanged;
             SpawnCount++;
 
+            ValueOnClient[NetworkManager.LocalClientId] = MyNetworkVariable.Value;
+
             base.OnNetworkSpawn();
         }
 
@@ -112,6 +114,7 @@ namespace Unity.Netcode.RuntimeTests
                         var curr = gameObject.GetComponent<HiddenVariableObject>().MyNetworkList;
 
                         // check that the two lists are identical
+
                         Debug.Assert(curr.Count == prev.Count);
                         for (int index = 0; index < curr.Count; index++)
                         {
@@ -143,7 +146,6 @@ namespace Unity.Netcode.RuntimeTests
         }
 
         [UnityTest]
-        [Ignore("Snapshot transition")]
         public IEnumerator HiddenVariableTest()
         {
             HiddenVariableObject.SpawnCount = 0;
@@ -211,7 +213,7 @@ namespace Unity.Netcode.RuntimeTests
             Debug.Log("Values changed");
 
             // ==== Show our object again to this client
-            HiddenVariableObject.ExpectedSize = 3;
+            HiddenVariableObject.ExpectedSize = 2;
             m_NetSpawnedObject.NetworkShow(otherClient.ClientId);
 
             // ==== Wait for object to be spawned
@@ -221,6 +223,8 @@ namespace Unity.Netcode.RuntimeTests
 
             // ==== We need a refresh for the newly re-spawned object
             yield return RefreshGameObects();
+
+            HiddenVariableObject.ExpectedSize = 3;
 
             // ==== Change the NetworkVariable value
             // we should get all notifications of value changing and no errors or exception

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/MessagingMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/MessagingMetricsTests.cs
@@ -90,7 +90,8 @@ namespace Unity.Netcode.RuntimeTests.Metrics
         [UnityTest]
         public IEnumerator TrackNamedMessageSentMetric()
         {
-            var waitForMetricValues = new WaitForMetricValues<NamedMessageEvent>(ServerMetrics.Dispatcher, NetworkMetricTypes.NamedMessageSent);
+            var waitForMetricValues = new WaitForMetricValues<NamedMessageEvent>(ServerMetrics.Dispatcher, NetworkMetricTypes.NamedMessageSent,
+                metric => metric.Name == nameof(NamedMessage));
 
             var messageName = Guid.NewGuid();
             using (var writer = new FastBufferWriter(1300, Allocator.Temp))
@@ -115,8 +116,9 @@ namespace Unity.Netcode.RuntimeTests.Metrics
         [UnityTest]
         public IEnumerator TrackNamedMessageSentMetricToMultipleClients()
         {
-            var waitForMetricValues = new WaitForMetricValues<NamedMessageEvent>(ServerMetrics.Dispatcher, NetworkMetricTypes.NamedMessageSent);
             var messageName = Guid.NewGuid();
+            var waitForMetricValues = new WaitForMetricValues<NamedMessageEvent>(ServerMetrics.Dispatcher, NetworkMetricTypes.NamedMessageSent,
+                metric => metric.Name == messageName.ToString());
             using (var writer = new FastBufferWriter(1300, Allocator.Temp))
             {
                 writer.WriteValueSafe(messageName);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/MessagingMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/MessagingMetricsTests.cs
@@ -63,7 +63,6 @@ namespace Unity.Netcode.RuntimeTests.Metrics
         }
 
         [UnityTest]
-        [Ignore("Snapshot transition")]
         public IEnumerator TrackNetworkMessageReceivedMetric()
         {
             var messageName = Guid.NewGuid();
@@ -89,7 +88,6 @@ namespace Unity.Netcode.RuntimeTests.Metrics
         }
 
         [UnityTest]
-        [Ignore("Snapshot transition")]
         public IEnumerator TrackNamedMessageSentMetric()
         {
             var waitForMetricValues = new WaitForMetricValues<NamedMessageEvent>(ServerMetrics.Dispatcher, NetworkMetricTypes.NamedMessageSent);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/MessagingMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/MessagingMetricsTests.cs
@@ -72,7 +72,9 @@ namespace Unity.Netcode.RuntimeTests.Metrics
             {
                 Debug.Log($"Received from {sender}");
             });
-            var waitForMetricValues = new WaitForMetricValues<NetworkMessageEvent>(FirstClientMetrics.Dispatcher, NetworkMetricTypes.NetworkMessageReceived);
+            var waitForMetricValues = new WaitForMetricValues<NetworkMessageEvent>(FirstClientMetrics.Dispatcher, NetworkMetricTypes.NetworkMessageReceived,
+                metric => metric.Name == nameof(NamedMessage));
+
             using (var writer = new FastBufferWriter(1300, Allocator.Temp))
             {
                 writer.WriteValueSafe(messageName);
@@ -90,8 +92,7 @@ namespace Unity.Netcode.RuntimeTests.Metrics
         [UnityTest]
         public IEnumerator TrackNamedMessageSentMetric()
         {
-            var waitForMetricValues = new WaitForMetricValues<NamedMessageEvent>(ServerMetrics.Dispatcher, NetworkMetricTypes.NamedMessageSent,
-                metric => metric.Name == nameof(NamedMessage));
+            var waitForMetricValues = new WaitForMetricValues<NamedMessageEvent>(ServerMetrics.Dispatcher, NetworkMetricTypes.NamedMessageSent);
 
             var messageName = Guid.NewGuid();
             using (var writer = new FastBufferWriter(1300, Allocator.Temp))
@@ -116,9 +117,8 @@ namespace Unity.Netcode.RuntimeTests.Metrics
         [UnityTest]
         public IEnumerator TrackNamedMessageSentMetricToMultipleClients()
         {
+            var waitForMetricValues = new WaitForMetricValues<NamedMessageEvent>(ServerMetrics.Dispatcher, NetworkMetricTypes.NamedMessageSent);
             var messageName = Guid.NewGuid();
-            var waitForMetricValues = new WaitForMetricValues<NamedMessageEvent>(ServerMetrics.Dispatcher, NetworkMetricTypes.NamedMessageSent,
-                metric => metric.Name == messageName.ToString());
             using (var writer = new FastBufferWriter(1300, Allocator.Temp))
             {
                 writer.WriteValueSafe(messageName);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/OwnershipChangeMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/OwnershipChangeMetricsTests.cs
@@ -43,7 +43,6 @@ namespace Unity.Netcode.RuntimeTests.Metrics
         }
 
         [UnityTest]
-        [Ignore("Snapshot transition")]
         public IEnumerator TrackOwnershipChangeSentMetric()
         {
             var networkObject = SpawnNetworkObject();
@@ -65,7 +64,6 @@ namespace Unity.Netcode.RuntimeTests.Metrics
         }
 
         [UnityTest]
-        [Ignore("Snapshot transition")]
         public IEnumerator TrackOwnershipChangeReceivedMetric()
         {
             var networkObject = SpawnNetworkObject();

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/ServerLogsMetricTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/ServerLogsMetricTests.cs
@@ -17,7 +17,6 @@ namespace Unity.Netcode.RuntimeTests.Metrics
         private static readonly int k_ServerLogReceivedMessageOverhead = 2;
 
         [UnityTest]
-        [Ignore("Snapshot transition")]
         public IEnumerator TrackServerLogSentMetric()
         {
             var waitForSentMetric = new WaitForMetricValues<ServerLogEvent>(ClientMetrics.Dispatcher, NetworkMetricTypes.ServerLogSent);
@@ -37,7 +36,6 @@ namespace Unity.Netcode.RuntimeTests.Metrics
         }
 
         [UnityTest]
-        [Ignore("Snapshot transition")]
         public IEnumerator TrackServerLogReceivedMetric()
         {
             var waitForReceivedMetric = new WaitForMetricValues<ServerLogEvent>(ServerMetrics.Dispatcher, NetworkMetricTypes.ServerLogReceived);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectDontDestroyWithOwnerTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectDontDestroyWithOwnerTests.cs
@@ -10,7 +10,6 @@ namespace Unity.Netcode.RuntimeTests
     public class NetworkObjectDontDestroyWithOwnerTests
     {
         [UnityTest]
-        [Ignore("Snapshot transition")]
         public IEnumerator DontDestroyWithOwnerTest()
         {
             // create server and client instances


### PR DESCRIPTION
This PR changes SnapshotSystem to use either ReadField or ReadDelta (and the matching writes) on NetworkVariables, depending on them being spawns or value updates

No backport wanted 
No need for changelog

## Testing and Documentation

HiddenVariableTest got re-enabled
