### PR TITLE
chore: network list contains missing changelog

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this package will be documented in this file. The format 
 ### Fixed
 
 - Lifted the limit of ~44KB for reliable payloads. Before the fix, attempting to send a payload larger than that with reliable delivery would silently fail. Note that it is still not recommended to send such large reliable payloads, since their delivery could take a few network round-trips. (#1596)
+- Fixed: NetworkList.contains value is inverted (issue #1363)
 
 ## [1.0.0-pre.4] - 2022-01-04
 

--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this package will be documented in this file. The format 
 ### Fixed
 
 - Lifted the limit of ~44KB for reliable payloads. Before the fix, attempting to send a payload larger than that with reliable delivery would silently fail. Note that it is still not recommended to send such large reliable payloads, since their delivery could take a few network round-trips. (#1596)
-- Fixed: NetworkList.contains value is inverted (issue #1363)
+- Fixed a bug where NetworkList.contains value was inverted (issue #1363)
 
 ## [1.0.0-pre.4] - 2022-01-04
 

--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this package will be documented in this file. The format 
 ### Fixed
 
 - Lifted the limit of ~44KB for reliable payloads. Before the fix, attempting to send a payload larger than that with reliable delivery would silently fail. Note that it is still not recommended to send such large reliable payloads, since their delivery could take a few network round-trips. (#1596)
-- Fixed a bug where NetworkList.contains value was inverted (issue #1363)
+- Fixed a bug where NetworkList.contains value was inverted (#1363)
 
 ## [1.0.0-pre.4] - 2022-01-04
 


### PR DESCRIPTION
Changelog entry was missing in #1363 this PR adds it.

MTT-2248

### PR Checklist
- [x] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [x] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR or a link to the documenation repo PR if this is a manual update. 


## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.
* Includes documentation for previously-undocumented public API entry points.
* Includes edits to existing public API documentation.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
