### PR TITLE
fix: NetworkManager always sent to the DDOL and cannot be nested - release 1.0.0 backport

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -43,6 +43,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Changed
 - The SDK no longer limits message size to 64k. (The transport may still impose its own limits, but the SDK no longer does.) (#1384)
 - Updated com.unity.collections to 1.1.0 (#1451)
+- NetworkManager's GameObject is no longer allowed to be nested under one or more GameObject(s).(#1484)
+- NetworkManager DontDestroy property was removed and now NetworkManager always is migrated into the DontDestroyOnLoad scene. (#1484)
 
 ## [1.0.0-pre.3] - 2021-10-22
 

--- a/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
@@ -15,7 +15,6 @@ namespace Unity.Netcode.Editor
         private static GUIStyle s_HelpBoxStyle;
 
         // Properties
-        private SerializedProperty m_DontDestroyOnLoadProperty;
         private SerializedProperty m_RunInBackgroundProperty;
         private SerializedProperty m_LogLevelProperty;
 
@@ -85,7 +84,6 @@ namespace Unity.Netcode.Editor
             m_NetworkManager = (NetworkManager)target;
 
             // Base properties
-            m_DontDestroyOnLoadProperty = serializedObject.FindProperty(nameof(NetworkManager.DontDestroy));
             m_RunInBackgroundProperty = serializedObject.FindProperty(nameof(NetworkManager.RunInBackground));
             m_LogLevelProperty = serializedObject.FindProperty(nameof(NetworkManager.LogLevel));
             m_NetworkConfigProperty = serializedObject.FindProperty(nameof(NetworkManager.NetworkConfig));
@@ -112,7 +110,6 @@ namespace Unity.Netcode.Editor
         private void CheckNullProperties()
         {
             // Base properties
-            m_DontDestroyOnLoadProperty = serializedObject.FindProperty(nameof(NetworkManager.DontDestroy));
             m_RunInBackgroundProperty = serializedObject.FindProperty(nameof(NetworkManager.RunInBackground));
             m_LogLevelProperty = serializedObject.FindProperty(nameof(NetworkManager.LogLevel));
             m_NetworkConfigProperty = serializedObject.FindProperty(nameof(NetworkManager.NetworkConfig));
@@ -223,7 +220,6 @@ namespace Unity.Netcode.Editor
             if (!m_NetworkManager.IsServer && !m_NetworkManager.IsClient)
             {
                 serializedObject.Update();
-                EditorGUILayout.PropertyField(m_DontDestroyOnLoadProperty);
                 EditorGUILayout.PropertyField(m_RunInBackgroundProperty);
                 EditorGUILayout.PropertyField(m_LogLevelProperty);
                 EditorGUILayout.Space();

--- a/com.unity.netcode.gameobjects/Editor/NetworkManagerHelper.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkManagerHelper.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+namespace Unity.Netcode.Editor
+{
+#if UNITY_EDITOR
+    /// <summary>
+    /// Specialized editor specific NetworkManager code
+    /// </summary>
+    public class NetworkManagerHelper : NetworkManager.INetworkManagerHelper
+    {
+        internal static NetworkManagerHelper Singleton;
+
+        // This is primarily to handle multiInstance scenarios where more than 1 NetworkManager could exist
+        private static Dictionary<NetworkManager, Transform> s_LastKnownNetworkManagerParents = new Dictionary<NetworkManager, Transform>();
+
+        /// <summary>
+        /// Initializes the singleton instance and registers for:
+        /// Hierarchy changed notification: to notify the user when they nest a NetworkManager
+        /// Play mode state change notification: to capture when entering or exiting play mode (currently only exiting)
+        /// </summary>
+        [InitializeOnLoadMethod]
+        private static void InitializeOnload()
+        {
+            Singleton = new NetworkManagerHelper();
+            NetworkManager.NetworkManagerHelper = Singleton;
+
+            EditorApplication.playModeStateChanged -= EditorApplication_playModeStateChanged;
+            EditorApplication.hierarchyChanged -= EditorApplication_hierarchyChanged;
+
+            EditorApplication.playModeStateChanged += EditorApplication_playModeStateChanged;
+            EditorApplication.hierarchyChanged += EditorApplication_hierarchyChanged;
+        }
+
+        private static void EditorApplication_playModeStateChanged(PlayModeStateChange playModeStateChange)
+        {
+            switch (playModeStateChange)
+            {
+                case PlayModeStateChange.ExitingEditMode:
+                    {
+                        s_LastKnownNetworkManagerParents.Clear();
+                        break;
+                    }
+            }
+        }
+
+        private static void EditorApplication_hierarchyChanged()
+        {
+            var allNetworkManagers = Resources.FindObjectsOfTypeAll<NetworkManager>();
+            foreach (var networkManager in allNetworkManagers)
+            {
+                networkManager.NetworkManagerCheckForParent();
+            }
+        }
+
+        /// <summary>
+        /// Handles notifying the user, via display dialog window, that they have nested a NetworkManager.
+        /// When in edit mode it provides the option to automatically fix the issue
+        /// When in play mode it just notifies the user when entering play mode as well as when the user
+        /// tries to start a network session while a NetworkManager is still nested.
+        /// </summary>
+        public bool NotifyUserOfNestedNetworkManager(NetworkManager networkManager, bool ignoreNetworkManagerCache = false, bool editorTest = false)
+        {
+            var gameObject = networkManager.gameObject;
+            var transform = networkManager.transform;
+            var isParented = transform.root != transform;
+
+            var message = NetworkManager.GenerateNestedNetworkManagerMessage(transform);
+            if (s_LastKnownNetworkManagerParents.ContainsKey(networkManager) && !ignoreNetworkManagerCache)
+            {
+                // If we have already notified the user, then don't notify them again
+                if (s_LastKnownNetworkManagerParents[networkManager] == transform.root)
+                {
+                    return isParented;
+                }
+                else // If we are no longer a child, then we can remove ourself from this list
+                if (transform.root == gameObject.transform)
+                {
+                    s_LastKnownNetworkManagerParents.Remove(networkManager);
+                }
+            }
+            if (!EditorApplication.isUpdating && isParented)
+            {
+                if (!EditorApplication.isPlaying && !editorTest)
+                {
+                    message += $"Click 'Auto-Fix' to automatically remove it from {transform.root.gameObject.name} or 'Manual-Fix' to fix it yourself in the hierarchy view.";
+                    if (EditorUtility.DisplayDialog("Invalid Nested NetworkManager", message, "Auto-Fix", "Manual-Fix"))
+                    {
+                        transform.parent = null;
+                        isParented = false;
+                    }
+                }
+                else
+                {
+                    Debug.LogError(message);
+                }
+
+                if (!s_LastKnownNetworkManagerParents.ContainsKey(networkManager) && isParented)
+                {
+                    s_LastKnownNetworkManagerParents.Add(networkManager, networkManager.transform.root);
+                }
+            }
+            return isParented;
+        }
+    }
+#endif
+}

--- a/com.unity.netcode.gameobjects/Editor/NetworkManagerHelper.cs.meta
+++ b/com.unity.netcode.gameobjects/Editor/NetworkManagerHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b26b53dc28ae1b5488bbbecc3e499bbc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -565,20 +565,8 @@ namespace Unity.Netcode
 
             GenerateScenesInBuild();
 
-            // If NetworkManager has this set to true, then we can get the DDOL (DontDestroyOnLoad) from its GaemObject
-            if (networkManager.DontDestroy)
-            {
-                DontDestroyOnLoadScene = networkManager.gameObject.scene;
-            }
-            else
-            {
-                // Otherwise, we have to create a GameObject and move it into the DDOL in order to
-                // register the DDOL scene handle with NetworkSceneManager
-                var myDDOLObject = new GameObject("DDOL-NWSM");
-                UnityEngine.Object.DontDestroyOnLoad(myDDOLObject);
-                DontDestroyOnLoadScene = myDDOLObject.scene;
-                UnityEngine.Object.Destroy(myDDOLObject);
-            }
+            // Since NetworkManager is now always migrated to the DDOL we will use this to get the DDOL scene
+            DontDestroyOnLoadScene = networkManager.gameObject.scene;
 
             ServerSceneHandleToClientSceneHandle.Add(DontDestroyOnLoadScene.handle, DontDestroyOnLoadScene.handle);
             ScenesLoaded.Add(DontDestroyOnLoadScene.handle, DontDestroyOnLoadScene);

--- a/com.unity.netcode.gameobjects/Tests/Editor/NetworkManagerConfigurationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/NetworkManagerConfigurationTests.cs
@@ -1,0 +1,38 @@
+using NUnit.Framework;
+using UnityEngine;
+using Unity.Netcode.Editor;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.EditorTests
+{
+    public class NetworkManagerConfigurationTests
+    {
+        /// <summary>
+        /// Does a simple check to make sure the nested network manager will
+        /// notify the user when in the editor.  This is just a unit test to
+        /// validate this is functioning
+        /// </summary>
+        [Test]
+        public void NestedNetworkManagerCheck()
+        {
+            var parent = new GameObject("ParentObject");
+            var networkManagerObject = new GameObject(nameof(NestedNetworkManagerCheck));
+            var networkManager = networkManagerObject.AddComponent<NetworkManager>();
+
+            // Make our NetworkManager's GameObject nested
+            networkManagerObject.transform.parent = parent.transform;
+
+            // Pre-generate the error message we are expecting to see
+            var messageToCheck = NetworkManager.GenerateNestedNetworkManagerMessage(networkManagerObject.transform);
+
+            // Trap for the nested NetworkManager exception
+            LogAssert.Expect(LogType.Error, messageToCheck);
+
+            // Since this is an in-editor test, we must force this invocation
+            NetworkManagerHelper.Singleton.NotifyUserOfNestedNetworkManager(networkManager, false, true);
+
+            // Clean up
+            Object.DestroyImmediate(parent);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Editor/NetworkManagerConfigurationTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Editor/NetworkManagerConfigurationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9b84044fccbd3cd49908f0efd5719347
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NestedNetworkManagerTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NestedNetworkManagerTests.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Unity.Netcode;
+using Unity.Netcode.RuntimeTests;
+using Object = UnityEngine.Object;
+
+namespace TestProject.RuntimeTests
+{
+    public class NestedNetworkManagerTests
+    {
+        [UnityTest]
+        public IEnumerator CheckNestedNetworkManager()
+        {
+            var parent = new GameObject("ParentObject");
+            var networkManagerObject = new GameObject(nameof(CheckNestedNetworkManager));
+
+            // Make our NetworkManager's GameObject nested
+            networkManagerObject.transform.parent = parent.transform;
+
+            // Pre-generate the error message we are expecting to see
+            var messageToCheck = NetworkManager.GenerateNestedNetworkManagerMessage(networkManagerObject.transform);
+            var transport = networkManagerObject.AddComponent<SIPTransport>();
+            var networkManager = networkManagerObject.AddComponent<NetworkManager>();
+            networkManager.NetworkConfig = new NetworkConfig() { NetworkTransport = transport };
+            // Trap for the nested NetworkManager exception
+            LogAssert.Expect(LogType.Error, messageToCheck);
+
+            yield return new WaitForSeconds(0.02f);
+
+            // Clean up
+            Object.Destroy(parent);
+
+            yield return null;
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NestedNetworkManagerTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NestedNetworkManagerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 738f6d8fc9319fe42a986c2f43989642
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/testproject/Assets/Tests/Runtime/DontDestroyOnLoadTests.cs
+++ b/testproject/Assets/Tests/Runtime/DontDestroyOnLoadTests.cs
@@ -87,9 +87,8 @@ namespace TestProject.RuntimeTests
 
 
         [UnityTest]
-        public IEnumerator ValidateNetworkObjectSynchronization([Values(true, false)] bool enableNetworkManagerDontDestroy)
+        public IEnumerator ValidateNetworkObjectSynchronization()
         {
-            m_ServerNetworkManager.DontDestroy = enableNetworkManagerDontDestroy;
             m_ServerNetworkManager.StartHost();
             var objectInstance = Object.Instantiate(m_DontDestroyOnLoadObject);
             var instanceNetworkObject = objectInstance.GetComponent<NetworkObject>();
@@ -104,7 +103,6 @@ namespace TestProject.RuntimeTests
 
             foreach (var networkManager in m_ClientNetworkManagers)
             {
-                networkManager.DontDestroy = enableNetworkManagerDontDestroy;
                 networkManager.StartClient();
             }
 


### PR DESCRIPTION
Networkmanage 's gameObject can't be a child of another gameObject. otherwise will show this issue:
Exception: Failed to find any loaded scene named "XXXX"
and everything related to the network will not working.

This addresses [Github-Issue #1417](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/1417) (described above) where users will now be provided notifications that the NetworkManager cannot be parented under another GameObject (nested). This PR also removes the DontDestroy property from the NetworkManager so that no NetworkManager instance can be destroyed by unloading a scene.

**Development Standalone Build:** The in-engine debug console displays the message that they cannot nest a NetworkManager
**Editor Edit-Mode:** A dialog box notifies the user that they cannot nest a NetworkManager and provides the option for the user to auto-fix or manually fix it
**Editor Play-Mode:** A dialog box just notifies the user that they cannot nest a NetworkManager

[MTT-1732](https://jira.unity3d.com/browse/MTT-1732)

This is a backport of [PR-1484](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/1484)

### PR Checklist
- [X] Have you updated the changelog? Each package has a `CHANGELOG.md` file.

## Changelog

### com.unity.netcode.gameobjects
- Changed: NetworkManager's GameObject is no longer allowed to be nested under one or more GameObject(s).(#1484)
- Changed: NetworkManager DontDestroy property was removed and now NetworkManager always is migrated into the DontDestroyOnLoad scene. (#1484)

## Testing and Documentation
Includes editor and runtime tests to validate the fix
No documentation changes or additions were necessary.