### PR TITLE
chore: Increment package versions for NGO 1.0.0-pre.5 and update changelogs

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -17,13 +17,13 @@ All notable changes to this package will be documented in this file. The format 
 ### Added
 
 - A new 'Server Listen Address' field under 'Connection Data' in the inspector has been added to specify the address a server should listen to, in case it differs from the main 'Address' field. The `SetConnectionData` method has been updated accordingly to take an optional parameter to specify that listen address. (#1605)
+- Added new methods to set the relay server data: `SetHostRelayData` and `SetClientRelayData`. These are meant to be less error-prone than `SetRelayServerData` (which remains available). (#1609)
 
 ### Changed
 
 - Updated Netcode for GameObjects dependency to 1.0.0-pre.5 (#1626)
 - Updated Unity Transport package to 1.0.0-pre.12. (#1615)
 - Rename the 'Send Queue Batch Size' property to 'Max Payload Size' to better reflect its usage. (#1584)
-- Added new methods to set the relay server data: `SetHostRelayData` and `SetClientRelayData`. These are meant to be less error-prone than `SetRelayServerData` (which remains available). (#1609)
 - Implicit conversions between `ConnectionAddressData` and `NetworkEndPoint` are now deprecated, since their semantics are no longer clear with the introduction of the new `ServerListenAddress` field (see above). (#1605)
 
 ### Fixed

--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -6,15 +6,24 @@ All notable changes to this package will be documented in this file. The format 
 
 ### Added
 
+### Changed
+
+- Updated Burst package to 1.6.4. (#1615)
+
+### Fixed
+
+## [1.0.0-pre.5] - 2022-01-26
+
+### Added
+
 - A new 'Server Listen Address' field under 'Connection Data' in the inspector has been added to specify the address a server should listen to, in case it differs from the main 'Address' field. The `SetConnectionData` method has been updated accordingly to take an optional parameter to specify that listen address. (#1605)
 
 ### Changed
 
 - Rename the 'Send Queue Batch Size' property to 'Max Payload Size' to better reflect its usage. (#1584)
-- Implicit conversions between `ConnectionAddressData` and `NetworkEndPoint` are now deprecated, since their semantics are no longer clear with the introduction of the new `ServerListenAddress` field (see above). (#1605)
 - Added new methods to set the relay server data: `SetHostRelayData` and `SetClientRelayData`. These are meant to be less error-prone than `SetRelayServerData` (which remains available). (#1609)
 - Updated Unity Transport package to 1.0.0-pre.12. (#1615)
-- Updated Burst package to 1.6.4. (#1615)
+- Implicit conversions between `ConnectionAddressData` and `NetworkEndPoint` are now deprecated, since their semantics are no longer clear with the introduction of the new `ServerListenAddress` field (see above). (#1605)
 
 ### Fixed
 

--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -20,9 +20,10 @@ All notable changes to this package will be documented in this file. The format 
 
 ### Changed
 
+- Updated Netcode for GameObjects dependency to 1.0.0-pre.5 (#1626)
+- Updated Unity Transport package to 1.0.0-pre.12. (#1615)
 - Rename the 'Send Queue Batch Size' property to 'Max Payload Size' to better reflect its usage. (#1584)
 - Added new methods to set the relay server data: `SetHostRelayData` and `SetClientRelayData`. These are meant to be less error-prone than `SetRelayServerData` (which remains available). (#1609)
-- Updated Unity Transport package to 1.0.0-pre.12. (#1615)
 - Implicit conversions between `ConnectionAddressData` and `NetworkEndPoint` are now deprecated, since their semantics are no longer clear with the introduction of the new `ServerListenAddress` field (see above). (#1605)
 
 ### Fixed

--- a/com.unity.netcode.adapter.utp/package.json
+++ b/com.unity.netcode.adapter.utp/package.json
@@ -2,11 +2,11 @@
   "name": "com.unity.netcode.adapter.utp",
   "displayName": "Unity Transport for Netcode for GameObjects",
   "description": "This package is plugging Unity Transport into Netcode for GameObjects, which is a network transport layer - the low-level interface for sending UDP data",
-  "version": "1.0.0-pre.4",
+  "version": "1.0.0-pre.5",
   "unity": "2020.3",
   "dependencies": {
     "com.unity.burst": "1.6.4",
-    "com.unity.netcode.gameobjects": "1.0.0-pre.4",
+    "com.unity.netcode.gameobjects": "1.0.0-pre.5",
     "com.unity.transport": "1.0.0-pre.12"
   }
 }

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,13 +10,11 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
-- Added `PreviousValue` in `NetworkListEvent`, when `Value` has changed (#1528)
 - Added InterestManager now has a `Disable` setting to allow the user to bypass its function for debugging (#1567)
 - SnapshotSystem carries Spawns, Despawns and NetworkVariable value updates (#1544)
 
 ### Fixed
 
-- Fixed The ClientNetworkTransform sample script to allow for owner changes at runtime. (#1606)
 - Fixed client player object being destroyed on server when the client's player object has DontDestroyWithOwner set. (#1433)
 - Fixed FastBufferReader being created with a length of 1 if provided an input of length 0. (#1480)
 - Fixed an exception being thrown during NetworkVariableDeltaMessage serialization when EnsureNetworkVariableLengthSafety is enabled (#1487)
@@ -24,13 +22,26 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed error when serializing ConnectionApprovalMessage with scene management disabled when one or more objects is hidden via the CheckObjectVisibility delegate (#1509)
 - Fixed The NetworkConfig's checksum hash includes the NetworkTick so that clients with a different tickrate than the server are identified and not allowed to connect. (#1513)
 - Fixed OwnedObjects not being properly modified when using ChangeOwnership. (#1572)
-- Fixed network tick value sometimes being duplicated or skipped. (#1614)
 
 ### Changed
 
 - ServerRpcParams and ClientRpcParams must be the last parameter of an RPC in order to function properly. Added a compile-time check to ensure this is the case and trigger an error if they're placed elsewhere. (#1318)
+
+## [1.0.0-pre.5] - 2022-01-26
+
+### Added
+
+- Added `PreviousValue` in `NetworkListEvent`, when `Value` has changed (#1528)
+
+### Changed
+
 - NetworkManager's GameObject is no longer allowed to be nested under one or more GameObject(s).(#1484)
 - NetworkManager DontDestroy property was removed and now NetworkManager always is migrated into the DontDestroyOnLoad scene. (#1484)
+
+### Fixed
+
+- Fixed network tick value sometimes being duplicated or skipped. (#1614)
+- Fixed The ClientNetworkTransform sample script to allow for owner changes at runtime. (#1606)
 
 ## [1.0.0-pre.4] - 2021-01-04
 

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -2,7 +2,7 @@
     "name": "com.unity.netcode.gameobjects",
     "displayName": "Netcode for GameObjects",
     "description": "Netcode for GameObjects is a high-level netcode SDK that provides networking capabilities to GameObject/MonoBehaviour workflows within Unity and sits on top of underlying transport layer.",
-    "version": "1.0.0-pre.4",
+    "version": "1.0.0-pre.5",
     "unity": "2020.3",
     "dependencies": {
         "com.unity.modules.animation": "1.0.0",


### PR DESCRIPTION
<!-- Replace this line with what this PR does and why.  Describe what you'd like reviewers to know, how you applied the Engineering principles, and any interesting tradeoffs made.  Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

<!-- Add JIRA link here. Short version (e.g. MTT-123) also works and gets auto-linked. -->

<!-- Add RFC link here if applicable. -->

<!-- Original PR link if this is a backport PR -->

<!-- When backporting is required please add the type:backport-release-<version> label to this PR. This should include all versions in which this should be backported to. -->

### PR Checklist
- [x] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR or a link to the documenation repo PR if this is a manual update. 

## Changelog

### com.unity.netcode.adapter.utp
Changed: Updated Netcode for GameObjects dependency to 1.0.0-pre.5
