### PR TITLE
chore: Increment package versions for NGO 1.0.0-pre.5 and update changelogs [backport to release/1.0.0]

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -2,14 +2,6 @@
 
 All notable changes to this package will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
-## [Unreleased]
-
-### Added
-
-### Changed
-
-### Fixed
-
 ## [1.0.0-pre.5] - 2022-01-26
 
 ### Added

--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -6,14 +6,23 @@ All notable changes to this package will be documented in this file. The format 
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [1.0.0-pre.5] - 2022-01-26
+
+### Added
+
 - A new 'Server Listen Address' field under 'Connection Data' in the inspector has been added to specify the address a server should listen to, in case it differs from the main 'Address' field. The `SetConnectionData` method has been updated accordingly to take an optional parameter to specify that listen address. (#1605)
 - Added new methods to set the relay server data: `SetHostRelayData` and `SetClientRelayData`. These are meant to be less error-prone than `SetRelayServerData` (which remains available). (#1609)
 
 ### Changed
 
+- Updated Netcode for GameObjects dependency to 1.0.0-pre.5 (#1626)
+- Updated Unity Transport package to 1.0.0-pre.12. (#1615)
 - Rename the 'Send Queue Batch Size' property to 'Max Payload Size' to better reflect its usage. (#1584)
 - Implicit conversions between `ConnectionAddressData` and `NetworkEndPoint` are now deprecated, since their semantics are no longer clear with the introduction of the new `ServerListenAddress` field (see above). (#1605)
-- Updated Unity Transport package to 1.0.0-pre.12. (#1615)
 
 ### Fixed
 

--- a/com.unity.netcode.adapter.utp/package.json
+++ b/com.unity.netcode.adapter.utp/package.json
@@ -2,10 +2,10 @@
   "name": "com.unity.netcode.adapter.utp",
   "displayName": "Unity Transport for Netcode for GameObjects",
   "description": "This package is plugging Unity Transport into Netcode for GameObjects, which is a network transport layer - the low-level interface for sending UDP data",
-  "version": "1.0.0-pre.4",
+  "version": "1.0.0-pre.5",
   "unity": "2020.3",
   "dependencies": {
-    "com.unity.netcode.gameobjects": "1.0.0-pre.4",
+    "com.unity.netcode.gameobjects": "1.0.0-pre.5",
     "com.unity.transport": "1.0.0-pre.12"
   }
 }

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,14 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
-## [Unreleased]
-
-### Added
-
-### Changed
-
-### Fixed
-
 ## [1.0.0-pre.5] - 2022-01-26
 
 ### Added

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,9 +10,24 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
-- Added `PreviousValue` in NetworkListEvent, when `Value` has changed (#1528)
+### Changed
 
 ### Fixed
+
+## [1.0.0-pre.5] - 2022-01-26
+
+### Added
+
+- Added `PreviousValue` in `NetworkListEvent`, when `Value` has changed (#1528)
+
+### Changed
+
+- NetworkManager's GameObject is no longer allowed to be nested under one or more GameObject(s).(#1484)
+- NetworkManager DontDestroy property was removed and now NetworkManager always is migrated into the DontDestroyOnLoad scene. (#1484)
+
+### Fixed
+
+- Fixed network tick value sometimes being duplicated or skipped. (#1614)
 - Fixed The ClientNetworkTransform sample script to allow for owner changes at runtime. (#1606)
 
 ## [1.0.0-pre.4] - 2021-01-04

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -2,7 +2,7 @@
     "name": "com.unity.netcode.gameobjects",
     "displayName": "Netcode for GameObjects",
     "description": "Netcode for GameObjects is a high-level netcode SDK that provides networking capabilities to GameObject/MonoBehaviour workflows within Unity and sits on top of underlying transport layer.",
-    "version": "1.0.0-pre.4",
+    "version": "1.0.0-pre.5",
     "unity": "2020.3",
     "dependencies": {
         "com.unity.modules.animation": "1.0.0",


### PR DESCRIPTION
This is a backport of https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/1626

## Changelog

### com.unity.netcode.adapter.utp
Changed: Updated Netcode for GameObjects dependency to 1.0.0-pre.5
