### PR TITLE
fix: Unity.Netcode.RuntimeTests Failing on Console

### DIFF
--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -830,7 +830,6 @@ namespace Unity.Netcode.Components
             {
                 // eventually, we could hoist this calculation so that it happens once for all objects, not once per object
                 var cachedDeltaTime = Time.deltaTime;
-
                 var serverTime = NetworkManager.ServerTime;
                 var cachedServerTime = serverTime.Time;
                 var cachedRenderTime = serverTime.TimeTicksAgo(1).Time;

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -806,9 +806,9 @@ namespace Unity.Netcode.Components
         }
         #endregion
 
-        public bool UseFixedUpdate;
-
-        private void InternalUpdate(float deltaTime)
+        // todo this is currently in update, to be able to catch any transform changes. A FixedUpdate mode could be added to be less intense, but it'd be
+        // conditional to users only making transform update changes in FixedUpdate.
+        protected virtual void Update()
         {
             if (!IsSpawned)
             {
@@ -829,7 +829,7 @@ namespace Unity.Netcode.Components
             if (m_CachedNetworkManager.IsConnectedClient || m_CachedNetworkManager.IsListening)
             {
                 // eventually, we could hoist this calculation so that it happens once for all objects, not once per object
-                var cachedDeltaTime = deltaTime;
+                var cachedDeltaTime = Time.deltaTime;
 
                 var serverTime = NetworkManager.ServerTime;
                 var cachedServerTime = serverTime.Time;
@@ -875,23 +875,6 @@ namespace Unity.Netcode.Components
             }
 
             m_LocalAuthoritativeNetworkState.IsTeleportingNextFrame = false;
-        }
-        // todo this is currently in update, to be able to catch any transform changes. A FixedUpdate mode could be added to be less intense, but it'd be
-        // conditional to users only making transform update changes in FixedUpdate.
-        protected virtual void Update()
-        {
-            if (!UseFixedUpdate)
-            {
-                InternalUpdate(Time.deltaTime);
-            }
-        }
-
-        private void FixedUpdate()
-        {
-            if (UseFixedUpdate)
-            {
-                InternalUpdate(Time.fixedDeltaTime);
-            }
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -806,9 +806,9 @@ namespace Unity.Netcode.Components
         }
         #endregion
 
-        // todo this is currently in update, to be able to catch any transform changes. A FixedUpdate mode could be added to be less intense, but it'd be
-        // conditional to users only making transform update changes in FixedUpdate.
-        protected virtual void Update()
+        public bool UseFixedUpdate;
+
+        private void InternalUpdate()
         {
             if (!IsSpawned)
             {
@@ -874,6 +874,23 @@ namespace Unity.Netcode.Components
             }
 
             m_LocalAuthoritativeNetworkState.IsTeleportingNextFrame = false;
+        }
+        // todo this is currently in update, to be able to catch any transform changes. A FixedUpdate mode could be added to be less intense, but it'd be
+        // conditional to users only making transform update changes in FixedUpdate.
+        protected virtual void Update()
+        {
+            if (!UseFixedUpdate)
+            {
+                InternalUpdate();
+            }
+        }
+
+        private void FixedUpdate()
+        {
+            if (UseFixedUpdate)
+            {
+                InternalUpdate();
+            }
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -808,7 +808,7 @@ namespace Unity.Netcode.Components
 
         public bool UseFixedUpdate;
 
-        private void InternalUpdate()
+        private void InternalUpdate(float deltaTime)
         {
             if (!IsSpawned)
             {
@@ -829,7 +829,8 @@ namespace Unity.Netcode.Components
             if (m_CachedNetworkManager.IsConnectedClient || m_CachedNetworkManager.IsListening)
             {
                 // eventually, we could hoist this calculation so that it happens once for all objects, not once per object
-                var cachedDeltaTime = Time.deltaTime;
+                var cachedDeltaTime = deltaTime;
+
                 var serverTime = NetworkManager.ServerTime;
                 var cachedServerTime = serverTime.Time;
                 var cachedRenderTime = serverTime.TimeTicksAgo(1).Time;
@@ -881,7 +882,7 @@ namespace Unity.Netcode.Components
         {
             if (!UseFixedUpdate)
             {
-                InternalUpdate();
+                InternalUpdate(Time.deltaTime);
             }
         }
 
@@ -889,7 +890,7 @@ namespace Unity.Netcode.Components
         {
             if (UseFixedUpdate)
             {
-                InternalUpdate();
+                InternalUpdate(Time.fixedDeltaTime);
             }
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/BaseMultiInstanceTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/BaseMultiInstanceTest.cs
@@ -235,7 +235,7 @@ namespace Unity.Netcode.RuntimeTests
     }
 
     /// <summary>
-    /// Can be used independently or a assigned to <see cref="BaseMultiInstanceTest.WaitForConditionOrTimeOut"></see> in the
+    /// Can be used independently or assigned to <see cref="BaseMultiInstanceTest.WaitForConditionOrTimeOut"></see> in the
     /// event the default timeout period needs to be adjusted
     /// </summary>
     public class TimeOutHelper

--- a/com.unity.netcode.gameobjects/Tests/Runtime/BaseMultiInstanceTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/BaseMultiInstanceTest.cs
@@ -18,10 +18,70 @@ namespace Unity.Netcode.RuntimeTests
 
         protected bool m_BypassStartAndWaitForClients = false;
 
+        static protected TimeOutHelper s_GloabalTimeOutHelper = new TimeOutHelper();
+
+        protected const uint k_DefaultTickRate = 30;
+        protected WaitForSeconds m_DefaultWaitForTick = new WaitForSeconds(1.0f / k_DefaultTickRate);
+
+        /// <summary>
+        /// An update to the original MultiInstanceHelpers.WaitForCondition that:
+        ///     -operates at the current tick rate
+        ///     -provides a value of type T to be passed into the checkForCondition function
+        ///     -allows for a unique TimeOutHelper handler (if none then uses the default)
+        ///     -adjusts its yield period to the settings of the m_ServerNetworkManager.NetworkConfig.TickRate
+        /// Notes: This method provides more stability when running integration tests that could
+        /// be impacted by:
+        ///     -how the integration test is being executed (i.e. in editor or in a stand alone build)
+        ///     -potential platform performance issues (i.e. VM is throttled or maxed)
+        /// </summary>
+        /// <typeparam name="T">type of the value to compare</typeparam>
+        /// <param name="checkForCondition">condition checking function that is passed valueToCompare to compare against</param>
+        /// <param name="valueToCompare">the value to compare against</param>
+        /// <param name="timeOutHelper">optional custom time out helper-handler</param>
+        /// <returns></returns>
+        protected IEnumerator WaitForConditionOrTimeOut<T>(Func<T, bool> checkForCondition, T valueToCompare, TimeOutHelper timeOutHelper = null)
+        {
+            if (checkForCondition == null)
+            {
+                throw new ArgumentNullException($"checkForCondition cannot be null!");
+            }
+
+            if (valueToCompare == null)
+            {
+                throw new ArgumentNullException($"The value to be compared cannot be null!");
+            }
+
+            // If none is provided we use the default global time out helper
+            if (timeOutHelper == null)
+            {
+                timeOutHelper = s_GloabalTimeOutHelper;
+            }
+
+            // Start checking for a timeout
+            timeOutHelper.Start();
+            while (!timeOutHelper.HasTimedOut())
+            {
+                // Update and check to see if the condition has been met
+                if (checkForCondition.Invoke(valueToCompare))
+                {
+                    break;
+                }
+
+                // Otherwise wait for 1 tick interval
+                yield return m_DefaultWaitForTick;
+            }
+            // Stop checking for a timeout
+            timeOutHelper.Stop();
+        }
+
         [UnitySetUp]
         public virtual IEnumerator Setup()
         {
             yield return StartSomeClientsAndServerWithPlayers(true, NbClients, _ => { });
+            if (m_ServerNetworkManager != null)
+            {
+                m_DefaultWaitForTick = new WaitForSeconds(1.0f / m_ServerNetworkManager.NetworkConfig.TickRate);
+            }
         }
 
         [UnityTearDown]
@@ -54,9 +114,12 @@ namespace Unity.Netcode.RuntimeTests
                 Object.DestroyImmediate(networkObject);
             }
 
-            // wait for next frame so everything is destroyed, so following tests can execute from clean environment
-            int nextFrameNumber = Time.frameCount + 1;
-            yield return new WaitUntil(() => Time.frameCount >= nextFrameNumber);
+            // wait for 1 tick interval so everything is destroyed and any following tests
+            // can execute from clean environment
+            yield return m_DefaultWaitForTick;
+
+            // reset the m_ServerWaitForTick for the next test to initialize
+            m_DefaultWaitForTick = new WaitForSeconds(1.0f / k_DefaultTickRate);
         }
 
         /// <summary>
@@ -168,6 +231,44 @@ namespace Unity.Netcode.RuntimeTests
                 // Wait for connection on server side
                 yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnectedToServer(server, useHost ? nbClients + 1 : nbClients));
             }
+        }
+    }
+
+    /// <summary>
+    /// Can be used independently or a assigned to <see cref="BaseMultiInstanceTest.WaitForConditionOrTimeOut"></see> in the
+    /// event the default timeout period needs to be adjusted
+    /// </summary>
+    public class TimeOutHelper
+    {
+        private const float k_DefaultTimeOutWaitPeriod = 2.0f;
+
+        private float m_MaximumTimeBeforeTimeOut;
+        private float m_TimeOutPeriod;
+
+        private bool m_IsStarted;
+        public bool TimedOut { get; internal set; }
+
+        public void Start()
+        {
+            m_MaximumTimeBeforeTimeOut = Time.realtimeSinceStartup + m_TimeOutPeriod;
+            m_IsStarted = true;
+            TimedOut = false;
+        }
+
+        public void Stop()
+        {
+            TimedOut = HasTimedOut();
+            m_IsStarted = false;
+        }
+
+        public bool HasTimedOut()
+        {
+            return m_IsStarted ? m_MaximumTimeBeforeTimeOut < Time.realtimeSinceStartup : TimedOut;
+        }
+
+        public TimeOutHelper(float timeOutPeriod = k_DefaultTimeOutWaitPeriod)
+        {
+            m_TimeOutPeriod = timeOutPeriod;
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOnSpawnTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOnSpawnTests.cs
@@ -13,6 +13,24 @@ namespace Unity.Netcode.RuntimeTests
 
         protected override int NbClients => 2;
 
+        private const float k_TimeOutWaitPeriod = 2.0f;
+        private static float s_TimeOutPeriod;
+
+        /// <summary>
+        /// This will simply advance the timeout period
+        /// </summary>
+        public static void AdvanceTimeOutPeriod()
+        {
+            s_TimeOutPeriod = Time.realtimeSinceStartup + k_TimeOutWaitPeriod;
+        }
+
+        /// <summary>
+        /// Checks if the timeout period has elapsed
+        /// </summary>
+        private static bool HasTimedOut()
+        {
+            return s_TimeOutPeriod <= Time.realtimeSinceStartup;
+        }
 
         /// <summary>
         /// Tests that instantiating a <see cref="NetworkObject"/> and destroying without spawning it
@@ -57,7 +75,6 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTearDown]
         public override IEnumerator Teardown()
         {
-
             if (m_TestNetworkObjectPrefab != null)
             {
                 Object.Destroy(m_TestNetworkObjectPrefab);
@@ -68,7 +85,6 @@ namespace Unity.Netcode.RuntimeTests
                 Object.Destroy(m_TestNetworkObjectInstance);
             }
             yield return base.Teardown();
-
         }
 
         /// <summary>
@@ -102,14 +118,33 @@ namespace Unity.Netcode.RuntimeTests
             // safety check despawned
             Assert.AreEqual(0, serverInstance.OnNetworkDespawnCalledCount);
 
-            // check spawned on client
-            foreach (var clientInstance in clientInstances)
+            AdvanceTimeOutPeriod();
+            var timedOut = false;
+            while (!HasTimedOut())
             {
-                Assert.AreEqual(1, clientInstance.OnNetworkSpawnCalledCount);
+                var spawnedCount = 0;
+                // check spawned on client
+                foreach (var clientInstance in clientInstances)
+                {
+                    if (clientInstance.OnNetworkSpawnCalledCount == 1)
+                    {
+                        spawnedCount++;
+                    }
 
-                // safety check despawned
-                Assert.AreEqual(0, clientInstance.OnNetworkDespawnCalledCount);
+                    // safety check despawned
+                    Assert.AreEqual(0, clientInstance.OnNetworkDespawnCalledCount);
+                }
+
+                timedOut = HasTimedOut();
+                if (spawnedCount >= NbClients)
+                {
+                    break;
+                }
+
+                yield return new WaitForSeconds(1.0f / m_ServerNetworkManager.NetworkConfig.TickRate);
             }
+
+            Assert.False(timedOut, "Timed out while waiting for client side spawns!");
 
             // despawn on server.  However, since we'll be using this object later in the test, don't delete it (false)
             serverInstance.GetComponent<NetworkObject>().Despawn(false);
@@ -117,51 +152,95 @@ namespace Unity.Netcode.RuntimeTests
             // check despawned on server
             Assert.AreEqual(1, serverInstance.OnNetworkDespawnCalledCount);
 
-            // wait long enough for player object to be despawned
-            int nextFrameNumber = Time.frameCount + 4;
-            yield return new WaitUntil(() => Time.frameCount >= nextFrameNumber);
-
-            // check despawned on clients
-            foreach (var clientInstance in clientInstances)
+            AdvanceTimeOutPeriod();
+            timedOut = false;
+            while (!HasTimedOut())
             {
-                Assert.AreEqual(1, clientInstance.OnNetworkDespawnCalledCount);
+                var deSpawnedCount = 0;
+                foreach (var clientInstance in clientInstances)
+                {
+                    if (clientInstance.OnNetworkDespawnCalledCount == 1)
+                    {
+                        deSpawnedCount++;
+                    }
+                }
+
+                timedOut = HasTimedOut();
+
+                if (deSpawnedCount >= NbClients)
+                {
+                    break;
+                }
+
+                yield return new WaitForSeconds(1.0f / m_ServerNetworkManager.NetworkConfig.TickRate);
             }
 
-            //----------- step 2 check spawn again and destroy
+            Assert.False(timedOut, "Timed out while waiting for client side despawns!");
 
+            //----------- step 2 check spawn again and destroy
             serverInstance.GetComponent<NetworkObject>().Spawn();
 
-            // wait long enough for player object to be spawned
-            nextFrameNumber = Time.frameCount + 2;
-            yield return new WaitUntil(() => Time.frameCount >= nextFrameNumber);
-
+            yield return new WaitForSeconds(1.0f / m_ServerNetworkManager.NetworkConfig.TickRate);
             // check spawned again on server this is 2 because we are reusing the object which was already spawned once.
             Assert.AreEqual(2, serverInstance.OnNetworkSpawnCalledCount);
 
-            // check spawned on client
-            foreach (var clientInstance in clientInstances)
+            AdvanceTimeOutPeriod();
+            timedOut = false;
+            while (!HasTimedOut())
             {
-                Assert.AreEqual(1, clientInstance.OnNetworkSpawnCalledCount);
+                var spawnedCount = 0;
+                // check spawned on client
+                foreach (var clientInstance in clientInstances)
+                {
+                    if (clientInstance.OnNetworkSpawnCalledCount == 1)
+                    {
+                        spawnedCount++;
+                    }
+                }
+
+                timedOut = HasTimedOut();
+                if (spawnedCount >= NbClients)
+                {
+                    break;
+                }
+
+                yield return new WaitForSeconds(1.0f / m_ServerNetworkManager.NetworkConfig.TickRate);
             }
+
+            Assert.False(timedOut, "Timed out while waiting for client side spawns! (2nd pass)");
 
             // destroy the server object
             Object.Destroy(serverInstance.gameObject);
 
-            // wait one frame for destroy to kick in
-            yield return null;
+            yield return new WaitForSeconds(1.0f / m_ServerNetworkManager.NetworkConfig.TickRate);
 
             // check whether despawned was called again on server instance
             Assert.AreEqual(2, serverInstance.OnNetworkDespawnCalledCount);
 
-            // wait long enough for player object to be despawned on client
-            nextFrameNumber = Time.frameCount + 2;
-            yield return new WaitUntil(() => Time.frameCount >= nextFrameNumber);
-
-            // check despawned on clients
-            foreach (var clientInstance in clientInstances)
+            AdvanceTimeOutPeriod();
+            timedOut = false;
+            while (!HasTimedOut())
             {
-                Assert.AreEqual(1, clientInstance.OnNetworkDespawnCalledCount);
+                var deSpawnedCount = 0;
+                foreach (var clientInstance in clientInstances)
+                {
+                    if (clientInstance.OnNetworkDespawnCalledCount == 1)
+                    {
+                        deSpawnedCount++;
+                    }
+                }
+
+                timedOut = HasTimedOut();
+
+                if (deSpawnedCount >= NbClients)
+                {
+                    break;
+                }
+
+                yield return new WaitForSeconds(1.0f / m_ServerNetworkManager.NetworkConfig.TickRate);
             }
+
+            Assert.False(timedOut, "Timed out while waiting for client side despawns! (2nd pass)");
         }
 
         private class TrackOnSpawnFunctions : NetworkBehaviour

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOnSpawnTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOnSpawnTests.cs
@@ -120,7 +120,7 @@ namespace Unity.Netcode.RuntimeTests
 
             AdvanceTimeOutPeriod();
             var timedOut = false;
-            while (!HasTimedOut())
+            while (!timedOut)
             {
                 var spawnedCount = 0;
                 // check spawned on client
@@ -154,7 +154,7 @@ namespace Unity.Netcode.RuntimeTests
 
             AdvanceTimeOutPeriod();
             timedOut = false;
-            while (!HasTimedOut())
+            while (!timedOut)
             {
                 var deSpawnedCount = 0;
                 foreach (var clientInstance in clientInstances)
@@ -186,7 +186,7 @@ namespace Unity.Netcode.RuntimeTests
 
             AdvanceTimeOutPeriod();
             timedOut = false;
-            while (!HasTimedOut())
+            while (!timedOut)
             {
                 var spawnedCount = 0;
                 // check spawned on client
@@ -219,7 +219,7 @@ namespace Unity.Netcode.RuntimeTests
 
             AdvanceTimeOutPeriod();
             timedOut = false;
-            while (!HasTimedOut())
+            while (!timedOut)
             {
                 var deSpawnedCount = 0;
                 foreach (var clientInstance in clientInstances)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOnSpawnTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOnSpawnTests.cs
@@ -135,13 +135,14 @@ namespace Unity.Netcode.RuntimeTests
                     Assert.AreEqual(0, clientInstance.OnNetworkDespawnCalledCount);
                 }
 
-                timedOut = HasTimedOut();
                 if (spawnedCount >= NbClients)
                 {
                     break;
                 }
 
                 yield return new WaitForSeconds(1.0f / m_ServerNetworkManager.NetworkConfig.TickRate);
+
+                timedOut = HasTimedOut();
             }
 
             Assert.False(timedOut, "Timed out while waiting for client side spawns!");
@@ -165,14 +166,14 @@ namespace Unity.Netcode.RuntimeTests
                     }
                 }
 
-                timedOut = HasTimedOut();
-
                 if (deSpawnedCount >= NbClients)
                 {
                     break;
                 }
 
                 yield return new WaitForSeconds(1.0f / m_ServerNetworkManager.NetworkConfig.TickRate);
+
+                timedOut = HasTimedOut();
             }
 
             Assert.False(timedOut, "Timed out while waiting for client side despawns!");
@@ -198,13 +199,14 @@ namespace Unity.Netcode.RuntimeTests
                     }
                 }
 
-                timedOut = HasTimedOut();
                 if (spawnedCount >= NbClients)
                 {
                     break;
                 }
 
                 yield return new WaitForSeconds(1.0f / m_ServerNetworkManager.NetworkConfig.TickRate);
+
+                timedOut = HasTimedOut();
             }
 
             Assert.False(timedOut, "Timed out while waiting for client side spawns! (2nd pass)");
@@ -230,14 +232,14 @@ namespace Unity.Netcode.RuntimeTests
                     }
                 }
 
-                timedOut = HasTimedOut();
-
                 if (deSpawnedCount >= NbClients)
                 {
                     break;
                 }
 
                 yield return new WaitForSeconds(1.0f / m_ServerNetworkManager.NetworkConfig.TickRate);
+
+                timedOut = HasTimedOut();
             }
 
             Assert.False(timedOut, "Timed out while waiting for client side despawns! (2nd pass)");

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -20,9 +20,9 @@ namespace Unity.Netcode.RuntimeTests
         private NetworkObject m_ClientSideClientPlayer;
         private NetworkObject m_ServerSideClientPlayer;
 
-        private bool m_TestWithClientNetworkTransform;
+        private readonly bool m_TestWithClientNetworkTransform;
 
-        private bool m_TestWithHost;
+        private readonly bool m_TestWithHost;
 
         public NetworkTransformTests(bool testWithHost, bool testWithClientNetworkTransform)
         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Linq;
 #if NGO_TRANSFORM_DEBUG
 using System.Text.RegularExpressions;
 #endif
@@ -20,11 +21,11 @@ namespace Unity.Netcode.RuntimeTests
         private NetworkObject m_ClientSideClientPlayer;
         private NetworkObject m_ServerSideClientPlayer;
 
-        private readonly bool m_TestWithClientNetworkTransform;
+        private bool m_TestWithClientNetworkTransform;
 
-        private readonly bool m_TestWithHost;
+        private bool m_TestWithHost;
 
-        public NetworkTransformTests(bool testWithHost, bool testWithClientNetworkTransform)
+        public NetworkTransformTests(bool testWithHost = false, bool testWithClientNetworkTransform = false)
         {
             m_TestWithHost = testWithHost; // from test fixture
             m_TestWithClientNetworkTransform = testWithClientNetworkTransform;
@@ -32,20 +33,49 @@ namespace Unity.Netcode.RuntimeTests
 
         protected override int NbClients => 1;
 
+        private const float k_TimeOutWaitPeriod = 2.0f;
+        private static float s_TimeOutPeriod;
+
+        /// <summary>
+        /// This will simply advance the timeout period
+        /// </summary>
+        private static void AdvanceTimeOutPeriod()
+        {
+            s_TimeOutPeriod = Time.realtimeSinceStartup + k_TimeOutWaitPeriod;
+        }
+
+        /// <summary>
+        /// Checks if the timeout period has elapsed
+        /// </summary>
+        private static bool HasTimedOut()
+        {
+            return s_TimeOutPeriod <= Time.realtimeSinceStartup;
+        }
+
         [UnitySetUp]
         public override IEnumerator Setup()
         {
-            yield return StartSomeClientsAndServerWithPlayers(useHost: m_TestWithHost, nbClients: NbClients, updatePlayerPrefab: playerPrefab =>
+            m_BypassStartAndWaitForClients = true;
+            yield return base.Setup();
+        }
+
+
+        public IEnumerator InitializeServerAndClients()
+        {
+
+            if (m_TestWithClientNetworkTransform)
             {
-                if (m_TestWithClientNetworkTransform)
-                {
-                    // playerPrefab.AddComponent<ClientNetworkTransform>();
-                }
-                else
-                {
-                    playerPrefab.AddComponent<NetworkTransform>();
-                }
-            });
+                // m_PlayerPrefab.AddComponent<ClientNetworkTransform>();
+            }
+            else
+            {
+                var networkTransform = m_PlayerPrefab.AddComponent<NetworkTransform>();
+                networkTransform.Interpolate = false;
+                networkTransform.UseFixedUpdate = true;
+            }
+
+            m_ServerNetworkManager.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
+            m_ClientNetworkManagers[0].NetworkConfig.PlayerPrefab = m_PlayerPrefab;
 
 #if NGO_TRANSFORM_DEBUG
             // Log assert for writing without authority is a developer log...
@@ -53,6 +83,16 @@ namespace Unity.Netcode.RuntimeTests
             m_ServerNetworkManager.LogLevel = LogLevel.Developer;
             m_ClientNetworkManagers[0].LogLevel = LogLevel.Developer;
 #endif
+            Assert.True(MultiInstanceHelpers.Start(m_TestWithHost, m_ServerNetworkManager, m_ClientNetworkManagers), "Failed to start server and client instances");
+
+            RegisterSceneManagerHandler();
+
+            // Wait for connection on client side
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(m_ClientNetworkManagers));
+
+            // Wait for connection on server side
+            var clientsToWaitFor = m_TestWithHost ? NbClients + 1 : NbClients;
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnectedToServer(m_ServerNetworkManager, clientsToWaitFor));
 
             // This is the *SERVER VERSION* of the *CLIENT PLAYER*
             var serverClientPlayerResult = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
@@ -64,12 +104,17 @@ namespace Unity.Netcode.RuntimeTests
 
             m_ServerSideClientPlayer = serverClientPlayerResult.Result;
             m_ClientSideClientPlayer = clientClientPlayerResult.Result;
+            //m_ServerSideClientPlayer = m_ServerNetworkManager.ConnectedClients.Where(c => c.Key == m_ClientNetworkManagers[0].LocalClientId).FirstOrDefault().Value.PlayerObject;
+            //m_ClientSideClientPlayer = m_ClientNetworkManagers[0].LocalClient.PlayerObject;
         }
 
         // TODO: rewrite after perms & authority changes
         [UnityTest]
         public IEnumerator TestAuthoritativeTransformChangeOneAtATime([Values] bool testLocalTransform)
         {
+            yield return InitializeServerAndClients();
+
+
             var waitResult = new MultiInstanceHelpers.CoroutineResultWrapper<bool>();
 
             NetworkTransform authoritativeNetworkTransform;
@@ -89,9 +134,6 @@ namespace Unity.Netcode.RuntimeTests
             Assert.That(!otherSideNetworkTransform.CanCommitToTransform);
             Assert.That(authoritativeNetworkTransform.CanCommitToTransform);
 
-            authoritativeNetworkTransform.Interpolate = false;
-            otherSideNetworkTransform.Interpolate = false;
-
             if (authoritativeNetworkTransform.CanCommitToTransform)
             {
                 authoritativeNetworkTransform.InLocalSpace = testLocalTransform;
@@ -106,13 +148,17 @@ namespace Unity.Netcode.RuntimeTests
 
             // test position
             var authPlayerTransform = authoritativeNetworkTransform.transform;
-            authPlayerTransform.position = new Vector3(10, 20, 30);
+
             Assert.AreEqual(Vector3.zero, otherSideNetworkTransform.transform.position, "server side pos should be zero at first"); // sanity check
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForCondition(() => otherSideNetworkTransform.transform.position.x > approximation, waitResult));
+
+            authPlayerTransform.position = new Vector3(10, 20, 30);
+
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForCondition(() => otherSideNetworkTransform.transform.position.x > approximation, waitResult, 5));
             if (!waitResult.Result)
             {
-                throw new Exception("timeout while waiting for position change");
+                throw new Exception($"timeout while waiting for position change! Otherside value {otherSideNetworkTransform.transform.position.x} vs. Approximation {approximation}");
             }
+
             Assert.True(new Vector3(10, 20, 30) == otherSideNetworkTransform.transform.position, $"wrong position on ghost, {otherSideNetworkTransform.transform.position}"); // Vector3 already does float approximation with ==
 
             // test rotation
@@ -150,6 +196,8 @@ namespace Unity.Netcode.RuntimeTests
         // [Ignore("skipping for now, still need to figure weird multiinstance issue with hosts")]
         public IEnumerator TestCantChangeTransformFromOtherSideAuthority([Values] bool testClientAuthority)
         {
+            yield return InitializeServerAndClients();
+
             // test server can't change client authoritative transform
             NetworkTransform authoritativeNetworkTransform;
             NetworkTransform otherSideNetworkTransform;
@@ -167,13 +215,11 @@ namespace Unity.Netcode.RuntimeTests
                 otherSideNetworkTransform = m_ClientSideClientPlayer.GetComponent<NetworkTransform>();
             }
 
-            authoritativeNetworkTransform.Interpolate = false;
-            otherSideNetworkTransform.Interpolate = false;
-
             Assert.AreEqual(Vector3.zero, otherSideNetworkTransform.transform.position, "other side pos should be zero at first"); // sanity check
+
             otherSideNetworkTransform.transform.position = new Vector3(4, 5, 6);
 
-            yield return null; // one frame
+            yield return new WaitForSeconds(1.0f / m_ServerNetworkManager.NetworkConfig.TickRate);
 
             Assert.AreEqual(Vector3.zero, otherSideNetworkTransform.transform.position, "got authority error, but other side still moved!");
 #if NGO_TRANSFORM_DEBUG

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -11,7 +11,7 @@ using UnityEngine.TestTools;
 
 namespace Unity.Netcode.RuntimeTests
 {
-    public class NetworkTransformTestComponent:NetworkTransform
+    public class NetworkTransformTestComponent : NetworkTransform
     {
         public bool ReadyToReceivePositionUpdate = false;
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -24,7 +24,7 @@ namespace Unity.Netcode.RuntimeTests
 
         private bool m_TestWithHost;
 
-        public NetworkTransformTests(bool testWithHost = false, bool testWithClientNetworkTransform = false)
+        public NetworkTransformTests(bool testWithHost, bool testWithClientNetworkTransform)
         {
             m_TestWithHost = testWithHost; // from test fixture
             m_TestWithClientNetworkTransform = testWithClientNetworkTransform;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -78,15 +78,16 @@ namespace Unity.Netcode.RuntimeTests
             RegisterSceneManagerHandler();
 
             // Wait for connection on client side
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(m_ClientNetworkManagers));
+            yield return MultiInstanceHelpers.WaitForClientsConnected(m_ClientNetworkManagers);
 
             // Wait for connection on server side
             var clientsToWaitFor = m_TestWithHost ? NbClients + 1 : NbClients;
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnectedToServer(m_ServerNetworkManager, clientsToWaitFor));
+            yield return MultiInstanceHelpers.WaitForClientsConnectedToServer(m_ServerNetworkManager, clientsToWaitFor);
 
             // This is the *SERVER VERSION* of the *CLIENT PLAYER*
             var serverClientPlayerResult = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation(x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId, m_ServerNetworkManager, serverClientPlayerResult));
+            yield return MultiInstanceHelpers.GetNetworkObjectByRepresentation(x => x.IsPlayerObject &&
+            x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId, m_ServerNetworkManager, serverClientPlayerResult);
             m_ServerSideClientPlayer = serverClientPlayerResult.Result;
 
             // Wait for 1 tick
@@ -94,7 +95,8 @@ namespace Unity.Netcode.RuntimeTests
 
             // This is the *CLIENT VERSION* of the *CLIENT PLAYER*
             var clientClientPlayerResult = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation(x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId, m_ClientNetworkManagers[0], clientClientPlayerResult));
+            yield return MultiInstanceHelpers.GetNetworkObjectByRepresentation(x => x.IsPlayerObject &&
+            x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId, m_ClientNetworkManagers[0], clientClientPlayerResult);
             m_ClientSideClientPlayer = clientClientPlayerResult.Result;
             var otherSideNetworkTransform = m_ClientSideClientPlayer.GetComponent<NetworkTransformTestComponent>();
 
@@ -152,7 +154,7 @@ namespace Unity.Netcode.RuntimeTests
 
             authPlayerTransform.position = new Vector3(10, 20, 30);
 
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForCondition(() => otherSideNetworkTransform.transform.position.x > approximation, waitResult, 5));
+            yield return MultiInstanceHelpers.WaitForCondition(() => otherSideNetworkTransform.transform.position.x > approximation, waitResult, 5);
             if (!waitResult.Result)
             {
                 throw new Exception($"timeout while waiting for position change! Otherside value {otherSideNetworkTransform.transform.position.x} vs. Approximation {approximation}");
@@ -163,7 +165,7 @@ namespace Unity.Netcode.RuntimeTests
             // test rotation
             authPlayerTransform.rotation = Quaternion.Euler(45, 40, 35); // using euler angles instead of quaternions directly to really see issues users might encounter
             Assert.AreEqual(Quaternion.identity, otherSideNetworkTransform.transform.rotation, "wrong initial value for rotation"); // sanity check
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForCondition(() => otherSideNetworkTransform.transform.rotation.eulerAngles.x > approximation, waitResult));
+            yield return MultiInstanceHelpers.WaitForCondition(() => otherSideNetworkTransform.transform.rotation.eulerAngles.x > approximation, waitResult);
             if (!waitResult.Result)
             {
                 throw new Exception("timeout while waiting for rotation change");
@@ -178,7 +180,7 @@ namespace Unity.Netcode.RuntimeTests
             UnityEngine.Assertions.Assert.AreApproximatelyEqual(1f, otherSideNetworkTransform.transform.lossyScale.y, "wrong initial value for scale"); // sanity check
             UnityEngine.Assertions.Assert.AreApproximatelyEqual(1f, otherSideNetworkTransform.transform.lossyScale.z, "wrong initial value for scale"); // sanity check
             authPlayerTransform.localScale = new Vector3(2, 3, 4);
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForCondition(() => otherSideNetworkTransform.transform.lossyScale.x > 1f + approximation, waitResult));
+            yield return MultiInstanceHelpers.WaitForCondition(() => otherSideNetworkTransform.transform.lossyScale.x > 1f + approximation, waitResult);
             if (!waitResult.Result)
             {
                 throw new Exception("timeout while waiting for scale change");

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections;
-using System.Linq;
 #if NGO_TRANSFORM_DEBUG
 using System.Text.RegularExpressions;
 #endif

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVarBufferCopyTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVarBufferCopyTest.cs
@@ -27,8 +27,6 @@ namespace Unity.Netcode.RuntimeTests
                 return Dirty;
             }
 
-            public const float TimeOutAdvancePeriod = 1.0f;
-
             public override void WriteDelta(FastBufferWriter writer)
             {
                 writer.TryBeginWrite(FastBufferWriter.GetWriteSize(k_DummyValue) + 1);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVarBufferCopyTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVarBufferCopyTest.cs
@@ -1,7 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework;
-using UnityEngine;
 using UnityEngine.TestTools;
 
 namespace Unity.Netcode.RuntimeTests

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVarBufferCopyTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVarBufferCopyTest.cs
@@ -103,9 +103,10 @@ namespace Unity.Netcode.RuntimeTests
         public static void ClientDummyNetBehaviourSpawned(DummyNetBehaviour dummyNetBehaviour)
         {
             s_ClientDummyNetBehavioursSpawned.Add(dummyNetBehaviour);
+            AdvanceTimeOutPeriod();
         }
 
-        private const float k_TimeOutWaitPeriod = 2.0f;
+        private const float k_TimeOutWaitPeriod = 5.0f;
         private static float s_TimeOutPeriod;
 
         /// <summary>
@@ -154,8 +155,8 @@ namespace Unity.Netcode.RuntimeTests
             var serverSideClientPlayer = serverClientPlayerResult.Result;
             var clientSideClientPlayer = clientClientPlayerResult.Result;
 
-            var serverComponent = (serverSideClientPlayer).GetComponent<DummyNetBehaviour>();
-            var clientComponent = (clientSideClientPlayer).GetComponent<DummyNetBehaviour>();
+            var serverComponent = serverSideClientPlayer.GetComponent<DummyNetBehaviour>();
+            var clientComponent = clientSideClientPlayer.GetComponent<DummyNetBehaviour>();
 
             var timedOut = false;
             AdvanceTimeOutPeriod();
@@ -176,6 +177,8 @@ namespace Unity.Netcode.RuntimeTests
 
             yield return new WaitForSeconds(1.0f / m_ServerNetworkManager.NetworkConfig.TickRate);
             Assert.True(serverComponent.NetVar.FieldWritten);
+            yield return new WaitForSeconds(1.0f / m_ServerNetworkManager.NetworkConfig.TickRate);
+            serverComponent.NetVar.Dirty = true;
             Assert.True(serverComponent.NetVar.DeltaWritten);
 
             timedOut = false;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVarBufferCopyTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVarBufferCopyTest.cs
@@ -159,7 +159,7 @@ namespace Unity.Netcode.RuntimeTests
 
             var timedOut = false;
             AdvanceTimeOutPeriod();
-            while(!HasTimedOut())
+            while (!HasTimedOut())
             {
                 if (s_ClientDummyNetBehavioursSpawned.Count >= 1)
                 {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVarBufferCopyTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVarBufferCopyTest.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -36,6 +37,7 @@ namespace Unity.Netcode.RuntimeTests
                 writer.WriteValue(k_DummyValue);
 
                 DeltaWritten = true;
+                AdvanceTimeOutPeriod();
             }
 
             public override void WriteField(FastBufferWriter writer)
@@ -48,6 +50,7 @@ namespace Unity.Netcode.RuntimeTests
                 writer.WriteValue(k_DummyValue);
 
                 FieldWritten = true;
+                AdvanceTimeOutPeriod();
             }
 
             public override void ReadField(FastBufferReader reader)
@@ -62,6 +65,7 @@ namespace Unity.Netcode.RuntimeTests
                 Assert.AreEqual(k_DummyValue, i);
 
                 FieldRead = true;
+                AdvanceTimeOutPeriod();
             }
 
             public override void ReadDelta(FastBufferReader reader, bool keepDirtyDelta)
@@ -76,24 +80,61 @@ namespace Unity.Netcode.RuntimeTests
                 Assert.AreEqual(k_DummyValue, i);
 
                 DeltaRead = true;
+                AdvanceTimeOutPeriod();
             }
         }
 
         public class DummyNetBehaviour : NetworkBehaviour
         {
             public DummyNetVar NetVar = new DummyNetVar();
+
+            public override void OnNetworkSpawn()
+            {
+                if (!IsServer)
+                {
+                    ClientDummyNetBehaviourSpawned(this);
+                }
+                base.OnNetworkSpawn();
+            }
         }
         protected override int NbClients => 1;
+
+        private static List<DummyNetBehaviour> s_ClientDummyNetBehavioursSpawned = new List<DummyNetBehaviour>();
+        public static void ClientDummyNetBehaviourSpawned(DummyNetBehaviour dummyNetBehaviour)
+        {
+            s_ClientDummyNetBehavioursSpawned.Add(dummyNetBehaviour);
+        }
+
+        private const float k_TimeOutWaitPeriod = 2.0f;
+        private static float s_TimeOutPeriod;
+
+        /// <summary>
+        /// This will simply advance the timeout period
+        /// </summary>
+        public static void AdvanceTimeOutPeriod()
+        {
+            s_TimeOutPeriod = Time.realtimeSinceStartup + k_TimeOutWaitPeriod;
+        }
+
+        /// <summary>
+        /// Checks if the timeout period has elapsed
+        /// </summary>
+        private static bool HasTimedOut()
+        {
+            return s_TimeOutPeriod <= Time.realtimeSinceStartup;
+        }
 
         [UnitySetUp]
         public override IEnumerator Setup()
         {
+            s_ClientDummyNetBehavioursSpawned.Clear();
             yield return StartSomeClientsAndServerWithPlayers(useHost: true, nbClients: NbClients,
                 updatePlayerPrefab: playerPrefab =>
                 {
                     var dummyNetBehaviour = playerPrefab.AddComponent<DummyNetBehaviour>();
                 });
         }
+
 
         [UnityTest]
         public IEnumerator TestEntireBufferIsCopiedOnNetworkVariableDelta()
@@ -116,15 +157,54 @@ namespace Unity.Netcode.RuntimeTests
             var serverComponent = (serverSideClientPlayer).GetComponent<DummyNetBehaviour>();
             var clientComponent = (clientSideClientPlayer).GetComponent<DummyNetBehaviour>();
 
+            var timedOut = false;
+            AdvanceTimeOutPeriod();
+            while(!HasTimedOut())
+            {
+                if (s_ClientDummyNetBehavioursSpawned.Count >= 1)
+                {
+                    break;
+                }
+                yield return new WaitForSeconds(1.0f / m_ServerNetworkManager.NetworkConfig.TickRate);
+                timedOut = HasTimedOut();
+            }
+
+            Assert.False(timedOut, "Timed out waiting for client side DummyNetBehaviour to register it was spawned!");
+
             // Send an update
             serverComponent.NetVar.Dirty = true;
 
-            yield return new WaitForSeconds(1.0f);
-
+            yield return new WaitForSeconds(1.0f / m_ServerNetworkManager.NetworkConfig.TickRate);
             Assert.True(serverComponent.NetVar.FieldWritten);
             Assert.True(serverComponent.NetVar.DeltaWritten);
-            Assert.True(clientComponent.NetVar.FieldRead);
-            Assert.True(clientComponent.NetVar.DeltaRead);
+
+            timedOut = false;
+            AdvanceTimeOutPeriod();
+            while (!HasTimedOut())
+            {
+                if (clientComponent.NetVar.FieldRead && clientComponent.NetVar.DeltaRead)
+                {
+                    break;
+                }
+                yield return new WaitForSeconds(1.0f / m_ServerNetworkManager.NetworkConfig.TickRate);
+                timedOut = HasTimedOut();
+            }
+
+            var timedOutMessage = "Timed out waiting for client reads: ";
+            if (timedOut)
+            {
+                if (!clientComponent.NetVar.FieldRead)
+                {
+                    timedOutMessage += "[FieldRead]";
+                }
+
+                if (!clientComponent.NetVar.DeltaRead)
+                {
+                    timedOutMessage += "[DeltaRead]";
+                }
+            }
+
+            Assert.False(timedOut, timedOutMessage);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -350,7 +350,7 @@ namespace Unity.Netcode.RuntimeTests
                        m_Player1OnClient1.TheList.Count == listCount;
 
                 // Check the client values against the server values to make sure they match
-                for(int i = 0; i < listCount; i++)
+                for (int i = 0; i < listCount; i++)
                 {
                     hasCorrectCountAndValues = hasCorrectCountAndValues && m_Player1OnServer.TheList[i] == m_Player1OnClient1.TheList[i];
                     if (!hasCorrectCountAndValues)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -125,25 +125,30 @@ namespace Unity.Netcode.RuntimeTests
             RegisterSceneManagerHandler();
 
             // Wait for connection on client side
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(m_ClientNetworkManagers));
+            yield return MultiInstanceHelpers.WaitForClientsConnected(m_ClientNetworkManagers);
+
+            yield return m_DefaultWaitForTick;
 
             // Wait for connection on server side
             var clientsToWaitFor = useHost ? NbClients + 1 : NbClients;
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnectedToServer(m_ServerNetworkManager, clientsToWaitFor));
+            yield return MultiInstanceHelpers.WaitForClientsConnectedToServer(m_ServerNetworkManager, clientsToWaitFor);
 
             // These are the *SERVER VERSIONS* of the *CLIENT PLAYER 1 & 2*
             var result = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
 
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation(
+            yield return MultiInstanceHelpers.GetNetworkObjectByRepresentation(
                 x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId,
-                m_ServerNetworkManager, result));
+                m_ServerNetworkManager, result);
+
+            // Assign server-side client's player
             m_Player1OnServer = result.Result.GetComponent<NetworkVariableTest>();
 
             // This is client1's view of itself
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation(
+            yield return MultiInstanceHelpers.GetNetworkObjectByRepresentation(
                 x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId,
-                m_ClientNetworkManagers[0], result));
+                m_ClientNetworkManagers[0], result);
 
+            // Assign client-side local player
             m_Player1OnClient1 = result.Result.GetComponent<NetworkVariableTest>();
 
             m_Player1OnServer.TheList.Clear();

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -88,9 +88,6 @@ namespace Unity.Netcode.RuntimeTests
 
         /// <summary>
         /// This will simply advance the timeout period
-        /// Note: When ClientSideNotifyObjectSpawned is invoked this will get
-        /// called to handle any potential latencies due to poor performance or
-        /// the like.
         /// </summary>
         private static void AdvanceTimeOutPeriod()
         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -85,6 +85,7 @@ namespace Unity.Netcode.RuntimeTests
 
         private const float k_TimeOutWaitPeriod = 2.0f;
         private static float s_TimeOutPeriod;
+
         /// <summary>
         /// This will simply advance the timeout period
         /// Note: When ClientSideNotifyObjectSpawned is invoked this will get
@@ -125,6 +126,10 @@ namespace Unity.Netcode.RuntimeTests
             yield return base.Setup();
         }
 
+        /// <summary>
+        /// This is an adjustment to how the server and clients are started in order
+        /// to avoid timing issues when running in a stand alone test runner build.
+        /// </summary>
         private IEnumerator InitializeServerAndClients(bool useHost)
         {
             s_ClientNetworkVariableTestInstances.Clear();

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -177,11 +177,14 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator AllNetworkVariableTypes([Values(true, false)] bool useHost)
         {
+            NetworkManager server;
             // Create, instantiate, and host
             // This would normally go in Setup, but since every other test but this one
             //  uses MultiInstanceHelper, and it does its own NetworkManager setup / teardown,
             //  for now we put this within this one test until we migrate it to MIH
-            Assert.IsTrue(NetworkManagerHelper.StartNetworkManager(out _));
+            Assert.IsTrue(NetworkManagerHelper.StartNetworkManager(out server, useHost ? NetworkManagerHelper.NetworkManagerOperatingMode.Host : NetworkManagerHelper.NetworkManagerOperatingMode.Server));
+
+            Assert.IsTrue(server.IsHost == useHost, $"{nameof(useHost)} does not match the server.IsHost value!");
 
             Guid gameObjectId = NetworkManagerHelper.AddGameNetworkObject("NetworkVariableTestComponent");
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -227,9 +227,6 @@ namespace Unity.Netcode.RuntimeTests
             yield return InitializeServerAndClients(useHost);
             m_Player1OnServer.FixedString32.Value = k_FixedStringTestValue;
 
-            // Wait a tick
-            yield return m_DefaultWaitForTick;
-
             // Now wait for the client side version to be updated to k_FixedStringTestValue
             yield return WaitForConditionOrTimeOut((c) => m_Player1OnClient1.FixedString32.Value == c, k_FixedStringTestValue);
             Assert.IsFalse(s_GloabalTimeOutHelper.TimedOut, "Timed out waiting for client-side NetworkVariable to update!");
@@ -269,7 +266,8 @@ namespace Unity.Netcode.RuntimeTests
         public IEnumerator WhenListContainsManyLargeValues_OverflowExceptionIsNotThrown([Values(true, false)] bool useHost)
         {
             yield return InitializeServerAndClients(useHost);
-            for (var i = 0; i < 20; ++i)
+            var numberOfEntries = 20;
+            for (var i = 0; i < numberOfEntries; ++i)
             {
                 m_Player1OnServer.TheLargeList.Add(new FixedString128Bytes());
             }
@@ -280,7 +278,7 @@ namespace Unity.Netcode.RuntimeTests
                        m_Player1OnClient1.TheLargeList.Count == listCount;
             }
 
-            yield return WaitForConditionOrTimeOut(TestCompleted, m_Player1OnServer.TheList.Count);
+            yield return WaitForConditionOrTimeOut(TestCompleted, numberOfEntries);
             Assert.IsFalse(s_GloabalTimeOutHelper.TimedOut, $"Timed out waiting for {nameof(WhenListContainsManyLargeValues_OverflowExceptionIsNotThrown)} to complete its test!");
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -386,19 +386,21 @@ namespace Unity.Netcode.RuntimeTests
 
             bool TestCompleted(int listCount)
             {
-                bool hasCorrectCountAndValues = m_Player1OnServer.TheList.Count == listCount &&
-                       m_Player1OnClient1.TheList.Count == listCount;
-
-                // Check the client values against the server values to make sure they match
-                for (int i = 0; i < listCount; i++)
+                // Wait until both sides have the same number of elements
+                if (m_Player1OnServer.TheList.Count != m_Player1OnClient1.TheList.Count)
                 {
-                    hasCorrectCountAndValues = hasCorrectCountAndValues && m_Player1OnServer.TheList[i] == m_Player1OnClient1.TheList[i];
-                    if (!hasCorrectCountAndValues)
+                    return false;
+                }
+
+                foreach (var serverSideValue in m_Player1OnServer.TheList)
+                {
+                    var indexToTest = m_Player1OnServer.TheList.IndexOf(serverSideValue);
+                    if (indexToTest != m_Player1OnServer.TheList.IndexOf(serverSideValue))
                     {
-                        break;
+                        return false;
                     }
                 }
-                return hasCorrectCountAndValues;
+                return true;
             }
 
             yield return WaitForConditionOrTimeOut(TestCompleted, m_Player1OnServer.TheList.Count);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -83,25 +83,6 @@ namespace Unity.Netcode.RuntimeTests
             s_ClientNetworkVariableTestInstances.Add(networkVariableTest);
         }
 
-        private const float k_TimeOutWaitPeriod = 2.0f;
-        private static float s_TimeOutPeriod;
-
-        /// <summary>
-        /// This will simply advance the timeout period
-        /// </summary>
-        private static void AdvanceTimeOutPeriod()
-        {
-            s_TimeOutPeriod = Time.realtimeSinceStartup + k_TimeOutWaitPeriod;
-        }
-
-        /// <summary>
-        /// Checks if the timeout period has elapsed
-        /// </summary>
-        private static bool HasTimedOut()
-        {
-            return s_TimeOutPeriod <= Time.realtimeSinceStartup;
-        }
-
         // Player1 component on the server
         private NetworkVariableTest m_Player1OnServer;
 
@@ -180,12 +161,13 @@ namespace Unity.Netcode.RuntimeTests
             var allClientNetworkVariableTestInstancesSpawned = false;
             var waitPeriod = 1.0f / m_ServerNetworkManager.NetworkConfig.TickRate;
             var timedOut = false;
-            AdvanceTimeOutPeriod();
-            while (!allClientNetworkVariableTestInstancesSpawned && !HasTimedOut())
+            var timeOutPeriod = Time.realtimeSinceStartup + 2.0f;
+
+            while (!allClientNetworkVariableTestInstancesSpawned && !timedOut)
             {
                 allClientNetworkVariableTestInstancesSpawned = s_ClientNetworkVariableTestInstances.Count >= NbClients;
-                timedOut = HasTimedOut();
                 yield return new WaitForSeconds(waitPeriod);
+                timedOut = timeOutPeriod < Time.realtimeSinceStartup;
             }
 
             Assert.False(timedOut, "Timed out waiting for all client NetworkVariableTest instances to register they have spawned!");

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -244,17 +244,24 @@ namespace Unity.Netcode.RuntimeTests
 
             bool TestCompleted(int listCount)
             {
-                return m_Player1OnServer.TheList.Count == listCount &&
-                    m_Player1OnClient1.TheList.Count == listCount &&
-                    m_Player1OnServer.ListDelegateTriggered &&
-                    m_Player1OnClient1.ListDelegateTriggered &&
-                    m_Player1OnServer.TheList[0] == k_TestVal1 &&
-                    m_Player1OnClient1.TheList[0] == k_TestVal1 &&
-                    m_Player1OnServer.TheList[1] == k_TestVal2 &&
-                    m_Player1OnClient1.TheList[1] == k_TestVal2;
+                bool hasCorrectCountAndValues = m_Player1OnServer.TheList.Count == listCount &&
+                       m_Player1OnClient1.TheList.Count == listCount &&
+                       m_Player1OnServer.ListDelegateTriggered &&
+                       m_Player1OnClient1.ListDelegateTriggered;
+
+                // Check the client values against the server values to make sure they match
+                for (int i = 0; i < listCount; i++)
+                {
+                    hasCorrectCountAndValues = hasCorrectCountAndValues && m_Player1OnServer.TheList[i] == m_Player1OnClient1.TheList[i];
+                    if (!hasCorrectCountAndValues)
+                    {
+                        break;
+                    }
+                }
+                return hasCorrectCountAndValues;
             }
 
-            yield return WaitForConditionOrTimeOut(TestCompleted, 2);
+            yield return WaitForConditionOrTimeOut(TestCompleted, m_Player1OnServer.TheList.Count);
             Assert.IsFalse(s_GloabalTimeOutHelper.TimedOut, $"Timed out waiting for {nameof(NetworkListAdd)} to complete its test!");
         }
 
@@ -273,7 +280,7 @@ namespace Unity.Netcode.RuntimeTests
                        m_Player1OnClient1.TheLargeList.Count == listCount;
             }
 
-            yield return WaitForConditionOrTimeOut(TestCompleted, 20);
+            yield return WaitForConditionOrTimeOut(TestCompleted, m_Player1OnServer.TheList.Count);
             Assert.IsFalse(s_GloabalTimeOutHelper.TimedOut, $"Timed out waiting for {nameof(WhenListContainsManyLargeValues_OverflowExceptionIsNotThrown)} to complete its test!");
         }
 
@@ -344,30 +351,15 @@ namespace Unity.Netcode.RuntimeTests
                 bool hasCorrectCountAndValues = m_Player1OnServer.TheList.Count == listCount &&
                        m_Player1OnClient1.TheList.Count == listCount;
 
-                if (listCount == 2)
+                // Check the client values against the server values to make sure they match
+                for(int i = 0; i < listCount; i++)
                 {
-                    hasCorrectCountAndValues = hasCorrectCountAndValues &&
-                        m_Player1OnServer.ListDelegateTriggered &&
-                        m_Player1OnClient1.ListDelegateTriggered &&
-                        m_Player1OnServer.TheList[0] == k_TestVal1 &&
-                        m_Player1OnClient1.TheList[0] == k_TestVal1 &&
-                        m_Player1OnServer.TheList[1] == k_TestVal2 &&
-                        m_Player1OnClient1.TheList[1] == k_TestVal2;
+                    hasCorrectCountAndValues = hasCorrectCountAndValues && m_Player1OnServer.TheList[i] == m_Player1OnClient1.TheList[i];
+                    if (!hasCorrectCountAndValues)
+                    {
+                        break;
+                    }
                 }
-                else
-                if (listCount == 3)
-                {
-                    hasCorrectCountAndValues = hasCorrectCountAndValues &&
-                        m_Player1OnServer.ListDelegateTriggered &&
-                        m_Player1OnClient1.ListDelegateTriggered &&
-                        m_Player1OnServer.TheList[0] == k_TestVal1 &&
-                        m_Player1OnClient1.TheList[0] == k_TestVal1 &&
-                        m_Player1OnServer.TheList[1] == k_TestVal3 &&
-                        m_Player1OnClient1.TheList[1] == k_TestVal3 &&
-                        m_Player1OnServer.TheList[2] == k_TestVal2 &&
-                        m_Player1OnClient1.TheList[2] == k_TestVal2;
-                }
-
                 return hasCorrectCountAndValues;
             }
 
@@ -396,17 +388,22 @@ namespace Unity.Netcode.RuntimeTests
 
             bool TestCompleted(int listCount)
             {
-                return m_Player1OnServer.TheList.Count == listCount &&
-                       m_Player1OnClient1.TheList.Count == listCount &&
-                       m_Player1OnServer.TheList.IndexOf(k_TestVal1) == 0 &&
-                       m_Player1OnClient1.TheList.IndexOf(k_TestVal1) == 0 &&
-                       m_Player1OnServer.TheList.IndexOf(k_TestVal2) == 1 &&
-                       m_Player1OnClient1.TheList.IndexOf(k_TestVal2) == 1 &&
-                       m_Player1OnServer.TheList.IndexOf(k_TestVal3) == 2 &&
-                       m_Player1OnClient1.TheList.IndexOf(k_TestVal3) == 2;
+                bool hasCorrectCountAndValues = m_Player1OnServer.TheList.Count == listCount &&
+                       m_Player1OnClient1.TheList.Count == listCount;
+
+                // Check the client values against the server values to make sure they match
+                for (int i = 0; i < listCount; i++)
+                {
+                    hasCorrectCountAndValues = hasCorrectCountAndValues && m_Player1OnServer.TheList[i] == m_Player1OnClient1.TheList[i];
+                    if (!hasCorrectCountAndValues)
+                    {
+                        break;
+                    }
+                }
+                return hasCorrectCountAndValues;
             }
 
-            yield return WaitForConditionOrTimeOut(TestCompleted, 3);
+            yield return WaitForConditionOrTimeOut(TestCompleted, m_Player1OnServer.TheList.Count);
             Assert.IsFalse(s_GloabalTimeOutHelper.TimedOut, $"Timed out waiting for {nameof(NetworkListIndexOf)} to complete its test!");
         }
 
@@ -414,23 +411,38 @@ namespace Unity.Netcode.RuntimeTests
         public IEnumerator NetworkListArrayOperator([Values(true, false)] bool useHost)
         {
             yield return InitializeServerAndClients(useHost);
-            m_Player1OnServer.TheList.Add(k_TestVal3);
-            m_Player1OnServer.TheList.Add(k_TestVal3);
-            m_Player1OnServer.TheList[0] = k_TestVal1;
-            m_Player1OnServer.TheList[1] = k_TestVal2;
 
             bool TestCompleted(int listCount)
             {
-                return m_Player1OnServer.TheList.Count == listCount &&
-                       m_Player1OnClient1.TheList.Count == listCount &&
-                       m_Player1OnServer.TheList[0] == k_TestVal1 &&
-                       m_Player1OnClient1.TheList[0] == k_TestVal1 &&
-                       m_Player1OnServer.TheList[1] == k_TestVal2 &&
-                       m_Player1OnClient1.TheList[1] == k_TestVal2;
+                bool hasCorrectCountAndValues = m_Player1OnServer.TheList.Count == listCount &&
+                       m_Player1OnClient1.TheList.Count == listCount;
+
+                // Check the client values against the server values to make sure they match
+                for (int i = 0; i < listCount; i++)
+                {
+                    hasCorrectCountAndValues = hasCorrectCountAndValues && m_Player1OnServer.TheList[i] == m_Player1OnClient1.TheList[i];
+                    if (!hasCorrectCountAndValues)
+                    {
+                        break;
+                    }
+                }
+                return hasCorrectCountAndValues;
             }
 
-            yield return WaitForConditionOrTimeOut(TestCompleted, 2);
-            Assert.IsFalse(s_GloabalTimeOutHelper.TimedOut, $"Timed out waiting for {nameof(NetworkListArrayOperator)} to complete its test!");
+            m_Player1OnServer.TheList.Add(k_TestVal3);
+            m_Player1OnServer.TheList.Add(k_TestVal3);
+
+            // Make sure the client has the initial values
+            yield return WaitForConditionOrTimeOut(TestCompleted, m_Player1OnServer.TheList.Count);
+            Assert.IsFalse(s_GloabalTimeOutHelper.TimedOut, $"{nameof(NetworkListArrayOperator)} timed out waiting for client to have the initial values!");
+
+            // Change the values pn server side using the array operator
+            m_Player1OnServer.TheList[0] = k_TestVal1;
+            m_Player1OnServer.TheList[1] = k_TestVal2;
+
+            // Make sure the client has the updated values
+            yield return WaitForConditionOrTimeOut(TestCompleted, m_Player1OnServer.TheList.Count);
+            Assert.IsFalse(s_GloabalTimeOutHelper.TimedOut, $"{nameof(NetworkListArrayOperator)} timed out waiting for client to have the updated values!");
         }
 
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using UnityEngine;
 using UnityEngine.TestTools;
 using NUnit.Framework;
 using Unity.Collections;
@@ -158,19 +157,13 @@ namespace Unity.Netcode.RuntimeTests
                 throw new Exception("at least one client network container not empty at start");
             }
 
-            var allClientNetworkVariableTestInstancesSpawned = false;
-            var waitPeriod = 1.0f / m_ServerNetworkManager.NetworkConfig.TickRate;
-            var timedOut = false;
-            var timeOutPeriod = Time.realtimeSinceStartup + 2.0f;
+            var instanceCount = useHost ? NbClients * 3 : NbClients * 2;
+            // Wait for the client-side to notify it is finished initializing and spawning.
+            yield return WaitForConditionOrTimeOut((c) => s_ClientNetworkVariableTestInstances.Count == c, instanceCount);
 
-            while (!allClientNetworkVariableTestInstancesSpawned && !timedOut)
-            {
-                allClientNetworkVariableTestInstancesSpawned = s_ClientNetworkVariableTestInstances.Count >= NbClients;
-                yield return new WaitForSeconds(waitPeriod);
-                timedOut = timeOutPeriod < Time.realtimeSinceStartup;
-            }
+            Assert.False(s_GloabalTimeOutHelper.TimedOut, "Timed out waiting for all client NetworkVariableTest instances to register they have spawned!");
 
-            Assert.False(timedOut, "Timed out waiting for all client NetworkVariableTest instances to register they have spawned!");
+            yield return m_DefaultWaitForTick;
         }
 
         /// <summary>
@@ -179,8 +172,6 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator AllNetworkVariableTypes([Values(true, false)] bool useHost)
         {
-            yield return InitializeServerAndClients(useHost);
-
             // Create, instantiate, and host
             // This would normally go in Setup, but since every other test but this one
             //  uses MultiInstanceHelper, and it does its own NetworkManager setup / teardown,
@@ -196,14 +187,8 @@ namespace Unity.Netcode.RuntimeTests
             // Start Testing
             networkVariableTestComponent.EnableTesting = true;
 
-            var testsAreComplete = networkVariableTestComponent.IsTestComplete();
-
-            // Wait for the NetworkVariable tests to complete
-            while (!testsAreComplete)
-            {
-                yield return new WaitForSeconds(0.003f);
-                testsAreComplete = networkVariableTestComponent.IsTestComplete();
-            }
+            yield return WaitForConditionOrTimeOut((c) => c == networkVariableTestComponent.IsTestComplete(), true);
+            Assert.IsFalse(s_GloabalTimeOutHelper.TimedOut, "Timed out waiting for the test to complete!");
 
             // Stop Testing
             networkVariableTestComponent.EnableTesting = false;
@@ -212,8 +197,6 @@ namespace Unity.Netcode.RuntimeTests
 
             // Disable this once we are done.
             networkVariableTestComponent.gameObject.SetActive(false);
-
-            Assert.IsTrue(testsAreComplete);
 
             // This would normally go in Teardown, but since every other test but this one
             //  uses MultiInstanceHelper, and it does its own NetworkManager setup / teardown,
@@ -236,34 +219,126 @@ namespace Unity.Netcode.RuntimeTests
             yield return InitializeServerAndClients(useHost);
             m_Player1OnServer.FixedString32.Value = k_FixedStringTestValue;
 
-            var timeOutperiod = Time.realtimeSinceStartup + 5.0f;
-            var timedOut = false;
-            var hasPlayerValueChanged = m_Player1OnClient1.FixedString32.Value == k_FixedStringTestValue;
-            var waitperiod = 1.0f / m_ServerNetworkManager.NetworkConfig.TickRate;
-            while (!hasPlayerValueChanged && !timedOut)
-            {
-                timedOut = timeOutperiod < Time.realtimeSinceStartup;
-                hasPlayerValueChanged = m_Player1OnClient1.FixedString32.Value == k_FixedStringTestValue;
-                yield return new WaitForSeconds(waitperiod);
-            }
+            // Wait a tick
+            yield return m_DefaultWaitForTick;
 
-            Assert.False(timedOut, "Timed out waiting for client-side NetworkVariable to update!");
+            // Now wait for the client side version to be updated to k_FixedStringTestValue
+            yield return WaitForConditionOrTimeOut((c) => m_Player1OnClient1.FixedString32.Value == c, k_FixedStringTestValue);
+            Assert.IsFalse(s_GloabalTimeOutHelper.TimedOut, "Timed out waiting for client-side NetworkVariable to update!");
         }
 
         [UnityTest]
         public IEnumerator NetworkListAdd([Values(true, false)] bool useHost)
         {
             yield return InitializeServerAndClients(useHost);
-            yield return MultiInstanceHelpers.RunAndWaitForCondition(
-                () =>
+            m_Player1OnServer.TheList.Add(k_TestVal1);
+            m_Player1OnServer.TheList.Add(k_TestVal2);
+
+            bool TestCompleted(int listCount)
+            {
+                return m_Player1OnServer.TheList.Count == listCount &&
+                    m_Player1OnClient1.TheList.Count == listCount &&
+                    m_Player1OnServer.ListDelegateTriggered &&
+                    m_Player1OnClient1.ListDelegateTriggered &&
+                    m_Player1OnServer.TheList[0] == k_TestVal1 &&
+                    m_Player1OnClient1.TheList[0] == k_TestVal1 &&
+                    m_Player1OnServer.TheList[1] == k_TestVal2 &&
+                    m_Player1OnClient1.TheList[1] == k_TestVal2;
+            }
+
+            yield return WaitForConditionOrTimeOut(TestCompleted, 2);
+            Assert.IsFalse(s_GloabalTimeOutHelper.TimedOut, $"Timed out waiting for {nameof(NetworkListAdd)} to complete its test!");
+        }
+
+        [UnityTest]
+        public IEnumerator WhenListContainsManyLargeValues_OverflowExceptionIsNotThrown([Values(true, false)] bool useHost)
+        {
+            yield return InitializeServerAndClients(useHost);
+            for (var i = 0; i < 20; ++i)
+            {
+                m_Player1OnServer.TheLargeList.Add(new FixedString128Bytes());
+            }
+
+            bool TestCompleted(int listCount)
+            {
+                return m_Player1OnServer.TheLargeList.Count == listCount &&
+                       m_Player1OnClient1.TheLargeList.Count == listCount;
+            }
+
+            yield return WaitForConditionOrTimeOut(TestCompleted, 20);
+            Assert.IsFalse(s_GloabalTimeOutHelper.TimedOut, $"Timed out waiting for {nameof(WhenListContainsManyLargeValues_OverflowExceptionIsNotThrown)} to complete its test!");
+        }
+
+        [UnityTest]
+        public IEnumerator NetworkListContains([Values(true, false)] bool useHost)
+        {
+            yield return InitializeServerAndClients(useHost);
+            m_Player1OnServer.TheList.Add(k_TestVal1);
+
+            bool TestCompleted(int listCount)
+            {
+                return m_Player1OnServer.TheList.Count == listCount &&
+                       m_Player1OnClient1.TheList.Count == listCount &&
+                       m_Player1OnServer.TheList.Contains(k_TestVal1) &&
+                       m_Player1OnClient1.TheList.Contains(k_TestVal1);
+            }
+
+            yield return WaitForConditionOrTimeOut(TestCompleted, m_Player1OnServer.TheList.Count);
+            Assert.IsFalse(s_GloabalTimeOutHelper.TimedOut, $"Timed out waiting for {nameof(NetworkListContains)} to complete its test!");
+        }
+
+        [UnityTest]
+        public IEnumerator NetworkListRemoveValue([Values(true, false)] bool useHost)
+        {
+            yield return InitializeServerAndClients(useHost);
+
+            m_Player1OnServer.TheList.Add(k_TestVal1);
+            m_Player1OnServer.TheList.Add(k_TestVal2);
+            m_Player1OnServer.TheList.Add(k_TestVal3);
+
+            // Check to verify the client has 3 elements in the list
+            yield return WaitForConditionOrTimeOut((c) => m_Player1OnServer.TheList.Count == c && m_Player1OnClient1.TheList.Count == c, m_Player1OnServer.TheList.Count);
+            Assert.IsFalse(s_GloabalTimeOutHelper.TimedOut, $"Timed out waiting for {nameof(NetworkListRemoveValue)} to check that " +
+                $"client has {m_Player1OnServer.TheList.Count} elements before removing one!");
+
+            // Now remove an element from the list
+            m_Player1OnServer.TheList.Remove(k_TestVal2);
+
+            // Test to assure the element was removed from the list on the client side
+            // and that the values are correct
+            bool TestCompleted(int listCount)
+            {
+                return m_Player1OnServer.TheList.Count == listCount &&
+                       m_Player1OnClient1.TheList.Count == listCount &&
+                       m_Player1OnServer.TheList[0] == k_TestVal1 &&
+                       m_Player1OnClient1.TheList[0] == k_TestVal1 &&
+                       m_Player1OnServer.TheList[1] == k_TestVal3 &&
+                       m_Player1OnClient1.TheList[1] == k_TestVal3;
+            }
+
+            yield return WaitForConditionOrTimeOut(TestCompleted, m_Player1OnServer.TheList.Count);
+            Assert.IsFalse(s_GloabalTimeOutHelper.TimedOut, $"Timed out waiting for {nameof(NetworkListRemoveValue)} to check that " +
+                $"the client removed the element from its list!");
+        }
+
+        [UnityTest]
+        public IEnumerator NetworkListInsert([Values(true, false)] bool useHost)
+        {
+            yield return InitializeServerAndClients(useHost);
+
+            m_Player1OnServer.TheList.Add(k_TestVal1);
+            m_Player1OnServer.TheList.Add(k_TestVal2);
+
+            // Tests pre-insertion count and values as well
+            // as post-insertion count and values
+            bool TestCompleted(int listCount)
+            {
+                bool hasCorrectCountAndValues = m_Player1OnServer.TheList.Count == listCount &&
+                       m_Player1OnClient1.TheList.Count == listCount;
+
+                if (listCount == 2)
                 {
-                    m_Player1OnServer.TheList.Add(k_TestVal1);
-                    m_Player1OnServer.TheList.Add(k_TestVal2);
-                },
-                () =>
-                {
-                    return m_Player1OnServer.TheList.Count == 2 &&
-                        m_Player1OnClient1.TheList.Count == 2 &&
+                    hasCorrectCountAndValues = hasCorrectCountAndValues &&
                         m_Player1OnServer.ListDelegateTriggered &&
                         m_Player1OnClient1.ListDelegateTriggered &&
                         m_Player1OnServer.TheList[0] == k_TestVal1 &&
@@ -271,144 +346,83 @@ namespace Unity.Netcode.RuntimeTests
                         m_Player1OnServer.TheList[1] == k_TestVal2 &&
                         m_Player1OnClient1.TheList[1] == k_TestVal2;
                 }
-            );
-        }
-
-        [UnityTest]
-        public IEnumerator WhenListContainsManyLargeValues_OverflowExceptionIsNotThrown([Values(true, false)] bool useHost)
-        {
-            yield return InitializeServerAndClients(useHost);
-            yield return MultiInstanceHelpers.RunAndWaitForCondition(
-                () =>
+                else
+                if (listCount == 3)
                 {
-                    for (var i = 0; i < 20; ++i)
-                    {
-                        m_Player1OnServer.TheLargeList.Add(new FixedString128Bytes());
-                    }
-                },
-                () =>
-                {
-                    return m_Player1OnServer.TheLargeList.Count == 20 &&
-                           m_Player1OnClient1.TheLargeList.Count == 20;
+                    hasCorrectCountAndValues = hasCorrectCountAndValues &&
+                        m_Player1OnServer.ListDelegateTriggered &&
+                        m_Player1OnClient1.ListDelegateTriggered &&
+                        m_Player1OnServer.TheList[0] == k_TestVal1 &&
+                        m_Player1OnClient1.TheList[0] == k_TestVal1 &&
+                        m_Player1OnServer.TheList[1] == k_TestVal3 &&
+                        m_Player1OnClient1.TheList[1] == k_TestVal3 &&
+                        m_Player1OnServer.TheList[2] == k_TestVal2 &&
+                        m_Player1OnClient1.TheList[2] == k_TestVal2;
                 }
-            );
-        }
 
-        [UnityTest]
-        public IEnumerator NetworkListContains([Values(true, false)] bool useHost)
-        {
-            yield return InitializeServerAndClients(useHost);
-            yield return MultiInstanceHelpers.RunAndWaitForCondition(
-                () =>
-                {
-                    m_Player1OnServer.TheList.Add(k_TestVal1);
-                },
-                () =>
-                {
-                    return m_Player1OnServer.TheList.Count == 1 &&
-                           m_Player1OnClient1.TheList.Count == 1 &&
-                           m_Player1OnServer.TheList.Contains(k_TestVal1) &&
-                           m_Player1OnClient1.TheList.Contains(k_TestVal1);
-                }
-            );
-        }
+                return hasCorrectCountAndValues;
+            }
 
-        [UnityTest]
-        public IEnumerator NetworkListRemoveValue([Values(true, false)] bool useHost)
-        {
-            yield return InitializeServerAndClients(useHost);
-            yield return MultiInstanceHelpers.RunAndWaitForCondition(
-                () =>
-                {
-                    m_Player1OnServer.TheList.Add(k_TestVal1);
-                    m_Player1OnServer.TheList.Add(k_TestVal2);
-                    m_Player1OnServer.TheList.Add(k_TestVal3);
-                    m_Player1OnServer.TheList.Remove(k_TestVal2);
-                },
-                () =>
-                {
-                    return m_Player1OnServer.TheList.Count == 2 &&
-                           m_Player1OnClient1.TheList.Count == 2 &&
-                           m_Player1OnServer.TheList[0] == k_TestVal1 &&
-                           m_Player1OnClient1.TheList[0] == k_TestVal1 &&
-                           m_Player1OnServer.TheList[1] == k_TestVal3 &&
-                           m_Player1OnClient1.TheList[1] == k_TestVal3;
-                }
-            );
-        }
+            // Wait for the client to have the initial number of entries and have their values validated
+            yield return WaitForConditionOrTimeOut(TestCompleted, m_Player1OnServer.TheList.Count);
+            Assert.IsFalse(s_GloabalTimeOutHelper.TimedOut, $"{nameof(NetworkListInsert)} timed out waiting for client to have the initial number " +
+                $"of entries ({m_Player1OnServer.TheList.Count}) in its list an the values validated!");
 
-        [UnityTest]
-        public IEnumerator NetworkListInsert([Values(true, false)] bool useHost)
-        {
-            yield return InitializeServerAndClients(useHost);
-            yield return MultiInstanceHelpers.RunAndWaitForCondition(
-                () =>
-                {
-                    m_Player1OnServer.TheList.Add(k_TestVal1);
-                    m_Player1OnServer.TheList.Add(k_TestVal2);
-                    m_Player1OnServer.TheList.Insert(1, k_TestVal3);
-                },
-                () =>
-                {
-                    return m_Player1OnServer.TheList.Count == 3 &&
-                           m_Player1OnClient1.TheList.Count == 3 &&
-                           m_Player1OnServer.ListDelegateTriggered &&
-                           m_Player1OnClient1.ListDelegateTriggered &&
-                           m_Player1OnServer.TheList[0] == k_TestVal1 &&
-                           m_Player1OnClient1.TheList[0] == k_TestVal1 &&
-                           m_Player1OnServer.TheList[1] == k_TestVal3 &&
-                           m_Player1OnClient1.TheList[1] == k_TestVal3 &&
-                           m_Player1OnServer.TheList[2] == k_TestVal2 &&
-                           m_Player1OnClient1.TheList[2] == k_TestVal2;
-                }
-            );
+            // Now insert a new entry to the list on the server
+            m_Player1OnServer.TheList.Insert(1, k_TestVal3);
+
+            // Wait for the client to get updated and its values validated
+            yield return WaitForConditionOrTimeOut(TestCompleted, m_Player1OnServer.TheList.Count);
+            Assert.IsFalse(s_GloabalTimeOutHelper.TimedOut, $"{nameof(NetworkListInsert)} timed out waiting for client to have the final number " +
+                $"of entries ({m_Player1OnServer.TheList.Count}) in its list an the values validated!");
         }
 
         [UnityTest]
         public IEnumerator NetworkListIndexOf([Values(true, false)] bool useHost)
         {
             yield return InitializeServerAndClients(useHost);
-            yield return MultiInstanceHelpers.RunAndWaitForCondition(
-                () =>
-                {
-                    m_Player1OnServer.TheList.Add(k_TestVal1);
-                    m_Player1OnServer.TheList.Add(k_TestVal2);
-                    m_Player1OnServer.TheList.Add(k_TestVal3);
-                },
-                () =>
-                {
-                    return m_Player1OnServer.TheList.IndexOf(k_TestVal1) == 0 &&
-                           m_Player1OnClient1.TheList.IndexOf(k_TestVal1) == 0 &&
-                           m_Player1OnServer.TheList.IndexOf(k_TestVal2) == 1 &&
-                           m_Player1OnClient1.TheList.IndexOf(k_TestVal2) == 1 &&
-                           m_Player1OnServer.TheList.IndexOf(k_TestVal3) == 2 &&
-                           m_Player1OnClient1.TheList.IndexOf(k_TestVal3) == 2;
-                }
-            );
+
+            m_Player1OnServer.TheList.Add(k_TestVal1);
+            m_Player1OnServer.TheList.Add(k_TestVal2);
+            m_Player1OnServer.TheList.Add(k_TestVal3);
+
+            bool TestCompleted(int listCount)
+            {
+                return m_Player1OnServer.TheList.Count == listCount &&
+                       m_Player1OnClient1.TheList.Count == listCount &&
+                       m_Player1OnServer.TheList.IndexOf(k_TestVal1) == 0 &&
+                       m_Player1OnClient1.TheList.IndexOf(k_TestVal1) == 0 &&
+                       m_Player1OnServer.TheList.IndexOf(k_TestVal2) == 1 &&
+                       m_Player1OnClient1.TheList.IndexOf(k_TestVal2) == 1 &&
+                       m_Player1OnServer.TheList.IndexOf(k_TestVal3) == 2 &&
+                       m_Player1OnClient1.TheList.IndexOf(k_TestVal3) == 2;
+            }
+
+            yield return WaitForConditionOrTimeOut(TestCompleted, 3);
+            Assert.IsFalse(s_GloabalTimeOutHelper.TimedOut, $"Timed out waiting for {nameof(NetworkListIndexOf)} to complete its test!");
         }
 
         [UnityTest]
         public IEnumerator NetworkListArrayOperator([Values(true, false)] bool useHost)
         {
             yield return InitializeServerAndClients(useHost);
-            yield return MultiInstanceHelpers.RunAndWaitForCondition(
-                () =>
-                {
-                    m_Player1OnServer.TheList.Add(k_TestVal3);
-                    m_Player1OnServer.TheList.Add(k_TestVal3);
-                    m_Player1OnServer.TheList[0] = k_TestVal1;
-                    m_Player1OnServer.TheList[1] = k_TestVal2;
-                },
-                () =>
-                {
-                    return m_Player1OnServer.TheList.Count == 2 &&
-                           m_Player1OnClient1.TheList.Count == 2 &&
-                           m_Player1OnServer.TheList[0] == k_TestVal1 &&
-                           m_Player1OnClient1.TheList[0] == k_TestVal1 &&
-                           m_Player1OnServer.TheList[1] == k_TestVal2 &&
-                           m_Player1OnClient1.TheList[1] == k_TestVal2;
-                }
-            );
+            m_Player1OnServer.TheList.Add(k_TestVal3);
+            m_Player1OnServer.TheList.Add(k_TestVal3);
+            m_Player1OnServer.TheList[0] = k_TestVal1;
+            m_Player1OnServer.TheList[1] = k_TestVal2;
+
+            bool TestCompleted(int listCount)
+            {
+                return m_Player1OnServer.TheList.Count == listCount &&
+                       m_Player1OnClient1.TheList.Count == listCount &&
+                       m_Player1OnServer.TheList[0] == k_TestVal1 &&
+                       m_Player1OnClient1.TheList[0] == k_TestVal1 &&
+                       m_Player1OnServer.TheList[1] == k_TestVal2 &&
+                       m_Player1OnClient1.TheList[1] == k_TestVal2;
+            }
+
+            yield return WaitForConditionOrTimeOut(TestCompleted, 2);
+            Assert.IsFalse(s_GloabalTimeOutHelper.TimedOut, $"Timed out waiting for {nameof(NetworkListArrayOperator)} to complete its test!");
         }
 
 


### PR DESCRIPTION
This should fix the issues when running Unity.Netcode.RuntimeTests in a stand alone test runner build.  These changes should get all console platforms passing for this assembly.
[MTT-2288](https://jira.unity3d.com/browse/MTT-2288)

With the fixes in place [all consoles are passing Unity.Netcode.RuntimeTests](https://unity-ci.cds.internal.unity3d.com/job/11430444/dependency-graph):
![image](https://user-images.githubusercontent.com/73188597/152630040-48fc1f2d-d468-4a69-ad87-51d204f39790.png)

## Testing and Documentation
* No tests have been added.
* No documentation changes or additions were necessary.