### PR TITLE
fix: NetworkSceneManager NetworkObjects in DDOL list can no longer exist

### DIFF
--- a/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/RuntimeTestsHelpers.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/RuntimeTestsHelpers.cs
@@ -18,13 +18,13 @@ namespace Unity.Netcode.UTP.RuntimeTests
         public const float MaxNetworkEventWaitTime = 0.5f;
 #endif
 
-        // Wait for an event to appear in the given event list (must be the very next event).
         public static IEnumerator WaitForNetworkEvent(NetworkEvent type, List<TransportEvent> events)
         {
             int initialCount = events.Count;
-            float startTime = Time.realtimeSinceStartup;
+            int previousCount = initialCount;
+            float timeOutPeriod = Time.realtimeSinceStartup + MaxNetworkEventWaitTime;
 
-            while (Time.realtimeSinceStartup - startTime < MaxNetworkEventWaitTime)
+            while (timeOutPeriod > Time.realtimeSinceStartup)
             {
                 if (events.Count > initialCount)
                 {
@@ -32,6 +32,12 @@ namespace Unity.Netcode.UTP.RuntimeTests
                     yield break;
                 }
 
+                if (previousCount < events.Count)
+                {
+                    timeOutPeriod += 0.01f;
+                }
+
+                previousCount = events.Count;
                 yield return null;
             }
 

--- a/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/RuntimeTestsHelpers.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/RuntimeTestsHelpers.cs
@@ -18,13 +18,13 @@ namespace Unity.Netcode.UTP.RuntimeTests
         public const float MaxNetworkEventWaitTime = 0.5f;
 #endif
 
+        // Wait for an event to appear in the given event list (must be the very next event).
         public static IEnumerator WaitForNetworkEvent(NetworkEvent type, List<TransportEvent> events)
         {
             int initialCount = events.Count;
-            int previousCount = initialCount;
-            float timeOutPeriod = Time.realtimeSinceStartup + MaxNetworkEventWaitTime;
+            float startTime = Time.realtimeSinceStartup;
 
-            while (timeOutPeriod > Time.realtimeSinceStartup)
+            while (Time.realtimeSinceStartup - startTime < MaxNetworkEventWaitTime)
             {
                 if (events.Count > initialCount)
                 {
@@ -32,12 +32,6 @@ namespace Unity.Netcode.UTP.RuntimeTests
                     yield break;
                 }
 
-                if (previousCount < events.Count)
-                {
-                    timeOutPeriod += 0.01f;
-                }
-
-                previousCount = events.Count;
                 yield return null;
             }
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -23,7 +23,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed The NetworkConfig's checksum hash includes the NetworkTick so that clients with a different tickrate than the server are identified and not allowed to connect. (#1513)
 - Fixed OwnedObjects not being properly modified when using ChangeOwnership. (#1572)
 - Fixed When the LogLevel is set to developer NetworkBehaviour generates warning messages when it should not (#1631)
-- Fixed NetworkSceneManager NetworkObjects in DDOL list can no longer exist. (#1633)
+- Fixed client-side exception from being thrown in NetworkSceneManager when migrating NetworkObjects to or from the DDOL scene. (#1633)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -22,6 +22,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed error when serializing ConnectionApprovalMessage with scene management disabled when one or more objects is hidden via the CheckObjectVisibility delegate (#1509)
 - Fixed The NetworkConfig's checksum hash includes the NetworkTick so that clients with a different tickrate than the server are identified and not allowed to connect. (#1513)
 - Fixed OwnedObjects not being properly modified when using ChangeOwnership. (#1572)
+- Fixed NetworkSceneManager NetworkObjects in DDOL list can no longer exist. (#1633)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1802,6 +1802,11 @@ namespace Unity.Netcode
             var objectsToKeep = new HashSet<NetworkObject>(m_NetworkManager.SpawnManager.SpawnedObjectsList);
             foreach (var sobj in objectsToKeep)
             {
+                if (sobj == null)
+                {
+                    continue;
+                }
+
                 if (!sobj.DestroyWithScene || sobj.gameObject.scene == DontDestroyOnLoadScene)
                 {
                     // Only move dynamically spawned network objects with no parent as child objects will follow
@@ -1877,6 +1882,10 @@ namespace Unity.Netcode
 
             foreach (var sobj in objectsToKeep)
             {
+                if (sobj == null)
+                {
+                    continue;
+                }
                 // If it is in the DDOL then
                 if (sobj.gameObject.scene == DontDestroyOnLoadScene)
                 {

--- a/testproject/Assets/Tests/Manual/Scripts/NetworkPrefabPool.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/NetworkPrefabPool.cs
@@ -238,6 +238,10 @@ namespace TestProject.ManualTests
 
             foreach (var obj in m_ObjectPool)
             {
+                if (obj == null)
+                {
+                    continue;
+                }
                 var networkObject = obj.GetComponent<NetworkObject>();
                 var genericBehaviour = obj.GetComponent<GenericNetworkObjectBehaviour>();
                 if (networkObject.IsSpawned)

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -1136,7 +1136,7 @@ namespace TestProject.RuntimeTests
 
             // Spawn some NetworkObjects
             var spawnedNetworkObjects = new List<GameObject>();
-            for(int i = 0; i < 10; i++)
+            for (int i = 0; i < 10; i++)
             {
                 var instance = Object.Instantiate(gameObject);
                 var instanceNetworkObject = instance.GetComponent<NetworkObject>();

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -919,6 +919,7 @@ namespace TestProject.RuntimeTests
             ClientProcessedNotification(clientId, SceneEventType.Load, true);
         }
         #endregion
+
     }
 
     /// <summary>
@@ -1097,4 +1098,66 @@ namespace TestProject.RuntimeTests
 
     }
 
+
+    public class NetworkSceneManagerFixValidationTests : BaseMultiInstanceTest
+    {
+        protected override int NbClients => 0;
+
+        public override IEnumerator Setup()
+        {
+            m_BypassStartAndWaitForClients = true;
+            return base.Setup();
+        }
+
+        /// <summary>
+        /// This validation test verifies that the NetworkSceneManager will not crash if
+        /// the SpawnManager.SpawnedObjectsList contains destroyed and invalid NetworkObjects.
+        /// </summary>
+        [Test]
+        public void DDOLPopulateWithNullNetworkObjectsValidation([Values] bool useHost)
+        {
+            var gameObject = new GameObject();
+            var networkObject = gameObject.AddComponent<NetworkObject>();
+            MultiInstanceHelpers.MakeNetworkObjectTestPrefab(networkObject);
+
+            m_ServerNetworkManager.NetworkConfig.NetworkPrefabs.Add(new NetworkPrefab() { Prefab = gameObject });
+
+            foreach (var clientNetworkManager in m_ClientNetworkManagers)
+            {
+                clientNetworkManager.NetworkConfig.NetworkPrefabs.Add(new NetworkPrefab() { Prefab = gameObject });
+            }
+
+            // Start the host and clients
+            if (!MultiInstanceHelpers.Start(useHost, m_ServerNetworkManager, m_ClientNetworkManagers))
+            {
+                Debug.LogError("Failed to start instances");
+                Assert.Fail("Failed to start instances");
+            }
+
+            // Spawn some NetworkObjects
+            var spawnedNetworkObjects = new List<GameObject>();
+            for(int i = 0; i < 10; i++)
+            {
+                var instance = Object.Instantiate(gameObject);
+                var instanceNetworkObject = instance.GetComponent<NetworkObject>();
+                instanceNetworkObject.NetworkManagerOwner = m_ServerNetworkManager;
+                instanceNetworkObject.Spawn();
+                spawnedNetworkObjects.Add(instance);
+            }
+
+            // Add a bogus entry to the SpawnManager
+            m_ServerNetworkManager.SpawnManager.SpawnedObjectsList.Add(null);
+
+            // Verify moving all NetworkObjects into the DDOL when some might be invalid will not crash
+            m_ServerNetworkManager.SceneManager.MoveObjectsToDontDestroyOnLoad();
+
+            // Verify moving all NetworkObjects from DDOL back into the active scene will not crash even if some are invalid
+            m_ServerNetworkManager.SceneManager.MoveObjectsFromDontDestroyOnLoadToScene(SceneManager.GetActiveScene());
+
+            // Now remove the invalid object
+            m_ServerNetworkManager.SpawnManager.SpawnedObjectsList.Remove(null);
+
+            // As long as there are no exceptions this test passes
+        }
+    }
 }


### PR DESCRIPTION
The DDOL list can have some of its NetworkObjects destroyed before the NetworkSceneManager has finished processing the NetworkObjects to be repopulated or populated into the new scene which causes an exception to occur which then causes the client side scene loading process to be interrupted.  This is primarily due to when the asynchronous callback for scene loading occurs vs when the NetworkObjects in the NetworkSpawnManager.SpawnedObjectsList are fully cleaned up.

[MTT-2300](https://jira.unity3d.com/browse/MTT-2300)

### PR Checklist
- [X] Have you updated the changelog? Each package has a `CHANGELOG.md` file.

## Changelog
### com.unity.netcode.gameobjects
- Fixed client-side exception from being thrown in NetworkSceneManager when migrating NetworkObjects to or from the DDOL scene. (#1633)

## Testing and Documentation
* Includes fix validation test: NetworkSceneManagerFixValidationTests:DDOLPopulateWithNullNetworkObjectsValidation
