### PR TITLE
chore: update Tools asmdef references

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/com.unity.netcode.runtime.asmdef
+++ b/com.unity.netcode.gameobjects/Runtime/com.unity.netcode.runtime.asmdef
@@ -2,6 +2,10 @@
     "name": "Unity.Netcode.Runtime",
     "rootNamespace": "Unity.Netcode",
     "references": [
+        "Unity.Multiplayer.MetricTypes",
+        "Unity.Multiplayer.NetStats",
+        "Unity.Multiplayer.NetStatsReporting",
+        "Unity.Multiplayer.NetworkSolutionInterface",
         "Unity.Multiplayer.Tools.MetricTypes",
         "Unity.Multiplayer.Tools.NetStats",
         "Unity.Multiplayer.Tools.NetStatsReporting",

--- a/com.unity.netcode.gameobjects/Runtime/com.unity.netcode.runtime.asmdef
+++ b/com.unity.netcode.gameobjects/Runtime/com.unity.netcode.runtime.asmdef
@@ -2,11 +2,11 @@
     "name": "Unity.Netcode.Runtime",
     "rootNamespace": "Unity.Netcode",
     "references": [
-        "Unity.Multiplayer.MetricTypes",
-        "Unity.Multiplayer.NetStats",
-        "Unity.Multiplayer.NetStatsReporting",
-        "Unity.Multiplayer.NetworkSolutionInterface",
-        "Unity.Collections"
+        "GUID:7c4416f9e8f132246b0e1c1ec45be7d6",
+        "GUID:b1cd7326e664a434ab35daa802773c7f",
+        "GUID:821943bbff0df3b48b43584136c29e17",
+        "GUID:272061007ed268345bb3d3df8b09b583",
+        "GUID:e0cd26848372d4e5c891c569017e11f1"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/com.unity.netcode.gameobjects/Runtime/com.unity.netcode.runtime.asmdef
+++ b/com.unity.netcode.gameobjects/Runtime/com.unity.netcode.runtime.asmdef
@@ -2,11 +2,11 @@
     "name": "Unity.Netcode.Runtime",
     "rootNamespace": "Unity.Netcode",
     "references": [
-        "GUID:7c4416f9e8f132246b0e1c1ec45be7d6",
-        "GUID:b1cd7326e664a434ab35daa802773c7f",
-        "GUID:821943bbff0df3b48b43584136c29e17",
-        "GUID:272061007ed268345bb3d3df8b09b583",
-        "GUID:e0cd26848372d4e5c891c569017e11f1"
+        "Unity.Multiplayer.Tools.MetricTypes",
+        "Unity.Multiplayer.Tools.NetStats",
+        "Unity.Multiplayer.Tools.NetStatsReporting",
+        "Unity.Multiplayer.Tools.NetworkSolutionInterface",
+        "Unity.Collections"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
This change will allow the multiplayer tools team to rename some assemblies (see here https://github.com/Unity-Technologies/com.unity.multiplayer.tools/pull/189). This will also make NGO resilient to any potential future renaming of assemblies in external dependencies (like multiplayer tools), though we do not have any future assembly renames in mind.

https://jira.unity3d.com/browse/MTT-1979

<!-- When backporting is required please add the type:backport-release-<version> label to this PR. This should include all versions in which this should be backported to. -->

Please comment if you think there are any other versions that this should be backported to, or have an opinion on this. I think this should be backported to all releases >=0.1.0, but this is my first time using your backporting label system and I'm not entirely sure that I've gotten it right.

### PR Checklist
- [x] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [x] ~~Have you updated the changelog? Each package has a `CHANGELOG.md` file.~~ **No changelog entry required.**
- [x] ~~Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR or a link to the documenation repo PR if this is a manual update.~~ **No documentation required.**

## Testing and Documentation
* No tests have been added.
* No documentation changes or additions were necessary.

