### PR TITLE
fix: NetworkBehaviour spam generated when LogLevel is set to developer - release 1.0.0 backport 

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -21,6 +21,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 - Fixed network tick value sometimes being duplicated or skipped. (#1614)
 - Fixed The ClientNetworkTransform sample script to allow for owner changes at runtime. (#1606)
+- Fixed When the LogLevel is set to developer NetworkBehaviour generates warning messages when it should not (#1631)
 
 ## [1.0.0-pre.4] - 2021-01-04
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -284,10 +284,14 @@ namespace Unity.Netcode
                     m_NetworkObject = GetComponentInParent<NetworkObject>();
                 }
 
-                if (m_NetworkObject == null || NetworkManager.Singleton == null ||
-                    (NetworkManager.Singleton != null && !NetworkManager.Singleton.ShutdownInProgress))
+                // ShutdownInProgress check:
+                // This prevents an edge case scenario where the NetworkManager is shutting down but user code
+                // in Update and/or in FixedUpdate could still be checking NetworkBehaviour.NetworkObject directly (i.e. does it exist?)
+                // or NetworkBehaviour.IsSpawned (i.e. to early exit if not spawned) which, in turn, could generate several Warning messages
+                // per spawned NetworkObject.  Checking for ShutdownInProgress prevents these unnecessary LogWarning messages.
+                if (m_NetworkObject == null && (NetworkManager.Singleton == null || !NetworkManager.Singleton.ShutdownInProgress))
                 {
-                    if (NetworkLog.CurrentLogLevel < LogLevel.Normal)
+                    if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
                     {
                         NetworkLog.LogWarning($"Could not get {nameof(NetworkObject)} for the {nameof(NetworkBehaviour)}. Are you missing a {nameof(NetworkObject)} component?");
                     }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
@@ -1,0 +1,60 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    /// <summary>
+    /// This class is for testing general fixes or functionality of NetworkBehaviours
+    /// </summary>
+    public class NetworkBehaviourGenericTests : BaseMultiInstanceTest
+    {
+        protected override int NbClients => 0;
+        public override IEnumerator Setup()
+        {
+            // Make sure we don't automatically start
+            m_BypassStartAndWaitForClients = true;
+
+            // Create the Host and add the SimpleNetworkBehaviour component
+            yield return base.Setup();
+        }
+
+        public class SimpleNetworkBehaviour : NetworkBehaviour
+        {
+        }
+
+        /// <summary>
+        /// This test validates a fix to NetworkBehaviour.NetworkObject when
+        /// the NetworkManager.LogLevel is set to Developer
+        /// Note: This test does not require any clients, but should not impact this
+        /// particular test if new tests are added to this class that do require clients
+        /// </summary>
+        [Test]
+        public void ValidateNoSpam()
+        {
+            var objectToTest = new GameObject();
+            var simpleNetworkBehaviour = objectToTest.AddComponent<SimpleNetworkBehaviour>();
+
+            // Now just start the Host
+            Assert.True(MultiInstanceHelpers.Start(true, m_ServerNetworkManager, new NetworkManager[] { }), "Failed to start the host!");
+
+            // set the log level to developer
+            m_ServerNetworkManager.LogLevel = LogLevel.Developer;
+
+            // Verify the warning gets logged under normal conditions
+            var isNull = simpleNetworkBehaviour.NetworkObject == null;
+            LogAssert.Expect(LogType.Warning, $"[Netcode] Could not get {nameof(NetworkObject)} for the {nameof(NetworkBehaviour)}. Are you missing a {nameof(NetworkObject)} component?");
+
+            var networkObjectToTest = objectToTest.AddComponent<NetworkObject>();
+            networkObjectToTest.Spawn();
+
+            // Assure no log messages are logged when they should not be logged
+            isNull = simpleNetworkBehaviour.NetworkObject != null;
+            LogAssert.NoUnexpectedReceived();
+
+            networkObjectToTest.Despawn();
+            Object.Destroy(networkObjectToTest);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
@@ -47,6 +47,7 @@ namespace Unity.Netcode.RuntimeTests
             LogAssert.Expect(LogType.Warning, $"[Netcode] Could not get {nameof(NetworkObject)} for the {nameof(NetworkBehaviour)}. Are you missing a {nameof(NetworkObject)} component?");
 
             var networkObjectToTest = objectToTest.AddComponent<NetworkObject>();
+            networkObjectToTest.NetworkManagerOwner = m_ServerNetworkManager;
             networkObjectToTest.Spawn();
 
             // Assure no log messages are logged when they should not be logged

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f87989d8d290ed24a9048b6dbddae527
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
When the LogLevel is set to developer, log warnings were spamming even when the NetworkBehaviour.NetworkObject was not null.  This PR addresses the issue such that the log warnings are still generated when there is no NetworkObject assigned to a NetworkBehaviour and are not generated when the NetworkBehaviour.NetworkObject is not null. 

[MTT-2289](https://jira.unity3d.com/browse/MTT-2289)

This is a backport of [PR-1631](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/1631)

### PR Checklist
- [x] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [X] Have you updated the changelog? Each package has a `CHANGELOG.md` file.

## Changelog
### com.unity.netcode.gameobjects
-Fixed: When the LogLevel is set to developer NetworkBehaviour generates warning messages when it should not

## Testing and Documentation
* Includes integration tests.