### PR TITLE
fix: Endpoint creation fails with empty listen address

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this package will be documented in this file. The format 
 
 ### Fixed
 
-- Fixed issue where the server `NetworkEndPoint` would fail to be created when 'Server Listen Address' was empty.
+- Fixed issue where the server `NetworkEndPoint` would fail to be created when 'Server Listen Address' is empty. (#1636)
 
 ## [1.0.0-pre.5] - 2022-01-26
 

--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this package will be documented in this file. The format 
 
 ### Fixed
 
+- Fixed issue where the server `NetworkEndPoint` would fail to be created when 'Server Listen Address' was empty.
+
 ## [1.0.0-pre.5] - 2022-01-26
 
 ### Added

--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -90,7 +90,7 @@ namespace Unity.Netcode
         public const int InitialMaxSendQueueSize = 16 * InitialMaxPayloadSize;
 
         private static ConnectionAddressData s_DefaultConnectionAddressData = new ConnectionAddressData()
-        { Address = "127.0.0.1", Port = 7777, ServerListenAddress = null };
+        { Address = "127.0.0.1", Port = 7777, ServerListenAddress = string.Empty };
 
 #pragma warning disable IDE1006 // Naming Styles
         public static INetworkStreamDriverConstructor s_DriverConstructor;
@@ -153,7 +153,8 @@ namespace Unity.Netcode
 
             public NetworkEndPoint ServerEndPoint => ParseNetworkEndpoint(Address, Port);
 
-            public NetworkEndPoint ListenEndPoint => ParseNetworkEndpoint(ServerListenAddress ?? Address, Port);
+            public NetworkEndPoint ListenEndPoint => ParseNetworkEndpoint(
+                (ServerListenAddress == string.Empty) ? Address : ServerListenAddress, Port);
 
             [Obsolete("Use ServerEndPoint or ListenEndPoint properties instead.")]
             public static implicit operator NetworkEndPoint(ConnectionAddressData d) =>
@@ -161,7 +162,7 @@ namespace Unity.Netcode
 
             [Obsolete("Construct manually from NetworkEndPoint.Address and NetworkEndPoint.Port instead.")]
             public static implicit operator ConnectionAddressData(NetworkEndPoint d) =>
-                new ConnectionAddressData() { Address = d.Address.Split(':')[0], Port = d.Port, ServerListenAddress = null };
+                new ConnectionAddressData() { Address = d.Address.Split(':')[0], Port = d.Port, ServerListenAddress = string.Empty };
         }
 
         public ConnectionAddressData ConnectionData = s_DefaultConnectionAddressData;
@@ -442,7 +443,7 @@ namespace Unity.Netcode
             {
                 Address = ipv4Address,
                 Port = port,
-                ServerListenAddress = listenAddress
+                ServerListenAddress = listenAddress ?? string.Empty
             };
 
             SetProtocol(ProtocolType.UnityTransport);
@@ -455,7 +456,7 @@ namespace Unity.Netcode
         {
             string serverAddress = endPoint.Address.Split(':')[0];
 
-            string listenAddress = null;
+            string listenAddress = string.Empty;
             if (listenEndPoint != default)
             {
                 listenAddress = listenEndPoint.Address.Split(':')[0];


### PR DESCRIPTION
MTT-2296

Fix the issue where the server endpoint creation would fail in the adapter when the listen address was empty. It's okay for it to be empty, but when I had written this I had (naively) used null as the empty value. But Unity deserializes null string fields as `string.Empty`, not as null. The error is on me, I should have double-checked how Unity handles deserialization of string fields.

## Changelog

### com.unity.netcode.adapter.utp

* Fixed: Fixed issue where the server `NetworkEndPoint` would fail to be created when 'Server Listen Address' is empty.

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.