### PR TITLE
fix: Improve stability of adapter max payload size test

### DIFF
--- a/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/RuntimeTestsHelpers.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/Helpers/RuntimeTestsHelpers.cs
@@ -19,12 +19,13 @@ namespace Unity.Netcode.UTP.RuntimeTests
 #endif
 
         // Wait for an event to appear in the given event list (must be the very next event).
-        public static IEnumerator WaitForNetworkEvent(NetworkEvent type, List<TransportEvent> events)
+        public static IEnumerator WaitForNetworkEvent(NetworkEvent type, List<TransportEvent> events,
+            float timeout = MaxNetworkEventWaitTime)
         {
             int initialCount = events.Count;
             float startTime = Time.realtimeSinceStartup;
 
-            while (Time.realtimeSinceStartup - startTime < MaxNetworkEventWaitTime)
+            while (Time.realtimeSinceStartup - startTime < timeout)
             {
                 if (events.Count > initialCount)
                 {
@@ -32,7 +33,7 @@ namespace Unity.Netcode.UTP.RuntimeTests
                     yield break;
                 }
 
-                yield return null;
+                yield return new WaitForSeconds(0.01f);
             }
 
             Assert.Fail("Timed out while waiting for network event.");

--- a/com.unity.netcode.adapter.utp/Tests/Runtime/TransportTests.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/TransportTests.cs
@@ -147,7 +147,7 @@ namespace Unity.Netcode.UTP.RuntimeTests
             var payload = new ArraySegment<byte>(payloadData);
             m_Client1.Send(m_Client1.ServerClientId, payload, delivery);
 
-            yield return WaitForNetworkEvent(NetworkEvent.Data, m_ServerEvents);
+            yield return WaitForNetworkEvent(NetworkEvent.Data, m_ServerEvents, MaxNetworkEventWaitTime * 2);
 
             Assert.AreEqual(payloadSize, m_ServerEvents[1].Data.Count);
 


### PR DESCRIPTION
Improve stability of the adapter's max payload size test. This test requires sending quite a bit of data, which with reliable delivery will require waiting for parts of the data to make it to the peer. This introduces extra delays, and on slower CI machines, this can lead to reaching the test's timeout before the data has been entirely received. To avoid this, this PR increases the timeout for the costliest operation in that test.

Also applied a suggestion from Noel to avoid yielding on every update when waiting for an event, which could be costly. Instead we wait for 10ms at a time (there's no point in checking more often than that).

No JIRA issue for this specifically, but I guess it technically contributes to MTT-2288.

## Changelog

### com.unity.netcode.adapter.utp

N/A

## Testing and Documentation

* No tests have been added (only one was modified).
* No documentation changes or additions were necessary.