### PR TITLE
fix: Correctly dispose of everything in adapter's OnDestroy

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this package will be documented in this file. The format 
 ### Fixed
 
 - Fixed issue where the server `NetworkEndPoint` would fail to be created when 'Server Listen Address' is empty. (#1636)
+- Fixed issue with native collections not all being disposed of when destroying the component without shutting it down properly. This would result in errors in the console and memory leaks. (#1640)
 
 ## [1.0.0-pre.5] - 2022-01-26
 


### PR DESCRIPTION
MTT-2305

Some of the native containers used by the adapter are not disposed of correctly when destroying the `UnityTransport` component. They're disposed of correctly when shutting down gracefully (through the `Shutdown` method), but not if the component is destroyed without shutting it down. To fix this, we now dispose of everything in `OnDestroy` too.

## Changelog

### com.unity.netcode.adapter.utp

* Fixed: Fixed issue with native collections not all being disposed of when destroying the component without shutting it down properly. This would result in errors in the console and memory leaks.

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.