### PR TITLE
fix: Correctly dispose of everything in adapter's OnDestroy (1.0.0)

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this package will be documented in this file. The format 
 ### Fixed
 
 - Fixed issue where the server `NetworkEndPoint` would fail to be created when 'Server Listen Address' is empty. (#1636)
+- Fixed issue with native collections not all being disposed of when destroying the component without shutting it down properly. This would result in errors in the console and memory leaks. (#1640)
 
 ## [1.0.0-pre.5] - 2022-01-26
 

--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -241,12 +241,21 @@ namespace Unity.Netcode
                 out m_ReliableSequencedPipeline);
         }
 
-        private void DisposeDriver()
+        private void DisposeInternals()
         {
             if (m_Driver.IsCreated)
             {
                 m_Driver.Dispose();
             }
+
+            m_NetworkSettings.Dispose();
+
+            foreach (var queue in m_SendQueue.Values)
+            {
+                queue.Dispose();
+            }
+
+            m_SendQueue.Clear();
         }
 
         private NetworkPipeline SelectSendPipeline(NetworkDelivery delivery)
@@ -658,7 +667,7 @@ namespace Unity.Netcode
 
         private void OnDestroy()
         {
-            DisposeDriver();
+            DisposeInternals();
         }
 
         private static unsafe ulong ParseClientId(NetworkConnection utpConnectionId)
@@ -814,23 +823,12 @@ namespace Unity.Netcode
                 return;
             }
 
-
             // Flush the driver's internal send queue. If we're shutting down because the
             // NetworkManager is shutting down, it probably has disconnected some peer(s)
             // in the process and we want to get these disconnect messages on the wire.
             m_Driver.ScheduleFlushSend(default).Complete();
 
-            DisposeDriver();
-
-            m_NetworkSettings.Dispose();
-
-            foreach (var queue in m_SendQueue.Values)
-            {
-                queue.Dispose();
-            }
-
-            // make sure we don't leak queues when we shutdown
-            m_SendQueue.Clear();
+            DisposeInternals();
 
             // We must reset this to zero because UTP actually re-uses clientIds if there is a clean disconnect
             m_ServerClientId = 0;


### PR DESCRIPTION
Backport of PR #1640 to `release/1.0.0`.

## Changelog

### com.unity.netcode.adapter.utp

* Fixed: Fixed issue with native collections not all being disposed of when destroying the component without shutting it down properly. This would result in errors in the console and memory leaks.

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.