### PR TITLE
refactor: Splitting MessagingSystem.SendMessage into a second part …

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1485,6 +1485,12 @@ namespace Unity.Netcode
             return MessagingSystem.SendMessage(ref message, delivery, clientId);
         }
 
+        internal int SendPreSerializedMessage<T>(in FastBufferWriter writer, int maxSize, ref T message, NetworkDelivery delivery, ulong clientId)
+            where T : INetworkMessage
+        {
+            return MessagingSystem.SendPreSerializedMessage(writer, maxSize, ref message, delivery, clientId);
+        }
+
         internal void HandleIncomingData(ulong clientId, ArraySegment<byte> payload, float receiveTime)
         {
 #if DEVELOPMENT_BUILD || UNITY_EDITOR

--- a/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/SnapshotSystem.cs
@@ -919,8 +919,7 @@ namespace Unity.Netcode
 
         internal int NetworkSendMessage(SnapshotDataMessage message, ulong clientId)
         {
-            m_NetworkManager.SendMessage(ref message, NetworkDelivery.ReliableFragmentedSequenced, clientId);
-
+            m_NetworkManager.SendPreSerializedMessage(message.WriteBuffer, TotalBufferMemory, ref message, NetworkDelivery.Unreliable, clientId);
             return 0;
         }
     }


### PR DESCRIPTION
SendPreSerializedMessage. This allows SnapshotSystem to send larger messages, while saving an allocation and a copy.
