### PR TITLE
chore: update tools asmdef references - release 1.0.0 backport

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/com.unity.netcode.runtime.asmdef
+++ b/com.unity.netcode.gameobjects/Runtime/com.unity.netcode.runtime.asmdef
@@ -6,6 +6,10 @@
         "Unity.Multiplayer.NetStats",
         "Unity.Multiplayer.NetStatsReporting",
         "Unity.Multiplayer.NetworkSolutionInterface",
+        "Unity.Multiplayer.Tools.MetricTypes",
+        "Unity.Multiplayer.Tools.NetStats",
+        "Unity.Multiplayer.Tools.NetStatsReporting",
+        "Unity.Multiplayer.Tools.NetworkSolutionInterface",
         "Unity.Collections"
     ],
     "includePlatforms": [],


### PR DESCRIPTION
This PR is a backport of #1643, which adds the new tool assembly names from https://github.com/Unity-Technologies/com.unity.multiplayer.tools/pull/189, alongside the old tool assembly names. Together these changes maintain compatibility between between NGO 1.0.0 and newer versions of tools, as well as future versions of NGO and older versions of tools.

https://jira.unity3d.com/browse/MTT-1979

Original PR is here: https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/1634


### PR Checklist
- [x] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [x] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR or a link to the documenation repo PR if this is a manual update. 
