### PR TITLE
fix: Add new tool assembly names that were missing

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Editor/com.unity.netcode.editortests.asmdef
+++ b/com.unity.netcode.gameobjects/Tests/Editor/com.unity.netcode.editortests.asmdef
@@ -7,7 +7,9 @@
         "Unity.Netcode.Editor",
         "Unity.Netcode.Components",
         "Unity.Multiplayer.MetricTypes",
-        "Unity.Multiplayer.NetStats"
+        "Unity.Multiplayer.NetStats",
+        "Unity.Multiplayer.Tools.MetricTypes",
+        "Unity.Multiplayer.Tools.NetStats"
     ],
     "optionalUnityReferences": [
         "TestAssemblies"

--- a/com.unity.netcode.gameobjects/Tests/Runtime/com.unity.netcode.runtimetests.asmdef
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/com.unity.netcode.runtimetests.asmdef
@@ -9,6 +9,8 @@
         "UnityEngine.TestRunner",
         "Unity.Multiplayer.MetricTypes",
         "Unity.Multiplayer.NetStats",
+        "Unity.Multiplayer.Tools.MetricTypes",
+        "Unity.Multiplayer.Tools.NetStats",
         "Unity.Netcode.Adapter.UTP",
         "ClientNetworkTransform",
         "Unity.PerformanceTesting"

--- a/testproject-tools-integration/Assets/Tests/Runtime/testproject.toolsintegration.runtimetests.asmdef
+++ b/testproject-tools-integration/Assets/Tests/Runtime/testproject.toolsintegration.runtimetests.asmdef
@@ -6,6 +6,8 @@
         "Unity.Netcode.RuntimeTests",
         "Unity.Multiplayer.MetricTypes",
         "Unity.Multiplayer.NetStats",
+        "Unity.Multiplayer.Tools.MetricTypes",
+        "Unity.Multiplayer.Tools.NetStats",
         "UnityEngine.TestRunner"
     ],
     "includePlatforms": [],


### PR DESCRIPTION
This PR adds some additional new tools assembly names to assembly references that were missed during the first PR: https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/1634

Jira ticket for the assembly rename is here: [MTT-1979](https://jira.unity3d.com/browse/MTT-1979)

<!-- Original PR link if this is a backport PR -->


### PR Checklist
- [x] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file. **(Not needed)**
- [x] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR or a link to the documenation repo PR if this is a manual update. **(Not needed)**


## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
