### PR TITLE
fix: add new tool assembly names that were missing - release 1.0.0 backport

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Editor/com.unity.netcode.editortests.asmdef
+++ b/com.unity.netcode.gameobjects/Tests/Editor/com.unity.netcode.editortests.asmdef
@@ -7,7 +7,9 @@
         "Unity.Netcode.Editor",
         "Unity.Netcode.Components",
         "Unity.Multiplayer.MetricTypes",
-        "Unity.Multiplayer.NetStats"
+        "Unity.Multiplayer.NetStats",
+        "Unity.Multiplayer.Tools.MetricTypes",
+        "Unity.Multiplayer.Tools.NetStats"
     ],
     "optionalUnityReferences": [
         "TestAssemblies"

--- a/com.unity.netcode.gameobjects/Tests/Runtime/com.unity.netcode.runtimetests.asmdef
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/com.unity.netcode.runtimetests.asmdef
@@ -9,6 +9,8 @@
         "UnityEngine.TestRunner",
         "Unity.Multiplayer.MetricTypes",
         "Unity.Multiplayer.NetStats",
+        "Unity.Multiplayer.Tools.MetricTypes",
+        "Unity.Multiplayer.Tools.NetStats",
         "Unity.Netcode.Adapter.UTP",
         "ClientNetworkTransform"
     ],

--- a/testproject-tools-integration/Assets/Tests/Runtime/testproject.toolsintegration.runtimetests.asmdef
+++ b/testproject-tools-integration/Assets/Tests/Runtime/testproject.toolsintegration.runtimetests.asmdef
@@ -6,6 +6,8 @@
         "Unity.Netcode.RuntimeTests",
         "Unity.Multiplayer.MetricTypes",
         "Unity.Multiplayer.NetStats",
+        "Unity.Multiplayer.Tools.MetricTypes",
+        "Unity.Multiplayer.Tools.NetStats",
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner"
     ],


### PR DESCRIPTION
This is a backport for https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/1650

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.