### PR TITLE
fix: mtt-1393

### DIFF
--- a/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
+++ b/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
@@ -69,6 +69,13 @@ namespace Unity.Netcode
 
         private bool InvalidState => m_Buffer.Count == 0 && m_LifetimeConsumedCount == 0;
 
+        public void Clear()
+        {
+            m_Buffer.Clear();
+            m_EndTimeConsumed = 0.0d;
+            m_StartTimeConsumed = 0.0d;
+        }
+
         public void ResetTo(T targetValue, double serverTime)
         {
             m_LifetimeConsumedCount = 1;

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -827,7 +827,7 @@ namespace Unity.Netcode.Components
 
             if (!Interpolate && m_LastInterpolate)
             {
-                // if we just stop interpolating
+                // if we just stopped interpolating, let's clear the interpolators
                 foreach (var interpolator in m_AllFloatInterpolators)
                 {
                     interpolator.Clear();


### PR DESCRIPTION
Prevents the interpolator from being used while interpolation is disabled.

The branch `fix/MTT-1393-bench` can be used to visualize/test/try the fix. Cubes spin in circle, and interpolation is visible, reducing the circle radius. [space] toggles interpolation on/off, with no visible artifacts.

[MTT-1393](https://jira.unity3d.com/browse/MTT-1393)

### PR Checklist
- [x] Have you added a backport label: yes

## Testing and Documentation

* No tests have been added.
