### PR TITLE
fix: Don't keep bad packets in the adapter's send queues (1.0.0)

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this package will be documented in this file. The format 
 
 - Fixed issue where the server `NetworkEndPoint` would fail to be created when 'Server Listen Address' is empty. (#1636)
 - Fixed issue with native collections not all being disposed of when destroying the component without shutting it down properly. This would result in errors in the console and memory leaks. (#1640)
-- Fixed an issue where packets causing errors would not be removed from the send queue, which would cause the error message to be spammed on every frame as the adapter would try to resend the packet.
+- Fixed an issue where packets causing errors would not be removed from the send queue, which would cause the error message to be spammed on every frame as the adapter would try to resend the packet. (#1648)
 
 ## [1.0.0-pre.5] - 2022-01-26
 

--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this package will be documented in this file. The format 
 
 - Fixed issue where the server `NetworkEndPoint` would fail to be created when 'Server Listen Address' is empty. (#1636)
 - Fixed issue with native collections not all being disposed of when destroying the component without shutting it down properly. This would result in errors in the console and memory leaks. (#1640)
+- Fixed an issue where packets causing errors would not be removed from the send queue, which would cause the error message to be spammed on every frame as the adapter would try to resend the packet.
 
 ## [1.0.0-pre.5] - 2022-01-26
 

--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -530,11 +530,14 @@ namespace Unity.Netcode
                 {
                     // Some error occured. If it's just the UTP queue being full, then don't log
                     // anything since that's okay (the unsent message(s) are still in the queue
-                    // and we'll retry sending the later);
+                    // and we'll retry sending the later). Otherwise log the error and remove the
+                    // message from the queue (we don't want to resend it again since we'll likely
+                    // just get the same error again).
                     if (result != (int)Networking.Transport.Error.StatusCode.NetworkSendQueueFull)
                     {
                         Debug.LogError("Error sending the message: " +
                             ErrorUtilities.ErrorToString((Networking.Transport.Error.StatusCode)result, clientId));
+                        queue.Consume(written);
                     }
 
                     return;


### PR DESCRIPTION
This is a backport of PR #1648 to `release/1.0.0`.

MTT-2408

## Changelog

### com.unity.netcode.adapter.utp

* Fixed: Fixed an issue where packets causing errors would not be removed from the send queue, which would cause the error message to be spammed on every frame as the adapter would try to resend the packet.

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.