### PR TITLE
fix: Clear adapter send queues on client disconnection (1.0.0)

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this package will be documented in this file. The format 
 
 ### Fixed
 
-- Fixed issue where disconnecting from the server with data still in the queue would result in an error message about a stale connection.
+- Fixed issue where disconnecting from the server with data still in the queue would result in an error message about a stale connection. (#1649)
 - Fixed issue where the server `NetworkEndPoint` would fail to be created when 'Server Listen Address' is empty. (#1636)
 - Fixed issue with native collections not all being disposed of when destroying the component without shutting it down properly. This would result in errors in the console and memory leaks. (#1640)
 

--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this package will be documented in this file. The format 
 
 ### Fixed
 
+- Fixed issue where disconnecting from the server with data still in the queue would result in an error message about a stale connection.
 - Fixed issue where the server `NetworkEndPoint` would fail to be created when 'Server Listen Address' is empty. (#1636)
 - Fixed issue with native collections not all being disposed of when destroying the component without shutting it down properly. This would result in errors in the console and memory leaks. (#1640)
 

--- a/com.unity.netcode.adapter.utp/Tests/Runtime/ConnectionTests.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/ConnectionTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -23,7 +24,7 @@ namespace Unity.Netcode.RuntimeTests
             if (m_Server)
             {
                 m_Server.Shutdown();
-                Object.DestroyImmediate(m_Server);
+                UnityEngine.Object.DestroyImmediate(m_Server);
             }
 
             foreach (var transport in m_Clients)
@@ -31,7 +32,7 @@ namespace Unity.Netcode.RuntimeTests
                 if (transport)
                 {
                     transport.Shutdown();
-                    Object.DestroyImmediate(transport);
+                    UnityEngine.Object.DestroyImmediate(transport);
                 }
             }
 
@@ -277,6 +278,46 @@ namespace Unity.Netcode.RuntimeTests
             Assert.AreEqual(NetworkEvent.Connect, m_ServerEvents[0].Type);
 
             yield return null;
+        }
+
+        // Check server disconnection with data in send queue.
+        [UnityTest]
+        public IEnumerator ServerDisconnectWithDataInQueue()
+        {
+            InitializeTransport(out m_Server, out m_ServerEvents);
+            InitializeTransport(out m_Clients[0], out m_ClientsEvents[0]);
+
+            m_Server.StartServer();
+            m_Clients[0].StartClient();
+
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ServerEvents);
+
+            var data = new ArraySegment<byte>(new byte[] { 42 });
+            m_Server.Send(m_ServerEvents[0].ClientID, data, NetworkDelivery.Unreliable);
+
+            m_Server.DisconnectRemoteClient(m_ServerEvents[0].ClientID);
+
+            yield return WaitForNetworkEvent(NetworkEvent.Disconnect, m_ClientsEvents[0]);
+        }
+
+        // Check client disconnection with data in send queue.
+        [UnityTest]
+        public IEnumerator ClientDisconnectWithDataInQueue()
+        {
+            InitializeTransport(out m_Server, out m_ServerEvents);
+            InitializeTransport(out m_Clients[0], out m_ClientsEvents[0]);
+
+            m_Server.StartServer();
+            m_Clients[0].StartClient();
+
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ServerEvents);
+
+            var data = new ArraySegment<byte>(new byte[] { 42 });
+            m_Clients[0].Send(m_Clients[0].ServerClientId, data, NetworkDelivery.Unreliable);
+
+            m_Clients[0].DisconnectLocalClient();
+
+            yield return WaitForNetworkEvent(NetworkEvent.Disconnect, m_ServerEvents);
         }
     }
 }


### PR DESCRIPTION
Backport of PR #1649 to `release/1.0.0`.

MTT-2329

## Changelog

### com.unity.netcode.adapter.utp

* Fixed: Fixed issue where disconnecting from the server with data still in the queue would result in an error message about a stale connection.

## Testing and Documentation

* Includes integration tests.
* No documentation changes or additions were necessary.