### PR TITLE
fix: Fix handling of disconnection events in the adapter

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this package will be documented in this file. The format 
 
 - Fixed issue where the server `NetworkEndPoint` would fail to be created when 'Server Listen Address' is empty. (#1636)
 - Fixed issue with native collections not all being disposed of when destroying the component without shutting it down properly. This would result in errors in the console and memory leaks. (#1640)
+- Fixed where a server would fail to disconnect a client if another client had previously disconnected itself.
 
 ## [1.0.0-pre.5] - 2022-01-26
 

--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this package will be documented in this file. The format 
 
 - Fixed issue where the server `NetworkEndPoint` would fail to be created when 'Server Listen Address' is empty. (#1636)
 - Fixed issue with native collections not all being disposed of when destroying the component without shutting it down properly. This would result in errors in the console and memory leaks. (#1640)
-- Fixed where a server would fail to disconnect a client if another client had previously disconnected itself.
+- Fixed and issue where a server would fail to disconnect a client if another client had previously disconnected itself. (#1673)
 
 ## [1.0.0-pre.5] - 2022-01-26
 

--- a/com.unity.netcode.adapter.utp/Tests/Runtime/ConnectionTests.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/ConnectionTests.cs
@@ -53,11 +53,11 @@ namespace Unity.Netcode.RuntimeTests
             m_Server.StartServer();
             m_Clients[0].StartClient();
 
-            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ServerEvents);
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[0]);
 
-            // Check we've received Connect event on client too.
-            Assert.AreEqual(1, m_ClientsEvents[0].Count);
-            Assert.AreEqual(NetworkEvent.Connect, m_ClientsEvents[0][0].Type);
+            // Check we've received Connect event on server too.
+            Assert.AreEqual(1, m_ServerEvents.Count);
+            Assert.AreEqual(NetworkEvent.Connect, m_ServerEvents[0].Type);
 
             yield return null;
         }
@@ -75,11 +75,15 @@ namespace Unity.Netcode.RuntimeTests
                 m_Clients[i].StartClient();
             }
 
-            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ServerEvents);
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[k_NumClients - 1]);
 
-            // Check that every client also received a Connect event.
+            // Check that every client received a Connect event.
             Assert.True(m_ClientsEvents.All(evs => evs.Count == 1));
             Assert.True(m_ClientsEvents.All(evs => evs[0].Type == NetworkEvent.Connect));
+
+            // Check we've received Connect events on server too.
+            Assert.AreEqual(k_NumClients, m_ServerEvents.Count);
+            Assert.True(m_ServerEvents.All(ev => ev.Type == NetworkEvent.Connect));
 
             yield return null;
         }
@@ -94,7 +98,7 @@ namespace Unity.Netcode.RuntimeTests
             m_Server.StartServer();
             m_Clients[0].StartClient();
 
-            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ServerEvents);
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[0]);
 
             m_Server.DisconnectRemoteClient(m_ServerEvents[0].ClientID);
 
@@ -116,7 +120,7 @@ namespace Unity.Netcode.RuntimeTests
                 m_Clients[i].StartClient();
             }
 
-            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ServerEvents);
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[k_NumClients - 1]);
 
             // Disconnect a single client.
             m_Server.DisconnectRemoteClient(m_ServerEvents[0].ClientID);
@@ -153,7 +157,7 @@ namespace Unity.Netcode.RuntimeTests
             m_Server.StartServer();
             m_Clients[0].StartClient();
 
-            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ServerEvents);
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[0]);
 
             m_Clients[0].DisconnectLocalClient();
 
@@ -173,7 +177,7 @@ namespace Unity.Netcode.RuntimeTests
                 m_Clients[i].StartClient();
             }
 
-            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ServerEvents);
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[k_NumClients - 1]);
 
             // Disconnect a single client.
             m_Clients[0].DisconnectLocalClient();
@@ -205,7 +209,7 @@ namespace Unity.Netcode.RuntimeTests
             m_Server.StartServer();
             m_Clients[0].StartClient();
 
-            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ServerEvents);
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[0]);
 
             m_Server.DisconnectRemoteClient(m_ServerEvents[0].ClientID);
 
@@ -236,7 +240,7 @@ namespace Unity.Netcode.RuntimeTests
             m_Server.StartServer();
             m_Clients[0].StartClient();
 
-            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ServerEvents);
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[0]);
 
             m_Clients[0].DisconnectLocalClient();
 


### PR DESCRIPTION
MTT-2467

How the adapter handled `Disconnect` events from the transport needed to be fixed in two ways:

1. Send and receive queues were not cleared, meaning memory would stay allocated for nothing.
2. The `m_State` would be set to `Disconnected`, but that should only be done on clients. Hosts have their `m_State` set to `Listening` and it should stay that way after a client has disconnected. This is likely what was causing MTT-2467.

This PR also brings in changes from PR #1649 since it provides a clean way of clearing the send queues. I also modified the connection tests to improve their stability (waiting for the client to be connected since this guarantees the server also is, otherwise there could be timing issues where the server is connected but not the client).

## Changelog

### com.unity.netcode.adapter.utp

* Fixed: Fixed and issue where a server would fail to disconnect a client if another client had previously disconnected itself.

## Testing and Documentation

* Includes unit/integration tests.
* No documentation changes or additions were necessary.