### PR TITLE
fix: Fix handling of disconnection events in the adapter (1.0.0)

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this package will be documented in this file. The format 
 
 - Fixed issue where the server `NetworkEndPoint` would fail to be created when 'Server Listen Address' is empty. (#1636)
 - Fixed issue with native collections not all being disposed of when destroying the component without shutting it down properly. This would result in errors in the console and memory leaks. (#1640)
+- Fixed where a server would fail to disconnect a client if another client had previously disconnected itself.
 
 ## [1.0.0-pre.5] - 2022-01-26
 

--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this package will be documented in this file. The format 
 
 - Fixed issue where the server `NetworkEndPoint` would fail to be created when 'Server Listen Address' is empty. (#1636)
 - Fixed issue with native collections not all being disposed of when destroying the component without shutting it down properly. This would result in errors in the console and memory leaks. (#1640)
-- Fixed where a server would fail to disconnect a client if another client had previously disconnected itself.
+- Fixed and issue where a server would fail to disconnect a client if another client had previously disconnected itself. (#1673)
 
 ## [1.0.0-pre.5] - 2022-01-26
 

--- a/com.unity.netcode.adapter.utp/Tests/Runtime/ConnectionTests.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/ConnectionTests.cs
@@ -53,11 +53,11 @@ namespace Unity.Netcode.RuntimeTests
             m_Server.StartServer();
             m_Clients[0].StartClient();
 
-            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ServerEvents);
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[0]);
 
-            // Check we've received Connect event on client too.
-            Assert.AreEqual(1, m_ClientsEvents[0].Count);
-            Assert.AreEqual(NetworkEvent.Connect, m_ClientsEvents[0][0].Type);
+            // Check we've received Connect event on server too.
+            Assert.AreEqual(1, m_ServerEvents.Count);
+            Assert.AreEqual(NetworkEvent.Connect, m_ServerEvents[0].Type);
 
             yield return null;
         }
@@ -75,11 +75,15 @@ namespace Unity.Netcode.RuntimeTests
                 m_Clients[i].StartClient();
             }
 
-            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ServerEvents);
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[k_NumClients - 1]);
 
-            // Check that every client also received a Connect event.
+            // Check that every client received a Connect event.
             Assert.True(m_ClientsEvents.All(evs => evs.Count == 1));
             Assert.True(m_ClientsEvents.All(evs => evs[0].Type == NetworkEvent.Connect));
+
+            // Check we've received Connect events on server too.
+            Assert.AreEqual(k_NumClients, m_ServerEvents.Count);
+            Assert.True(m_ServerEvents.All(ev => ev.Type == NetworkEvent.Connect));
 
             yield return null;
         }
@@ -94,7 +98,7 @@ namespace Unity.Netcode.RuntimeTests
             m_Server.StartServer();
             m_Clients[0].StartClient();
 
-            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ServerEvents);
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[0]);
 
             m_Server.DisconnectRemoteClient(m_ServerEvents[0].ClientID);
 
@@ -116,7 +120,7 @@ namespace Unity.Netcode.RuntimeTests
                 m_Clients[i].StartClient();
             }
 
-            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ServerEvents);
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[k_NumClients - 1]);
 
             // Disconnect a single client.
             m_Server.DisconnectRemoteClient(m_ServerEvents[0].ClientID);
@@ -153,7 +157,7 @@ namespace Unity.Netcode.RuntimeTests
             m_Server.StartServer();
             m_Clients[0].StartClient();
 
-            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ServerEvents);
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[0]);
 
             m_Clients[0].DisconnectLocalClient();
 
@@ -173,7 +177,7 @@ namespace Unity.Netcode.RuntimeTests
                 m_Clients[i].StartClient();
             }
 
-            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ServerEvents);
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[k_NumClients - 1]);
 
             // Disconnect a single client.
             m_Clients[0].DisconnectLocalClient();
@@ -205,7 +209,7 @@ namespace Unity.Netcode.RuntimeTests
             m_Server.StartServer();
             m_Clients[0].StartClient();
 
-            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ServerEvents);
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[0]);
 
             m_Server.DisconnectRemoteClient(m_ServerEvents[0].ClientID);
 
@@ -236,7 +240,7 @@ namespace Unity.Netcode.RuntimeTests
             m_Server.StartServer();
             m_Clients[0].StartClient();
 
-            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ServerEvents);
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[0]);
 
             m_Clients[0].DisconnectLocalClient();
 


### PR DESCRIPTION
Backport of PR #1673 to `release/1.0.0`.

MTT-2467

## Changelog

### com.unity.netcode.adapter.utp

* Fixed: Fixed and issue where a server would fail to disconnect a client if another client had previously disconnected itself.

## Testing and Documentation

* Includes unit/integration tests.
* No documentation changes or additions were necessary.