### PR TITLE
fix!: networktransport initialize networkmanager parameter

### DIFF
--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -182,6 +182,8 @@ namespace Unity.Netcode
 
         private RelayServerData m_RelayServerData;
 
+        internal NetworkManager NetworkManager;
+
 #if UNITY_EDITOR
         private static int ClientPacketDelayMs => UnityEditor.EditorPrefs.GetInt($"NetcodeGameObjects_{Application.productName}_ClientDelay");
         private static int ClientPacketJitterMs => UnityEditor.EditorPrefs.GetInt($"NetcodeGameObjects_{Application.productName}_ClientJitter");
@@ -747,10 +749,12 @@ namespace Unity.Netcode
             return 0;
         }
 
-        public override void Initialize()
+        public override void Initialize(NetworkManager networkManager = null)
         {
             Debug.Assert(sizeof(ulong) == UnsafeUtility.SizeOf<NetworkConnection>(),
                 "Netcode connection id size does not match UTP connection id size");
+
+            NetworkManager = networkManager;
 
             m_NetworkSettings = new NetworkSettings(Allocator.Persistent);
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -15,13 +15,14 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Changed
 
 - NetworkManager's GameObject is no longer allowed to be nested under one or more GameObject(s).(#1484)
-- NetworkManager DontDestroy property was removed and now NetworkManager always is migrated into the DontDestroyOnLoad scene. (#1484)
+- NetworkManager DontDestroy property was removed and now NetworkManager always is migrated into the DontDestroyOnLoad scene. (#1484)'
 
 ### Fixed
 
 - Fixed network tick value sometimes being duplicated or skipped. (#1614)
 - Fixed The ClientNetworkTransform sample script to allow for owner changes at runtime. (#1606)
 - Fixed When the LogLevel is set to developer NetworkBehaviour generates warning messages when it should not (#1631)
+- Fixed NetworkTransport Initialize now can receive the associated NetworkManager instance to avoid using NetworkManager.Singleton in transport layer (#1677)
 
 ## [1.0.0-pre.4] - 2021-01-04
 

--- a/com.unity.netcode.gameobjects/Runtime/Transports/NetworkTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/NetworkTransport.cs
@@ -95,6 +95,6 @@ namespace Unity.Netcode
         /// <summary>
         /// Initializes the transport
         /// </summary>
-        public abstract void Initialize();
+        public abstract void Initialize(NetworkManager networkManager = null);
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Transports/NetworkTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/NetworkTransport.cs
@@ -95,6 +95,7 @@ namespace Unity.Netcode
         /// <summary>
         /// Initializes the transport
         /// </summary>
+        /// /// <param name="networkManager">optionally pass in NetworkManager</param>
         public abstract void Initialize(NetworkManager networkManager = null);
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UNET/UNetTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UNET/UNetTransport.cs
@@ -41,6 +41,8 @@ namespace Unity.Netcode.Transports.UNET
 
         public override ulong ServerClientId => GetNetcodeClientId(0, 0, true);
 
+        internal NetworkManager NetworkManager;
+
         protected void LateUpdate()
         {
             if (UnityEngine.Networking.NetworkTransport.IsStarted && MessageSendMode == SendMode.Queued)
@@ -48,7 +50,7 @@ namespace Unity.Netcode.Transports.UNET
 #if UNITY_WEBGL
                 Debug.LogError("Cannot use queued sending mode for WebGL");
 #else
-                if (NetworkManager.Singleton.IsServer)
+                if (NetworkManager != null && NetworkManager.IsServer)
                 {
                     foreach (var targetClient in NetworkManager.Singleton.ConnectedClientsList)
                     {
@@ -230,8 +232,10 @@ namespace Unity.Netcode.Transports.UNET
             UnityEngine.Networking.NetworkTransport.Shutdown();
         }
 
-        public override void Initialize()
+        public override void Initialize(NetworkManager networkManager = null)
         {
+            NetworkManager = networkManager;
+
             m_MessageBuffer = new byte[MessageBufferSize];
 
             UnityEngine.Networking.NetworkTransport.Init();

--- a/com.unity.netcode.gameobjects/Tests/Editor/NetworkManagerMessageHandlerTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/NetworkManagerMessageHandlerTests.cs
@@ -47,7 +47,7 @@ namespace Unity.Netcode.EditorTests
         {
         }
 
-        public override void Initialize()
+        public override void Initialize(NetworkManager networkManager = null)
         {
         }
     }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transport/SIPTransport.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transport/SIPTransport.cs
@@ -104,7 +104,7 @@ namespace Unity.Netcode.RuntimeTests
             return 50;
         }
 
-        public override void Initialize()
+        public override void Initialize(NetworkManager networkManager = null)
         {
         }
 


### PR DESCRIPTION
Adding the ability for NetworkTransport to receive the NetworkManager instance that instantiated it.
[MTT-2478](https://jira.unity3d.com/browse/MTT-2478)
## Testing and Documentation
* No tests have been added.
* No documentation changes or additions were necessary.

