### PR TITLE
fix: unet removed from unity trunk v1.0.0

### DIFF
--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -39,9 +39,9 @@ projects:
       - 2021.2
       - 2020.3
       - trunk
-  - name: testproject-tools-integration
-    path: testproject-tools-integration
-    validate: false
-    test_editors:
-      - 2021.2
-      - trunk
+ #- name: testproject-tools-integration
+ #   path: testproject-tools-integration
+ #   validate: false
+ #   test_editors:
+ #     - 2021.2
+ #     - trunk

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -39,9 +39,9 @@ projects:
       - 2021.2
       - 2020.3
       - trunk
- #- name: testproject-tools-integration
- #   path: testproject-tools-integration
- #   validate: false
- #   test_editors:
- #     - 2021.2
- #     - trunk
+  - name: testproject-tools-integration
+    path: testproject-tools-integration
+    validate: false
+    test_editors:
+      - 2021.2
+      - trunk

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UNET/UNetChannel.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UNET/UNetChannel.cs
@@ -1,3 +1,4 @@
+#if UNITY_UNET_PRESENT
 using System;
 #if UNITY_EDITOR
 using UnityEditor;
@@ -50,3 +51,4 @@ namespace Unity.Netcode.Transports.UNET
 #endif
     }
 }
+#endif

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UNET/UNetTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UNET/UNetTransport.cs
@@ -1,3 +1,4 @@
+#if UNITY_UNET_PRESENT
 #pragma warning disable 618 // disable is obsolete
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 using System;
@@ -279,3 +280,4 @@ namespace Unity.Netcode.Transports.UNET
 }
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 #pragma warning restore 618 // restore is obsolete
+#endif

--- a/com.unity.netcode.gameobjects/Runtime/com.unity.netcode.runtime.asmdef
+++ b/com.unity.netcode.gameobjects/Runtime/com.unity.netcode.runtime.asmdef
@@ -24,6 +24,11 @@
             "name": "com.unity.multiplayer.tools",
             "expression": "",
             "define": "MULTIPLAYER_TOOLS"
+        },
+        {
+            "name": "Unity",
+            "expression": "(0,2022.2.0a5)",
+            "define": "UNITY_UNET_PRESENT"
         }
     ],
     "noEngineReferences": false

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Helpers/NetworkManagerHelper.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Helpers/NetworkManagerHelper.cs
@@ -2,9 +2,6 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using NUnit.Framework;
-//#if UNITY_UNET_PRESENT
-//using Unity.Netcode.Transports.UNET;
-//#endif
 
 namespace Unity.Netcode.RuntimeTests
 {
@@ -70,6 +67,10 @@ namespace Unity.Netcode.RuntimeTests
 
                 Debug.Log($"{nameof(NetworkManager)} Instantiated.");
 
+                // NOTE: For now we only use SIPTransport for tests until UnityTransport
+                // has been verified working in nightly builds
+                // TODO-MTT-2486: Provide support for other transports once tested and verified
+                // working on consoles.
                 var sipTransport = NetworkManagerGameObject.AddComponent<SIPTransport>();
                 if (networkConfig == null)
                 {
@@ -80,13 +81,6 @@ namespace Unity.Netcode.RuntimeTests
                 }
 
                 NetworkManagerObject.NetworkConfig = networkConfig;
-
-                //unetTransport.ConnectAddress = "127.0.0.1";
-                //unetTransport.ConnectPort = 7777;
-                //unetTransport.ServerListenPort = 7777;
-                //unetTransport.MessageBufferSize = 65535;
-                //unetTransport.MaxConnections = 100;
-                //unetTransport.MessageSendMode = UNetTransport.SendMode.Immediately;
                 NetworkManagerObject.NetworkConfig.NetworkTransport = sipTransport;
 
                 // Starts the network manager in the mode specified

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Helpers/NetworkManagerHelper.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Helpers/NetworkManagerHelper.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using NUnit.Framework;
+#if UNITY_UNET_PRESENT
 using Unity.Netcode.Transports.UNET;
+#endif
 
 namespace Unity.Netcode.RuntimeTests
 {
@@ -68,7 +70,7 @@ namespace Unity.Netcode.RuntimeTests
 
                 Debug.Log($"{nameof(NetworkManager)} Instantiated.");
 
-                var unetTransport = NetworkManagerGameObject.AddComponent<UNetTransport>();
+                var sipTransport = NetworkManagerGameObject.AddComponent<SIPTransport>();
                 if (networkConfig == null)
                 {
                     networkConfig = new NetworkConfig
@@ -79,13 +81,13 @@ namespace Unity.Netcode.RuntimeTests
 
                 NetworkManagerObject.NetworkConfig = networkConfig;
 
-                unetTransport.ConnectAddress = "127.0.0.1";
-                unetTransport.ConnectPort = 7777;
-                unetTransport.ServerListenPort = 7777;
-                unetTransport.MessageBufferSize = 65535;
-                unetTransport.MaxConnections = 100;
-                unetTransport.MessageSendMode = UNetTransport.SendMode.Immediately;
-                NetworkManagerObject.NetworkConfig.NetworkTransport = unetTransport;
+                //unetTransport.ConnectAddress = "127.0.0.1";
+                //unetTransport.ConnectPort = 7777;
+                //unetTransport.ServerListenPort = 7777;
+                //unetTransport.MessageBufferSize = 65535;
+                //unetTransport.MaxConnections = 100;
+                //unetTransport.MessageSendMode = UNetTransport.SendMode.Immediately;
+                NetworkManagerObject.NetworkConfig.NetworkTransport = sipTransport;
 
                 // Starts the network manager in the mode specified
                 StartNetworkManagerMode(managerMode);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Helpers/NetworkManagerHelper.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Helpers/NetworkManagerHelper.cs
@@ -2,9 +2,9 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using NUnit.Framework;
-#if UNITY_UNET_PRESENT
-using Unity.Netcode.Transports.UNET;
-#endif
+//#if UNITY_UNET_PRESENT
+//using Unity.Netcode.Transports.UNET;
+//#endif
 
 namespace Unity.Netcode.RuntimeTests
 {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Helpers/NetworkManagerHelper.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Helpers/NetworkManagerHelper.cs
@@ -2,6 +2,9 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using NUnit.Framework;
+#if UNITY_UNET_PRESENT
+using Unity.Netcode.Transports.UNET;
+#endif
 
 namespace Unity.Netcode.RuntimeTests
 {
@@ -67,11 +70,8 @@ namespace Unity.Netcode.RuntimeTests
 
                 Debug.Log($"{nameof(NetworkManager)} Instantiated.");
 
-                // NOTE: For now we only use SIPTransport for tests until UnityTransport
-                // has been verified working in nightly builds
-                // TODO-MTT-2486: Provide support for other transports once tested and verified
-                // working on consoles.
-                var sipTransport = NetworkManagerGameObject.AddComponent<SIPTransport>();
+#if UNITY_UNET_PRESENT
+                var unetTransport = NetworkManagerGameObject.AddComponent<UNetTransport>();
                 if (networkConfig == null)
                 {
                     networkConfig = new NetworkConfig
@@ -81,7 +81,25 @@ namespace Unity.Netcode.RuntimeTests
                 }
 
                 NetworkManagerObject.NetworkConfig = networkConfig;
+                unetTransport.ConnectAddress = "127.0.0.1";
+                unetTransport.ConnectPort = 7777;
+                unetTransport.ServerListenPort = 7777;
+                unetTransport.MessageBufferSize = 65535;
+                unetTransport.MaxConnections = 100;
+                unetTransport.MessageSendMode = UNetTransport.SendMode.Immediately;
+                NetworkManagerObject.NetworkConfig.NetworkTransport = unetTransport;
+#else
+                var sipTransport = NetworkManagerGameObject.AddComponent<SIPTransport>();
+                if (networkConfig == null)
+                {
+                    networkConfig = new NetworkConfig
+                    {
+                        EnableSceneManagement = false,
+                    };
+                }
+                NetworkManagerObject.NetworkConfig = networkConfig;
                 NetworkManagerObject.NetworkConfig.NetworkTransport = sipTransport;
+#endif
 
                 // Starts the network manager in the mode specified
                 StartNetworkManagerMode(managerMode);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/com.unity.netcode.runtimetests.asmdef
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/com.unity.netcode.runtimetests.asmdef
@@ -30,6 +30,11 @@
             "name": "com.unity.multiplayer.tools",
             "expression": "",
             "define": "MULTIPLAYER_TOOLS"
+        },
+        {
+            "name": "Unity",
+            "expression": "(0,2022.2.0a5)",
+            "define": "UNITY_UNET_PRESENT"
         }
     ],
     "noEngineReferences": false

--- a/testproject/Assets/Scripts/CommandLineHandler.cs
+++ b/testproject/Assets/Scripts/CommandLineHandler.cs
@@ -201,9 +201,11 @@ public class CommandLineProcessor
         var transport = NetworkManager.Singleton.NetworkConfig.NetworkTransport;
         switch (transport)
         {
+#if UNITY_UNET_PRESENT
             case UNetTransport unetTransport:
                 unetTransport.ConnectAddress = address;
                 break;
+#endif
         }
     }
 
@@ -212,10 +214,12 @@ public class CommandLineProcessor
         var transport = NetworkManager.Singleton.NetworkConfig.NetworkTransport;
         switch (transport)
         {
+#if UNITY_UNET_PRESENT
             case UNetTransport unetTransport:
                 unetTransport.ConnectPort = port;
                 unetTransport.ServerListenPort = port;
                 break;
+#endif
         }
     }
 }
@@ -233,6 +237,5 @@ public class CommandLineHandler : MonoBehaviour
         {
             s_CommandLineProcessorInstance = new CommandLineProcessor(Environment.GetCommandLineArgs());
         }
-
     }
 }

--- a/testproject/Assets/Scripts/CommandLineHandler.cs
+++ b/testproject/Assets/Scripts/CommandLineHandler.cs
@@ -3,8 +3,9 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using Unity.Netcode;
+#if UNITY_UNET_PRESENT
 using Unity.Netcode.Transports.UNET;
-
+#endif
 
 /// <summary>
 /// Provides basic command line handling capabilities

--- a/testproject/Assets/Scripts/CommandLineHandler.cs
+++ b/testproject/Assets/Scripts/CommandLineHandler.cs
@@ -206,6 +206,15 @@ public class CommandLineProcessor
                 unetTransport.ConnectAddress = address;
                 break;
 #endif
+            case UnityTransport utpTransport:
+                {
+                    utpTransport.ConnectionData.Address = address;
+                    if (utpTransport.ConnectionData.ServerListenAddress == string.Empty)
+                    {
+                        utpTransport.ConnectionData.ServerListenAddress = address;
+                    }
+                    break;
+                }
         }
     }
 
@@ -220,6 +229,11 @@ public class CommandLineProcessor
                 unetTransport.ServerListenPort = port;
                 break;
 #endif
+            case UnityTransport utpTransport:
+                {
+                    utpTransport.ConnectionData.Port = port;
+                    break;
+                }
         }
     }
 }

--- a/testproject/Assets/Scripts/testproject.asmdef
+++ b/testproject/Assets/Scripts/testproject.asmdef
@@ -22,6 +22,11 @@
             "name": "com.unity.services.relay",
             "expression": "0.0.1-preview.3",
             "define": "ENABLE_RELAY_SERVICE"
+        },
+        {
+            "name": "Unity",
+            "expression": "(0,2022.2.0a5)",
+            "define": "UNITY_UNET_PRESENT"
         }
     ],
     "noEngineReferences": false

--- a/testproject/Assets/Tests/Runtime/testproject.runtimetests.asmdef
+++ b/testproject/Assets/Tests/Runtime/testproject.runtimetests.asmdef
@@ -26,11 +26,6 @@
     ],
     "versionDefines": [
         {
-            "name": "com.unity.services.relay",
-            "expression": "0.0.1-preview.3",
-            "define": "ENABLE_RELAY_SERVICE"
-        },
-        {
             "name": "Unity",
             "expression": "(0,2022.2.0a5)",
             "define": "UNITY_UNET_PRESENT"

--- a/testproject/Assets/Tests/Runtime/testproject.runtimetests.asmdef
+++ b/testproject/Assets/Tests/Runtime/testproject.runtimetests.asmdef
@@ -24,6 +24,17 @@
         "UNITY_EDITOR",
         "UNITY_INCLUDE_TESTS"
     ],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.services.relay",
+            "expression": "0.0.1-preview.3",
+            "define": "ENABLE_RELAY_SERVICE"
+        },
+        {
+            "name": "Unity",
+            "expression": "(0,2022.2.0a5)",
+            "define": "UNITY_UNET_PRESENT"
+        }
+    ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
Fixing the most recent update to unity trunk where UNet no longer exists.
[MTT-2483](https://jira.unity3d.com/browse/MTT-2483)
This is a backport of #1678.

## Changelog
### com.unity.netcode.gameobjects
- Fixed: Issue where Alpha release versions of Unity (version 20202.2.0a5 and later) will not compile due to the UNet Transport no longer existing (#1678)

## Testing and Documentation
* No tests have been added.
* No documentation changes or additions were necessary.