### PR TITLE
feat: networkscenemanager interface override (backport)

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs
@@ -1,0 +1,28 @@
+using System;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace Unity.Netcode
+{
+    /// <summary>
+    /// Used to override the LoadSceneAsync and UnloadSceneAsync methods called
+    /// within the NetworkSceneManager.
+    /// </summary>
+    internal interface ISceneManagerHandler
+    {
+        // Generic action to call when a scene is finished loading/unloading
+        struct SceneEventAction
+        {
+            internal uint SceneEventId;
+            internal Action<uint> EventAction;
+            internal void Invoke()
+            {
+                EventAction.Invoke(SceneEventId);
+            }
+        }
+
+        AsyncOperation LoadSceneAsync(string sceneName, LoadSceneMode loadSceneMode, SceneEventAction sceneEventAction);
+
+        AsyncOperation UnloadSceneAsync(Scene scene, SceneEventAction sceneEventAction);
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: de907a9fb8151e240800dbcc97f8e745
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -139,13 +139,7 @@ namespace Unity.Netcode
         /// Used to detect if a scene event is underway
         /// Only 1 scene event can occur on the server at a time for now.
         /// </summary>
-        private static bool s_IsSceneEventActive = false;
-
-        // TODO: Remove `m_IsRunningUnitTest` entirely after we switch to multi-process testing
-        // In MultiInstance tests, we cannot allow clients to load additional scenes as they're sharing the same scene space / Unity instance.
-#if UNITY_INCLUDE_TESTS
-        private readonly bool m_IsRunningUnitTest = SceneManager.GetActiveScene().name.StartsWith("InitTestScene");
-#endif
+        private bool m_IsSceneEventActive = false;
 
         /// <summary>
         /// The delegate callback definition for scene event notifications.<br/>
@@ -323,6 +317,31 @@ namespace Unity.Netcode
         /// <b>Server Side:</b> <see cref="LoadScene(string, LoadSceneMode)"/> will return <see cref="SceneEventProgressStatus"/>.
         /// </summary>
         public VerifySceneBeforeLoadingDelegateHandler VerifySceneBeforeLoading;
+
+        /// <summary>
+        ///  Proof of concept: Interface version that allows for the decoupling from
+        ///  the SceneManager's Load and Unload methods for testing purposes (potentially other future usage)
+        /// </summary>
+        private class DefaultSceneManagerHandler : ISceneManagerHandler
+        {
+            public AsyncOperation LoadSceneAsync(string sceneName, LoadSceneMode loadSceneMode, ISceneManagerHandler.SceneEventAction sceneEventAction)
+            {
+                var operation = SceneManager.LoadSceneAsync(sceneName, loadSceneMode);
+                operation.completed += new Action<AsyncOperation>(asyncOp2 => { sceneEventAction.Invoke(); });
+                return operation;
+            }
+
+            public AsyncOperation UnloadSceneAsync(Scene scene, ISceneManagerHandler.SceneEventAction sceneEventAction)
+            {
+                var operation = SceneManager.UnloadSceneAsync(scene);
+                operation.completed += new Action<AsyncOperation>(asyncOp2 => { sceneEventAction.Invoke(); });
+                return operation;
+            }
+        }
+
+        internal ISceneManagerHandler SceneManagerHandler = new DefaultSceneManagerHandler();
+        /// End of Proof of Concept
+
 
         internal readonly Dictionary<Guid, SceneEventProgress> SceneEventProgressTracking = new Dictionary<Guid, SceneEventProgress>();
 
@@ -789,7 +808,7 @@ namespace Unity.Netcode
         private SceneEventProgress ValidateSceneEvent(string sceneName, bool isUnloading = false)
         {
             // Return scene event already in progress if one is already in progress
-            if (s_IsSceneEventActive)
+            if (m_IsSceneEventActive)
             {
                 return new SceneEventProgress(null, SceneEventProgressStatus.SceneEventInProgress);
             }
@@ -818,7 +837,7 @@ namespace Unity.Netcode
                 IsSpawnedObjectsPendingInDontDestroyOnLoad = true;
             }
 
-            s_IsSceneEventActive = true;
+            m_IsSceneEventActive = true;
 
             // Set our callback delegate handler for completion
             sceneEventProgress.OnComplete = OnSceneEventProgressCompleted;
@@ -917,8 +936,9 @@ namespace Unity.Netcode
 
             ScenesLoaded.Remove(scene.handle);
 
-            AsyncOperation sceneUnload = SceneManager.UnloadSceneAsync(scene);
-            sceneUnload.completed += (AsyncOperation asyncOp2) => { OnSceneUnloaded(sceneEventData.SceneEventId); };
+            var sceneUnload = SceneManagerHandler.UnloadSceneAsync(scene,
+                    new ISceneManagerHandler.SceneEventAction() { SceneEventId = sceneEventData.SceneEventId, EventAction = OnSceneUnloaded });
+
             sceneEventProgress.SetSceneLoadOperation(sceneUnload);
 
             // Notify local server that a scene is going to be unloaded
@@ -948,8 +968,10 @@ namespace Unity.Netcode
 
             if (!ServerSceneHandleToClientSceneHandle.ContainsKey(sceneEventData.SceneHandle))
             {
-                throw new Exception($"Client failed to unload scene {sceneName} " +
-                    $"because we are missing the client scene handle due to the server scene handle {sceneEventData.SceneHandle} not being found!");
+                Debug.Log($"Client failed to unload scene {sceneName} " +
+                    $"because we are missing the client scene handle due to the server scene handle {sceneEventData.SceneHandle} not being found.");
+                EndSceneEvent(sceneEventId);
+                return;
             }
 
             var sceneHandle = ServerSceneHandleToClientSceneHandle[sceneEventData.SceneHandle];
@@ -960,22 +982,11 @@ namespace Unity.Netcode
                 throw new Exception($"Client failed to unload scene {sceneName} " +
                     $"because the client scene handle {sceneHandle} was not found in ScenesLoaded!");
             }
-            s_IsSceneEventActive = true;
-            var sceneUnload = (AsyncOperation)null;
-#if UNITY_INCLUDE_TESTS
-            if (m_IsRunningUnitTest)
-            {
-                sceneUnload = new AsyncOperation();
-            }
-            else
-            {
-                sceneUnload = SceneManager.UnloadSceneAsync(ScenesLoaded[sceneHandle]);
-                sceneUnload.completed += asyncOp2 => OnSceneUnloaded(sceneEventId);
-            }
-#else
-            sceneUnload = SceneManager.UnloadSceneAsync(ScenesLoaded[sceneHandle]);
-            sceneUnload.completed += asyncOp2 => OnSceneUnloaded(sceneEventId);
-#endif
+            m_IsSceneEventActive = true;
+
+            var sceneUnload = SceneManagerHandler.UnloadSceneAsync(ScenesLoaded[sceneHandle],
+                new ISceneManagerHandler.SceneEventAction() { SceneEventId = sceneEventData.SceneEventId, EventAction = OnSceneUnloaded });
+
             ScenesLoaded.Remove(sceneHandle);
 
             // Remove our server to scene handle lookup
@@ -992,13 +1003,6 @@ namespace Unity.Netcode
             });
 
             OnUnload?.Invoke(m_NetworkManager.LocalClientId, sceneName, sceneUnload);
-
-#if UNITY_INCLUDE_TESTS
-            if (m_IsRunningUnitTest)
-            {
-                OnSceneUnloaded(sceneEventId);
-            }
-#endif
         }
 
         /// <summary>
@@ -1045,7 +1049,12 @@ namespace Unity.Netcode
 
             EndSceneEvent(sceneEventId);
             // This scene event is now considered "complete"
-            s_IsSceneEventActive = false;
+            m_IsSceneEventActive = false;
+        }
+
+        private void EmptySceneUnloadedOperation(uint sceneEventId)
+        {
+            // Do nothing (this is a stub call since it is only used to flush all currently loaded scenes)
         }
 
         /// <summary>
@@ -1053,17 +1062,21 @@ namespace Unity.Netcode
         /// Since we assume a single mode loaded scene will be considered the "currently active scene",
         /// we only unload any additively loaded scenes.
         /// </summary>
-        internal void UnloadAdditivelyLoadedScenes()
+        internal void UnloadAdditivelyLoadedScenes(uint sceneEventId)
         {
             // Unload all additive scenes while making sure we don't try to unload the base scene ( loaded in single mode ).
             var currentActiveScene = SceneManager.GetActiveScene();
             foreach (var keyHandleEntry in ScenesLoaded)
             {
-                if (currentActiveScene.name != keyHandleEntry.Value.name)
+                // Validate the scene as well as ignore the DDOL (which will have a negative buildIndex)
+                if (currentActiveScene.name != keyHandleEntry.Value.name && keyHandleEntry.Value.buildIndex >= 0)
                 {
+                    var sceneUnload = SceneManagerHandler.UnloadSceneAsync(keyHandleEntry.Value,
+                        new ISceneManagerHandler.SceneEventAction() { SceneEventId = sceneEventId, EventAction = EmptySceneUnloadedOperation });
+
                     OnSceneEvent?.Invoke(new SceneEvent()
                     {
-                        AsyncOperation = SceneManager.UnloadSceneAsync(keyHandleEntry.Value),
+                        AsyncOperation = sceneUnload,
                         SceneEventType = SceneEventType.Unload,
                         SceneName = keyHandleEntry.Value.name,
                         LoadSceneMode = LoadSceneMode.Additive, // The only scenes unloaded are scenes that were additively loaded
@@ -1103,8 +1116,8 @@ namespace Unity.Netcode
             sceneEventData.LoadSceneMode = loadSceneMode;
 
             // This both checks to make sure the scene is valid and if not resets the active scene event
-            s_IsSceneEventActive = ValidateSceneBeforeLoading(sceneEventData.SceneHash, loadSceneMode);
-            if (!s_IsSceneEventActive)
+            m_IsSceneEventActive = ValidateSceneBeforeLoading(sceneEventData.SceneHash, loadSceneMode);
+            if (!m_IsSceneEventActive)
             {
                 EndSceneEvent(sceneEventData.SceneEventId);
                 return SceneEventProgressStatus.SceneFailedVerification;
@@ -1119,12 +1132,13 @@ namespace Unity.Netcode
                 MoveObjectsToDontDestroyOnLoad();
 
                 // Now Unload all currently additively loaded scenes
-                UnloadAdditivelyLoadedScenes();
+                UnloadAdditivelyLoadedScenes(sceneEventData.SceneEventId);
             }
 
             // Now start loading the scene
-            AsyncOperation sceneLoad = SceneManager.LoadSceneAsync(sceneName, loadSceneMode);
-            sceneLoad.completed += (AsyncOperation asyncOp2) => { OnSceneLoaded(sceneEventData.SceneEventId, sceneName); };
+            var sceneLoad = SceneManagerHandler.LoadSceneAsync(sceneName, loadSceneMode,
+                new ISceneManagerHandler.SceneEventAction() { SceneEventId = sceneEventData.SceneEventId, EventAction = OnSceneLoaded });
+
             sceneEventProgress.SetSceneLoadOperation(sceneLoad);
 
             // Notify the local server that a scene loading event has begun
@@ -1160,44 +1174,13 @@ namespace Unity.Netcode
                 return;
             }
 
-#if UNITY_INCLUDE_TESTS
-            if (m_IsRunningUnitTest)
-            {
-                // Send the loading message
-                OnSceneEvent?.Invoke(new SceneEvent()
-                {
-                    AsyncOperation = new AsyncOperation(),
-                    SceneEventType = sceneEventData.SceneEventType,
-                    LoadSceneMode = sceneEventData.LoadSceneMode,
-                    SceneName = sceneName,
-                    ClientId = m_NetworkManager.LocalClientId
-                });
-
-                // Only for testing
-                OnLoad?.Invoke(m_NetworkManager.ServerClientId, sceneName, sceneEventData.LoadSceneMode, new AsyncOperation());
-
-                // Unit tests must mirror the server's scenes loaded dictionary, otherwise this portion will fail
-                if (ScenesLoaded.ContainsKey(sceneEventData.SceneHandle))
-                {
-                    OnClientLoadedScene(sceneEventId, ScenesLoaded[sceneEventData.SceneHandle]);
-                }
-                else
-                {
-                    EndSceneEvent(sceneEventId);
-                    throw new Exception($"Could not find the scene handle {sceneEventData.SceneHandle} for scene {sceneName} " +
-                        $"during unit test.  Did you forget to register this in the unit test?");
-                }
-                return;
-            }
-#endif
-
             if (sceneEventData.LoadSceneMode == LoadSceneMode.Single)
             {
                 // Move ALL NetworkObjects to the temp scene
                 MoveObjectsToDontDestroyOnLoad();
 
                 // Now Unload all currently additively loaded scenes
-                UnloadAdditivelyLoadedScenes();
+                UnloadAdditivelyLoadedScenes(sceneEventData.SceneEventId);
             }
 
             // The Condition: While a scene is asynchronously loaded in single loading scene mode, if any new NetworkObjects are spawned
@@ -1205,13 +1188,14 @@ namespace Unity.Netcode
             // When it is set: Just before starting the asynchronous loading call
             // When it is unset: After the scene has loaded, the PopulateScenePlacedObjects is called, and all NetworkObjects in the do
             // not destroy temporary scene are moved into the active scene
+            // TODO: When Snapshot scene spawning is enabled this needs to be removed.
             if (sceneEventData.LoadSceneMode == LoadSceneMode.Single)
             {
                 IsSpawnedObjectsPendingInDontDestroyOnLoad = true;
             }
 
-            var sceneLoad = SceneManager.LoadSceneAsync(sceneName, sceneEventData.LoadSceneMode);
-            sceneLoad.completed += asyncOp2 => OnSceneLoaded(sceneEventId, sceneName);
+            var sceneLoad = SceneManagerHandler.LoadSceneAsync(sceneName, sceneEventData.LoadSceneMode,
+                new ISceneManagerHandler.SceneEventAction() { SceneEventId = sceneEventId, EventAction = OnSceneLoaded });
 
             OnSceneEvent?.Invoke(new SceneEvent()
             {
@@ -1230,10 +1214,10 @@ namespace Unity.Netcode
         /// Client and Server:
         /// Generic on scene loaded callback method to be called upon a scene loading
         /// </summary>
-        private void OnSceneLoaded(uint sceneEventId, string sceneName)
+        private void OnSceneLoaded(uint sceneEventId)
         {
             var sceneEventData = SceneEventDataStore[sceneEventId];
-            var nextScene = GetAndAddNewlyLoadedSceneByName(sceneName);
+            var nextScene = GetAndAddNewlyLoadedSceneByName(SceneNameFromHash(sceneEventData.SceneHash));
             if (!nextScene.isLoaded || !nextScene.IsValid())
             {
                 throw new Exception($"Failed to find valid scene internal Unity.Netcode for {nameof(GameObject)}s error!");
@@ -1319,7 +1303,7 @@ namespace Unity.Netcode
                 }
             }
 
-            s_IsSceneEventActive = false;
+            m_IsSceneEventActive = false;
             //First, notify local server that the scene was loaded
             OnSceneEvent?.Invoke(new SceneEvent()
             {
@@ -1351,7 +1335,7 @@ namespace Unity.Netcode
 
             sceneEventData.SceneEventType = SceneEventType.LoadComplete;
             SendSceneEventData(sceneEventId, new ulong[] { m_NetworkManager.ServerClientId });
-            s_IsSceneEventActive = false;
+            m_IsSceneEventActive = false;
 
             // Notify local client that the scene was loaded
             OnSceneEvent?.Invoke(new SceneEvent()
@@ -1474,6 +1458,10 @@ namespace Unity.Netcode
                 ScenePlacedObjects.Clear();
             }
 
+            // Store the sceneHandle and hash
+            sceneEventData.ClientSceneHandle = sceneHandle;
+            sceneEventData.ClientSceneHash = sceneHash;
+
             var shouldPassThrough = false;
             var sceneLoad = (AsyncOperation)null;
 
@@ -1485,38 +1473,28 @@ namespace Unity.Netcode
                 shouldPassThrough = true;
             }
 
-#if UNITY_INCLUDE_TESTS
-            if (m_IsRunningUnitTest)
-            {
-                // In unit tests, we don't allow clients to load additional scenes since
-                // MultiInstance unit tests share the same scene space.
-                shouldPassThrough = true;
-                sceneLoad = new AsyncOperation();
-            }
-#endif
             if (!shouldPassThrough)
             {
                 // If not, then load the scene
-                sceneLoad = SceneManager.LoadSceneAsync(sceneName, loadSceneMode);
-                sceneLoad.completed += asyncOp2 => ClientLoadedSynchronization(sceneEventId, sceneHash, sceneHandle);
+                sceneLoad = SceneManagerHandler.LoadSceneAsync(sceneName, loadSceneMode,
+                new ISceneManagerHandler.SceneEventAction() { SceneEventId = sceneEventId, EventAction = ClientLoadedSynchronization });
+
+                // Notify local client that a scene load has begun
+                OnSceneEvent?.Invoke(new SceneEvent()
+                {
+                    AsyncOperation = sceneLoad,
+                    SceneEventType = SceneEventType.Load,
+                    LoadSceneMode = loadSceneMode,
+                    SceneName = sceneName,
+                    ClientId = m_NetworkManager.LocalClientId,
+                });
+
+                OnLoad?.Invoke(m_NetworkManager.LocalClientId, sceneName, loadSceneMode, sceneLoad);
             }
-
-            // Notify local client that a scene load has begun
-            OnSceneEvent?.Invoke(new SceneEvent()
-            {
-                AsyncOperation = sceneLoad,
-                SceneEventType = SceneEventType.Load,
-                LoadSceneMode = loadSceneMode,
-                SceneName = sceneName,
-                ClientId = m_NetworkManager.LocalClientId,
-            });
-
-            OnLoad?.Invoke(m_NetworkManager.LocalClientId, sceneName, loadSceneMode, sceneLoad);
-
-            if (shouldPassThrough)
+            else
             {
                 // If so, then pass through
-                ClientLoadedSynchronization(sceneEventId, sceneHash, sceneHandle);
+                ClientLoadedSynchronization(sceneEventId);
             }
         }
 
@@ -1525,10 +1503,10 @@ namespace Unity.Netcode
         /// This handles all of the in-scene and dynamically spawned NetworkObject synchronization
         /// </summary>
         /// <param name="sceneIndex">Netcode scene index that was loaded</param>
-        private void ClientLoadedSynchronization(uint sceneEventId, uint sceneHash, int sceneHandle)
+        private void ClientLoadedSynchronization(uint sceneEventId)
         {
             var sceneEventData = SceneEventDataStore[sceneEventId];
-            var sceneName = SceneNameFromHash(sceneHash);
+            var sceneName = SceneNameFromHash(sceneEventData.ClientSceneHash);
             var nextScene = GetAndAddNewlyLoadedSceneByName(sceneName);
 
             if (!nextScene.isLoaded || !nextScene.IsValid())
@@ -1536,7 +1514,7 @@ namespace Unity.Netcode
                 throw new Exception($"Failed to find valid scene internal Unity.Netcode for {nameof(GameObject)}s error!");
             }
 
-            var loadSceneMode = (sceneHash == sceneEventData.SceneHash ? sceneEventData.LoadSceneMode : LoadSceneMode.Additive);
+            var loadSceneMode = (sceneEventData.ClientSceneHash == sceneEventData.SceneHash ? sceneEventData.LoadSceneMode : LoadSceneMode.Additive);
 
             // For now, during a synchronization event, we will make the first scene the "base/master" scene that denotes a "complete scene switch"
             if (loadSceneMode == LoadSceneMode.Single)
@@ -1544,9 +1522,9 @@ namespace Unity.Netcode
                 SceneManager.SetActiveScene(nextScene);
             }
 
-            if (!ServerSceneHandleToClientSceneHandle.ContainsKey(sceneHandle))
+            if (!ServerSceneHandleToClientSceneHandle.ContainsKey(sceneEventData.ClientSceneHandle))
             {
-                ServerSceneHandleToClientSceneHandle.Add(sceneHandle, nextScene.handle);
+                ServerSceneHandleToClientSceneHandle.Add(sceneEventData.ClientSceneHandle, nextScene.handle);
             }
             else
             {
@@ -1561,7 +1539,7 @@ namespace Unity.Netcode
             var responseSceneEventData = BeginSceneEvent();
             responseSceneEventData.LoadSceneMode = loadSceneMode;
             responseSceneEventData.SceneEventType = SceneEventType.LoadComplete;
-            responseSceneEventData.SceneHash = sceneHash;
+            responseSceneEventData.SceneHash = sceneEventData.ClientSceneHash;
 
 
             var message = new SceneEventMessage
@@ -1824,6 +1802,11 @@ namespace Unity.Netcode
             var objectsToKeep = new HashSet<NetworkObject>(m_NetworkManager.SpawnManager.SpawnedObjectsList);
             foreach (var sobj in objectsToKeep)
             {
+                if (sobj == null)
+                {
+                    continue;
+                }
+
                 if (!sobj.DestroyWithScene || sobj.gameObject.scene == DontDestroyOnLoadScene)
                 {
                     // Only move dynamically spawned network objects with no parent as child objects will follow
@@ -1899,6 +1882,10 @@ namespace Unity.Netcode
 
             foreach (var sobj in objectsToKeep)
             {
+                if (sobj == null)
+                {
+                    continue;
+                }
                 // If it is in the DDOL then
                 if (sobj.gameObject.scene == DontDestroyOnLoadScene)
                 {

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using Unity.Collections;
 using UnityEngine.SceneManagement;
 
-
 namespace Unity.Netcode
 {
     /// <summary>
@@ -99,6 +98,10 @@ namespace Unity.Netcode
 
         internal uint SceneHash;
         internal int SceneHandle;
+
+        // Used by the client during synchronization
+        internal uint ClientSceneHash;
+        internal int ClientSceneHandle;
 
         /// Only used for <see cref="SceneEventType.Synchronize"/> scene events, this assures permissions when writing
         /// NetworkVariable information.  If that process changes, then we need to update this

--- a/com.unity.netcode.gameobjects/Tests/Runtime/BaseMultiInstanceTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/BaseMultiInstanceTest.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Linq;
 using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 using Object = UnityEngine.Object;
 
@@ -11,8 +10,6 @@ namespace Unity.Netcode.RuntimeTests
 {
     public abstract class BaseMultiInstanceTest
     {
-        private const string k_FirstPartOfTestRunnerSceneName = "InitTestScene";
-
         protected GameObject m_PlayerPrefab;
         protected NetworkManager m_ServerNetworkManager;
         protected NetworkManager[] m_ClientNetworkManagers;
@@ -108,6 +105,12 @@ namespace Unity.Netcode.RuntimeTests
             // Shutdown and clean up both of our NetworkManager instances
             try
             {
+                if (MultiInstanceHelpers.ClientSceneHandler != null)
+                {
+                    MultiInstanceHelpers.ClientSceneHandler.CanClientsLoad -= ClientSceneHandler_CanClientsLoad;
+                    MultiInstanceHelpers.ClientSceneHandler.CanClientsUnload -= ClientSceneHandler_CanClientsUnload;
+                }
+
                 MultiInstanceHelpers.Destroy();
             }
             catch (Exception e) { throw e; }
@@ -141,20 +144,20 @@ namespace Unity.Netcode.RuntimeTests
         /// Override this method to control when clients
         /// fake-load a scene.
         /// </summary>
-        //protected virtual bool CanClientsLoad()
-        //{
-        //    return true;
-        //}
+        protected virtual bool CanClientsLoad()
+        {
+            return true;
+        }
 
         /// <summary>
         /// NSS-TODO: See RegisterSceneManagerHandler
         /// Override this method to control when clients
         /// fake-unload a scene.
         /// </summary>
-        //protected virtual bool CanClientsUnload()
-        //{
-        //    return true;
-        //}
+        protected virtual bool CanClientsUnload()
+        {
+            return true;
+        }
 
         /// <summary>
         /// NSS-TODO: Back port PR-1405 to get this functionality
@@ -163,53 +166,18 @@ namespace Unity.Netcode.RuntimeTests
         /// </summary>
         protected void RegisterSceneManagerHandler()
         {
-            //MultiInstanceHelpers.ClientSceneHandler.CanClientsLoad += ClientSceneHandler_CanClientsLoad;
-            //MultiInstanceHelpers.ClientSceneHandler.CanClientsUnload += ClientSceneHandler_CanClientsUnload;
+            MultiInstanceHelpers.ClientSceneHandler.CanClientsLoad += ClientSceneHandler_CanClientsLoad;
+            MultiInstanceHelpers.ClientSceneHandler.CanClientsUnload += ClientSceneHandler_CanClientsUnload;
         }
 
-        /// <summary>
-        /// We want to exclude the TestRunner scene on the host-server side so it won't try to tell clients to
-        /// synchronize to this scene when they connect
-        /// </summary>
-        private static bool VerifySceneIsValidForClientsToLoad(int sceneIndex, string sceneName, LoadSceneMode loadSceneMode)
+        private bool ClientSceneHandler_CanClientsUnload()
         {
-            // exclude test runner scene
-            if (sceneName.StartsWith(k_FirstPartOfTestRunnerSceneName))
-            {
-                return false;
-            }
-            return true;
+            return CanClientsUnload();
         }
 
-        /// <summary>
-        /// This registers scene validation callback for the server to prevent it from telling connecting
-        /// clients to synchronize (i.e. load) the test runner scene.  This will also register the test runner
-        /// scene and its handle for both client(s) and server-host.
-        /// </summary>
-        public static void SceneManagerValidationAndTestRunnerInitialization(NetworkManager networkManager)
+        private bool ClientSceneHandler_CanClientsLoad()
         {
-            // If VerifySceneBeforeLoading is not already set, then go ahead and set it so the host/server
-            // will not try to synchronize clients to the TestRunner scene.  We only need to do this for the server.
-            if (networkManager.IsServer && networkManager.SceneManager.VerifySceneBeforeLoading == null)
-            {
-                networkManager.SceneManager.VerifySceneBeforeLoading = VerifySceneIsValidForClientsToLoad;
-                // If a unit/integration test does not handle this on their own, then Ignore the validation warning
-                networkManager.SceneManager.DisableValidationWarnings(true);
-            }
-
-            // Register the test runner scene so it will be able to synchronize NetworkObjects without logging a
-            // warning about using the currently active scene
-            var scene = SceneManager.GetActiveScene();
-            // As long as this is a test runner scene (or most likely a test runner scene)
-            if (scene.name.StartsWith(k_FirstPartOfTestRunnerSceneName))
-            {
-                // Register the test runner scene just so we avoid another warning about not being able to find the
-                // scene to synchronize NetworkObjects.  Next, add the currently active test runner scene to the scenes
-                // loaded and register the server to client scene handle since host-server shares the test runner scene
-                // with the clients.
-                networkManager.SceneManager.GetAndAddNewlyLoadedSceneByName(scene.name);
-                networkManager.SceneManager.ServerSceneHandleToClientSceneHandle.Add(scene.handle, scene.handle);
-            }
+            return CanClientsLoad();
         }
 
         /// <summary>
@@ -270,11 +238,13 @@ namespace Unity.Netcode.RuntimeTests
             {
                 // Start the instances and pass in our SceneManagerInitialization action that is invoked immediately after host-server
                 // is started and after each client is started.
-                if (!MultiInstanceHelpers.Start(useHost, server, clients, SceneManagerValidationAndTestRunnerInitialization))
+                if (!MultiInstanceHelpers.Start(useHost, server, clients))
                 {
                     Debug.LogError("Failed to start instances");
                     Assert.Fail("Failed to start instances");
                 }
+
+                RegisterSceneManagerHandler();
 
                 // Wait for connection on client side
                 yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(clients));

--- a/com.unity.netcode.gameobjects/Tests/Runtime/IntegrationTestSceneHandler.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/IntegrationTestSceneHandler.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using Object = UnityEngine.Object;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    /// <summary>
+    /// The default SceneManagerHandler used for all unit/integration tests that
+    /// require MultiInstance tests.
+    /// </summary>
+    internal class IntegrationTestSceneHandler : ISceneManagerHandler, IDisposable
+    {
+        internal CoroutineRunner CoroutineRunner;
+
+        // Default client simulated delay time
+        protected const float k_ClientLoadingSimulatedDelay = 0.02f;
+
+        // Controls the client simulated delay time
+        protected float m_ClientLoadingSimulatedDelay = k_ClientLoadingSimulatedDelay;
+
+        public delegate bool CanClientsLoadUnloadDelegateHandler();
+        public event CanClientsLoadUnloadDelegateHandler CanClientsLoad;
+        public event CanClientsLoadUnloadDelegateHandler CanClientsUnload;
+
+        internal List<Coroutine> CoroutinesRunning = new List<Coroutine>();
+
+        /// <summary>
+        /// Used to control when clients should attempt to fake-load a scene
+        /// Note: Unit/Integration tests that only use MutiInstanceHelpers
+        /// need to subscribe to the CanClientsLoad and CanClientsUnload events
+        /// in order to control when clients can fake-load.
+        /// Tests that derive from BaseMultiInstanceTest already have integrated
+        /// support and you can override BaseMultiInstanceTest.CanClientsLoad and
+        /// BaseMultiInstanceTest.CanClientsUnload.
+        /// </summary>
+        protected bool OnCanClientsLoad()
+        {
+            if (CanClientsLoad != null)
+            {
+                return CanClientsLoad.Invoke();
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Fake-Loads a scene for a client
+        /// </summary>
+        internal IEnumerator ClientLoadSceneCoroutine(string sceneName, ISceneManagerHandler.SceneEventAction sceneEventAction)
+        {
+            yield return new WaitForSeconds(m_ClientLoadingSimulatedDelay);
+            while (!OnCanClientsLoad())
+            {
+                yield return new WaitForSeconds(m_ClientLoadingSimulatedDelay);
+            }
+            sceneEventAction.Invoke();
+        }
+
+        protected bool OnCanClientsUnload()
+        {
+            if (CanClientsUnload != null)
+            {
+                return CanClientsUnload.Invoke();
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Fake-Unloads a scene for a client
+        /// </summary>
+        internal IEnumerator ClientUnloadSceneCoroutine(ISceneManagerHandler.SceneEventAction sceneEventAction)
+        {
+            yield return new WaitForSeconds(m_ClientLoadingSimulatedDelay);
+            while (!OnCanClientsUnload())
+            {
+                yield return new WaitForSeconds(m_ClientLoadingSimulatedDelay);
+            }
+            sceneEventAction.Invoke();
+        }
+
+        public AsyncOperation LoadSceneAsync(string sceneName, LoadSceneMode loadSceneMode, ISceneManagerHandler.SceneEventAction sceneEventAction)
+        {
+            CoroutinesRunning.Add(CoroutineRunner.StartCoroutine(ClientLoadSceneCoroutine(sceneName, sceneEventAction)));
+            // This is OK to return a "nothing" AsyncOperation since we are simulating client loading
+            return new AsyncOperation();
+        }
+
+        public AsyncOperation UnloadSceneAsync(Scene scene, ISceneManagerHandler.SceneEventAction sceneEventAction)
+        {
+            CoroutinesRunning.Add(CoroutineRunner.StartCoroutine(ClientUnloadSceneCoroutine(sceneEventAction)));
+            // This is OK to return a "nothing" AsyncOperation since we are simulating client loading
+            return new AsyncOperation();
+        }
+
+        public IntegrationTestSceneHandler()
+        {
+            if (CoroutineRunner == null)
+            {
+                CoroutineRunner = new GameObject("UnitTestSceneHandlerCoroutine").AddComponent<CoroutineRunner>();
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (var coroutine in CoroutinesRunning)
+            {
+                CoroutineRunner.StopCoroutine(coroutine);
+            }
+            CoroutineRunner.StopAllCoroutines();
+
+            Object.Destroy(CoroutineRunner.gameObject);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/IntegrationTestSceneHandler.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/IntegrationTestSceneHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 384935cc0ae40d641910e4c3924038c6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/MultiInstanceHelpers.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/MultiInstanceHelpers.cs
@@ -21,6 +21,8 @@ namespace Unity.Netcode.RuntimeTests
         private static int s_ClientCount;
         private static int s_OriginalTargetFrameRate = -1;
 
+        private const string k_FirstPartOfTestRunnerSceneName = "InitTestScene";
+
         public static List<NetworkManager> NetworkManagerInstances => s_NetworkManagerInstances;
 
         public enum InstanceTransport
@@ -29,6 +31,62 @@ namespace Unity.Netcode.RuntimeTests
 #if UTP_ADAPTER
             UTP
 #endif
+        }
+
+        internal static IntegrationTestSceneHandler ClientSceneHandler = null;
+
+        /// <summary>
+        /// Registers the IntegrationTestSceneHandler for integration tests.
+        /// The default client behavior is to not load scenes on the client side.
+        /// </summary>
+        private static void RegisterSceneManagerHandler(NetworkManager networkManager)
+        {
+            if (!networkManager.IsServer)
+            {
+                if (ClientSceneHandler == null)
+                {
+                    ClientSceneHandler = new IntegrationTestSceneHandler();
+                }
+                networkManager.SceneManager.SceneManagerHandler = ClientSceneHandler;
+            }
+        }
+
+        /// <summary>
+        /// Call this to clean up the IntegrationTestSceneHandler and destroy the s_CoroutineRunner.
+        /// Note:
+        /// If deriving from BaseMultiInstanceTest or using MultiInstanceHelpers.Destroy then you
+        /// typically won't need to do this.
+        /// </summary>
+        internal static void CleanUpHandlers()
+        {
+            if (ClientSceneHandler != null)
+            {
+                ClientSceneHandler.Dispose();
+                ClientSceneHandler = null;
+            }
+
+            // Destroy the temporary GameObject used to run co-routines
+            if (s_CoroutineRunner != null)
+            {
+                s_CoroutineRunner.StopAllCoroutines();
+                Object.DestroyImmediate(s_CoroutineRunner.gameObject);
+            }
+        }
+
+        /// <summary>
+        /// Call this to register scene validation and the IntegrationTestSceneHandler
+        /// Note:
+        /// If deriving from BaseMultiInstanceTest or using MultiInstanceHelpers.Destroy then you
+        /// typically won't need to call this.
+        /// </summary>
+        internal static void RegisterHandlers(NetworkManager networkManager, bool serverSideSceneManager = false)
+        {
+            SceneManagerValidationAndTestRunnerInitialization(networkManager);
+
+            if (!networkManager.IsServer || networkManager.IsServer && serverSideSceneManager)
+            {
+                RegisterSceneManagerHandler(networkManager);
+            }
         }
 
         /// <summary>
@@ -155,7 +213,54 @@ namespace Unity.Netcode.RuntimeTests
                 Object.DestroyImmediate(s_CoroutineRunner);
             }
 
+            CleanUpHandlers();
+
             Application.targetFrameRate = s_OriginalTargetFrameRate;
+        }
+
+        /// <summary>
+        /// We want to exclude the TestRunner scene on the host-server side so it won't try to tell clients to
+        /// synchronize to this scene when they connect
+        /// </summary>
+        private static bool VerifySceneIsValidForClientsToLoad(int sceneIndex, string sceneName, LoadSceneMode loadSceneMode)
+        {
+            // exclude test runner scene
+            if (sceneName.StartsWith(k_FirstPartOfTestRunnerSceneName))
+            {
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// This registers scene validation callback for the server to prevent it from telling connecting
+        /// clients to synchronize (i.e. load) the test runner scene.  This will also register the test runner
+        /// scene and its handle for both client(s) and server-host.
+        /// </summary>
+        private static void SceneManagerValidationAndTestRunnerInitialization(NetworkManager networkManager)
+        {
+            // If VerifySceneBeforeLoading is not already set, then go ahead and set it so the host/server
+            // will not try to synchronize clients to the TestRunner scene.  We only need to do this for the server.
+            if (networkManager.IsServer && networkManager.SceneManager.VerifySceneBeforeLoading == null)
+            {
+                networkManager.SceneManager.VerifySceneBeforeLoading = VerifySceneIsValidForClientsToLoad;
+                // If a unit/integration test does not handle this on their own, then Ignore the validation warning
+                networkManager.SceneManager.DisableValidationWarnings(true);
+            }
+
+            // Register the test runner scene so it will be able to synchronize NetworkObjects without logging a
+            // warning about using the currently active scene
+            var scene = SceneManager.GetActiveScene();
+            // As long as this is a test runner scene (or most likely a test runner scene)
+            if (scene.name.StartsWith(k_FirstPartOfTestRunnerSceneName))
+            {
+                // Register the test runner scene just so we avoid another warning about not being able to find the
+                // scene to synchronize NetworkObjects.  Next, add the currently active test runner scene to the scenes
+                // loaded and register the server to client scene handle since host-server shares the test runner scene
+                // with the clients.
+                networkManager.SceneManager.GetAndAddNewlyLoadedSceneByName(scene.name);
+                networkManager.SceneManager.ServerSceneHandleToClientSceneHandle.Add(scene.handle, scene.handle);
+            }
         }
 
         /// <summary>
@@ -166,7 +271,7 @@ namespace Unity.Netcode.RuntimeTests
         /// <param name="clients">The Clients NetworkManager</param>
         /// <param name="startInitializationCallback">called immediately after server and client(s) are started</param>
         /// <returns></returns>
-        public static bool Start(bool host, NetworkManager server, NetworkManager[] clients, Action<NetworkManager> startInitializationCallback = null)
+        public static bool Start(bool host, NetworkManager server, NetworkManager[] clients)
         {
             if (s_IsStarted)
             {
@@ -186,23 +291,20 @@ namespace Unity.Netcode.RuntimeTests
             }
 
             // if set, then invoke this for the server
-            startInitializationCallback?.Invoke(server);
+            RegisterHandlers(server);
 
             for (int i = 0; i < clients.Length; i++)
             {
                 clients[i].StartClient();
 
                 // if set, then invoke this for the client
-                startInitializationCallback?.Invoke(clients[i]);
+                RegisterHandlers(clients[i]);
             }
 
             return true;
         }
 
-        // Empty MonoBehaviour that is a holder of coroutine
-        private class CoroutineRunner : MonoBehaviour
-        {
-        }
+
 
         private static CoroutineRunner s_CoroutineRunner;
 
@@ -527,5 +629,10 @@ namespace Unity.Netcode.RuntimeTests
                 Assert.True(res, "PREDICATE CONDITION");
             }
         }
+    }
+
+    // Empty MonoBehaviour that is a holder of coroutine
+    internal class CoroutineRunner : MonoBehaviour
+    {
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeInitializationTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeInitializationTest.cs
@@ -25,7 +25,7 @@ namespace Unity.Netcode.RuntimeTests
             }
 
             yield return new WaitForSeconds(serverStartDelay);
-            MultiInstanceHelpers.Start(false, server, new NetworkManager[] { }, BaseMultiInstanceTest.SceneManagerValidationAndTestRunnerInitialization); // passing no clients on purpose to start them manually later
+            MultiInstanceHelpers.Start(false, server, new NetworkManager[] { }); // passing no clients on purpose to start them manually later
 
             // 0 ticks should have passed
             var serverTick = server.NetworkTickSystem.ServerTime.Tick;
@@ -58,7 +58,7 @@ namespace Unity.Netcode.RuntimeTests
             var clientStartRealTime = Time.time;
 
             m_Client.StartClient();
-            BaseMultiInstanceTest.SceneManagerValidationAndTestRunnerInitialization(clients[0]);
+            MultiInstanceHelpers.RegisterHandlers(clients[0]);
 
             m_Client.NetworkTickSystem.Tick += NetworkTickSystemOnTick;
             m_ClientTickCounter = 0;

--- a/testproject-tools-integration/Assets/Tests/Runtime/SceneEventTests.cs
+++ b/testproject-tools-integration/Assets/Tests/Runtime/SceneEventTests.cs
@@ -29,7 +29,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             m_ServerNetworkSceneManager = Server.SceneManager;
             Server.NetworkConfig.EnableSceneManagement = true;
 
-            m_ClientNetworkSceneManager.OnSceneEvent += RegisterLoadedSceneCallback;
+            m_ServerNetworkSceneManager.OnSceneEvent += RegisterLoadedSceneCallback;
         }
 
         [UnityTearDown]
@@ -48,10 +48,9 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             // the message is sent to the client. AsyncOperation is the ScceneManager.LoadSceneAsync operation.
             m_ServerNetworkSceneManager.OnSceneEvent += sceneEvent =>
             {
-                if (sceneEvent.SceneEventType.Equals(SceneEventType.Load))
+                if (sceneEvent.SceneEventType.Equals(SceneEventType.LoadComplete) && && sceneEvent.ClientId == Server.LocalClientId)
                 {
-                    serverSceneLoaded = sceneEvent.AsyncOperation.isDone;
-                    sceneEvent.AsyncOperation.completed += _ => serverSceneLoaded = true;
+                    serverSceneLoaded = true;
                 }
             };
 
@@ -251,10 +250,9 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             // as this is when the message is sent
             m_ServerNetworkSceneManager.OnSceneEvent += sceneEvent =>
             {
-                if (sceneEvent.SceneEventType.Equals(SceneEventType.Unload))
+                if (sceneEvent.SceneEventType.Equals(SceneEventType.LoadComplete) && && sceneEvent.ClientId == Server.LocalClientId)
                 {
-                    serverSceneUnloaded = sceneEvent.AsyncOperation.isDone;
-                    sceneEvent.AsyncOperation.completed += _ => serverSceneUnloaded = true;
+                    serverSceneLoaded = true;
                 }
             };
 
@@ -684,15 +682,6 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             }
 
             m_LoadedScene = SceneManager.GetSceneByName(sceneEvent.SceneName);
-            if (m_ClientNetworkSceneManager.ScenesLoaded.ContainsKey(m_LoadedScene.handle))
-            {
-                return;
-            }
-
-            // As we are running the client and the server using the multi-instance test runner we need to sync the
-            // scene handles manually here, as they share a SceneManager.
-            m_ClientNetworkSceneManager.ScenesLoaded.Add(m_LoadedScene.handle, m_LoadedScene);
-            m_ClientNetworkSceneManager.ServerSceneHandleToClientSceneHandle.Add(m_LoadedScene.handle, m_LoadedScene.handle);
         }
 
         private class WaitForSceneEvent

--- a/testproject/Assets/Tests/Runtime/DontDestroyOnLoadTests.cs
+++ b/testproject/Assets/Tests/Runtime/DontDestroyOnLoadTests.cs
@@ -59,6 +59,8 @@ namespace TestProject.RuntimeTests
         [UnityTearDown]
         public IEnumerator Teardown()
         {
+            MultiInstanceHelpers.CleanUpHandlers();
+
             m_ServerNetworkManager.Shutdown();
             foreach (var networkManager in m_ClientNetworkManagers)
             {
@@ -90,6 +92,7 @@ namespace TestProject.RuntimeTests
         public IEnumerator ValidateNetworkObjectSynchronization()
         {
             m_ServerNetworkManager.StartHost();
+            MultiInstanceHelpers.RegisterHandlers(m_ServerNetworkManager);
             var objectInstance = Object.Instantiate(m_DontDestroyOnLoadObject);
             var instanceNetworkObject = objectInstance.GetComponent<NetworkObject>();
             instanceNetworkObject.NetworkManagerOwner = m_ServerNetworkManager;
@@ -103,6 +106,7 @@ namespace TestProject.RuntimeTests
             foreach (var networkManager in m_ClientNetworkManagers)
             {
                 networkManager.StartClient();
+                MultiInstanceHelpers.RegisterHandlers(networkManager);
             }
 
             yield return MultiInstanceHelpers.WaitForClientsConnected(m_ClientNetworkManagers);

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -83,7 +83,7 @@ namespace TestProject.RuntimeTests
             var isHost = serverType == ServerType.Host ? true : false;
 
             // Start the host and  clients
-            if (!MultiInstanceHelpers.Start(isHost, m_ServerNetworkManager, m_ClientNetworkManagers, SceneManagerValidationAndTestRunnerInitialization))
+            if (!MultiInstanceHelpers.Start(isHost, m_ServerNetworkManager, m_ClientNetworkManagers))
             {
                 Debug.LogError("Failed to start instances");
                 Assert.Fail("Failed to start instances");
@@ -333,6 +333,7 @@ namespace TestProject.RuntimeTests
                             {
                                 m_ScenesLoaded.Add(scene);
                             }
+                            m_ClientsAreOkToLoad = true;
 
                             foreach (var manager in m_ClientNetworkManagers)
                             {
@@ -409,6 +410,12 @@ namespace TestProject.RuntimeTests
             return m_ClientVerifyScene;
         }
 
+        private bool m_ClientsAreOkToLoad = true;
+        protected override bool CanClientsLoad()
+        {
+            return m_ClientsAreOkToLoad;
+        }
+
         /// <summary>
         /// Unit test to verify that user defined scene verification process works on both the client and
         /// the server side.
@@ -464,6 +471,7 @@ namespace TestProject.RuntimeTests
             m_ClientVerifyScene = false;
             m_IsTestingVerifyScene = true;
             m_ClientsThatFailedVerification = 0;
+            m_ClientsAreOkToLoad = false;
             result = m_ServerNetworkManager.SceneManager.LoadScene(m_CurrentSceneName, LoadSceneMode.Additive);
             Assert.True(result == SceneEventProgressStatus.Started);
 
@@ -473,6 +481,17 @@ namespace TestProject.RuntimeTests
 
             // Now unload the scene the server loaded from last test
             ResetWait();
+
+            // All clients did not load this scene, so we can ignore them for the wait
+            foreach (var listItem in m_ShouldWaitList)
+            {
+                if (listItem.ClientId == m_ServerNetworkManager.LocalClientId)
+                {
+                    continue;
+                }
+                listItem.ProcessedEvent = true;
+            }
+
             m_IsTestingVerifyScene = false;
             result = m_ServerNetworkManager.SceneManager.UnloadScene(m_CurrentScene);
             Assert.True(result == SceneEventProgressStatus.Started);
@@ -734,11 +753,12 @@ namespace TestProject.RuntimeTests
             yield return Setup();
 
             // Start the host and  clients
-            if (!MultiInstanceHelpers.Start(true, m_ServerNetworkManager, m_ClientNetworkManagers, SceneManagerValidationAndTestRunnerInitialization))
+            if (!MultiInstanceHelpers.Start(true, m_ServerNetworkManager, m_ClientNetworkManagers))
             {
                 Debug.LogError("Failed to start instances");
                 Assert.Fail("Failed to start instances");
             }
+            RegisterSceneManagerHandler();
 
             // Immediately register for all pertinent event notifications we want to test and validate working
             // For the server:
@@ -871,21 +891,6 @@ namespace TestProject.RuntimeTests
                         if (sceneEvent.ClientId == m_ServerNetworkManager.LocalClientId)
                         {
                             m_CurrentScene = sceneEvent.Scene;
-                            var sceneHandle = sceneEvent.Scene.handle;
-                            var scene = sceneEvent.Scene;
-
-                            foreach (var manager in m_ClientNetworkManagers)
-                            {
-                                if (!manager.SceneManager.ScenesLoaded.ContainsKey(sceneHandle))
-                                {
-                                    manager.SceneManager.ScenesLoaded.Add(sceneHandle, scene);
-                                }
-
-                                if (!manager.SceneManager.ServerSceneHandleToClientSceneHandle.ContainsKey(sceneHandle))
-                                {
-                                    manager.SceneManager.ServerSceneHandleToClientSceneHandle.Add(sceneHandle, sceneHandle);
-                                }
-                            }
                         }
                         break;
                     }

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -334,19 +334,6 @@ namespace TestProject.RuntimeTests
                                 m_ScenesLoaded.Add(scene);
                             }
                             m_ClientsAreOkToLoad = true;
-
-                            foreach (var manager in m_ClientNetworkManagers)
-                            {
-                                if (!manager.SceneManager.ScenesLoaded.ContainsKey(sceneHandle))
-                                {
-                                    manager.SceneManager.ScenesLoaded.Add(sceneHandle, scene);
-                                }
-
-                                if (!manager.SceneManager.ServerSceneHandleToClientSceneHandle.ContainsKey(sceneHandle))
-                                {
-                                    manager.SceneManager.ServerSceneHandleToClientSceneHandle.Add(sceneHandle, sceneHandle);
-                                }
-                            }
                         }
                         Assert.AreEqual(sceneEvent.SceneName, m_CurrentSceneName);
                         Assert.IsTrue(ContainsClient(sceneEvent.ClientId));

--- a/testproject/Assets/Tests/Runtime/ObjectParenting/NetworkObjectParentingTests.cs
+++ b/testproject/Assets/Tests/Runtime/ObjectParenting/NetworkObjectParentingTests.cs
@@ -38,15 +38,6 @@ namespace TestProject.RuntimeTests
             }
         }
 
-        private bool VerifySceneBeforeLoading(int sceneIndex, string sceneName, LoadSceneMode loadSceneMode)
-        {
-            if (sceneName.StartsWith("InitTestScene"))
-            {
-                return false;
-            }
-            return true;
-        }
-
         [UnitySetUp]
         public IEnumerator Setup()
         {
@@ -92,14 +83,6 @@ namespace TestProject.RuntimeTests
 
             // Start server and client NetworkManager instances
             Assert.That(MultiInstanceHelpers.Start(true, m_ServerNetworkManager, m_ClientNetworkManagers));
-
-            // Register our scene verification delegate handler so we don't load the unit test scene
-            m_ServerNetworkManager.SceneManager.VerifySceneBeforeLoading = VerifySceneBeforeLoading;
-            foreach (var entry in m_ClientNetworkManagers)
-            {
-                // Register our scene verification delegate handler so we don't load the unit test scene
-                entry.SceneManager.VerifySceneBeforeLoading = VerifySceneBeforeLoading;
-            }
 
             // Wait for connection on client side
             yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(m_ClientNetworkManagers));


### PR DESCRIPTION
## Summary
This removes all unit test checks within NetworkSceneManager in order to allow for better integration testing.  This version intercepts the SceneManager's Load and Unload via the ISceneManagerHandler implementation that is overridden during unit testing in order to prevent clients from actually loading scenes when they don't need to and it provides the ability to allow clients to load scenes during unit/integration tests.

## Additional Changes
- Made minor tweaks to SceneEventTests
- Adjusted some Transport tests to destroy the GameObject and not just the component
- Adjusted the BaseMultiInstanceTest Coroutine destruction to destroy the GameObject and not just the component.

[MTT-1672](https://jira.unity3d.com/browse/MTT-1672)

This is a backport of #1405 into the develop branch (from experimental-develop)

## Testing and Documentation
* No tests have been added (all existing tests validate the changes made)
* No documentation changes or additions were necessary.
