### PR TITLE
chore: Update UTP dependency to 1.0.0-pre.13 (1.0.0)

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this package will be documented in this file. The format 
 
 ### Changed
 
+- Updated Unity Transport package to 1.0.0-pre.13. (#1696)
+
 ### Fixed
 
 - Fixed issue where disconnecting from the server with data still in the queue would result in an error message about a stale connection. (#1649)

--- a/com.unity.netcode.adapter.utp/package.json
+++ b/com.unity.netcode.adapter.utp/package.json
@@ -6,6 +6,6 @@
   "unity": "2020.3",
   "dependencies": {
     "com.unity.netcode.gameobjects": "1.0.0-pre.5",
-    "com.unity.transport": "1.0.0-pre.12"
+    "com.unity.transport": "1.0.0-pre.13"
   }
 }


### PR DESCRIPTION
Backport of PR #1696 to `release/1.0.0`.

## Changelog

### com.unity.netcode.adapter.utp

* Changed: Updated Unity Transport package to 1.0.0-pre.13.

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.