### PR TITLE
test: pr-1633 lost its network scene manager validation tests 

### DIFF
--- a/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -1104,4 +1104,65 @@ namespace TestProject.RuntimeTests
 
     }
 
+    public class NetworkSceneManagerFixValidationTests : BaseMultiInstanceTest
+    {
+        protected override int NbClients => 0;
+
+        public override IEnumerator Setup()
+        {
+            m_BypassStartAndWaitForClients = true;
+            return base.Setup();
+        }
+
+        /// <summary>
+        /// This validation test verifies that the NetworkSceneManager will not crash if
+        /// the SpawnManager.SpawnedObjectsList contains destroyed and invalid NetworkObjects.
+        /// </summary>
+        [Test]
+        public void DDOLPopulateWithNullNetworkObjectsValidation([Values] bool useHost)
+        {
+            var gameObject = new GameObject();
+            var networkObject = gameObject.AddComponent<NetworkObject>();
+            MultiInstanceHelpers.MakeNetworkObjectTestPrefab(networkObject);
+
+            m_ServerNetworkManager.NetworkConfig.NetworkPrefabs.Add(new NetworkPrefab() { Prefab = gameObject });
+
+            foreach (var clientNetworkManager in m_ClientNetworkManagers)
+            {
+                clientNetworkManager.NetworkConfig.NetworkPrefabs.Add(new NetworkPrefab() { Prefab = gameObject });
+            }
+
+            // Start the host and clients
+            if (!MultiInstanceHelpers.Start(useHost, m_ServerNetworkManager, m_ClientNetworkManagers))
+            {
+                Debug.LogError("Failed to start instances");
+                Assert.Fail("Failed to start instances");
+            }
+
+            // Spawn some NetworkObjects
+            var spawnedNetworkObjects = new List<GameObject>();
+            for (int i = 0; i < 10; i++)
+            {
+                var instance = Object.Instantiate(gameObject);
+                var instanceNetworkObject = instance.GetComponent<NetworkObject>();
+                instanceNetworkObject.NetworkManagerOwner = m_ServerNetworkManager;
+                instanceNetworkObject.Spawn();
+                spawnedNetworkObjects.Add(instance);
+            }
+
+            // Add a bogus entry to the SpawnManager
+            m_ServerNetworkManager.SpawnManager.SpawnedObjectsList.Add(null);
+
+            // Verify moving all NetworkObjects into the DDOL when some might be invalid will not crash
+            m_ServerNetworkManager.SceneManager.MoveObjectsToDontDestroyOnLoad();
+
+            // Verify moving all NetworkObjects from DDOL back into the active scene will not crash even if some are invalid
+            m_ServerNetworkManager.SceneManager.MoveObjectsFromDontDestroyOnLoadToScene(SceneManager.GetActiveScene());
+
+            // Now remove the invalid object
+            m_ServerNetworkManager.SpawnManager.SpawnedObjectsList.Remove(null);
+
+            // As long as there are no exceptions this test passes
+        }
+    }
 }

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -1104,6 +1104,9 @@ namespace TestProject.RuntimeTests
 
     }
 
+    /// <summary>
+    /// Use this test group for validating NetworkSceneManager fixes.
+    /// </summary>
     public class NetworkSceneManagerFixValidationTests : BaseMultiInstanceTest
     {
         protected override int NbClients => 0;


### PR DESCRIPTION
This was a test that got lost during backports.



## Testing and Documentation
* Includes unit tests
* No documentation changes or additions were necessary.
