### PR TITLE
chore: Backport PR #1332: Remove UnityEditor dependency from testproject-tools-integration

### DIFF
--- a/testproject-tools-integration/Assets/Tests/Runtime/testproject.toolsintegration.runtimetests.asmdef
+++ b/testproject-tools-integration/Assets/Tests/Runtime/testproject.toolsintegration.runtimetests.asmdef
@@ -8,8 +8,7 @@
         "Unity.Multiplayer.NetStats",
         "Unity.Multiplayer.Tools.MetricTypes",
         "Unity.Multiplayer.Tools.NetStats",
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner",
+        "UnityEngine.TestRunner"
         "Unity.Collections"
     ],
     "includePlatforms": [],


### PR DESCRIPTION
MTT-2443

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.