### PR TITLE
chore: backport 1502 fix: avoid truncation errors when comparing string to fixed string

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/NetworkObjectMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/NetworkObjectMetricsTests.cs
@@ -13,7 +13,9 @@ namespace Unity.Netcode.RuntimeTests.Metrics
 {
     internal class NetworkObjectMetricsTests : SingleClientMetricTestBase
     {
-        private const string k_NewNetworkObjectName = "TestNetworkObjectToSpawn";
+        // Keep less than 23 chars to avoid issues if compared against a 32-byte fixed string
+        //   since it will have "(Clone)" appended
+        private const string k_NewNetworkObjectName = "TestObjectToSpawn";
         private NetworkObject m_NewNetworkPrefab;
 
         protected override Action<GameObject> UpdatePlayerPrefab => _ =>


### PR DESCRIPTION
Backport of PR from experimental-develop: https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/1502/files

https://jira.unity3d.com/browse/MTT-2444