### PR TITLE
fix: error when serializing ConnectionApprovalMessage with scene management disabled when one or more objects is hidden via the CheckObjectVisibility delegate (backport)

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -22,6 +22,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed messages larger than 64k being written with incorrectly truncated message size in header (#1686) (credit: @kaen)
 - Fixed overloading RPC methods causing collisions and failing on IL2CPP targets. (#1694)
 - Fixed spawn flow to propagate `IsSceneObject` down to children NetworkObjects, decouple implicit relationship between object spawning & `IsSceneObject` flag (#1685)
+- Fixed error when serializing ConnectionApprovalMessage with scene management disabled when one or more objects is hidden via the CheckObjectVisibility delegate (#1720)
 
 ## [1.0.0-pre.5] - 2022-01-26
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1706,7 +1706,6 @@ namespace Unity.Netcode
                     {
                         if (SpawnManager.SpawnedObjectsList.Count != 0)
                         {
-                            message.SceneObjectCount = SpawnManager.SpawnedObjectsList.Count;
                             message.SpawnedObjectsList = SpawnManager.SpawnedObjectsList;
                         }
                     }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Components/NetworkVisibilityComponent.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Components/NetworkVisibilityComponent.cs
@@ -1,0 +1,13 @@
+namespace Unity.Netcode.RuntimeTests
+{
+    public class NetworkVisibilityComponent : NetworkBehaviour
+    {
+        public void Hide()
+        {
+            GetComponent<NetworkObject>().CheckObjectVisibility += HandleCheckObjectVisibility;
+        }
+
+        protected virtual bool HandleCheckObjectVisibility(ulong clientId) => false;
+
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Components/NetworkVisibilityComponent.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Components/NetworkVisibilityComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c8284d1c5a9f4c3783a16e314376ea3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/MultiInstanceHelpers.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/MultiInstanceHelpers.cs
@@ -263,15 +263,17 @@ namespace Unity.Netcode.RuntimeTests
             }
         }
 
+        public delegate void BeforeClientStartCallback();
+
         /// <summary>
         /// Starts NetworkManager instances created by the Create method.
         /// </summary>
         /// <param name="host">Whether or not to create a Host instead of Server</param>
         /// <param name="server">The Server NetworkManager</param>
         /// <param name="clients">The Clients NetworkManager</param>
-        /// <param name="startInitializationCallback">called immediately after server and client(s) are started</param>
+        /// <param name="callback">called immediately after server is started and before client(s) are started</param>
         /// <returns></returns>
-        public static bool Start(bool host, NetworkManager server, NetworkManager[] clients)
+        public static bool Start(bool host, NetworkManager server, NetworkManager[] clients, BeforeClientStartCallback callback = null)
         {
             if (s_IsStarted)
             {
@@ -292,6 +294,8 @@ namespace Unity.Netcode.RuntimeTests
 
             // if set, then invoke this for the server
             RegisterHandlers(server);
+
+            callback?.Invoke();
 
             for (int i = 0; i < clients.Length; i++)
             {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVisibilityTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVisibilityTests.cs
@@ -1,0 +1,70 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    public class NetworkVisibilityTests
+    {
+        private NetworkObject m_NetSpawnedObject;
+        private GameObject m_TestNetworkPrefab;
+
+        [TearDown]
+        public void TearDown()
+        {
+            MultiInstanceHelpers.Destroy();
+            if (m_TestNetworkPrefab)
+            {
+                Object.Destroy(m_TestNetworkPrefab);
+                m_TestNetworkPrefab = null;
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator HiddenObjectsTest()
+        {
+
+            const int numClients = 1;
+            Assert.True(MultiInstanceHelpers.Create(numClients, out NetworkManager server, out NetworkManager[] clients));
+            m_TestNetworkPrefab = new GameObject("Object");
+            var networkObject = m_TestNetworkPrefab.AddComponent<NetworkObject>();
+            m_TestNetworkPrefab.AddComponent<NetworkVisibilityComponent>();
+
+            // Make it a prefab
+            MultiInstanceHelpers.MakeNetworkObjectTestPrefab(networkObject);
+
+            var validNetworkPrefab = new NetworkPrefab();
+            validNetworkPrefab.Prefab = m_TestNetworkPrefab;
+            server.NetworkConfig.NetworkPrefabs.Add(validNetworkPrefab);
+            server.NetworkConfig.EnableSceneManagement = false;
+            foreach (var client in clients)
+            {
+                client.NetworkConfig.NetworkPrefabs.Add(validNetworkPrefab);
+                client.NetworkConfig.EnableSceneManagement = false;
+            }
+
+            // Start the instances
+            if (!MultiInstanceHelpers.Start(true, server, clients, () =>
+            {
+                var serverObject = Object.Instantiate(m_TestNetworkPrefab, Vector3.zero, Quaternion.identity);
+                NetworkObject serverNetworkObject = serverObject.GetComponent<NetworkObject>();
+                serverNetworkObject.NetworkManagerOwner = server;
+                serverNetworkObject.Spawn();
+                serverObject.GetComponent<NetworkVisibilityComponent>().Hide();
+            }))
+            {
+                Debug.LogError("Failed to start instances");
+                Assert.Fail("Failed to start instances");
+            }
+
+            // [Client-Side] Wait for a connection to the server
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(clients, null, 512));
+
+            // [Host-Side] Check to make sure all clients are connected
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnectedToServer(server, clients.Length + 1, null, 512));
+
+            Assert.AreEqual(2, Object.FindObjectsOfType<NetworkVisibilityComponent>().Length);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVisibilityTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVisibilityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45ff8252bf32540509fde11c19e0f3c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
bringing #1509 back from `experimental-develop` into `develop`