### PR TITLE
fix: Creating a zero-length FastBufferReader no longer reports its size as 1 (backport)

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -25,6 +25,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed error when serializing ConnectionApprovalMessage with scene management disabled when one or more objects is hidden via the CheckObjectVisibility delegate (#1720)
 - Fixed CheckObjectVisibility delegate not being properly invoked for connecting clients when Scene Management is enabled. (#1680)
 - Fixed NetworkList to properly call INetworkSerializable's NetworkSerialize() method (#1682)
+- Fixed FastBufferReader being created with a length of 1 if provided an input of length 0 (#1724)
 
 ## [1.0.0-pre.5] - 2022-01-26
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -208,7 +208,6 @@ namespace Unity.Netcode
                 };
                 clientRpcMessage.ReadBuffer = tempBuffer;
                 clientRpcMessage.Handle(ref context);
-                rpcWriteSize = tempBuffer.Length;
             }
 
             bufferWriter.Dispose();

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
@@ -76,7 +76,7 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Create a FastBufferReader from a NativeArray.
-        /// 
+        ///
         /// A new buffer will be created using the given allocator and the value will be copied in.
         /// FastBufferReader will then own the data.
         ///
@@ -98,7 +98,7 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Create a FastBufferReader from an ArraySegment.
-        /// 
+        ///
         /// A new buffer will be created using the given allocator and the value will be copied in.
         /// FastBufferReader will then own the data.
         ///
@@ -117,13 +117,13 @@ namespace Unity.Netcode
             }
             fixed (byte* data = buffer.Array)
             {
-                Handle = CreateHandle(data, Math.Max(1, length == -1 ? buffer.Count : length), offset, allocator);
+                Handle = CreateHandle(data, length == -1 ? buffer.Count : length, offset, allocator);
             }
         }
 
         /// <summary>
         /// Create a FastBufferReader from an existing byte array.
-        /// 
+        ///
         /// A new buffer will be created using the given allocator and the value will be copied in.
         /// FastBufferReader will then own the data.
         ///
@@ -148,7 +148,7 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Create a FastBufferReader from an existing byte buffer.
-        /// 
+        ///
         /// A new buffer will be created using the given allocator and the value will be copied in.
         /// FastBufferReader will then own the data.
         ///
@@ -170,7 +170,7 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Create a FastBufferReader from a FastBufferWriter.
-        /// 
+        ///
         /// A new buffer will be created using the given allocator and the value will be copied in.
         /// FastBufferReader will then own the data.
         ///
@@ -250,7 +250,7 @@ namespace Unity.Netcode
         /// When you know you will be reading multiple fields back-to-back and you know the total size,
         /// you can call TryBeginRead() once on the total size, and then follow it with calls to
         /// ReadValue() instead of ReadValueSafe() for faster serialization.
-        /// 
+        ///
         /// Unsafe read operations will throw OverflowException in editor and development builds if you
         /// go past the point you've marked using TryBeginRead(). In release builds, OverflowException will not be thrown
         /// for performance reasons, since the point of using TryBeginRead is to avoid bounds checking in the following
@@ -284,7 +284,7 @@ namespace Unity.Netcode
         /// When you know you will be reading multiple fields back-to-back and you know the total size,
         /// you can call TryBeginRead() once on the total size, and then follow it with calls to
         /// ReadValue() instead of ReadValueSafe() for faster serialization.
-        /// 
+        ///
         /// Unsafe read operations will throw OverflowException in editor and development builds if you
         /// go past the point you've marked using TryBeginRead(). In release builds, OverflowException will not be thrown
         /// for performance reasons, since the point of using TryBeginRead is to avoid bounds checking in the following

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
@@ -93,7 +93,7 @@ namespace Unity.Netcode
         /// <param name="offset"></param>
         public unsafe FastBufferReader(NativeArray<byte> buffer, Allocator allocator, int length = -1, int offset = 0)
         {
-            Handle = CreateHandle((byte*)buffer.GetUnsafePtr(), Math.Max(1, length == -1 ? buffer.Length : length), offset, allocator);
+            Handle = CreateHandle((byte*)buffer.GetUnsafePtr(), length == -1 ? buffer.Length : length, offset, allocator);
         }
 
         /// <summary>
@@ -142,7 +142,7 @@ namespace Unity.Netcode
             }
             fixed (byte* data = buffer)
             {
-                Handle = CreateHandle(data, Math.Max(1, length == -1 ? buffer.Length : length), offset, allocator);
+                Handle = CreateHandle(data, length == -1 ? buffer.Length : length, offset, allocator);
             }
         }
 
@@ -165,7 +165,7 @@ namespace Unity.Netcode
         /// <param name="offset">The offset of the buffer to start copying from</param>
         public unsafe FastBufferReader(byte* buffer, Allocator allocator, int length, int offset = 0)
         {
-            Handle = CreateHandle(buffer, Math.Max(1, length), offset, allocator);
+            Handle = CreateHandle(buffer, length, offset, allocator);
         }
 
         /// <summary>
@@ -187,7 +187,7 @@ namespace Unity.Netcode
         /// <param name="offset">The offset of the buffer to start copying from</param>
         public unsafe FastBufferReader(FastBufferWriter writer, Allocator allocator, int length = -1, int offset = 0)
         {
-            Handle = CreateHandle(writer.GetUnsafePtr(), Math.Max(1, length == -1 ? writer.Length : length), offset, allocator);
+            Handle = CreateHandle(writer.GetUnsafePtr(), length == -1 ? writer.Length : length, offset, allocator);
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Tests/Editor/Serialization/FastBufferReaderTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Serialization/FastBufferReaderTests.cs
@@ -346,6 +346,52 @@ namespace Unity.Netcode.EditorTests
             }
         }
 
+        [Test]
+        public void WhenCreatingAReaderFromAnEmptyArraySegment_LengthIsZero()
+        {
+            var bytes = new byte[] { };
+            var input = new ArraySegment<byte>(bytes, 0, 0);
+            using var reader = new FastBufferReader(input, Allocator.Temp);
+            Assert.AreEqual(0, reader.Length);
+        }
+
+        [Test]
+        public void WhenCreatingAReaderFromAnEmptyArray_LengthIsZero()
+        {
+            var input = new byte[] { };
+            using var reader = new FastBufferReader(input, Allocator.Temp);
+            Assert.AreEqual(0, reader.Length);
+        }
+
+        [Test]
+        public void WhenCreatingAReaderFromAnEmptyNativeArray_LengthIsZero()
+        {
+            var input = new NativeArray<byte>(0, Allocator.Temp);
+            using var reader = new FastBufferReader(input, Allocator.Temp);
+            Assert.AreEqual(0, reader.Length);
+        }
+
+        [Test]
+        public void WhenCreatingAReaderFromAnEmptyFastBufferWriter_LengthIsZero()
+        {
+            var input = new FastBufferWriter(0, Allocator.Temp);
+            using var reader = new FastBufferReader(input, Allocator.Temp);
+            Assert.AreEqual(0, reader.Length);
+        }
+
+        [Test]
+        public void WhenCreatingAReaderFromAnEmptyBuffer_LengthIsZero()
+        {
+            var input = new byte[] { };
+            unsafe
+            {
+                fixed (byte* ptr = input)
+                {
+                    using var reader = new FastBufferReader(ptr, Allocator.Temp, 0);
+                    Assert.AreEqual(0, reader.Length);
+                }
+            }
+        }
 
         [Test]
         public void WhenCallingReadByteWithoutCallingTryBeingReadFirst_OverflowExceptionIsThrown()


### PR DESCRIPTION
bringing #1480 back from `experimental-develop` into `develop`