### PR TITLE
test: add test to confirm client ID on disconnect is correct (backport)

### DIFF
--- a/testproject/Assets/Tests/Runtime/SenderIdTests.cs
+++ b/testproject/Assets/Tests/Runtime/SenderIdTests.cs
@@ -89,5 +89,37 @@ namespace TestProject.RuntimeTests
             Assert.IsTrue(firstReceived);
             Assert.IsTrue(secondReceived);
         }
+
+        [UnityTest]
+        public IEnumerator WhenClientDisconnectsFromServer_ClientIdIsCorrect()
+        {
+            var firstClientId = FirstClient.LocalClientId;
+            bool received = false;
+            void firstCallback(ulong id)
+            {
+                Assert.AreEqual(firstClientId, id);
+                received = true;
+            }
+            m_ServerNetworkManager.OnClientDisconnectCallback += firstCallback;
+            FirstClient.Shutdown();
+
+            yield return new WaitForSeconds(0.2f);
+
+            Assert.IsTrue(received);
+            var secondClientId = SecondClient.LocalClientId;
+            received = false;
+
+            m_ServerNetworkManager.OnClientDisconnectCallback -= firstCallback;
+            m_ServerNetworkManager.OnClientDisconnectCallback += id =>
+            {
+                Assert.AreEqual(secondClientId, id);
+                received = true;
+            };
+            SecondClient.Shutdown();
+
+            yield return new WaitForSeconds(0.2f);
+
+            Assert.IsTrue(received);
+        }
     }
 }


### PR DESCRIPTION
bringing #1482 back from `experimental-develop` into `develop`