### PR TITLE
fix: disable using "Send" and "Receive" variants of RpcParams as RPC arguments (backport)

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/CodeGen/CodeGenHelpers.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/CodeGenHelpers.cs
@@ -22,6 +22,10 @@ namespace Unity.Netcode.Editor.CodeGen
         public static readonly string ClientRpcAttribute_FullName = typeof(ClientRpcAttribute).FullName;
         public static readonly string ServerRpcParams_FullName = typeof(ServerRpcParams).FullName;
         public static readonly string ClientRpcParams_FullName = typeof(ClientRpcParams).FullName;
+        public static readonly string ClientRpcSendParams_FullName = typeof(ClientRpcSendParams).FullName;
+        public static readonly string ClientRpcReceiveParams_FullName = typeof(ClientRpcReceiveParams).FullName;
+        public static readonly string ServerRpcSendParams_FullName = typeof(ServerRpcSendParams).FullName;
+        public static readonly string ServerRpcReceiveParams_FullName = typeof(ServerRpcReceiveParams).FullName;
         public static readonly string INetworkSerializable_FullName = typeof(INetworkSerializable).FullName;
         public static readonly string UnityColor_FullName = typeof(Color).FullName;
         public static readonly string UnityColor32_FullName = typeof(Color32).FullName;

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -941,6 +941,19 @@ namespace Unity.Netcode.Editor.CodeGen
                 {
                     var paramDef = methodDefinition.Parameters[paramIndex];
                     var paramType = paramDef.ParameterType;
+                    if (paramType.FullName == CodeGenHelpers.ClientRpcSendParams_FullName ||
+                        paramType.FullName == CodeGenHelpers.ClientRpcReceiveParams_FullName)
+                    {
+                        m_Diagnostics.AddError($"Rpcs may not accept {paramType.FullName} as a parameter. Use {nameof(ClientRpcParams)} instead.");
+                        continue;
+                    }
+
+                    if (paramType.FullName == CodeGenHelpers.ServerRpcSendParams_FullName ||
+                        paramType.FullName == CodeGenHelpers.ServerRpcReceiveParams_FullName)
+                    {
+                        m_Diagnostics.AddError($"Rpcs may not accept {paramType.FullName} as a parameter. Use {nameof(ServerRpcParams)} instead.");
+                        continue;
+                    }
                     // ServerRpcParams
                     if (paramType.FullName == CodeGenHelpers.ServerRpcParams_FullName && isServerRpc && paramIndex == paramCount - 1)
                     {


### PR DESCRIPTION
bringing #1483 back from `experimental-develop` into `develop`