### PR TITLE
fix: NetworkConfig checksum hash include TickRate (backport)

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -25,6 +25,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed error when serializing ConnectionApprovalMessage with scene management disabled when one or more objects is hidden via the CheckObjectVisibility delegate (#1720)
 - Fixed CheckObjectVisibility delegate not being properly invoked for connecting clients when Scene Management is enabled. (#1680)
 - Fixed NetworkList to properly call INetworkSerializable's NetworkSerialize() method (#1682)
+- Fixed The NetworkConfig's checksum hash includes the NetworkTick so that clients with a different tickrate than the server are identified and not allowed to connect (#1728)
 
 ## [1.0.0-pre.5] - 2022-01-26
 

--- a/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkConfig.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkConfig.cs
@@ -239,6 +239,8 @@ namespace Unity.Netcode
                         writer.WriteValueSafe(sortedEntry.Key);
                     }
                 }
+
+                writer.WriteValueSafe(TickRate);
                 writer.WriteValueSafe(ConnectionApproval);
                 writer.WriteValueSafe(ForceSamePrefabs);
                 writer.WriteValueSafe(EnableSceneManagement);


### PR DESCRIPTION
bringing #1513 back from `experimental-develop` into `develop`