### PR TITLE
fix: better error message when calling RPCs on NetworkObjects that haven't been spawned yet (backport)

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/RpcMessages.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/RpcMessages.cs
@@ -66,7 +66,10 @@ namespace Unity.Netcode
         public static void Handle(ref NetworkContext context, ref RpcMetadata metadata, ref FastBufferReader payload, ref __RpcParams rpcParams)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
-            var networkObject = networkManager.SpawnManager.SpawnedObjects[metadata.NetworkObjectId];
+            if (!networkManager.SpawnManager.SpawnedObjects.TryGetValue(metadata.NetworkObjectId, out var networkObject))
+            {
+                throw new InvalidOperationException($"An RPC called on a {nameof(NetworkObject)} that is not in the spawned objects list. Please make sure the {nameof(NetworkObject)} is spawned before calling RPCs.");
+            }
             var networkBehaviour = networkObject.GetNetworkBehaviourAtOrderIndex(metadata.NetworkBehaviourId);
 
             try


### PR DESCRIPTION
bringing #1521 back from `experimental-develop` into `develop`