### PR TITLE
fix: OwnedObjects not being added to when using ChangeOwnership (backport)

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -25,6 +25,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed error when serializing ConnectionApprovalMessage with scene management disabled when one or more objects is hidden via the CheckObjectVisibility delegate (#1720)
 - Fixed CheckObjectVisibility delegate not being properly invoked for connecting clients when Scene Management is enabled. (#1680)
 - Fixed NetworkList to properly call INetworkSerializable's NetworkSerialize() method (#1682)
+- Fixed OwnedObjects not being properly modified when using ChangeOwnership (#1731)
 
 ## [1.0.0-pre.5] - 2022-01-26
 

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -280,6 +280,10 @@ namespace Unity.Netcode
 
             networkObject.OwnerClientId = clientId;
 
+            if (TryGetNetworkClient(clientId, out NetworkClient newNetworkClient))
+            {
+                newNetworkClient.OwnedObjects.Add(networkObject);
+            }
 
             var message = new ChangeOwnershipMessage
             {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectNetworkClientOwnedObjectsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectNetworkClientOwnedObjectsTests.cs
@@ -1,0 +1,60 @@
+using System.Collections;
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    public class NetworkObjectNetworkClientOwnedObjectsTests
+    {
+        [UnityTest]
+        public IEnumerator ChangeOwnershipOwnedObjectsAddTest()
+        {
+            // create server and client instances
+            MultiInstanceHelpers.Create(1, out NetworkManager server, out NetworkManager[] clients);
+
+            // create prefab
+            var gameObject = new GameObject("ClientOwnedObject");
+            var networkObject = gameObject.AddComponent<NetworkObject>();
+            MultiInstanceHelpers.MakeNetworkObjectTestPrefab(networkObject);
+
+            server.NetworkConfig.NetworkPrefabs.Add(new NetworkPrefab()
+            {
+                Prefab = gameObject
+            });
+
+            for (int i = 0; i < clients.Length; i++)
+            {
+                clients[i].NetworkConfig.NetworkPrefabs.Add(new NetworkPrefab()
+                {
+                    Prefab = gameObject
+                });
+            }
+
+            // start server and connect clients
+            MultiInstanceHelpers.Start(false, server, clients);
+
+            // wait for connection on client side
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientsConnected(clients));
+
+            // wait for connection on server side
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.WaitForClientConnectedToServer(server));
+
+            NetworkObject serverObject = Object.Instantiate(gameObject).GetComponent<NetworkObject>();
+            serverObject.NetworkManagerOwner = server;
+            serverObject.Spawn();
+
+            // The object is owned by server
+            Assert.False(server.ConnectedClients[clients[0].LocalClientId].OwnedObjects.Any(x => x.NetworkObjectId == serverObject.NetworkObjectId));
+
+            // Change the ownership
+            serverObject.ChangeOwnership(clients[0].LocalClientId);
+
+            // Ensure it's now added to the list
+            Assert.True(server.ConnectedClients[clients[0].LocalClientId].OwnedObjects.Any(x => x.NetworkObjectId == serverObject.NetworkObjectId));
+
+            MultiInstanceHelpers.Destroy();
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectNetworkClientOwnedObjectsTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectNetworkClientOwnedObjectsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 067d53283c8fa4c31b638b830473c5b7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
bringing #1572 back from `experimental-develop` into `develop`