### PR TITLE
fix: network animator override

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -9,11 +9,11 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ## [Unreleased]
 
 ### Added
+- First set of tests for NetworkAnimator - parameter syncing, trigger set / reset, override network animator (#7135)
 
 ### Changed
 
 ### Fixed
-
 - Fixed an issue where sometimes the first client to connect to the server could see messages from the server as coming from itself. (#1683)
 - Fixed an issue where clients seemed to be able to send messages to ClientId 1, but these messages would actually still go to the server (id 0) instead of that client. (#1683)
 - Improved clarity of error messaging when a client attempts to send a message to a destination other than the server, which isn't allowed. (#1683)
@@ -27,6 +27,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed NetworkList to properly call INetworkSerializable's NetworkSerialize() method (#1682)
 - Fixed The NetworkConfig's checksum hash includes the NetworkTick so that clients with a different tickrate than the server are identified and not allowed to connect (#1728)
 - Fixed OwnedObjects not being properly modified when using ChangeOwnership (#1731)
+- Improved performance in NetworkAnimator (#1735)
+- Fixed display over "always sync" network animator parameters even when an animator controller override is in use (#1735)
 
 ## [1.0.0-pre.5] - 2022-01-26
 

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -314,10 +314,6 @@ namespace Unity.Netcode.Components
                 if (cacheValue.Type == AnimationParamEnumWrapper.AnimatorControllerParameterInt)
                 {
                     var valueInt = m_Animator.GetInteger(hash);
-                    if (autoSend)
-                    {
-                        Debug.Log("SENDING INT " + valueInt);
-                    }
                     fixed (void* value = cacheValue.Value)
                     {
                         UnsafeUtility.WriteArrayElement(value, 0, valueInt);
@@ -327,10 +323,6 @@ namespace Unity.Netcode.Components
                 else if (cacheValue.Type == AnimationParamEnumWrapper.AnimatorControllerParameterBool)
                 {
                     var valueBool = m_Animator.GetBool(hash);
-                    if (autoSend)
-                    {
-                        Debug.Log("SENDING BOOL" + valueBool);
-                    }
                     fixed (void* value = cacheValue.Value)
                     {
                         UnsafeUtility.WriteArrayElement(value, 0, valueBool);
@@ -340,10 +332,6 @@ namespace Unity.Netcode.Components
                 else if (cacheValue.Type == AnimationParamEnumWrapper.AnimatorControllerParameterFloat)
                 {
                     var valueFloat = m_Animator.GetFloat(hash);
-                    if (autoSend)
-                    {
-                        Debug.Log("SENDING FLOAT " + valueFloat);
-                    }
                     fixed (void* value = cacheValue.Value)
                     {
 

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -67,7 +67,7 @@ namespace Unity.Netcode.Components
          * get replicated on a regular basis regardless of a state change. The thinking
          * behind this is that many of the parameters people use are usually booleans
          * which result in a state change and thus would cause a full sync of state.
-         * Thus if you really care about a parameter syncing then you need to be explict
+         * Thus if you really care about a parameter syncing then you need to be explicit
          * by selecting it in the inspector when an NetworkAnimator is selected.
          */
         public void SetParameterAutoSend(int index, bool value)
@@ -107,7 +107,7 @@ namespace Unity.Netcode.Components
         private FastBufferWriter m_ParameterWriter = new FastBufferWriter(K_MaxAnimationParams * sizeof(float), Allocator.Persistent);
         private NativeArray<AnimatorParamCache> m_CachedAnimatorParameters;
 
-        // We cache these values because UnsafeUtility.EnumToInt use direct IL that allows a nonboxing conversion
+        // We cache these values because UnsafeUtility.EnumToInt uses direct IL that allows a non-boxing conversion
         private struct AnimationParamEnumWrapper
         {
             public static readonly int AnimatorControllerParameterInt;
@@ -133,7 +133,7 @@ namespace Unity.Netcode.Components
             m_ParameterSendBits = 0;
         }
 
-        private bool sendMessagesAllowed
+        private bool SendMessagesAllowed
         {
             get
             {
@@ -201,7 +201,7 @@ namespace Unity.Netcode.Components
 
         private void FixedUpdate()
         {
-            if (!sendMessagesAllowed)
+            if (!SendMessagesAllowed)
             {
                 return;
             }
@@ -233,7 +233,7 @@ namespace Unity.Netcode.Components
         private void CheckAndSend()
         {
             var networkTime = NetworkManager.ServerTime.Time;
-            if (sendMessagesAllowed && m_SendRate != 0 && m_NextSendTime < networkTime)
+            if (SendMessagesAllowed && m_SendRate != 0 && m_NextSendTime < networkTime)
             {
                 m_NextSendTime = networkTime + m_SendRate;
 

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -438,11 +438,24 @@ namespace Unity.Netcode.Components
             }
         }
 
+        /// <summary>
+        /// Sets the trigger for the associated animation
+        ///  Note, triggers are special vs other kinds of parameters.  For all the other parameters we watch for changes
+        ///  in FixedUpdate and users can just set them normally off of Animator. But because triggers are transitory
+        ///  and likely to come and go between FixedUpdate calls, we require users to set them here to guarantee us to
+        ///  catch it...then we forward it to the Animator component
+        /// </summary>
+        /// <param name="triggerName">The string name of the trigger to activate</param>
         public void SetTrigger(string triggerName)
         {
             SetTrigger(Animator.StringToHash(triggerName));
         }
 
+        /// <summary>
+        /// Sets the trigger for the associated animation.  See note for SetTrigger(string)
+        /// </summary>
+        /// <param name="hash">The hash for the trigger to activate</param>
+        /// <param name="reset">If true, resets the trigger</param>
         public void SetTrigger(int hash, bool reset = false)
         {
             var animMsg = new AnimationTriggerMessage();
@@ -455,11 +468,19 @@ namespace Unity.Netcode.Components
             }
         }
 
+        /// <summary>
+        /// Resets the trigger for the associated animation.  See note for SetTrigger(string)
+        /// </summary>
+        /// <param name="triggerName">The string name of the trigger to reset</param>
         public void ResetTrigger(string triggerName)
         {
             ResetTrigger(Animator.StringToHash(triggerName));
         }
 
+        /// <summary>
+        /// Resets the trigger for the associated animation.  See note for SetTrigger(string)
+        /// </summary>
+        /// <param name="hash">The hash for the trigger to reset</param>
         public void ResetTrigger(int hash)
         {
             SetTrigger(hash, true);

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -62,11 +62,11 @@ namespace Unity.Netcode.Components
             }
         }
 
-        /* 
-         * AutoSend is the ability to select which parameters linked to this animator 
+        /*
+         * AutoSend is the ability to select which parameters linked to this animator
          * get replicated on a regular basis regardless of a state change. The thinking
-         * behind this is that many of the parameters people use are usually booleans 
-         * which result in a state change and thus would cause a full sync of state. 
+         * behind this is that many of the parameters people use are usually booleans
+         * which result in a state change and thus would cause a full sync of state.
          * Thus if you really care about a parameter syncing then you need to be explict
          * by selecting it in the inspector when an NetworkAnimator is selected.
          */
@@ -103,7 +103,7 @@ namespace Unity.Netcode.Components
             public fixed byte Value[4]; // this is a max size of 4 bytes
         }
 
-        // 128bytes per Animator 
+        // 128bytes per Animator
         private FastBufferWriter m_ParameterWriter = new FastBufferWriter(K_MaxAnimationParams * sizeof(float), Allocator.Persistent);
         private NativeArray<AnimatorParamCache> m_CachedAnimatorParameters;
 
@@ -290,8 +290,8 @@ namespace Unity.Netcode.Components
 
         /* $AS TODO: Right now we are not checking for changed values this is because
         the read side of this function doesn't have similar logic which would cause
-        an overflow read because it doesn't know if the value is there or not. So 
-        there needs to be logic to track which indexes changed in order for there 
+        an overflow read because it doesn't know if the value is there or not. So
+        there needs to be logic to track which indexes changed in order for there
         to be proper value change checking. Will revist in 1.1.0.
         */
         private unsafe bool WriteParameters(FastBufferWriter writer, bool autoSend)
@@ -314,6 +314,10 @@ namespace Unity.Netcode.Components
                 if (cacheValue.Type == AnimationParamEnumWrapper.AnimatorControllerParameterInt)
                 {
                     var valueInt = m_Animator.GetInteger(hash);
+                    if (autoSend)
+                    {
+                        Debug.Log("SENDING INT " + valueInt);
+                    }
                     fixed (void* value = cacheValue.Value)
                     {
                         UnsafeUtility.WriteArrayElement(value, 0, valueInt);
@@ -323,6 +327,10 @@ namespace Unity.Netcode.Components
                 else if (cacheValue.Type == AnimationParamEnumWrapper.AnimatorControllerParameterBool)
                 {
                     var valueBool = m_Animator.GetBool(hash);
+                    if (autoSend)
+                    {
+                        Debug.Log("SENDING BOOL" + valueBool);
+                    }
                     fixed (void* value = cacheValue.Value)
                     {
                         UnsafeUtility.WriteArrayElement(value, 0, valueBool);
@@ -332,6 +340,10 @@ namespace Unity.Netcode.Components
                 else if (cacheValue.Type == AnimationParamEnumWrapper.AnimatorControllerParameterFloat)
                 {
                     var valueFloat = m_Animator.GetFloat(hash);
+                    if (autoSend)
+                    {
+                        Debug.Log("SENDING FLOAT " + valueFloat);
+                    }
                     fixed (void* value = cacheValue.Value)
                     {
 

--- a/com.unity.netcode.gameobjects/Editor/NetworkAnimatorEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkAnimatorEditor.cs
@@ -66,7 +66,17 @@ namespace Unity.Netcode.Editor
                 return;
             }
 
-            var controller = m_AnimSync.Animator.runtimeAnimatorController as AnimatorController;
+            AnimatorController controller;
+            var overrideController = m_AnimSync.Animator.runtimeAnimatorController as AnimatorOverrideController;
+            if (overrideController != null)
+            {
+                controller = overrideController.runtimeAnimatorController as AnimatorController;
+            }
+            else
+            {
+                controller = m_AnimSync.Animator.runtimeAnimatorController as AnimatorController;
+            }
+
             if (controller != null)
             {
                 var showWarning = false;

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -370,10 +370,7 @@ namespace Unity.Netcode
             InitializeVariables();
         }
 
-        internal void InternalOnNetworkDespawn()
-        {
-
-        }
+        internal void InternalOnNetworkDespawn() { }
 
         /// <summary>
         /// Gets called when the local client gains ownership of this object

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3acde7838205d4b09ae3a035554c51c5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/NetworkAnimatorTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/NetworkAnimatorTests.cs
@@ -89,7 +89,7 @@ namespace Unity.Netcode.RuntimeTest
 
             // verify trigger is set for client and server
             yield return WaitForConditionOrTimeOut(() =>
-                asHash ?  m_PlayerOnServerAnimator.GetBool(triggerHash) : m_PlayerOnServerAnimator.GetBool(triggerString));
+                asHash ? m_PlayerOnServerAnimator.GetBool(triggerHash) : m_PlayerOnServerAnimator.GetBool(triggerString));
             Assert.False(s_GloabalTimeOutHelper.TimedOut, "Timed out on server trigger set check");
 
             yield return WaitForConditionOrTimeOut(() =>

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/NetworkAnimatorTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/NetworkAnimatorTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using NUnit.Framework;
 using Unity.Netcode.Components;
 using Unity.Netcode.RuntimeTests;
@@ -10,10 +11,16 @@ using UnityEngine.UI;
 
 namespace Unity.Netcode.RuntimeTest
 {
-    public class AnimatorTests : BaseMultiInstanceTest
+    public class NetworkAnimatorTests : BaseMultiInstanceTest
     {
         protected override int NbClients => 1;
         private GameObject m_TestPrefab;
+
+        private GameObject m_PlayerOnServer;
+        private GameObject m_PlayerOnClient;
+
+        private Animator m_PlayerOnServerAnimator;
+        private Animator m_PlayerOnClientAnimator;
 
         [UnitySetUp]
         public override IEnumerator Setup()
@@ -21,6 +28,8 @@ namespace Unity.Netcode.RuntimeTest
             yield return StartSomeClientsAndServerWithPlayers(useHost: true, nbClients: NbClients,
                 updatePlayerPrefab: playerPrefab =>
                 {
+                // ideally, we would build up the AnimatorController entirely in code and not need an asset,
+                //  but after some attempts this doesn't seem readily doable.  Instead, we load a controller
                     AnimatorController controller = Resources.Load("TestAnimatorController") as AnimatorController;
                     var animator = playerPrefab.AddComponent<Animator>();
                     animator.runtimeAnimatorController = controller;
@@ -28,42 +37,103 @@ namespace Unity.Netcode.RuntimeTest
                     var theAnimator = playerPrefab.AddComponent<NetworkAnimator>();
                     theAnimator.Animator = animator;
                 });
+
+            // This is the *SERVER VERSION* of the *CLIENT PLAYER*
+            var serverClientPlayerResult = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId), m_ServerNetworkManager, serverClientPlayerResult));
+            m_PlayerOnServer = serverClientPlayerResult.Result.gameObject;
+            m_PlayerOnServerAnimator = m_PlayerOnServer.GetComponent<Animator>();
+
+            // This is the *CLIENT VERSION* of the *CLIENT PLAYER*
+            var clientClientPlayerResult = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId), m_ClientNetworkManagers[0], clientClientPlayerResult));
+            m_PlayerOnClient = clientClientPlayerResult.Result.gameObject;
+            m_PlayerOnClientAnimator = m_PlayerOnClient.GetComponent<Animator>();
+        }
+
+        private bool HasClip(Animator animator, string clipName)
+        {
+            List<AnimatorClipInfo> clips = new List<AnimatorClipInfo>();
+            animator.GetCurrentAnimatorClipInfo(0, clips);
+            foreach (var clip in clips)
+            {
+                if (clip.clip.name == clipName)
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         [UnityTest]
         public IEnumerator AnimationStateSyncTest()
         {
-            // This is the *SERVER VERSION* of the *CLIENT PLAYER*
-            var serverClientPlayerResult = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId), m_ServerNetworkManager, serverClientPlayerResult));
-            var serverPlayer = serverClientPlayerResult.Result.gameObject;
-            var serverAnimator =  serverPlayer.GetComponent<Animator>();
+            // check that we have started in the default state
+            Assert.True(m_PlayerOnServerAnimator.GetCurrentAnimatorStateInfo(0).IsName("DefaultState"));
+            Assert.True(m_PlayerOnClientAnimator.GetCurrentAnimatorStateInfo(0).IsName("DefaultState"));
 
-            // This is the *CLIENT VERSION* of the *CLIENT PLAYER*
-            var clientClientPlayerResult = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
-            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId), m_ClientNetworkManagers[0], clientClientPlayerResult));
-            var clientPlayer = clientClientPlayerResult.Result.gameObject;
-            var clientAnimator = clientPlayer.GetComponent<Animator>();
-
-            var serverAnimatorStateInfo = serverAnimator.GetCurrentAnimatorStateInfo(0);
-            var clientAnimatorStateInfo = clientAnimator.GetCurrentAnimatorStateInfo(0);
-
-            // we start in the default state
-            Assert.True(serverAnimatorStateInfo.IsName("DefaultState"));
-            Assert.True(clientAnimatorStateInfo.IsName("DefaultState"));
-
-            serverAnimator.SetBool("AlphaParameter", true);
-
-            // (ugh)
-            yield return new WaitForSeconds(4.0f);
+            // cause a change to the AlphaState state by setting AlphaParameter, which is
+            //  the variable bound to the transition from default to AlphaState (see the TestAnimatorController asset)
+            m_PlayerOnServerAnimator.SetBool("AlphaParameter", true);
 
             // ...and now we should be in the AlphaState having triggered the AlphaParameter
-            serverAnimatorStateInfo = serverAnimator.GetCurrentAnimatorStateInfo(0);
-            clientAnimatorStateInfo = clientAnimator.GetCurrentAnimatorStateInfo(0);
-            yield return WaitForConditionOrTimeOut(() => serverAnimatorStateInfo.IsName("AlphaState"));
-            Assert.True(serverAnimatorStateInfo.IsName("AlphaState"));
-            yield return WaitForConditionOrTimeOut(() => clientAnimatorStateInfo.IsName("AlphaState"));
-            Assert.True(clientAnimatorStateInfo.IsName("AlphaState"));
+            yield return WaitForConditionOrTimeOut(() =>
+                m_PlayerOnServerAnimator.GetCurrentAnimatorStateInfo(0).IsName("AlphaState"));
+            Assert.False(s_GloabalTimeOutHelper.TimedOut, "Server failed to reach its animation state");
+
+            // ...and now the client should also have sync'd and arrived at the correct state
+            yield return WaitForConditionOrTimeOut(() =>
+                m_PlayerOnClientAnimator.GetCurrentAnimatorStateInfo(0).IsName("AlphaState"));
+            Assert.False(s_GloabalTimeOutHelper.TimedOut, "Client failed to sync its animation state from the server");
+        }
+
+        [UnityTest]
+        public IEnumerator AnimationStateSyncTriggerTest()
+        {
+            // check that we have started in the default state
+            Assert.True(m_PlayerOnServerAnimator.GetCurrentAnimatorStateInfo(0).IsName("DefaultState"));
+            Assert.True(m_PlayerOnClientAnimator.GetCurrentAnimatorStateInfo(0).IsName("DefaultState"));
+
+            // cause a change to the AlphaState state by setting AlphaParameter, which is
+            //  the variable bound to the transition from default to AlphaState (see the TestAnimatorController asset)
+            m_PlayerOnServer.GetComponent<NetworkAnimator>().SetTrigger("TestTrigger");
+
+            // ...and now we should be in the AlphaState having triggered the AlphaParameter
+            yield return WaitForConditionOrTimeOut(() =>
+                m_PlayerOnServerAnimator.GetCurrentAnimatorStateInfo(0).IsName("TriggeredState"));
+            Assert.False(s_GloabalTimeOutHelper.TimedOut, "Server failed to reach its animation state via trigger");
+
+            // ...and now the client should also have sync'd and arrived at the correct state
+            yield return WaitForConditionOrTimeOut(() =>
+                m_PlayerOnClientAnimator.GetCurrentAnimatorStateInfo(0).IsName("TriggeredState"));
+            Assert.False(s_GloabalTimeOutHelper.TimedOut, "Client failed to sync its animation state from the server via trigger");
+        }
+
+        [UnityTest]
+        public IEnumerator AnimationStateSyncTestWithOverride()
+        {
+            // set up the animation override controller
+            AnimatorOverrideController overrideController = Resources.Load("TestAnimatorOverrideController") as AnimatorOverrideController;
+            m_PlayerOnServer.GetComponent<Animator>().runtimeAnimatorController = overrideController;
+            m_PlayerOnClient.GetComponent<Animator>().runtimeAnimatorController = overrideController;
+
+            // in our default state, we should see the OverrideDefaultAnimation clip
+            Assert.True(HasClip(m_PlayerOnServerAnimator, "OverrideDefaultAnimation"));
+            Assert.True(HasClip(m_PlayerOnClientAnimator, "OverrideDefaultAnimation"));
+
+            // cause a change to the AlphaState state by setting AlphaParameter, which is
+            //  the variable bound to the transition from default to AlphaState (see the TestAnimatorController asset)
+            m_PlayerOnServerAnimator.SetBool("AlphaParameter", true);
+
+            // ...and now we should be in the AlphaState having triggered the AlphaParameter
+            yield return WaitForConditionOrTimeOut(() =>
+                HasClip(m_PlayerOnServerAnimator, "OverrideAlphaAnimation"));
+            Assert.False(s_GloabalTimeOutHelper.TimedOut, "Server failed to reach its overriden animation state");
+
+            // ...and now the client should also have sync'd and arrived at the correct state
+            yield return WaitForConditionOrTimeOut(() =>
+                HasClip(m_PlayerOnServerAnimator, "OverrideAlphaAnimation"));
+            Assert.False(s_GloabalTimeOutHelper.TimedOut, "Client failed to reach its overriden animation state");
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/NetworkAnimatorTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/NetworkAnimatorTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections;
+using NUnit.Framework;
+using Unity.Netcode.Components;
+using Unity.Netcode.RuntimeTests;
+using UnityEditor.Animations;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UI;
+
+namespace Unity.Netcode.RuntimeTest
+{
+    public class AnimatorTests : BaseMultiInstanceTest
+    {
+        protected override int NbClients => 1;
+        private GameObject m_TestPrefab;
+
+        [UnitySetUp]
+        public override IEnumerator Setup()
+        {
+            yield return StartSomeClientsAndServerWithPlayers(useHost: true, nbClients: NbClients,
+                updatePlayerPrefab: playerPrefab =>
+                {
+                    AnimatorController controller = Resources.Load("TestAnimatorController") as AnimatorController;
+                    var animator = playerPrefab.AddComponent<Animator>();
+                    animator.runtimeAnimatorController = controller;
+
+                    var theAnimator = playerPrefab.AddComponent<NetworkAnimator>();
+                    theAnimator.Animator = animator;
+                });
+        }
+
+        [UnityTest]
+        public IEnumerator AnimationStateSyncTest()
+        {
+            // This is the *SERVER VERSION* of the *CLIENT PLAYER*
+            var serverClientPlayerResult = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId), m_ServerNetworkManager, serverClientPlayerResult));
+            var serverPlayer = serverClientPlayerResult.Result.gameObject;
+            var serverAnimator =  serverPlayer.GetComponent<Animator>();
+
+            // This is the *CLIENT VERSION* of the *CLIENT PLAYER*
+            var clientClientPlayerResult = new MultiInstanceHelpers.CoroutineResultWrapper<NetworkObject>();
+            yield return MultiInstanceHelpers.Run(MultiInstanceHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId), m_ClientNetworkManagers[0], clientClientPlayerResult));
+            var clientPlayer = clientClientPlayerResult.Result.gameObject;
+            var clientAnimator = clientPlayer.GetComponent<Animator>();
+
+            var serverAnimatorStateInfo = serverAnimator.GetCurrentAnimatorStateInfo(0);
+            var clientAnimatorStateInfo = clientAnimator.GetCurrentAnimatorStateInfo(0);
+
+            // we start in the default state
+            Assert.True(serverAnimatorStateInfo.IsName("DefaultState"));
+            Assert.True(clientAnimatorStateInfo.IsName("DefaultState"));
+
+            serverAnimator.SetBool("AlphaParameter", true);
+
+            // (ugh)
+            yield return new WaitForSeconds(4.0f);
+
+            // ...and now we should be in the AlphaState having triggered the AlphaParameter
+            serverAnimatorStateInfo = serverAnimator.GetCurrentAnimatorStateInfo(0);
+            clientAnimatorStateInfo = clientAnimator.GetCurrentAnimatorStateInfo(0);
+            yield return WaitForConditionOrTimeOut(() => serverAnimatorStateInfo.IsName("AlphaState"));
+            Assert.True(serverAnimatorStateInfo.IsName("AlphaState"));
+            yield return WaitForConditionOrTimeOut(() => clientAnimatorStateInfo.IsName("AlphaState"));
+            Assert.True(clientAnimatorStateInfo.IsName("AlphaState"));
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/NetworkAnimatorTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/NetworkAnimatorTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework;
@@ -7,7 +6,6 @@ using Unity.Netcode.RuntimeTests;
 using UnityEditor.Animations;
 using UnityEngine;
 using UnityEngine.TestTools;
-using UnityEngine.UI;
 
 namespace Unity.Netcode.RuntimeTest
 {
@@ -28,9 +26,9 @@ namespace Unity.Netcode.RuntimeTest
             yield return StartSomeClientsAndServerWithPlayers(useHost: true, nbClients: NbClients,
                 updatePlayerPrefab: playerPrefab =>
                 {
-                // ideally, we would build up the AnimatorController entirely in code and not need an asset,
-                //  but after some attempts this doesn't seem readily doable.  Instead, we load a controller
-                    AnimatorController controller = Resources.Load("TestAnimatorController") as AnimatorController;
+                    // ideally, we would build up the AnimatorController entirely in code and not need an asset,
+                    //  but after some attempts this doesn't seem readily doable.  Instead, we load a controller
+                    var controller = Resources.Load("TestAnimatorController") as AnimatorController;
                     var animator = playerPrefab.AddComponent<Animator>();
                     animator.runtimeAnimatorController = controller;
 
@@ -53,7 +51,7 @@ namespace Unity.Netcode.RuntimeTest
 
         private bool HasClip(Animator animator, string clipName)
         {
-            List<AnimatorClipInfo> clips = new List<AnimatorClipInfo>();
+            var clips = new List<AnimatorClipInfo>();
             animator.GetCurrentAnimatorClipInfo(0, clips);
             foreach (var clip in clips)
             {
@@ -113,7 +111,7 @@ namespace Unity.Netcode.RuntimeTest
         public IEnumerator AnimationStateSyncTestWithOverride()
         {
             // set up the animation override controller
-            AnimatorOverrideController overrideController = Resources.Load("TestAnimatorOverrideController") as AnimatorOverrideController;
+            var overrideController = Resources.Load("TestAnimatorOverrideController") as AnimatorOverrideController;
             m_PlayerOnServer.GetComponent<Animator>().runtimeAnimatorController = overrideController;
             m_PlayerOnClient.GetComponent<Animator>().runtimeAnimatorController = overrideController;
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/NetworkAnimatorTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/NetworkAnimatorTests.cs
@@ -32,8 +32,8 @@ namespace Unity.Netcode.RuntimeTest
                     var animator = playerPrefab.AddComponent<Animator>();
                     animator.runtimeAnimatorController = controller;
 
-                    var theAnimator = playerPrefab.AddComponent<NetworkAnimator>();
-                    theAnimator.Animator = animator;
+                    var networkAnimator = playerPrefab.AddComponent<NetworkAnimator>();
+                    networkAnimator.Animator = animator;
                 });
 
             // This is the *SERVER VERSION* of the *CLIENT PLAYER*
@@ -49,6 +49,7 @@ namespace Unity.Netcode.RuntimeTest
             m_PlayerOnClientAnimator = m_PlayerOnClient.GetComponent<Animator>();
         }
 
+        // helper function to scan an animator and verify a given clip is present
         private bool HasClip(Animator animator, string clipName)
         {
             var clips = new List<AnimatorClipInfo>();
@@ -92,8 +93,11 @@ namespace Unity.Netcode.RuntimeTest
             Assert.True(m_PlayerOnServerAnimator.GetCurrentAnimatorStateInfo(0).IsName("DefaultState"));
             Assert.True(m_PlayerOnClientAnimator.GetCurrentAnimatorStateInfo(0).IsName("DefaultState"));
 
-            // cause a change to the AlphaState state by setting AlphaParameter, which is
-            //  the variable bound to the transition from default to AlphaState (see the TestAnimatorController asset)
+            // cause a change to the AlphaState state by setting TestTrigger
+            //  note, the reason we have a special test for triggers is because activating triggers via the
+            //  NetworkAnimator is special; for other parameters you set them on the Animator and NetworkAnimator
+            //  listens.  But because triggers are super short and transitory, we require users to call
+            //  NetworkAnimator.SetTrigger so we don't miss it
             m_PlayerOnServer.GetComponent<NetworkAnimator>().SetTrigger("TestTrigger");
 
             // ...and now we should be in the AlphaState having triggered the AlphaParameter

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/NetworkAnimatorTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/NetworkAnimatorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c2e5a740c1abd4315801e3f26ecf8adb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c3a8707ef624947a7ae8843ca6c70c0a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/AlphaAnimation.anim
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/AlphaAnimation.anim
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AlphaAnimation
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/AlphaAnimation.anim.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/AlphaAnimation.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: db8faf64ca46248abb6624513ac1fb1b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/DefaultAnimation.anim
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/DefaultAnimation.anim
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: DefaultAnimation
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/DefaultAnimation.anim.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/DefaultAnimation.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1f6191147839943ab93e2171cc15c5e9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/OverrideAlphaAnimation.anim
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/OverrideAlphaAnimation.anim
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: OverrideAlphaAnimation
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/OverrideAlphaAnimation.anim.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/OverrideAlphaAnimation.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 05a2afc2ff8884d32afc64ed6765880a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/OverrideDefaultAnimation.anim
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/OverrideDefaultAnimation.anim
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: OverrideDefaultAnimation
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/OverrideDefaultAnimation.anim.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/OverrideDefaultAnimation.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cf503a5569d0b4df4910a26d09ce4530
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/TestAnimatorController.controller
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/TestAnimatorController.controller
@@ -52,6 +52,31 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &-6097014330458455406
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: AlphaParameter
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -1198466922477486815}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1107 &-1914299053840757887
 AnimatorStateMachine:
   serializedVersion: 6
@@ -63,10 +88,13 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: -1198466922477486815}
-    m_Position: {x: 100, y: 280, z: 0}
+    m_Position: {x: 70, y: 290, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 320527679719022362}
-    m_Position: {x: 130, y: 420, z: 0}
+    m_Position: {x: 110, y: 490, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 3942933370568001311}
+    m_Position: {x: 380, y: 280, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
@@ -89,6 +117,7 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 232953446134799302}
+  - {fileID: 8340347106517238820}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -98,7 +127,7 @@ AnimatorState:
   m_MirrorParameterActive: 0
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
-  m_Motion: {fileID: 0}
+  m_Motion: {fileID: 7400000, guid: 1f6191147839943ab93e2171cc15c5e9, type: 2}
   m_Tag: 
   m_SpeedParameter: 
   m_MirrorParameter: 
@@ -118,7 +147,13 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
+  - m_Name: TestTrigger
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -167,8 +202,7 @@ AnimatorState:
   m_Name: AlphaState
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions:
-  - {fileID: 3691899516182323195}
+  m_Transitions: []
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -178,13 +212,39 @@ AnimatorState:
   m_MirrorParameterActive: 0
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
-  m_Motion: {fileID: 0}
+  m_Motion: {fileID: 7400000, guid: db8faf64ca46248abb6624513ac1fb1b, type: 2}
   m_Tag: 
   m_SpeedParameter: 
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
---- !u!1101 &3691899516182323195
+--- !u!1102 &3942933370568001311
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: TriggeredState
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: db8faf64ca46248abb6624513ac1fb1b, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &5326371122012901575
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -197,6 +257,31 @@ AnimatorStateTransition:
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -1198466922477486815}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &8340347106517238820
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: TestTrigger
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 3942933370568001311}
   m_Solo: 0
   m_Mute: 0
   m_IsExit: 0

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/TestAnimatorController.controller
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/TestAnimatorController.controller
@@ -147,13 +147,19 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: TestTrigger
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
+  - m_Name: UnboundTrigger
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/TestAnimatorController.controller
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/TestAnimatorController.controller
@@ -1,0 +1,211 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1102 &-8144973961595650150
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: New State
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &-7257898091357968356
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: New State
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1107 &-1914299053840757887
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: -1198466922477486815}
+    m_Position: {x: 100, y: 280, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 320527679719022362}
+    m_Position: {x: 130, y: 420, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 30, y: 180, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: -1198466922477486815}
+--- !u!1102 &-1198466922477486815
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: DefaultState
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 232953446134799302}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: TestAnimatorController
+  serializedVersion: 5
+  m_AnimatorParameters:
+  - m_Name: AlphaParameter
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: -1914299053840757887}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}
+--- !u!1101 &232953446134799302
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: AlphaParameter
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 320527679719022362}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &320527679719022362
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AlphaState
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 3691899516182323195}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &3691899516182323195
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: AlphaParameter
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -1198466922477486815}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/TestAnimatorController.controller.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/TestAnimatorController.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a0b8ebecb362240989d16159bdfa067c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/TestAnimatorOverrideController.overrideController
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/TestAnimatorOverrideController.overrideController
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!221 &22100000
+AnimatorOverrideController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: TestAnimatorOverrideController
+  m_Controller: {fileID: 9100000, guid: a0b8ebecb362240989d16159bdfa067c, type: 2}
+  m_Clips:
+  - m_OriginalClip: {fileID: 7400000, guid: 1f6191147839943ab93e2171cc15c5e9, type: 2}
+    m_OverrideClip: {fileID: 7400000, guid: cf503a5569d0b4df4910a26d09ce4530, type: 2}
+  - m_OriginalClip: {fileID: 7400000, guid: db8faf64ca46248abb6624513ac1fb1b, type: 2}
+    m_OverrideClip: {fileID: 7400000, guid: 05a2afc2ff8884d32afc64ed6765880a, type: 2}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/TestAnimatorOverrideController.overrideController.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/TestAnimatorOverrideController.overrideController.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 16a21d7fd66d54fd8afc0e6925d10c64
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 22100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This addresses [MTT-2530](https://jira.unity3d.com/browse/MTT-2530), that using an Animator Override controller breaks the "always sync" checkboxes in the editor.  This was a pretty straightforward bugfix

I also create a NetworkAnimator test

## Changelog

### com.unity.netcode.gameobjects
- Added: The package whose Changelog should be added to should be in the header. Delete the changelog section entirely if it's not needed.
- Fixed: If you update multiple packages, create a new section with a new header for the other package. 
- Removed/Deprecated/Changed: Each bullet should be prefixed with Added, Fixed, Removed, Deprecated, or Changed to indicate where the entry should go.

## Testing and Documentation

* Includes integration tests.
* We should update the documentation to point out that (now) you can use the Animator Override controller
