### PR TITLE
chore: update `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,11 @@
 # see https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners for more information
 # Order is important; the last matching pattern takes the most precedence.
 
+* @Unity-Technologies/multiplayer-sdk
 Profiling/ @Unity-Technologies/multiplayer-tools
-/com.unity.netcode.gameobjects/Runtime/Transports/ @Unity-Technologies/server-team
-/com.unity.netcode.gameobjects/Runtime/SceneManagement/ @NoelStephensUnity
-/com.unity.netcode.adapter.utp/ @Unity-Technologies/server-team
-Documentation~/ @Briancoughlin
+Metrics/ @Unity-Technologies/multiplayer-tools
+/com.unity.netcode.gameobjects/Runtime/Transports/ @Unity-Technologies/multiplayer-server
+/com.unity.netcode.adapter.utp/ @Unity-Technologies/multiplayer-server
+*.asmdef @mfatihmar
+package.json @mfatihmar
+AssemblyInfo.cs @mfatihmar

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,6 @@
 # see https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners for more information
 # Order is important; the last matching pattern takes the most precedence.
 
-* @Unity-Technologies/multiplayer-sdk
 Profiling/ @Unity-Technologies/multiplayer-tools
 Metrics/ @Unity-Technologies/multiplayer-tools
 /com.unity.netcode.gameobjects/Runtime/Transports/ @Unity-Technologies/multiplayer-server

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,3 +8,7 @@ Metrics/ @Unity-Technologies/multiplayer-tools
 *.asmdef @mfatihmar
 package.json @mfatihmar
 AssemblyInfo.cs @mfatihmar
+.editorconfig @mfatihmar
+.gitignore @mfatihmar
+.github/ @mfatihmar
+.yamato/ @mfatihmar

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,5 +10,5 @@ package.json @mfatihmar
 AssemblyInfo.cs @mfatihmar
 .editorconfig @mfatihmar
 .gitignore @mfatihmar
-.github/ @mfatihmar
-.yamato/ @mfatihmar
+.github/ @mfatihmar @lpmaurice @ashwinimurt
+.yamato/ @mfatihmar @lpmaurice @ashwinimurt


### PR DESCRIPTION
- adding `Metrics/` for @Unity-Technologies/multiplayer-tools
- replacing @Unity-Technologies/server-team with @Unity-Technologies/multiplayer-server
- adding myself (@mfatihmar) as the sole owner of `*.asmdef`, `package.json`, `AssemblyInfo.cs`, `.gitignore` and `.editorconfig`
- adding @mfatihmar, @lpmaurice and @ashwinimurt as owners of `.github/` and `.yamato/`