### PR TITLE
fix: reintroduce backwards compatible assembly references to tools package

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/com.unity.netcode.runtime.asmdef
+++ b/com.unity.netcode.gameobjects/Runtime/com.unity.netcode.runtime.asmdef
@@ -2,6 +2,10 @@
     "name": "Unity.Netcode.Runtime",
     "rootNamespace": "Unity.Netcode",
     "references": [
+        "Unity.Multiplayer.MetricTypes",
+        "Unity.Multiplayer.NetStats",
+        "Unity.Multiplayer.NetStatsReporting",
+        "Unity.Multiplayer.NetworkSolutionInterface",
         "Unity.Multiplayer.Tools.MetricTypes",
         "Unity.Multiplayer.Tools.NetStats",
         "Unity.Multiplayer.Tools.NetStatsReporting",


### PR DESCRIPTION
Reintroduces old assembly name references to tools package. Without this change, older versions of the tools package do not work with newer versions of NGO. This was mistakenly removed in backport PR https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/1665

## Changelog

- Fix for in flight changes, no update to changelog needed

## Testing and Documentation

* No testing added. We don't currently have multi-version compatibility testing for tools. Tools team has a backlog item for this.