### PR TITLE
fix: remove editor dependency in runtime test

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/NetworkAnimatorTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/NetworkAnimatorTests.cs
@@ -2,11 +2,10 @@ using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework;
 using Unity.Netcode.Components;
-using Unity.Netcode.RuntimeTests;
 using UnityEngine;
 using UnityEngine.TestTools;
 
-namespace Unity.Netcode.RuntimeTest
+namespace Unity.Netcode.RuntimeTests
 {
     public class NetworkAnimatorTests : BaseMultiInstanceTest
     {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/NetworkAnimatorTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/NetworkAnimatorTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using NUnit.Framework;
 using Unity.Netcode.Components;
 using Unity.Netcode.RuntimeTests;
-using UnityEditor.Animations;
 using UnityEngine;
 using UnityEngine.TestTools;
 
@@ -28,7 +27,7 @@ namespace Unity.Netcode.RuntimeTest
                 {
                     // ideally, we would build up the AnimatorController entirely in code and not need an asset,
                     //  but after some attempts this doesn't seem readily doable.  Instead, we load a controller
-                    var controller = Resources.Load("TestAnimatorController") as AnimatorController;
+                    var controller = Resources.Load("TestAnimatorController") as RuntimeAnimatorController;
                     var animator = playerPrefab.AddComponent<Animator>();
                     animator.runtimeAnimatorController = controller;
 


### PR DESCRIPTION
Quick fix to eliminate the editor assembly dependency in a runtime test.  I was loading the resource as an `Animator`, when I needed to load it in as type `RuntimeAnimatorController`

[MTT-2530]

* No tests have been added.
