### PR TITLE
fix: remove auto-send animation parameters

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -28,7 +28,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed The NetworkConfig's checksum hash includes the NetworkTick so that clients with a different tickrate than the server are identified and not allowed to connect (#1728)
 - Fixed OwnedObjects not being properly modified when using ChangeOwnership (#1731)
 - Improved performance in NetworkAnimator (#1735)
-- Fixed display over "always sync" network animator parameters even when an animator controller override is in use (#1735)
+- Removed the "always sync" network animator (aka "autosend") parameters (#1746)
 
 ## [1.0.0-pre.5] - 2022-01-26
 

--- a/com.unity.netcode.gameobjects/Editor/NetworkAnimatorEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkAnimatorEditor.cs
@@ -1,113 +1,23 @@
-using System;
 using Unity.Netcode.Components;
 using UnityEditor;
-using UnityEditor.Animations;
 using UnityEngine;
 
 namespace Unity.Netcode.Editor
 {
-    public static class TextUtility
-    {
-        public static GUIContent TextContent(string name, string tooltip)
-        {
-            var newContent = new GUIContent(name);
-            newContent.tooltip = tooltip;
-            return newContent;
-        }
-
-        public static GUIContent TextContent(string name)
-        {
-            return new GUIContent(name);
-        }
-    }
-
     [CustomEditor(typeof(NetworkAnimator), true)]
     [CanEditMultipleObjects]
     public class NetworkAnimatorEditor : UnityEditor.Editor
     {
-        private NetworkAnimator m_AnimSync;
-        [NonSerialized] private bool m_Initialized;
-        private SerializedProperty m_AnimatorProperty;
-        private GUIContent m_AnimatorLabel;
-
-        private void Init()
-        {
-            if (m_Initialized)
-            {
-                return;
-            }
-
-            m_Initialized = true;
-            m_AnimSync = target as NetworkAnimator;
-
-            m_AnimatorProperty = serializedObject.FindProperty("m_Animator");
-            m_AnimatorLabel = TextUtility.TextContent("Animator", "The Animator component to synchronize.");
-        }
-
         public override void OnInspectorGUI()
         {
-            Init();
             serializedObject.Update();
-            DrawControls();
-            serializedObject.ApplyModifiedProperties();
-        }
 
-        private void DrawControls()
-        {
             EditorGUI.BeginChangeCheck();
-            EditorGUILayout.PropertyField(m_AnimatorProperty, m_AnimatorLabel);
-            if (EditorGUI.EndChangeCheck())
-            {
-                m_AnimSync.ResetParameterOptions();
-            }
+            var label = new GUIContent("Animator", "The Animator component to synchronize");
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("m_Animator"), label);
+            EditorGUI.EndChangeCheck();
 
-            if (m_AnimSync.Animator == null)
-            {
-                return;
-            }
-
-            AnimatorController controller;
-            var overrideController = m_AnimSync.Animator.runtimeAnimatorController as AnimatorOverrideController;
-            if (overrideController != null)
-            {
-                controller = overrideController.runtimeAnimatorController as AnimatorController;
-            }
-            else
-            {
-                controller = m_AnimSync.Animator.runtimeAnimatorController as AnimatorController;
-            }
-
-            if (controller != null)
-            {
-                var showWarning = false;
-                EditorGUI.indentLevel += 1;
-                int i = 0;
-
-                foreach (var p in controller.parameters)
-                {
-                    if (i >= NetworkAnimator.K_MaxAnimationParams)
-                    {
-                        showWarning = true;
-                        break;
-                    }
-
-                    bool oldSend = m_AnimSync.GetParameterAutoSend(i);
-                    bool send = EditorGUILayout.Toggle(p.name, oldSend);
-                    if (send != oldSend)
-                    {
-                        m_AnimSync.SetParameterAutoSend(i, send);
-                        EditorUtility.SetDirty(target);
-                    }
-                    i += 1;
-                }
-
-                if (showWarning)
-                {
-                    EditorGUILayout.HelpBox($"NetworkAnimator can only select between the first {NetworkAnimator.K_MaxAnimationParams} parameters in a mecanim controller", MessageType.Warning);
-                }
-
-                EditorGUI.indentLevel -= 1;
-            }
+            serializedObject.ApplyModifiedProperties();
         }
     }
 }


### PR DESCRIPTION
This autoSend parameter feature was a bit of a mystery.  After doing some digging this turns out to be something inspired by HLAPI.  The best I and folks like @larus can tell, this "force parameter sync unconditionally" option might help were we to be transmitting this in an unreliable fashion, which we aren't (and even if we were, we'd use some other mechanism).

All things considered I can't find a good reason for this feature to live on / update.  It has confused users who understandably but wrongly conclude the NetworkAnimator checkboxes mean "if you want this parameter, sync this"

Even more info is found in MTT-2530

* No tests have been added.
* No documentation is needed, because we didn't document this feature before