### PR TITLE
feat: Implement GetCurrentRtt in the adapter

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this package will be documented in this file. The format 
 ### Added
 
 - New parameters are available to simulate network conditions (delay, jitter, packet loss) in the editor and in development builds. The parameters are available under the 'Debug Simulator' section of the 'Unity Transport' component, or can be set with the `SetDebugSimulatorParameters` call. (#1745)
+- `GetCurrentRtt` is now properly implemented. (#1755)
 
 ### Changed
 

--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -864,7 +864,22 @@ namespace Unity.Netcode
 
         public override ulong GetCurrentRtt(ulong clientId)
         {
-            return 0;
+            // We don't know if this is getting called from inside NGO (which presumably knows to
+            // use the transport client ID) or from a user (which will be using the NGO client ID).
+            // So we just try both cases (ExtractRtt returns 0 for invalid connections).
+
+            if (NetworkManager != null)
+            {
+                var transportId = NetworkManager.ClientIdToTransportId(clientId);
+
+                var rtt = ExtractRtt(ParseClientId(transportId));
+                if (rtt > 0)
+                {
+                    return (ulong)rtt;
+                }
+            }
+
+            return (ulong)ExtractRtt(ParseClientId(clientId));
         }
 
         public override void Initialize(NetworkManager networkManager = null)

--- a/com.unity.netcode.adapter.utp/Tests/Runtime/TransportTests.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/TransportTests.cs
@@ -367,12 +367,12 @@ namespace Unity.Netcode.UTP.RuntimeTests
         [UnityPlatform(include = new[] { RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor })]
         public IEnumerator CurrentRttReportedCorrectly()
         {
-            const int SimulatedRtt = 25;
+            const int simulatedRtt = 25;
 
             InitializeTransport(out m_Server, out m_ServerEvents);
             InitializeTransport(out m_Client1, out m_Client1Events);
 
-            m_Server.SetDebugSimulatorParameters(SimulatedRtt, 0, 0);
+            m_Server.SetDebugSimulatorParameters(simulatedRtt, 0, 0);
 
             m_Server.StartServer();
             m_Client1.StartClient();
@@ -383,9 +383,9 @@ namespace Unity.Netcode.UTP.RuntimeTests
             m_Client1.Send(m_Client1.ServerClientId, data, NetworkDelivery.Reliable);
 
             yield return WaitForNetworkEvent(NetworkEvent.Data, m_ServerEvents,
-                timeout: MaxNetworkEventWaitTime + (2 * SimulatedRtt));
+                timeout: MaxNetworkEventWaitTime + (2 * simulatedRtt));
 
-            Assert.GreaterOrEqual(m_Client1.GetCurrentRtt(m_Client1.ServerClientId), SimulatedRtt);
+            Assert.GreaterOrEqual(m_Client1.GetCurrentRtt(m_Client1.ServerClientId), simulatedRtt);
 
             yield return null;
         }

--- a/com.unity.netcode.adapter.utp/Tests/Runtime/TransportTests.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/TransportTests.cs
@@ -361,6 +361,34 @@ namespace Unity.Netcode.UTP.RuntimeTests
 
             yield return null;
         }
+
+        // Check that RTT is reported correctly.
+        [UnityTest]
+        [UnityPlatform(include = new[] { RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor })]
+        public IEnumerator CurrentRttReportedCorrectly()
+        {
+            const int SimulatedRtt = 25;
+
+            InitializeTransport(out m_Server, out m_ServerEvents);
+            InitializeTransport(out m_Client1, out m_Client1Events);
+
+            m_Server.SetDebugSimulatorParameters(SimulatedRtt, 0, 0);
+
+            m_Server.StartServer();
+            m_Client1.StartClient();
+
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_Client1Events);
+
+            var data = new ArraySegment<byte>(new byte[] { 42 });
+            m_Client1.Send(m_Client1.ServerClientId, data, NetworkDelivery.Reliable);
+
+            yield return WaitForNetworkEvent(NetworkEvent.Data, m_ServerEvents,
+                timeout: MaxNetworkEventWaitTime + (2 * SimulatedRtt));
+
+            Assert.GreaterOrEqual(m_Client1.GetCurrentRtt(m_Client1.ServerClientId), SimulatedRtt);
+
+            yield return null;
+        }
     }
 }
 #endif


### PR DESCRIPTION
MTT-2683

Implement `GetCurrentRtt` in the adapter, using the code already used for the metrics gathering. Had to make a few adjustments to `ExtractRtt` to make it easier to use in `GetCurrentRtt`.

Note that the returned value only reflects RTT for reliable traffic, but this should be a good approximation of RTT for any kind of traffic (and with NGO sending most things reliably currently, the limitation is a bit moot).

## Changelog

### com.unity.netcode.adapter.utp

* Added: `GetCurrentRtt` is now properly implemented.

## Testing and Documentation

* Includes unit/integration test.
* No documentation changes or additions were necessary.