### PR TITLE
fix: NetcodeIntegrationTest destroy GameObjects not NetworkObjects during shutdown sequence

### DIFF
--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -493,10 +493,17 @@ namespace Unity.Netcode.TestHelpers.Runtime
             var networkObjects = Object.FindObjectsOfType<NetworkObject>();
             foreach (var networkObject in networkObjects)
             {
-                if (CanDestroyNetworkObject(networkObject))
+                if (networkObject != null && CanDestroyNetworkObject(networkObject))
                 {
-                    // Destroy the GameObject that holds the NetworkObject component
-                    Object.DestroyImmediate(networkObject.gameObject);
+                    if (networkObject.gameObject != null)
+                    {
+                        // Destroy the GameObject that holds the NetworkObject component
+                        Object.DestroyImmediate(networkObject.gameObject);
+                    }
+                    else
+                    {
+                        Object.DestroyImmediate(networkObject);
+                    }
                 }
             }
         }

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -495,7 +495,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             {
                 if (CanDestroyNetworkObject(networkObject))
                 {
-                    Object.DestroyImmediate(networkObject);
+                    Object.DestroyImmediate(networkObject.gameObject);
                 }
             }
         }

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -493,17 +493,22 @@ namespace Unity.Netcode.TestHelpers.Runtime
             var networkObjects = Object.FindObjectsOfType<NetworkObject>();
             foreach (var networkObject in networkObjects)
             {
-                if (networkObject != null && CanDestroyNetworkObject(networkObject))
+                // This can sometimes be null depending upon order of operations
+                // when dealing with parented NetworkObjects.  If NetworkObjectB
+                // is a child of NetworkObjectA and NetworkObjectA comes before
+                // NetworkObjectB in the list of NeworkObjects found, then when
+                // NetworkObjectA's GameObject is destroyed it will also destroy
+                // NetworkObjectB's GameObject which will destroy NetworkObjectB.
+                // If there is a null entry in the list, this is the most likely
+                // scenario and so we just skip over it.
+                if (networkObject == null)
                 {
-                    if (networkObject.gameObject != null)
-                    {
-                        // Destroy the GameObject that holds the NetworkObject component
-                        Object.DestroyImmediate(networkObject.gameObject);
-                    }
-                    else
-                    {
-                        Object.DestroyImmediate(networkObject);
-                    }
+                    continue;
+                }
+                if (CanDestroyNetworkObject(networkObject))
+                {
+                    // Destroy the GameObject that holds the NetworkObject component
+                    Object.DestroyImmediate(networkObject.gameObject);
                 }
             }
         }

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -495,6 +495,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             {
                 if (CanDestroyNetworkObject(networkObject))
                 {
+                    // Destroy the GameObject that holds the NetworkObject component
                     Object.DestroyImmediate(networkObject.gameObject);
                 }
             }


### PR DESCRIPTION
This fixes a minor oversight in the NetcodeIntegrationTest where the DestroySceneNetworkObjects method was destroying the NetworkObject component and not the GameObject the NetworkObject component is assigned to.

[MTT-2686](https://jira.unity3d.com/browse/MTT-2686)

## Testing and Documentation
* No tests have been added.
