### PR TITLE
chore: create job for multiprocess tests running on a single node

### DIFF
--- a/.yamato/_run-all.yml
+++ b/.yamato/_run-all.yml
@@ -14,7 +14,6 @@ run_all_tests:
     - .yamato/package-tests.yml#test_{{ project.name}}_{{ package.name }}_{{ editor }}_{{ platform.name }}
 {% endfor -%}
     - .yamato/project-tests.yml#test_{{ project.name }}_{{ editor }}_{{ platform.name }}
-    - .yamato/multiprocess-project-tests.yml#run_all_singlenode_multiprocess_tests
 {% endfor -%}
 {% endfor -%}
 {% endfor -%}
@@ -43,6 +42,20 @@ all_package_tests:
 {% for package in project.packages -%}
     - .yamato/package-tests.yml#test_{{ project.name}}_{{ package.name }}_{{ editor }}_{{ platform.name }}
 {% endfor -%}
+{% endfor -%}
+{% endfor -%}
+{% endfor -%}
+
+all_singlenode_multiprocess_tests:
+  name: Run All Multiprocess Tests - Single Node
+  dependencies:
+    # Pull in package and validate jobs through the badges job
+{% for platform in test_platforms -%}
+{% for project in projects -%}
+{% for editor in project.test_editors -%}
+{% if editor != "trunk" %}
+    - .yamato/multiprocess-project-tests.yml#singlenode_multiprocess_test_testproject_{{ editor }}_{{ platform.name }}
+{% endif %}
 {% endfor -%}
 {% endfor -%}
 {% endfor -%}

--- a/.yamato/_run-all.yml
+++ b/.yamato/_run-all.yml
@@ -14,6 +14,7 @@ run_all_tests:
     - .yamato/package-tests.yml#test_{{ project.name}}_{{ package.name }}_{{ editor }}_{{ platform.name }}
 {% endfor -%}
     - .yamato/project-tests.yml#test_{{ project.name }}_{{ editor }}_{{ platform.name }}
+    - .yamato/multiprocess-project-tests.yml#run_all_singlenode_multiprocess_tests
 {% endfor -%}
 {% endfor -%}
 {% endfor -%}

--- a/.yamato/_run-all.yml
+++ b/.yamato/_run-all.yml
@@ -14,7 +14,6 @@ run_all_tests:
     - .yamato/package-tests.yml#test_{{ project.name}}_{{ package.name }}_{{ editor }}_{{ platform.name }}
 {% endfor -%}
     - .yamato/project-tests.yml#test_{{ project.name }}_{{ editor }}_{{ platform.name }}
-    - .yamato/project-tests.yml#multiprocess_test_testproject_{{ editor }}_{{ platform.name }}
 {% endfor -%}
 {% endfor -%}
 {% endfor -%}

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -10,7 +10,7 @@ develop_nightly_trigger:
       rerun: always
   dependencies:
     - .yamato/_run-all.yml#run_all_tests
-    - .yamato/multiprocess-project-tests.yml#run_all_singlenode_multiprocess_tests
+    - .yamato/_run-all.yml#all_singlenode_multiprocess_tests
 {% for project in projects -%}
     - .yamato/code-coverage.yml#code_coverage_win_{{ project.name }}
 {% endfor -%}

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -10,6 +10,7 @@ develop_nightly_trigger:
       rerun: always
   dependencies:
     - .yamato/_run-all.yml#run_all_tests
+    - .yamato/multiprocess-project-tests.yml#run_all_singlenode_multiprocess_tests
 {% for project in projects -%}
     - .yamato/code-coverage.yml#code_coverage_win_{{ project.name }}
 {% endfor -%}

--- a/.yamato/multiprocess-project-tests.yml
+++ b/.yamato/multiprocess-project-tests.yml
@@ -21,8 +21,11 @@ singlenode_multiprocess_test_testproject_{{ editor }}_{{ platform.name }}:
     - {{ platform.utr }} --suite=playmode --testproject=testproject --editor-location=.Editor --testfilter=Unity.Netcode.MultiprocessRuntimeTests --extra-editor-arg=-bypassIgnoreUTR
 {% endif %}
   after:
+    - echo "After block"
+{% if editor != "trunk" %}
 {% if platform.name == "win" %}    - copy %USERPROFILE%\.multiprocess\logfile* .{% endif %}
 {% if platform.name != "win" %}    - cp $HOME/.multiprocess/logfile* .{% endif %}
+{% endif %}
   artifacts:
     logs:
       paths:

--- a/.yamato/multiprocess-project-tests.yml
+++ b/.yamato/multiprocess-project-tests.yml
@@ -2,7 +2,7 @@
 ---
 
 run_all_singlenode_multiprocess_tests:
-  name: Run All multiprocess tests on a single node
+  name: Run All Multiprocess Tests - Single Node
   dependencies:
     # Pull in package and validate jobs through the badges job
 {% for platform in test_platforms -%}
@@ -21,7 +21,7 @@ run_all_singlenode_multiprocess_tests:
 {% for editor in project.test_editors -%}
 {% for platform in test_platforms -%}
 singlenode_multiprocess_test_testproject_{{ editor }}_{{ platform.name }}:
-  name : multiprocess tests - {{ editor }} on {{ platform.name }}
+  name : Multiprocess Tests - {{ editor }} on {{ platform.name }}
   agent:
     type: {{ platform.type }}
     image: {{ platform.image }}

--- a/.yamato/multiprocess-project-tests.yml
+++ b/.yamato/multiprocess-project-tests.yml
@@ -1,6 +1,21 @@
 {% metadata_file .yamato/project.metafile %}
 ---
 
+run_all_singlenode_multiprocess_tests:
+  name: Run All multiprocess tests on a single node
+  dependencies:
+    # Pull in package and validate jobs through the badges job
+{% for platform in test_platforms -%}
+{% for project in projects -%}
+{% for editor in project.test_editors -%}
+{% if editor != "trunk" %}
+    - .yamato/multiprocess-project-tests.yml#singlenode_multiprocess_test_testproject_{{ editor }}_{{ platform.name }}
+{% endif %}
+{% endfor -%}
+{% endfor -%}
+{% endfor -%}
+
+
 {% for project in projects -%}
 {% if project.name == "testproject" %}
 {% for editor in project.test_editors -%}

--- a/.yamato/multiprocess-project-tests.yml
+++ b/.yamato/multiprocess-project-tests.yml
@@ -1,21 +1,6 @@
 {% metadata_file .yamato/project.metafile %}
 ---
 
-run_all_singlenode_multiprocess_tests:
-  name: Run All Multiprocess Tests - Single Node
-  dependencies:
-    # Pull in package and validate jobs through the badges job
-{% for platform in test_platforms -%}
-{% for project in projects -%}
-{% for editor in project.test_editors -%}
-{% if editor != "trunk" %}
-    - .yamato/multiprocess-project-tests.yml#singlenode_multiprocess_test_testproject_{{ editor }}_{{ platform.name }}
-{% endif %}
-{% endfor -%}
-{% endfor -%}
-{% endfor -%}
-
-
 {% for project in projects -%}
 {% if project.name == "testproject" %}
 {% for editor in project.test_editors -%}

--- a/.yamato/multiprocess-project-tests.yml
+++ b/.yamato/multiprocess-project-tests.yml
@@ -1,0 +1,39 @@
+{% metadata_file .yamato/project.metafile %}
+---
+
+{% for project in projects -%}
+{% if project.name == "testproject" %}
+{% for editor in project.test_editors -%}
+{% for platform in test_platforms -%}
+singlenode_multiprocess_test_testproject_{{ editor }}_{{ platform.name }}:
+  name : multiprocess tests - {{ editor }} on {{ platform.name }}
+  agent:
+    type: {{ platform.type }}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor}}
+  commands:
+    - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
+{% if editor != "trunk" %}
+    - unity-downloader-cli -u {{ editor }} -c editor -w --fast
+    - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr{% if platform.name == "win" %}.bat --output utr.bat{% endif %}{% if platform.name != "win" %} --output utr && chmod +x ./utr{% endif %}
+    - {{ platform.editorpath }} -projectpath testproject -batchmode -nographics -quit -logfile BuildMultiprocessTestPlayer.log -executeMethod Unity.Netcode.MultiprocessRuntimeTests.BuildMultiprocessTestPlayer.BuildRelease
+{% if platform.name == "mac" %}    -  sudo codesign --force --deep --sign - ./testproject/Builds/MultiprocessTests/MultiprocessTestPlayer.app{% endif %}
+    - {{ platform.utr }} --suite=playmode --testproject=testproject --editor-location=.Editor --testfilter=Unity.Netcode.MultiprocessRuntimeTests --extra-editor-arg=-bypassIgnoreUTR
+{% endif %}
+  after:
+{% if platform.name == "win" %}    - copy %USERPROFILE%\.multiprocess\logfile* .{% endif %}
+{% if platform.name != "win" %}    - cp $HOME/.multiprocess/logfile* .{% endif %}
+  artifacts:
+    logs:
+      paths:
+        - "upm-ci~/test-results/**/*"
+        - BuildMultiprocessTestPlayer.log
+        - "logfile*"
+        - "*.log"
+        - "*.txt"
+  dependencies:
+    - .yamato/project-pack.yml#pack_{{ project.name }}
+{% endfor -%}
+{% endfor -%}
+{% endif -%}
+{% endfor -%}

--- a/.yamato/project-tests.yml
+++ b/.yamato/project-tests.yml
@@ -55,37 +55,3 @@ test_{{ project.name }}_{{ editor }}_{{ platform.name }}:
 {% endfor -%}
 {% endfor -%}
 
-{% for project in projects -%}
-{% if project.name == "testproject" %}
-{% for editor in project.test_editors -%}
-{% for platform in test_platforms -%}
-multiprocess_test_testproject_{{ editor }}_{{ platform.name }}:
-  name : multiprocess tests - {{ editor }} on {{ platform.name }}
-  agent:
-    type: {{ platform.type }}
-    image: {{ platform.image }}
-    flavor: {{ platform.flavor}}
-  commands:
-    - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
-    - unity-downloader-cli -u {{ editor }} -c editor -w --fast
-    - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr{% if platform.name == "win" %}.bat --output utr.bat{% endif %}{% if platform.name != "win" %} --output utr && chmod +x ./utr{% endif %}
-    - {{ platform.editorpath }} -projectpath testproject -batchmode -nographics -quit -logfile BuildMultiprocessTestPlayer.log -executeMethod Unity.Netcode.MultiprocessRuntimeTests.BuildMultiprocessTestPlayer.BuildRelease
-{% if platform.name == "mac" %}    -  sudo codesign --force --deep --sign - ./testproject/Builds/MultiprocessTests/MultiprocessTestPlayer.app{% endif %}
-    - {{ platform.utr }} --suite=playmode --testproject=testproject --editor-location=.Editor --testfilter=Unity.Netcode.MultiprocessRuntimeTests --extra-editor-arg=-bypassIgnoreUTR
-  after:
-{% if platform.name == "win" %}    - copy %USERPROFILE%\.multiprocess\logfile* .{% endif %}
-{% if platform.name != "win" %}    - cp $HOME/.multiprocess/logfile* .{% endif %}
-  artifacts:
-    logs:
-      paths:
-        - "upm-ci~/test-results/**/*"
-        - BuildMultiprocessTestPlayer.log
-        - "logfile*"
-        - "*.log"
-        - "*.txt"
-  dependencies:
-    - .yamato/project-pack.yml#pack_{{ project.name }}
-{% endfor -%}
-{% endfor -%}
-{% endif -%}
-{% endfor -%}


### PR DESCRIPTION
As per request, the multiprocess tests are being moved into their own job file to facilitate the creation of their own triggers so that they can be included or excluded more surgically.