### PR TITLE
chore: Remove 2021.1

### DIFF
--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -41,7 +41,6 @@ projects:
       - name: com.unity.netcode.adapter.utp
         path: com.unity.netcode.adapter.utp
     test_editors:
-      - 2021.1
       - 2021.2
       - 2020.3
       - trunk


### PR DESCRIPTION
We don't need to run tests on 2021.1 because its already out the door, currently we run on 2021.2.