### PR TITLE
fix: weighted layer support in NetworkAnimator MTT-2698

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -9,8 +9,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ## [Unreleased]
 
 ### Added
-
-- Added first set of tests for NetworkAnimator - parameter syncing, trigger set / reset, override network animator (#7135)
+- NetworkAnimator now properly synchrhonizes all animation layers as well as runtime-adjusted weighting between them (#1765)
+- Added first set of tests for NetworkAnimator - parameter syncing, trigger set / reset, override network animator (#1735)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -14,14 +14,19 @@ namespace Unity.Netcode.Components
     {
         internal struct AnimationMessage : INetworkSerializable
         {
-            public int StateHash;      // if non-zero, then Play() this animation, skipping transitions
+            // state hash per layer.  if non-zero, then Play() this animation, skipping transitions
+            public int StateHash;
             public float NormalizedTime;
+            public int Layer;
+            public float Weight;
             public byte[] Parameters;
 
             public void NetworkSerialize<T>(BufferSerializer<T> serializer) where T : IReaderWriter
             {
                 serializer.SerializeValue(ref StateHash);
                 serializer.SerializeValue(ref NormalizedTime);
+                serializer.SerializeValue(ref Layer);
+                serializer.SerializeValue(ref Weight);
                 serializer.SerializeValue(ref Parameters);
             }
         }
@@ -54,10 +59,9 @@ namespace Unity.Netcode.Components
         // Animators only support up to 32 params
         public static int K_MaxAnimationParams = 32;
 
-        private int m_TransitionHash;
-
-        private int m_AnimationHash;
-        public int AnimationHash { get => m_AnimationHash; }
+        private int[] m_TransitionHash;
+        private int[] m_AnimationHash;
+        private float[] m_LayerWeights;
 
         private unsafe struct AnimatorParamCache
         {
@@ -100,11 +104,15 @@ namespace Unity.Netcode.Components
             if (IsServer)
             {
                 m_SendMessagesAllowed = true;
+                int layers = m_Animator.layerCount;
+
+                m_TransitionHash = new int[layers];
+                m_AnimationHash = new int[layers];
+                m_LayerWeights = new float[layers];
             }
+
             var parameters = m_Animator.parameters;
             m_CachedAnimatorParameters = new NativeArray<AnimatorParamCache>(parameters.Length, Allocator.Persistent);
-
-            m_AnimationHash = -1;
 
             for (var i = 0; i < parameters.Length; i++)
             {
@@ -157,66 +165,81 @@ namespace Unity.Netcode.Components
 
         private void FixedUpdate()
         {
-            if (!m_SendMessagesAllowed)
+            if (!m_SendMessagesAllowed || !m_Animator || !m_Animator.enabled)
             {
                 return;
             }
 
-            int stateHash;
-            float normalizedTime;
-            if (!CheckAnimStateChanged(out stateHash, out normalizedTime))
+            for (int layer = 0; layer < m_Animator.layerCount; layer++)
             {
-                return;
+                int stateHash;
+                float normalizedTime;
+                if (!CheckAnimStateChanged(out stateHash, out normalizedTime, layer))
+                {
+                    continue;
+                }
+
+                var animMsg = new AnimationMessage
+                {
+                    StateHash = stateHash,
+                    NormalizedTime = normalizedTime,
+                    Layer = layer,
+                    Weight = m_LayerWeights[layer]
+                };
+
+                m_ParameterWriter.Seek(0);
+                m_ParameterWriter.Truncate();
+
+                WriteParameters(m_ParameterWriter);
+                animMsg.Parameters = m_ParameterWriter.ToArray();  // not layered
+
+                SendAnimStateClientRpc(animMsg);
             }
-
-            var animMsg = new AnimationMessage
-            {
-                StateHash = stateHash,
-                NormalizedTime = normalizedTime
-            };
-
-            m_ParameterWriter.Seek(0);
-            m_ParameterWriter.Truncate();
-
-            WriteParameters(m_ParameterWriter);
-            animMsg.Parameters = m_ParameterWriter.ToArray();
-
-            SendAnimStateClientRpc(animMsg);
         }
 
-        private bool CheckAnimStateChanged(out int stateHash, out float normalizedTime)
+        private bool CheckAnimStateChanged(out int stateHash, out float normalizedTime, int layer)
         {
+            bool shouldUpdate = false;
             stateHash = 0;
             normalizedTime = 0;
 
-            if (m_Animator.IsInTransition(0))
+            float layerWeightNow = m_Animator.GetLayerWeight(layer);
+
+            if (!Mathf.Approximately(layerWeightNow, m_LayerWeights[layer]))
             {
-                AnimatorTransitionInfo tt = m_Animator.GetAnimatorTransitionInfo(0);
-                if (tt.fullPathHash != m_TransitionHash)
+                m_LayerWeights[layer] = layerWeightNow;
+                shouldUpdate = true;
+            }
+            if (m_Animator.IsInTransition(layer))
+            {
+                AnimatorTransitionInfo tt = m_Animator.GetAnimatorTransitionInfo(layer);
+                if (tt.fullPathHash != m_TransitionHash[layer])
                 {
-                    // first time in this transition
-                    m_TransitionHash = tt.fullPathHash;
-                    m_AnimationHash = 0;
+                    // first time in one or more of the per-layer transitions
+                    m_TransitionHash[layer] = tt.fullPathHash;
+                    m_AnimationHash[layer] = 0;
                     return true;
                 }
-                return false;
+                // if our transition hash hasn't changed, but our weight has, still update
+                return shouldUpdate;
             }
 
-            AnimatorStateInfo st = m_Animator.GetCurrentAnimatorStateInfo(0);
-            if (st.fullPathHash != m_AnimationHash)
+            AnimatorStateInfo st = m_Animator.GetCurrentAnimatorStateInfo(layer);
+            if (st.fullPathHash != m_AnimationHash[layer])
             {
                 // first time in this animation state
-                if (m_AnimationHash != 0)
+                if (m_AnimationHash[layer] != 0)
                 {
                     // came from another animation directly - from Play()
                     stateHash = st.fullPathHash;
                     normalizedTime = st.normalizedTime;
                 }
-                m_TransitionHash = 0;
-                m_AnimationHash = st.fullPathHash;
+                m_TransitionHash[layer] = 0;
+                m_AnimationHash[layer] = st.fullPathHash;
                 return true;
             }
-            return false;
+
+            return shouldUpdate;
         }
 
         /* $AS TODO: Right now we are not checking for changed values this is because
@@ -311,9 +334,9 @@ namespace Unity.Netcode.Components
         {
             if (animSnapshot.StateHash != 0)
             {
-                m_AnimationHash = animSnapshot.StateHash;
-                m_Animator.Play(animSnapshot.StateHash, 0, animSnapshot.NormalizedTime);
+                m_Animator.Play(animSnapshot.StateHash, animSnapshot.Layer, animSnapshot.NormalizedTime);
             }
+            m_Animator.SetLayerWeight(animSnapshot.Layer, animSnapshot.Weight);
 
             if (animSnapshot.Parameters != null && animSnapshot.Parameters.Length != 0)
             {

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -1,6 +1,5 @@
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
-
 using UnityEngine;
 
 namespace Unity.Netcode.Components
@@ -191,7 +190,7 @@ namespace Unity.Netcode.Components
                 m_ParameterWriter.Truncate();
 
                 WriteParameters(m_ParameterWriter);
-                animMsg.Parameters = m_ParameterWriter.ToArray();  // not layered
+                animMsg.Parameters = m_ParameterWriter.ToArray();
 
                 SendAnimStateClientRpc(animMsg);
             }
@@ -215,28 +214,28 @@ namespace Unity.Netcode.Components
                 AnimatorTransitionInfo tt = m_Animator.GetAnimatorTransitionInfo(layer);
                 if (tt.fullPathHash != m_TransitionHash[layer])
                 {
-                    // first time in one or more of the per-layer transitions
+                    // first time in this transition for this layer
                     m_TransitionHash[layer] = tt.fullPathHash;
                     m_AnimationHash[layer] = 0;
-                    return true;
+                    shouldUpdate = true;
                 }
-                // if our transition hash hasn't changed, but our weight has, still update
-                return shouldUpdate;
             }
-
-            AnimatorStateInfo st = m_Animator.GetCurrentAnimatorStateInfo(layer);
-            if (st.fullPathHash != m_AnimationHash[layer])
+            else
             {
-                // first time in this animation state
-                if (m_AnimationHash[layer] != 0)
+                AnimatorStateInfo st = m_Animator.GetCurrentAnimatorStateInfo(layer);
+                if (st.fullPathHash != m_AnimationHash[layer])
                 {
-                    // came from another animation directly - from Play()
-                    stateHash = st.fullPathHash;
-                    normalizedTime = st.normalizedTime;
+                    // first time in this animation state
+                    if (m_AnimationHash[layer] != 0)
+                    {
+                        // came from another animation directly - from Play()
+                        stateHash = st.fullPathHash;
+                        normalizedTime = st.normalizedTime;
+                    }
+                    m_TransitionHash[layer] = 0;
+                    m_AnimationHash[layer] = st.fullPathHash;
+                    shouldUpdate = true;
                 }
-                m_TransitionHash[layer] = 0;
-                m_AnimationHash[layer] = st.fullPathHash;
-                return true;
             }
 
             return shouldUpdate;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/NetworkAnimatorTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/NetworkAnimatorTests.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using NUnit.Framework;
 using Unity.Netcode.Components;
 using UnityEngine;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/Layer2Animation.anim
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/Layer2Animation.anim
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Layer2Animation
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/Layer2Animation.anim.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/Layer2Animation.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d31c84f6372c54d7eb8decb27010d005
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/TestAnimatorController.controller
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/Resources/TestAnimatorController.controller
@@ -52,6 +52,31 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &-7235917949335567458
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: Layer2AlphaParameter
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 6016706997111698284}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 2
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &-6097014330458455406
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -160,6 +185,12 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 9100000}
+  - m_Name: Layer2AlphaParameter
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -170,6 +201,18 @@ AnimatorController:
     m_BlendingMode: 0
     m_SyncedLayerIndex: -1
     m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}
+  - serializedVersion: 5
+    m_Name: Layer2
+    m_StateMachine: {fileID: 1433017894673297828}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 1
     m_IKPass: 0
     m_SyncedLayerAffectsTiming: 0
     m_Controller: {fileID: 9100000}
@@ -224,6 +267,58 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1102 &927597079590233140
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Layer2AlphaState
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -7235917949335567458}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: d31c84f6372c54d7eb8decb27010d005, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1107 &1433017894673297828
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Layer2
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: 6016706997111698284}
+    m_Position: {x: 160, y: 250, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 927597079590233140}
+    m_Position: {x: 270, y: 370, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 50, y: 120, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: 6016706997111698284}
 --- !u!1102 &3942933370568001311
 AnimatorState:
   serializedVersion: 6
@@ -273,6 +368,58 @@ AnimatorStateTransition:
   m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &6016706997111698284
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: DefaultStateLayer2
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 6324505406226331058}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &6324505406226331058
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Layer2AlphaParameter
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 927597079590233140}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 2
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
 --- !u!1101 &8340347106517238820


### PR DESCRIPTION
NetworkAnimator previously lacked 2 things:
- it only looked at the primary layer (0)
- it did not sync runtime-adjusted layer weights

This meant users with multiple layers had partial success at best.  In this update all active layers of an animator are scanned and synchronized.  Also, the weight setting for each layer is detected and forwarded.

MTT-2698

* Includes integration tests.
* We need to document that this feature is available.  But no changes are required from the user to continue use this feature