### PR TITLE
chore: Bump package version to pre.6 for ngo and adapter

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this package will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
-## [Unreleased]
+## [1.0.0-pre.6] - 2022-03-02
 
 ### Added
 
@@ -12,6 +12,7 @@ All notable changes to this package will be documented in this file. The format 
 ### Changed
 
 - Updated Unity Transport package to 1.0.0-pre.14. (#1760)
+- Updated Netcode for GameObjects dependency to 1.0.0-pre.6 (#1771)
 - Overflowing the reliable send queue of a connection will now result in the connection being closed, rather than spamming the log with errors about not being able to send a payload. It is deemed better to close the connection than to lose reliable traffic (which could cause all sorts of weird synchronization issues). (#1747)
 
 ### Fixed

--- a/com.unity.netcode.adapter.utp/package.json
+++ b/com.unity.netcode.adapter.utp/package.json
@@ -2,10 +2,10 @@
   "name": "com.unity.netcode.adapter.utp",
   "displayName": "Unity Transport for Netcode for GameObjects",
   "description": "This package is plugging Unity Transport into Netcode for GameObjects, which is a network transport layer - the low-level interface for sending UDP data",
-  "version": "1.0.0-pre.5",
+  "version": "1.0.0-pre.6",
   "unity": "2020.3",
   "dependencies": {
-    "com.unity.netcode.gameobjects": "1.0.0-pre.5",
+    "com.unity.netcode.gameobjects": "1.0.0-pre.6",
     "com.unity.transport": "1.0.0-pre.14"
   }
 }

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
-## [Unreleased]
+## [1.0.0-pre.6] - 2022-03-02
 
 ### Added
 - NetworkAnimator now properly synchrhonizes all animation layers as well as runtime-adjusted weighting between them (#1765)

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -2,7 +2,7 @@
     "name": "com.unity.netcode.gameobjects",
     "displayName": "Netcode for GameObjects",
     "description": "Netcode for GameObjects is a high-level netcode SDK that provides networking capabilities to GameObject/MonoBehaviour workflows within Unity and sits on top of underlying transport layer.",
-    "version": "1.0.0-pre.5",
+    "version": "1.0.0-pre.6",
     "unity": "2020.3",
     "dependencies": {
         "com.unity.modules.animation": "1.0.0",


### PR DESCRIPTION
## Changelog

### com.unity.netcode.adapter.utp
- Updated Netcode for GameObjects dependency to 1.0.0-pre.6

