### PR TITLE
fix: notify networkmanager and networkobject not allowed

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
+## [Unreleased]
+### Added
+### Changed
+### Fixed
+- Fixed lack of notification that NetworkManager and NetworkObject cannot be added to the same GameObject with in-editor notifications (#1777)
+
 ## [1.0.0-pre.6] - 2022-03-02
 
 ### Added

--- a/com.unity.netcode.gameobjects/Editor/NetworkManagerHelper.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkManagerHelper.cs
@@ -58,13 +58,20 @@ namespace Unity.Netcode.Editor
                     var networkObject = networkManager.gameObject.GetComponent<NetworkObject>();
                     if (networkObject != null)
                     {
-                        NetworkManager.NetworkManagerHelper.NotifyUserOfNetworkObjectAssignment(networkManager, networkObject);
+                        NetworkManager.NetworkManagerHelper.NotifyUserNetworkObjectRemoved(networkManager, networkObject);
                     }
                 }
             }
         }
 
-        public void NotifyUserOfNetworkObjectAssignment(NetworkManager networkManager, NetworkObject networkObject)
+        /// <summary>
+        /// Handles notifying users that they cannot add a NetworkObject component
+        /// to a GameObject that also has a NetworkManager component. The NetworkObject
+        /// will always be removed.
+        /// GameObject + NetworkObject then NetworkManager = NetworkObject removed
+        /// GameObject + NetworkManager then NetworkObject = NetworkObject removed
+        /// </summary>
+        public void NotifyUserNetworkObjectRemoved(NetworkManager networkManager, NetworkObject networkObject)
         {
             if (!EditorApplication.isUpdating)
             {

--- a/com.unity.netcode.gameobjects/Editor/NetworkManagerHelper.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkManagerHelper.cs
@@ -73,9 +73,10 @@ namespace Unity.Netcode.Editor
         {
             // Check for any NetworkObject at the same gameObject relative layer
             var networkObject = networkManager.gameObject.GetComponent<NetworkObject>();
+
             if (networkObject == null)
             {
-                // if none is found, check to see if any children have a GameObject
+                // if none is found, check to see if any children have a NetworkObject
                 networkObject = networkManager.gameObject.GetComponentInChildren<NetworkObject>();
                 if (networkObject == null)
                 {
@@ -86,17 +87,21 @@ namespace Unity.Netcode.Editor
             if (!EditorApplication.isUpdating)
             {
                 Object.DestroyImmediate(networkObject);
-                var message = $"A {nameof(GameObject)} cannot have both a {nameof(NetworkManager)} and {nameof(NetworkObject)} assigned to it.";
 
                 if (!EditorApplication.isPlaying && !editorTest)
                 {
-                    EditorUtility.DisplayDialog($"Removing {nameof(NetworkObject)}", message, "OK");
+                    EditorUtility.DisplayDialog($"Removing {nameof(NetworkObject)}", NetworkManagerAndNetworkObjectNotAllowedMessage(), "OK");
                 }
                 else
                 {
-                    Debug.LogError(message);
+                    Debug.LogError(NetworkManagerAndNetworkObjectNotAllowedMessage());
                 }
             }
+        }
+
+        public string NetworkManagerAndNetworkObjectNotAllowedMessage()
+        {
+            return $"A {nameof(GameObject)} cannot have both a {nameof(NetworkManager)} and {nameof(NetworkObject)} assigned to it or any children under it.";
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1014,6 +1014,7 @@ namespace Unity.Netcode
         internal interface INetworkManagerHelper
         {
             bool NotifyUserOfNestedNetworkManager(NetworkManager networkManager, bool ignoreNetworkManagerCache = false, bool editorTest = false);
+            void NotifyUserOfNetworkObjectAssignment(NetworkManager networkManager, NetworkObject networkObject);
         }
 #endif
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1014,7 +1014,7 @@ namespace Unity.Netcode
         internal interface INetworkManagerHelper
         {
             bool NotifyUserOfNestedNetworkManager(NetworkManager networkManager, bool ignoreNetworkManagerCache = false, bool editorTest = false);
-            void NotifyUserNetworkObjectRemoved(NetworkManager networkManager, NetworkObject networkObject);
+            void CheckAndNotifyUserNetworkObjectRemoved(NetworkManager networkManager, bool editorTest = false);
         }
 #endif
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1014,7 +1014,7 @@ namespace Unity.Netcode
         internal interface INetworkManagerHelper
         {
             bool NotifyUserOfNestedNetworkManager(NetworkManager networkManager, bool ignoreNetworkManagerCache = false, bool editorTest = false);
-            void NotifyUserOfNetworkObjectAssignment(NetworkManager networkManager, NetworkObject networkObject);
+            void NotifyUserNetworkObjectRemoved(NetworkManager networkManager, NetworkObject networkObject);
         }
 #endif
 

--- a/com.unity.netcode.gameobjects/Tests/Editor/NetworkManagerConfigurationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/NetworkManagerConfigurationTests.cs
@@ -56,12 +56,10 @@ namespace Unity.Netcode.EditorTests
 
             var networkManager = gameObject.AddComponent<NetworkManager>();
 
-            // The error message we should expect
-            var messageToCheck = $"A {nameof(GameObject)} cannot have both a {nameof(NetworkManager)} and {nameof(NetworkObject)} assigned to it.";
+            // Trap for the error message generated when a NetworkObject is discovered on the same GameObject or any children under it
+            LogAssert.Expect(LogType.Error, NetworkManagerHelper.Singleton.NetworkManagerAndNetworkObjectNotAllowedMessage());
 
-            // Trap for the nested NetworkManager exception
-            LogAssert.Expect(LogType.Error, messageToCheck);
-
+            // Add the NetworkObject
             var networkObject = targetforNetworkObject.AddComponent<NetworkObject>();
 
             // Since this is an in-editor test, we must force this invocation

--- a/com.unity.netcode.gameobjects/Tests/Editor/NetworkManagerConfigurationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/NetworkManagerConfigurationTests.cs
@@ -66,9 +66,9 @@ namespace Unity.Netcode.EditorTests
             NetworkManagerHelper.Singleton.CheckAndNotifyUserNetworkObjectRemoved(networkManager, true);
 
             // Validate that the NetworkObject has been removed
-            if(networkObjectPlacement == NetworkObjectPlacement.Root)
+            if (networkObjectPlacement == NetworkObjectPlacement.Root)
             {
-                Assert.IsNull(networkManager.gameObject.GetComponent<NetworkObject>(),$"There is still a {nameof(NetworkObject)} on {nameof(NetworkManager)}'s GameObject!");
+                Assert.IsNull(networkManager.gameObject.GetComponent<NetworkObject>(), $"There is still a {nameof(NetworkObject)} on {nameof(NetworkManager)}'s GameObject!");
             }
             else
             {

--- a/com.unity.netcode.gameobjects/Tests/Editor/NetworkManagerConfigurationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/NetworkManagerConfigurationTests.cs
@@ -65,6 +65,16 @@ namespace Unity.Netcode.EditorTests
             // Since this is an in-editor test, we must force this invocation
             NetworkManagerHelper.Singleton.CheckAndNotifyUserNetworkObjectRemoved(networkManager, true);
 
+            // Validate that the NetworkObject has been removed
+            if(networkObjectPlacement == NetworkObjectPlacement.Root)
+            {
+                Assert.IsNull(networkManager.gameObject.GetComponent<NetworkObject>(),$"There is still a {nameof(NetworkObject)} on {nameof(NetworkManager)}'s GameObject!");
+            }
+            else
+            {
+                Assert.IsNull(networkManager.gameObject.GetComponentInChildren<NetworkObject>(), $"There is still a {nameof(NetworkObject)} on {nameof(NetworkManager)}'s child GameObject!");
+            }
+
             // Clean up
             Object.DestroyImmediate(gameObject);
         }


### PR DESCRIPTION
Adding a GameObject with a NetworkObject component as a child to the GameObject that is assigned the NetworkManager component will cause a soft synchronization error. It is advised to avoid assigning NetworkObjects to the parent GameObject with the NetworkManager component or to any child GameObject of the parent GameObject. This only applies to a GameObject with the NetworkManager component assigned to it.

Users should be notified of this while within the editor and should not allow them to proceed with any configuration as described above.
[MTT-1598](https://jira.unity3d.com/browse/MTT-1598)
[MTT-1634](https://jira.unity3d.com/browse/MTT-1634)

## Changelog

### com.unity.netcode.gameobjects
- Fixed lack of notification that NetworkManager and NetworkObject cannot be added to the same GameObject with in-editor notifications

## Testing and Documentation
* No tests have been added (editor only update)

## Notification Displayed:
![image](https://user-images.githubusercontent.com/73188597/156858583-0c8e7715-80a2-4efb-87f3-30dbddb4db9b.png)

## NetworkObject Removed
![image](https://user-images.githubusercontent.com/73188597/156858621-46ae1631-ac8a-4ef7-8b53-e7076fe69ad0.png)
