### PR TITLE
fix: spawning new player does not remove previous

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
+## [Unreleased]
+### Added
+### Changed
+### Fixed
+- Fixed issue when spawning new player if an already existing player exists it does not remove IsPlayer from the previous player (#1779)
 
 ## [1.0.0-pre.6] - 2022-03-02
 

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -494,6 +494,12 @@ namespace Unity.Netcode
                 {
                     if (playerObject)
                     {
+                        // If there was an already existing player object for this player, then mark it as no longer
+                        // a player object.
+                        if (NetworkManager.ConnectedClients[ownerClientId.Value].PlayerObject != null)
+                        {
+                            NetworkManager.ConnectedClients[ownerClientId.Value].PlayerObject.IsPlayerObject = false;
+                        }
                         NetworkManager.ConnectedClients[ownerClientId.Value].PlayerObject = networkObject;
                     }
                     else
@@ -503,6 +509,12 @@ namespace Unity.Netcode
                 }
                 else if (playerObject && ownerClientId.Value == NetworkManager.LocalClientId)
                 {
+                    // If there was an already existing player object for this player, then mark it as no longer
+                    // a player object.
+                    if (NetworkManager.LocalClient.PlayerObject != null)
+                    {
+                        NetworkManager.LocalClient.PlayerObject.IsPlayerObject = false;
+                    }
                     NetworkManager.LocalClient.PlayerObject = networkObject;
                 }
             }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/PlayerObjectTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/PlayerObjectTests.cs
@@ -37,11 +37,12 @@ namespace Unity.Netcode.RuntimeTests
             // Spawn this instance as a new player object for the client who already has an assigned player object
             newPlayerNetworkObject.SpawnAsPlayerObject(m_ClientNetworkManagers[0].LocalClientId);
 
-            // Make sure server-side changes are detected
+            // Make sure server-side changes are detected, the original player object should no longer be marked as a player
+            // and the local new player object should.
             yield return WaitForConditionOrTimeOut(() => !originalPlayer.IsPlayerObject && newPlayerNetworkObject.IsPlayerObject);
             Assert.False(s_GlobalTimeoutHelper.TimedOut, "Timed out waiting for server-side player object to change!");
 
-            // Make sure client-side changes are detected
+            // Make sure the client-side changes are the same
             yield return WaitForConditionOrTimeOut(() => m_ClientNetworkManagers[0].LocalClient.PlayerObject != playerLocalClient && !playerLocalClient.IsPlayerObject
             && m_ClientNetworkManagers[0].LocalClient.PlayerObject.IsPlayerObject);
             Assert.False(s_GlobalTimeoutHelper.TimedOut, "Timed out waiting for client0side player object to change!");

--- a/com.unity.netcode.gameobjects/Tests/Runtime/PlayerObjectTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/PlayerObjectTests.cs
@@ -45,7 +45,7 @@ namespace Unity.Netcode.RuntimeTests
             // Make sure the client-side changes are the same
             yield return WaitForConditionOrTimeOut(() => m_ClientNetworkManagers[0].LocalClient.PlayerObject != playerLocalClient && !playerLocalClient.IsPlayerObject
             && m_ClientNetworkManagers[0].LocalClient.PlayerObject.IsPlayerObject);
-            Assert.False(s_GlobalTimeoutHelper.TimedOut, "Timed out waiting for client0side player object to change!");
+            Assert.False(s_GlobalTimeoutHelper.TimedOut, "Timed out waiting for client-side player object to change!");
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/PlayerObjectTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/PlayerObjectTests.cs
@@ -1,0 +1,41 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Unity.Netcode.TestHelpers.Runtime;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    public class PlayerObjectTests : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 1;
+
+        protected GameObject m_NewPlayerToSpawn;
+
+        public PlayerObjectTests(HostOrServer hostOrServer) : base(hostOrServer) { }
+
+        protected override void OnServerAndClientsCreated()
+        {
+            m_NewPlayerToSpawn = CreateNetworkObjectPrefab("NewPlayerInstance");
+            base.OnServerAndClientsCreated();
+        }
+
+        [UnityTest]
+        public IEnumerator SpawnAnotherPlayerObject()
+        {
+            var originalPlayer = m_PlayerNetworkObjects[1][1];
+            var playerLocalClient = m_ClientNetworkManagers[0].LocalClient.PlayerObject;
+            var newPlayer = Object.Instantiate(m_NewPlayerToSpawn);
+            var newPlayerNetworkObject = newPlayer.GetComponent<NetworkObject>();
+            newPlayerNetworkObject.NetworkManagerOwner = m_ServerNetworkManager;
+            newPlayerNetworkObject.SpawnAsPlayerObject(1);
+            yield return WaitForConditionOrTimeOut(() => !originalPlayer.IsPlayerObject && newPlayerNetworkObject.IsPlayerObject);
+            Assert.False(s_GlobalTimeoutHelper.TimedOut, "Timed out waiting for server-side player object to change!");
+            yield return WaitForConditionOrTimeOut(() => m_ClientNetworkManagers[0].LocalClient.PlayerObject != playerLocalClient && !playerLocalClient.IsPlayerObject
+            && m_ClientNetworkManagers[0].LocalClient.PlayerObject.IsPlayerObject);
+            Assert.False(s_GlobalTimeoutHelper.TimedOut, "Timed out waiting for client0side player object to change!");
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/PlayerObjectTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/PlayerObjectTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ee94262f06e591e45a9382582013cf7a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Spawning a new player object with SpawnAsPlayerObject does not set the IsPlayerObject property of the previous player object to false allowing for multiple player objects which shouldn't be the case.
[MTT-1570](https://jira.unity3d.com/browse/MTT-1570)

## Changelog
### com.unity.netcode.gameobjects
-Fixed: issue when spawning new player if an already existing player exists it does not remove IsPlayer from the previous player.

## Testing and Documentation
* Includes integration tests.
