### PR TITLE
fix: networkmanager starts when transport does not

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -13,7 +13,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Changed
 
 ### Fixed
-- Fixed issue where NetworkManager would continue starting if the NetworkTransport selected failed. (#1780)
+- Fixed issue where NetworkManager would continue starting even if the NetworkTransport selected failed. (#1780)
 - Fixed issue when spawning new player if an already existing player exists it does not remove IsPlayer from the previous player (#1779)
 - Fixed lack of notification that NetworkManager and NetworkObject cannot be added to the same GameObject with in-editor notifications (#1777)
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
+## [Unreleased]
+### Added
+### Changed
+### Fixed
+- Fixed issue where NetworkManager would continue starting if the NetworkTransport selected failed. (#1780)
+
 ## [1.0.0-pre.6] - 2022-03-02
 
 ### Added

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -7,17 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
 ## [Unreleased]
-### Added
-### Changed
-### Fixed
-- Fixed issue when spawning new player if an already existing player exists it does not remove IsPlayer from the previous player (#1779)
-- Fixed lack of notification that NetworkManager and NetworkObject cannot be added to the same GameObject with in-editor notifications (#1777)
 
-## [Unreleased]
 ### Added
+
 ### Changed
+
 ### Fixed
 - Fixed issue where NetworkManager would continue starting if the NetworkTransport selected failed. (#1780)
+- Fixed issue when spawning new player if an already existing player exists it does not remove IsPlayer from the previous player (#1779)
+- Fixed lack of notification that NetworkManager and NetworkObject cannot be added to the same GameObject with in-editor notifications (#1777)
 
 ## [1.0.0-pre.6] - 2022-03-02
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -827,10 +827,8 @@ namespace Unity.Netcode
 
             Initialize(true);
 
-
-            var result = NetworkConfig.NetworkTransport.StartServer();
             // If we failed to start then shutdown and notify user that the transport failed to start
-            if (result)
+            if (NetworkConfig.NetworkTransport.StartServer())
             {
                 IsServer = true;
                 IsClient = false;
@@ -839,6 +837,7 @@ namespace Unity.Netcode
                 SpawnManager.ServerSpawnSceneObjectsOnStartSweep();
 
                 OnServerStarted?.Invoke();
+                return true;
             }
             else
             {
@@ -846,7 +845,7 @@ namespace Unity.Netcode
                 Shutdown();
             }
 
-            return result;
+            return false;
         }
 
         /// <summary>
@@ -872,19 +871,18 @@ namespace Unity.Netcode
             Initialize(false);
             MessagingSystem.ClientConnected(ServerClientId);
 
-            var result = NetworkConfig.NetworkTransport.StartClient();
-            if (!result)
+            if (!NetworkConfig.NetworkTransport.StartClient())
             {
                 Debug.LogError($"Client is shutting down due to network transport start failure of {NetworkConfig.NetworkTransport.GetType().Name}!");
                 Shutdown();
-                return result;
+                return false;
             }
 
             IsServer = false;
             IsClient = true;
             IsListening = true;
 
-            return result;
+            return true;
         }
 
         /// <summary>
@@ -921,13 +919,12 @@ namespace Unity.Netcode
 
             Initialize(true);
 
-            var result = NetworkConfig.NetworkTransport.StartServer();
             // If we failed to start then shutdown and notify user that the transport failed to start
-            if (!result)
+            if (!NetworkConfig.NetworkTransport.StartServer())
             {
                 Debug.LogError($"Server is shutting down due to network transport start failure of {NetworkConfig.NetworkTransport.GetType().Name}!");
                 Shutdown();
-                return result;
+                return false;
             }
 
             MessagingSystem.ClientConnected(ServerClientId);
@@ -965,7 +962,7 @@ namespace Unity.Netcode
 
             OnServerStarted?.Invoke();
 
-            return result;
+            return true;
         }
 
         public void SetSingleton()

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerTransportTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.TestTools;
+using NUnit.Framework;
+using Unity.Netcode.TestHelpers.Runtime;
+using Object = UnityEngine.Object;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    public class NetworkManagerTransportTests : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 1;
+
+        private bool m_CanStartServerAndClients = false;
+
+        public NetworkManagerTransportTests(HostOrServer hostOrServer) : base(hostOrServer) { }
+
+        protected override IEnumerator OnSetup()
+        {
+            m_CanStartServerAndClients = false;
+            return base.OnSetup();
+        }
+
+        protected override bool CanStartServerAndClients()
+        {
+            return m_CanStartServerAndClients;
+        }
+
+        protected override void OnServerAndClientsCreated()
+        {
+
+        }
+
+        [UnityTest]
+        public IEnumerator DoesNotStartWhenTransportFails([Values] bool testClient)
+        {
+            // The error message we should expect
+            var messageToCheck = "";
+            if (!testClient)
+            {
+                Object.DestroyImmediate(m_ServerNetworkManager.NetworkConfig.NetworkTransport);
+                m_ServerNetworkManager.NetworkConfig.NetworkTransport = m_ServerNetworkManager.gameObject.AddComponent<FailedTransport>();
+                m_ServerNetworkManager.NetworkConfig.NetworkTransport.Initialize(m_ServerNetworkManager);
+                // The error message we should expect
+                messageToCheck = $"Server is shutting down due to network transport start failure of {m_ServerNetworkManager.NetworkConfig.NetworkTransport.GetType().Name}!";
+            }
+            else
+            {
+                foreach (var client in m_ClientNetworkManagers)
+                {
+                    Object.DestroyImmediate(client.NetworkConfig.NetworkTransport);
+                    client.NetworkConfig.NetworkTransport = client.gameObject.AddComponent<FailedTransport>();
+                    client.NetworkConfig.NetworkTransport.Initialize(m_ServerNetworkManager);
+                }
+                // The error message we should expect
+                messageToCheck = $"Client is shutting down due to network transport start failure of {m_ClientNetworkManagers[0].NetworkConfig.NetworkTransport.GetType().Name}!";
+            }
+
+            // Trap for the nested NetworkManager exception
+            LogAssert.Expect(LogType.Error, messageToCheck);
+            m_CanStartServerAndClients = true;
+            if (testClient)
+            {
+                NetcodeIntegrationTestHelpers.Start(m_UseHost, m_ServerNetworkManager, m_ClientNetworkManagers);
+            }
+            else
+            {
+                NetcodeIntegrationTestHelpers.Start(m_UseHost, m_ServerNetworkManager, new NetworkManager[] { });
+            }
+            yield return s_DefaultWaitForTick;
+        }
+    }
+
+
+    /// <summary>
+    /// Does nothing but simulate a transport that failed to start
+    /// </summary>
+    public class FailedTransport : TestingNetworkTransport
+    {
+        public override void Shutdown()
+        {
+        }
+
+        public override ulong ServerClientId => 0;
+
+        public override NetworkEvent PollEvent(out ulong clientId, out ArraySegment<byte> payload, out float receiveTime)
+        {
+            clientId = 0;
+            payload = null;
+            receiveTime = 0;
+            return NetworkEvent.Nothing;
+        }
+
+        public override bool StartClient()
+        {
+            // Simulate failure, always return false
+            return false;
+        }
+
+        public override bool StartServer()
+        {
+            // Simulate failure, always return false
+            return false;
+        }
+
+
+
+        public override void Send(ulong clientId, ArraySegment<byte> payload, NetworkDelivery networkDelivery)
+        {
+        }
+
+        public override void DisconnectRemoteClient(ulong clientId)
+        {
+        }
+
+        public override void Initialize(NetworkManager networkManager = null)
+        {
+        }
+        public override ulong GetCurrentRtt(ulong clientId)
+        {
+            return 0;
+        }
+        public override void DisconnectLocalClient()
+        {
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerTransportTests.cs
@@ -97,7 +97,7 @@ namespace Unity.Netcode.RuntimeTests
         public override NetworkEvent PollEvent(out ulong clientId, out ArraySegment<byte> payload, out float receiveTime)
         {
             clientId = 0;
-            payload = null;
+            payload = new ArraySegment<byte>();
             receiveTime = 0;
             return NetworkEvent.Nothing;
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerTransportTests.cs
@@ -29,11 +29,6 @@ namespace Unity.Netcode.RuntimeTests
             return m_CanStartServerAndClients;
         }
 
-        protected override void OnServerAndClientsCreated()
-        {
-
-        }
-
         /// <summary>
         /// Validate that if the NetworkTransport fails to start the NetworkManager
         /// will not continue the startup process and will shut itself down.

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerTransportTests.cs
@@ -68,7 +68,7 @@ namespace Unity.Netcode.RuntimeTests
             {
                 NetcodeIntegrationTestHelpers.Start(m_UseHost, m_ServerNetworkManager, m_ClientNetworkManagers);
                 yield return s_DefaultWaitForTick;
-                foreach(var client in m_ClientNetworkManagers)
+                foreach (var client in m_ClientNetworkManagers)
                 {
                     Assert.False(client.IsListening);
                     Assert.False(client.IsConnectedClient);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerTransportTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerTransportTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 798d76599e527b245a14b7cc9cfd2607
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
When the NetworkTransport.StartServer returns false, we need to stop the startup process for both the StartHost or StartServer methods in NetworkManager. Otherwise there are failure to bind error messages and the server or host still thinks it is started.
[MTT-2598](https://jira.unity3d.com/browse/MTT-2598)

## Changelog

### com.unity.netcode.gameobjects
-Fixed: issue where NetworkManager would continue starting if the NetworkTransport selected failed. 

## Testing and Documentation
* Includes integration tests.