### PR TITLE
fix: clamp interpolation time to a minimum of 0 in NetworkTransform

### DIFF
--- a/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
+++ b/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
@@ -186,7 +186,9 @@ namespace Unity.Netcode
 
                     if (t < 0.0f)
                     {
-                        throw new OverflowException($"t = {t} but must be >= 0. range {range}, RenderTime {renderTime}, Start time {m_StartTimeConsumed}, end time {m_EndTimeConsumed}");
+                        // There is no mechanism to guarantee renderTime to not be before m_StartTimeConsumed
+                        // This clamps t to a minimum of 0 and fixes issues with longer frames and pauses
+                        t = 0.0f;
                     }
 
                     if (t > 3.0f) // max extrapolation

--- a/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
+++ b/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
@@ -188,6 +188,11 @@ namespace Unity.Netcode
                     {
                         // There is no mechanism to guarantee renderTime to not be before m_StartTimeConsumed
                         // This clamps t to a minimum of 0 and fixes issues with longer frames and pauses
+
+                        if (NetworkLog.CurrentLogLevel <= LogLevel.Developer)
+                        {
+                            NetworkLog.LogError($"renderTime was before m_StartTimeConsumed. This should never happen. {nameof(renderTime)} is {renderTime}, {nameof(m_StartTimeConsumed)} is {m_StartTimeConsumed}");
+                        }
                         t = 0.0f;
                     }
 
@@ -220,6 +225,8 @@ namespace Unity.Netcode
                 {
                     m_LastBufferedItemReceived = new BufferedItem(newMeasurement, sentTime);
                     ResetTo(newMeasurement, sentTime);
+                    // Next line keeps renderTime above m_StartTimeConsumed. Fixes pause/unpause issues
+                    m_Buffer.Add(m_LastBufferedItemReceived);
                 }
 
                 return;

--- a/com.unity.netcode.gameobjects/Runtime/AssemblyInfo.cs
+++ b/com.unity.netcode.gameobjects/Runtime/AssemblyInfo.cs
@@ -11,4 +11,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Unity.Netcode.RuntimeTests")]
 [assembly: InternalsVisibleTo("Unity.Netcode.TestHelpers.Runtime")]
 [assembly: InternalsVisibleTo("Unity.Netcode.Adapter.UTP")]
-
+[assembly: InternalsVisibleTo("Unity.Netcode.Components")]

--- a/com.unity.netcode.gameobjects/Runtime/AssemblyInfo.cs
+++ b/com.unity.netcode.gameobjects/Runtime/AssemblyInfo.cs
@@ -11,4 +11,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Unity.Netcode.RuntimeTests")]
 [assembly: InternalsVisibleTo("Unity.Netcode.TestHelpers.Runtime")]
 [assembly: InternalsVisibleTo("Unity.Netcode.Adapter.UTP")]
-[assembly: InternalsVisibleTo("Unity.Netcode.Components")]
+


### PR DESCRIPTION
Clamp the interpolation time to a minimum of 0 in NetworkTransform.

MTT-1421
