### PR TITLE
fix: catch duplicate scene entries

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -488,8 +488,15 @@ namespace Unity.Netcode
                 var scenePath = SceneUtility.GetScenePathByBuildIndex(i);
                 var hash = XXHash.Hash32(scenePath);
                 var buildIndex = SceneUtility.GetBuildIndexByScenePath(scenePath);
-                HashToBuildIndex.Add(hash, buildIndex);
-                BuildIndexToHash.Add(buildIndex, hash);
+                if (!HashToBuildIndex.ContainsKey(hash))
+                {
+                    HashToBuildIndex.Add(hash, buildIndex);
+                    BuildIndexToHash.Add(buildIndex, hash);
+                }
+                else
+                {
+                    Debug.LogError($"{nameof(NetworkSceneManager)} is skipping duplicate scene path entry {scenePath}. Make sure your scenes in build list does not contain duplicates!");
+                }
             }
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -488,6 +488,9 @@ namespace Unity.Netcode
                 var scenePath = SceneUtility.GetScenePathByBuildIndex(i);
                 var hash = XXHash.Hash32(scenePath);
                 var buildIndex = SceneUtility.GetBuildIndexByScenePath(scenePath);
+
+                // In the rare-case scenario where a programmatically generated build has duplicate
+                // scene entries, we will log an error and skip the entry
                 if (!HashToBuildIndex.ContainsKey(hash))
                 {
                     HashToBuildIndex.Add(hash, buildIndex);


### PR DESCRIPTION
When a programmatically generated build erroneously contains duplicate scene entries, the NetworkSceneManager would crash when building the hash lookup table.  
This PR resolves this issue.

[MTT-2494 ](https://jira.unity3d.com/browse/MTT-2494)

## Testing and Documentation
* No tests have been added.

## One way to test this fix:
_Create a ScriptBatch.cs file in your scripts folder and add the below code.
This will add all existing scenes and then randomly add a duplicate scene from the known list of added scenes._
```
#if UNITY_EDITOR
using UnityEditor;
using UnityEngine;
using System.Collections.Generic;

public class ScriptBatch
{
    [MenuItem("BuildIt/BuildIt %b")]
    public static void BuildGame()
    {
        var buildPlayerOptions = new BuildPlayerOptions();
        buildPlayerOptions.locationPathName = "./Builds/testproject.exe";
        buildPlayerOptions.target = BuildTarget.StandaloneWindows64;
        buildPlayerOptions.options = BuildOptions.Development | BuildOptions.ShowBuiltPlayer;
        var scenePaths = new List<string>();
        foreach(var sceneEntry in EditorBuildSettings.scenes)
        {
            if (!sceneEntry.enabled || sceneEntry.path == string.Empty)
            {
                continue;
            }
            scenePaths.Add(sceneEntry.path);
        }

        // Randomly duplicate an entry
        scenePaths.Add(scenePaths[Random.Range(0, scenePaths.Count - 1)]);

        buildPlayerOptions.scenes = scenePaths.ToArray();

         // Build player.
        BuildPipeline.BuildPlayer(buildPlayerOptions);
    }
}
#endif

```