### PR TITLE
fix: NetworkBehaviour Property Initialization Updates

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -321,7 +321,7 @@ namespace Unity.Netcode
         /// <summary>
         /// Gets whether or not this NetworkBehaviour instance has a NetworkObject owner.
         /// </summary>
-        public bool HasNetworkObject => m_NetworkObject != null;
+        public bool HasNetworkObject => NetworkObject != null;
 
         private NetworkObject m_NetworkObject = null;
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -238,7 +238,7 @@ namespace Unity.Netcode
         /// If a NetworkObject is assigned, it will return whether or not this NetworkObject
         /// is the local player object.  If no NetworkObject is assigned it will always return false.
         /// </summary>
-        public bool IsLocalPlayer => m_NetworkObject != null ? m_NetworkObject.IsLocalPlayer : false;
+        public bool IsLocalPlayer { get; private set; }
 
         /// <summary>
         /// Gets if the object is owned by the local player or if the object is the local player object
@@ -366,6 +366,8 @@ namespace Unity.Netcode
             {
                 // Set identification related properties
                 NetworkObjectId = NetworkObject.NetworkObjectId;
+                IsLocalPlayer = NetworkObject.IsLocalPlayer;
+
                 // This is "OK" because GetNetworkBehaviourOrderIndex uses the order of
                 // NetworkObject.ChildNetworkBehaviours which is set once when first
                 // accessed.
@@ -384,7 +386,7 @@ namespace Unity.Netcode
                     IsServer = NetworkManager.IsListening && NetworkManager.IsServer;
                 }
             }
-            else // Shouldn't happen, but if so then set the default value to properties;
+            else // Shouldn't happen, but if so then set the properties to their default value;
             {
                 OwnerClientId = NetworkObjectId = default;
                 IsOwnedByServer = IsOwner = IsHost = IsClient = IsServer = default;

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -361,8 +361,8 @@ namespace Unity.Netcode
             {
                 NetworkObjectId = NetworkObject.NetworkObjectId;
                 // This is "OK" because GetNetworkBehaviourOrderIndex uses the order of
-                // NetworkObject.ChildNetworkBehaviours which is set once when the first
-                // attempt to access it happens.
+                // NetworkObject.ChildNetworkBehaviours which is set once when first
+                // accessed.
                 NetworkBehaviourId = NetworkObject.GetNetworkBehaviourOrderIndex(this);
 
                 if (NetworkManager != null && NetworkManager.IsListening)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -365,7 +365,7 @@ namespace Unity.Netcode
                 // accessed.
                 NetworkBehaviourId = NetworkObject.GetNetworkBehaviourOrderIndex(this);
 
-                if (NetworkManager != null && NetworkManager.IsListening)
+                if (NetworkManager != null)
                 {
                     m_IsHost = NetworkManager.IsListening && NetworkManager.IsHost;
                     m_IsClient = NetworkManager.IsListening && NetworkManager.IsClient;

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -372,6 +372,12 @@ namespace Unity.Netcode
                     m_IsServer = NetworkManager.IsListening && NetworkManager.IsServer;
                 }
             }
+            else // Shouldn't happen, but if it does then just clear out everything
+            {
+                NetworkObjectId = 0;
+                m_IsHost = m_IsClient = m_IsServer = false;
+                NetworkBehaviourId = 0;
+            }
         }
 
         /// <summary>
@@ -406,6 +412,11 @@ namespace Unity.Netcode
                 IsOwnedByServer = NetworkObject.IsOwnedByServer;
                 IsOwner = NetworkObject.IsOwner;
                 OwnerClientId = NetworkObject.OwnerClientId;
+            }
+            else // Shouldn't happen, but if it does then just clear out everything
+            {
+                IsOwnedByServer = IsOwner = false;
+                OwnerClientId = 0;
             }
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -549,7 +549,7 @@ namespace Unity.Netcode
         {
             for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
             {
-                ChildNetworkBehaviours[i].OnLostOwnership();
+                ChildNetworkBehaviours[i].LostOwnership();
             }
         }
 
@@ -557,7 +557,7 @@ namespace Unity.Netcode
         {
             for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
             {
-                ChildNetworkBehaviours[i].OnGainedOwnership();
+                ChildNetworkBehaviours[i].GainedOwnership();
             }
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -549,7 +549,7 @@ namespace Unity.Netcode
         {
             for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
             {
-                ChildNetworkBehaviours[i].LostOwnership();
+                ChildNetworkBehaviours[i].InternalOnLostOwnership();
             }
         }
 
@@ -557,7 +557,7 @@ namespace Unity.Netcode
         {
             for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
             {
-                ChildNetworkBehaviours[i].GainedOwnership();
+                ChildNetworkBehaviours[i].InternalOnGainedOwnership();
             }
         }
 
@@ -796,7 +796,6 @@ namespace Unity.Netcode
             for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
             {
                 ChildNetworkBehaviours[i].InternalOnNetworkSpawn();
-                ChildNetworkBehaviours[i].OnNetworkSpawn();
             }
         }
 
@@ -805,7 +804,6 @@ namespace Unity.Netcode
             for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
             {
                 ChildNetworkBehaviours[i].InternalOnNetworkDespawn();
-                ChildNetworkBehaviours[i].OnNetworkDespawn();
             }
         }
 

--- a/testproject/Assets/Tests/Runtime/MessageOrdering.cs
+++ b/testproject/Assets/Tests/Runtime/MessageOrdering.cs
@@ -173,22 +173,10 @@ namespace TestProject.RuntimeTests
 
             Assert.AreEqual(NetworkUpdateStage.EarlyUpdate, Support.SpawnRpcDespawn.StageExecutedByReceiver);
             Assert.AreEqual(Support.SpawnRpcDespawn.ServerUpdateCount, Support.SpawnRpcDespawn.ClientUpdateCount);
-            doubleCheckTime = Time.realtimeSinceStartup + 2.0f;
-            while (!handler.WasDestroyed)
-            {
-                if (Time.frameCount > maxFrames)
-                {
-                    // This is here in the event a platform is running at a higher
-                    // frame rate than expected
-                    if (doubleCheckTime < Time.realtimeSinceStartup)
-                    {
-                        Assert.Fail("Timed out waiting for handler to be destroyed");
-                        break;
-                    }
-                }
-                var nextFrameNumber = Time.frameCount + 1;
-                yield return new WaitUntil(() => Time.frameCount >= nextFrameNumber);
-            }
+
+            // Wait 1 tic for the GameObjet and associated components to be destroyed
+            yield return new WaitForSeconds(1.0f / server.NetworkConfig.TickRate);
+
             Assert.True(handler.WasDestroyed);
         }
 

--- a/testproject/Assets/Tests/Runtime/Support/SpawnRpcDespawn.cs
+++ b/testproject/Assets/Tests/Runtime/Support/SpawnRpcDespawn.cs
@@ -86,7 +86,6 @@ namespace TestProject.RuntimeTests.Support
         private void RunTest()
         {
             Debug.Log("Running test...");
-            GetComponent<NetworkObject>().Spawn();
             IncrementUpdateCount();
             Destroy(gameObject);
             m_Active = false;


### PR DESCRIPTION
Accessing specific properties of NetworkBehaviour can too easily cause exceptions to occur.  Depending upon frequency of usage, they can also impact performance unnecessarily. 

[MTT-2785](https://jira.unity3d.com/browse/MTT-2785)

## Changelog
### com.unity.netcode.gameobjects
- Fixed: If you update multiple packages, create a new section with a new header for the other package. 

## Testing and Documentation
* One test was updated.
* The rest validate the change