### PR TITLE
fix: remove unnecessary physics package dep MTT-2704

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Fixed
 - Fixed issue when spawning new player if an already existing player exists it does not remove IsPlayer from the previous player (#1779)
 - Fixed lack of notification that NetworkManager and NetworkObject cannot be added to the same GameObject with in-editor notifications (#1777)
+- Remove unnecessary Physics / Physics2D package dependencies (#1786)
 
 ## [1.0.0-pre.6] - 2022-03-02
 

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -6,8 +6,6 @@
     "unity": "2020.3",
     "dependencies": {
         "com.unity.modules.animation": "1.0.0",
-        "com.unity.modules.physics": "1.0.0",
-        "com.unity.modules.physics2d": "1.0.0",
         "com.unity.nuget.mono-cecil": "1.10.1",
         "com.unity.collections": "1.1.0"
     }


### PR DESCRIPTION
Our package currently specifies a physics dependency which is not used nor necessary

MTT-2704

## Changelog

## Testing and Documentation
* No tests have been added.
