### PR TITLE
chore: making the NetworkLog logging functions publicly available

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Logging/NetworkLog.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Logging/NetworkLog.cs
@@ -14,9 +14,9 @@ namespace Unity.Netcode
         public static LogLevel CurrentLogLevel => NetworkManager.Singleton == null ? LogLevel.Normal : NetworkManager.Singleton.LogLevel;
 
         // internal logging
-        internal static void LogInfo(string message) => Debug.Log($"[Netcode] {message}");
-        internal static void LogWarning(string message) => Debug.LogWarning($"[Netcode] {message}");
-        internal static void LogError(string message) => Debug.LogError($"[Netcode] {message}");
+        public static void LogInfo(string message) => Debug.Log($"[Netcode] {message}");
+        public static void LogWarning(string message) => Debug.LogWarning($"[Netcode] {message}");
+        public static void LogError(string message) => Debug.LogError($"[Netcode] {message}");
 
         /// <summary>
         /// Logs an info log locally and on the server if possible.


### PR DESCRIPTION
https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/1781 exposes the need for this API.