### PR TITLE
fix: remove `HasNetworkVariables` prop, always send NetVars when we send `CreateObjectMessage`

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1765,7 +1765,7 @@ namespace Unity.Netcode
 
                 var message = new CreateObjectMessage
                 {
-                    ObjectInfo = ConnectedClients[clientId].PlayerObject.GetMessageSceneObject(clientPair.Key, false)
+                    ObjectInfo = ConnectedClients[clientId].PlayerObject.GetMessageSceneObject(clientPair.Key)
                 };
                 message.ObjectInfo.Header.Hash = playerPrefabHash;
                 message.ObjectInfo.Header.IsSceneObject = false;

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -918,7 +918,6 @@ namespace Unity.Netcode
                 public bool IsSceneObject;
                 public bool HasTransform;
                 public bool IsReparented;
-                public bool HasNetworkVariables;
             }
 
             public HeaderData Header;
@@ -979,10 +978,7 @@ namespace Unity.Netcode
                     }
                 }
 
-                if (Header.HasNetworkVariables)
-                {
-                    OwnerObject.WriteNetworkVariableData(writer, TargetClientId);
-                }
+                OwnerObject.WriteNetworkVariableData(writer, TargetClientId);
             }
 
             public unsafe void Deserialize(FastBufferReader reader)
@@ -1022,7 +1018,7 @@ namespace Unity.Netcode
             }
         }
 
-        internal SceneObject GetMessageSceneObject(ulong targetClientId, bool includeNetworkVariableData = true)
+        internal SceneObject GetMessageSceneObject(ulong targetClientId)
         {
             var obj = new SceneObject
             {
@@ -1033,7 +1029,6 @@ namespace Unity.Netcode
                     OwnerClientId = OwnerClientId,
                     IsSceneObject = IsSceneObject ?? true,
                     Hash = HostCheckForGlobalObjectIdHashOverride(),
-                    HasNetworkVariables = includeNetworkVariableData
                 },
                 OwnerObject = this,
                 TargetClientId = targetClientId

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -452,10 +452,7 @@ namespace Unity.Netcode
                 throw new SpawnStateException("Object is already spawned");
             }
 
-            if (sceneObject.Header.HasNetworkVariables)
-            {
-                networkObject.SetNetworkVariableData(variableData);
-            }
+            networkObject.SetNetworkVariableData(variableData);
 
             SpawnNetworkObjectLocallyCommon(networkObject, sceneObject.Header.NetworkObjectId, sceneObject.Header.IsSceneObject, sceneObject.Header.IsPlayerObject, sceneObject.Header.OwnerClientId, destroyWithScene);
         }


### PR DESCRIPTION
I believe old behavior inside `NetworkManager::ApprovedPlayerSpawn` was assuming snapshot system to be there but we didn't get it — we should fix the behavior (and make it consistent with every other place in the codebase).