### PR TITLE
chore: Updating multiplayer tools release version to point to 1.0.0-pre6

### DIFF
--- a/testproject-tools-integration/Packages/manifest.json
+++ b/testproject-tools-integration/Packages/manifest.json
@@ -2,7 +2,7 @@
     "registry": "https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-candidates",
     "dependencies": {
         "com.unity.ide.rider": "3.0.7",
-        "com.unity.multiplayer.tools": "1.0.0-pre.5",
+        "com.unity.multiplayer.tools": "https://github.com/Unity-Technologies/com.unity.multiplayer.tools.git#cfb8fd305c3e46bb1251b40ec5f6cb621a267e7f",
         "com.unity.netcode.adapter.utp": "file:../../com.unity.netcode.adapter.utp",
         "com.unity.netcode.gameobjects": "file:../../com.unity.netcode.gameobjects",
         "com.unity.test-framework": "1.1.31",

--- a/testproject-tools-integration/Packages/packages-lock.json
+++ b/testproject-tools-integration/Packages/packages-lock.json
@@ -43,9 +43,9 @@
       "url": "https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-candidates"
     },
     "com.unity.multiplayer.tools": {
-      "version": "1.0.0-pre.5",
+      "version": "https://github.com/Unity-Technologies/com.unity.multiplayer.tools.git#cfb8fd305c3e46bb1251b40ec5f6cb621a267e7f",
       "depth": 0,
-      "source": "registry",
+      "source": "git",
       "dependencies": {
         "com.unity.profiling.core": "1.0.0-pre.1",
         "com.unity.nuget.newtonsoft-json": "2.0.0",


### PR DESCRIPTION
Updating multiplayer tools release version to point to 1.0.0-pre6

Thank you Ashwini for brilliant suggestion :)

## Changelog

### com.unity.netcode.gameobjects
N/A

## Testing and Documentation

* No tests have been added.
* Includes unit tests.
* Includes integration tests.
* No documentation changes or additions were necessary.
* Includes documentation for previously-undocumented public API entry points.
* Includes edits to existing public API documentation.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->