### PR TITLE
feat: Connection count metrics

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1296,6 +1296,7 @@ namespace Unity.Netcode
             {
                 MessagingSystem.ProcessSendQueues();
                 NetworkMetrics.UpdateNetworkObjectsCount(SpawnManager.SpawnedObjects.Count);
+                NetworkMetrics.UpdateConnectionsCount((IsServer) ? ConnectedClients.Count : 1);
                 NetworkMetrics.DispatchFrame();
             }
             SpawnManager.CleanupStaleTriggers();

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/INetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/INetworkMetrics.cs
@@ -91,6 +91,8 @@ namespace Unity.Netcode
 
         void UpdateNetworkObjectsCount(int count);
 
+        void UpdateConnectionsCount(int count);
+
         void DispatchFrame();
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
@@ -83,6 +83,10 @@ namespace Unity.Netcode
         {
             ShouldResetOnDispatch = true,
         };
+        private readonly Gauge m_ConnectionsGauge = new Gauge(NetworkMetricTypes.ConnectedClients.Id)
+        {
+            ShouldResetOnDispatch = true,
+        };
 #endif
 
         private ulong m_NumberOfMetricsThisFrame;
@@ -105,6 +109,7 @@ namespace Unity.Netcode
                 .WithCounters(m_PacketSentCounter, m_PacketReceivedCounter)
                 .WithGauges(m_RttToServerGauge)
                 .WithGauges(m_NetworkObjectsGauge)
+                .WithGauges(m_ConnectionsGauge)
 #endif
                 .Build();
 
@@ -478,6 +483,18 @@ namespace Unity.Netcode
             }
 
             m_NetworkObjectsGauge.Set(count);
+#endif
+        }
+
+        public void UpdateConnectionsCount(int count)
+        {
+#if MULTIPLAYER_TOOLS_1_0_0_PRE_7
+            if (!CanSendMetrics)
+            {
+                return;
+            }
+
+            m_ConnectionsGauge.Set(count);
 #endif
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/NullNetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/NullNetworkMetrics.cs
@@ -153,6 +153,10 @@ namespace Unity.Netcode
         {
         }
 
+        public void UpdateConnectionsCount(int count)
+        {
+        }
+
         public void DispatchFrame()
         {
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/ConnectionMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/ConnectionMetricsTests.cs
@@ -1,0 +1,69 @@
+#if MULTIPLAYER_TOOLS
+#if MULTIPLAYER_TOOLS_1_0_0_PRE_7
+
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Unity.Multiplayer.Tools.MetricTypes;
+using Unity.Netcode.TestHelpers.Runtime;
+using Unity.Netcode.TestHelpers.Runtime.Metrics;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests.Metrics
+{
+    [TestFixture(ClientCount.OneClient, HostOrServer.Host)]
+    [TestFixture(ClientCount.TwoClients, HostOrServer.Host)]
+    [TestFixture(ClientCount.OneClient, HostOrServer.Server)]
+    [TestFixture(ClientCount.TwoClients, HostOrServer.Server)]
+    public class ConnectionMetricsTests : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => m_ClientCount;
+
+        private int m_ClientCount;
+
+        public enum ClientCount
+        {
+            OneClient = 1,
+            TwoClients,
+        }
+
+        public ConnectionMetricsTests(ClientCount clientCount, HostOrServer hostOrServer)
+            : base(hostOrServer)
+        {
+            m_ClientCount = (int)clientCount;
+        }
+
+        private int GetClientCountForFixture()
+        {
+            return m_ClientCount + ((m_UseHost) ? 1 : 0);
+        }
+
+        [UnityTest]
+        public IEnumerator UpdateConnectionCountOnServer()
+        {
+            var waitForGaugeValues = new WaitForGaugeMetricValues((m_ServerNetworkManager.NetworkMetrics as NetworkMetrics).Dispatcher, NetworkMetricTypes.ConnectedClients);
+
+            yield return waitForGaugeValues.WaitForMetricsReceived();
+
+            var value = waitForGaugeValues.AssertMetricValueHaveBeenFound();
+            Assert.AreEqual(GetClientCountForFixture(), value);
+        }
+
+        [UnityTest]
+        public IEnumerator UpdateConnectionCountOnClient()
+        {
+            foreach (var clientNetworkManager in m_ClientNetworkManagers)
+            {
+                var waitForGaugeValues = new WaitForGaugeMetricValues((clientNetworkManager.NetworkMetrics as NetworkMetrics).Dispatcher, NetworkMetricTypes.ConnectedClients);
+
+                yield return waitForGaugeValues.WaitForMetricsReceived();
+
+                var value = waitForGaugeValues.AssertMetricValueHaveBeenFound();
+                Assert.AreEqual(1, value);
+            }
+        }
+    }
+}
+
+#endif
+#endif

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/ConnectionMetricsTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/ConnectionMetricsTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1845aef61dbb4f2b9d2be9145262ab90
+timeCreated: 1647023529


### PR DESCRIPTION
This implements a tracking of the active connection count on the server. This information is not limited on the client and always return 1 because the client can only perceive it's own connection to the client.

MTT-2699

## Changelog

## Testing and Documentation

* Includes integration tests.