### PR TITLE
fix: Flush the adapter send queues in Shutdown

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this package will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+
+### Fixed
+
+- Flush internal send queues to the network during `Shutdown`. Prior to this fix, calling `NetworkManager.Shutdown` with `discardMessageQueue` set to false would not actually get messages from the outgoing queue to the network. (#1800)
+
 ## [1.0.0-pre.6] - 2022-03-02
 
 ### Added

--- a/com.unity.netcode.adapter.utp/Tests/Runtime/TransportTests.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/TransportTests.cs
@@ -389,6 +389,27 @@ namespace Unity.Netcode.UTP.RuntimeTests
 
             yield return null;
         }
+
+        [UnityTest]
+        public IEnumerator SendQueuesFlushedOnShutdown([ValueSource("k_DeliveryParameters")] NetworkDelivery delivery)
+        {
+            InitializeTransport(out m_Server, out m_ServerEvents);
+            InitializeTransport(out m_Client1, out m_Client1Events);
+
+            m_Server.StartServer();
+            m_Client1.StartClient();
+
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_Client1Events);
+
+            var data = new ArraySegment<byte>(new byte[] { 42 });
+            m_Client1.Send(m_Client1.ServerClientId, data, delivery);
+
+            m_Client1.Shutdown();
+
+            yield return WaitForNetworkEvent(NetworkEvent.Data, m_ServerEvents);
+
+            yield return null;
+        }
     }
 }
 #endif


### PR DESCRIPTION
MTT-2821

`NetworkManager.Shutdown` has the option of flushing its outgoing queue. When enabled, this ends up calling the adapter's `Send` method to send the messages to the network. But the `Send` method doesn't actually get anything on the wire. It just puts messages in the internal adapter send queues. Normally they'd then be sent on the next update, but during shutdown there will not be a next update, and the messages will not actually be sent on the network. To fix this issue, have the adapter's `Shutdown` method flush all its internal queues to the network.

## Changelog

### com.unity.netcode.adapter.utp

* Fixed: Flush internal send queues to the network during `Shutdown`. Prior to this fix, calling `NetworkManager.Shutdown` with `discardMessageQueue` set to false would not actually get messages from the outgoing queue to the network.

## Testing and Documentation

* Includes unit/integration test.
* No documentation changes or additions were necessary.