### PR TITLE
fix: Make the adapter compile on WebGL

### DIFF
--- a/com.unity.netcode.adapter.utp/CHANGELOG.md
+++ b/com.unity.netcode.adapter.utp/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this package will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed compilation on WebGL. Note that the platform is still unsupported, but at least including the package in a WebGL project will not create compilation errors anymore. (#1802)
+
 ## [1.0.0-pre.6] - 2022-03-02
 
 ### Added

--- a/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
+++ b/com.unity.netcode.adapter.utp/Runtime/UnityTransport.cs
@@ -100,9 +100,11 @@ namespace Unity.Netcode
         [Tooltip("Which protocol should be selected (Relay/Non-Relay).")]
         [SerializeField] private ProtocolType m_ProtocolType;
 
+#pragma warning disable CS0414 // Assigned-but-not-used (only an issue in WebGL builds)
         [Tooltip("The maximum amount of packets that can be in the internal send/receive queues. " +
             "Basically this is how many packets can be sent/received in a single update/frame.")]
         [SerializeField] private int m_MaxPacketQueueSize = InitialMaxPacketQueueSize;
+#pragma warning restore CS0414
 
         [Tooltip("The maximum size of a payload that can be handled by the transport.")]
         [FormerlySerializedAs("m_SendQueueBatchSize")]
@@ -891,6 +893,7 @@ namespace Unity.Netcode
 
             m_NetworkSettings = new NetworkSettings(Allocator.Persistent);
 
+#if !UNITY_WEBGL
             // If the user sends a message of exactly m_MaxPayloadSize in length, we need to
             // account for the overhead of its length when we store it in the send queue.
             var fragmentationCapacity = m_MaxPayloadSize + BatchedSendQueue.PerMessageOverhead;
@@ -900,6 +903,7 @@ namespace Unity.Netcode
                 .WithBaselibNetworkInterfaceParameters(
                     receiveQueueCapacity: m_MaxPacketQueueSize,
                     sendQueueCapacity: m_MaxPacketQueueSize);
+#endif
         }
 
         public override NetcodeNetworkEvent PollEvent(out ulong clientId, out ArraySegment<byte> payload, out float receiveTime)


### PR DESCRIPTION
MTT-2823

The adapter makes (indirect) references to baselib socket parameters, which are not available in WebGL builds. This causes the package to produce compilation errors when installed (even if not used). While WebGL may not be supported, there are reports of users installing the package in WebGL projects (say if they use the UTP transport for non-WebGL builds, and another transport for WebGL builds). This PR fixes compilation of the package on WebGL.

## Changelog

### com.unity.netcode.adapter.utp

* Fixed: Fixed compilation on WebGL. Note that the platform is still unsupported, but at least including the package in a WebGL project will not create compilation errors anymore.

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.