### PR TITLE
fix: notification of missing networkobject on standalone networkbehaviour

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -13,7 +13,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Changed
 
 ### Fixed
-
+- Fixed user never being notified in the editor that a NetworkBehaviour requires a NetworkObject to function properly. (#1808)
 - Fixed PlayerObjects and dynamically spawned NetworkObjects not being added to the NetworkClient's OwnedObjects (#1801)
 - Fixed issue where NetworkManager would continue starting even if the NetworkTransport selected failed. (#1780)
 - Fixed issue when spawning new player if an already existing player exists it does not remove IsPlayer from the previous player (#1779)

--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -271,6 +271,12 @@ namespace Unity.Netcode.Editor
             }
         }
 
+        /// <summary>
+        /// This allows users to reset the Auto-Add NetworkObject preference
+        /// so the next time they add a NetworkBehaviour to a GameObject without
+        /// a NetworkObject it will display the dialog box again and not
+        /// automatically add a NetworkObject.
+        /// </summary>
         [MenuItem("Netcode/General/Reset Auto-Add NetworkObject", false, 1)]
         private static void ResetMultiplayerToolsTipStatus()
         {

--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -211,5 +211,64 @@ namespace Unity.Netcode.Editor
             serializedObject.ApplyModifiedProperties();
             EditorGUI.EndChangeCheck();
         }
+
+        /// <summary>
+        /// Invoked once when a NetworkBehaviour component is
+        /// displayed in the inspector view.
+        /// </summary>
+        private void OnEnable()
+        {
+            // When we first add a NetworkBehaviour this editor will be enabled
+            // so we go ahead and check for an already existing NetworkObject here
+            CheckForNetworkObject((target as NetworkBehaviour).gameObject);
+        }
+
+        internal const string AutoAddNetworkObjectIfNoneExists = "AutoAdd-NetworkObject-When-None-Exist";
+
+        public static void CheckForNetworkObject(GameObject gameObject, bool networkObjectRemoved = false)
+        {
+            // If there are no NetworkBehaviours or no gameObject, then exit early
+            if (gameObject == null || gameObject.GetComponent<NetworkBehaviour>() == null && gameObject.GetComponentInChildren<NetworkBehaviour>() == null)
+            {
+                return;
+            }
+
+            // Otherwise, check to see if there is a NetworkObject and if not notify the user that NetworkBehaviours
+            // require that the relative GameObject has a NetworkObject component.
+            var networkObject = gameObject.GetComponent<NetworkObject>();
+            if (networkObject == null)
+            {
+                networkObject = gameObject.GetComponentInChildren<NetworkObject>();
+
+                if (networkObject == null)
+                {
+                    if (networkObjectRemoved && EditorPrefs.HasKey(AutoAddNetworkObjectIfNoneExists) && EditorPrefs.GetBool(AutoAddNetworkObjectIfNoneExists))
+                    {
+                        Debug.LogWarning($"{gameObject.name} still has {nameof(NetworkBehaviour)}s and Auto-Add NetworkObjects is enabled. A NetworkObject is being added back to {gameObject.name}.");
+                        Debug.Log($"To reset Auto-Add NetworkObjects: Select the Netcode->General->Reset Auto-Add NetworkObject menu item.");
+                    }
+
+                    // Notify and provide the option to add it one time, always add a NetworkObject, or do nothing and let the user manually add it
+                    if (EditorUtility.DisplayDialog($"{nameof(NetworkBehaviour)}s require a {nameof(NetworkObject)}",
+                    $"{gameObject.name} does not have a {nameof(NetworkObject)} component.  Would you like to add one now?", "Yes", "No (manually add it)",
+                    DialogOptOutDecisionType.ForThisMachine, AutoAddNetworkObjectIfNoneExists))
+                    {
+                        gameObject.AddComponent<NetworkObject>();
+                        var activeScene = UnityEngine.SceneManagement.SceneManager.GetActiveScene();
+                        UnityEditor.SceneManagement.EditorSceneManager.MarkSceneDirty(activeScene);
+                        UnityEditor.SceneManagement.EditorSceneManager.SaveScene(activeScene);
+                    }
+                }
+            }
+        }
+
+        [MenuItem("Netcode/General/Reset Auto-Add NetworkObject", false, 1)]
+        private static void ResetMultiplayerToolsTipStatus()
+        {
+            if (EditorPrefs.HasKey(AutoAddNetworkObjectIfNoneExists))
+            {
+                EditorPrefs.SetBool(AutoAddNetworkObjectIfNoneExists, false);
+            }
+        }
     }
 }

--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -225,6 +225,11 @@ namespace Unity.Netcode.Editor
 
         internal const string AutoAddNetworkObjectIfNoneExists = "AutoAdd-NetworkObject-When-None-Exist";
 
+        /// <summary>
+        /// Used to determine if a GameObject has one or more NetworkBehaviours but
+        /// does not already have a NetworkObject component.  If not it will notify
+        /// the user that NetworkBehaviours require a NetworkObject.
+        /// </summary>
         public static void CheckForNetworkObject(GameObject gameObject, bool networkObjectRemoved = false)
         {
             // If there are no NetworkBehaviours or no gameObject, then exit early
@@ -242,6 +247,10 @@ namespace Unity.Netcode.Editor
 
                 if (networkObject == null)
                 {
+                    // If we are removing a NetworkObject but there is still one or more NetworkBehaviour components
+                    // and the user has already turned "Auto-Add NetworkObject" on when first notified about the requirement
+                    // then just send a reminder to the user why the NetworkObject they just deleted seemingly "re-appeared"
+                    // again.
                     if (networkObjectRemoved && EditorPrefs.HasKey(AutoAddNetworkObjectIfNoneExists) && EditorPrefs.GetBool(AutoAddNetworkObjectIfNoneExists))
                     {
                         Debug.LogWarning($"{gameObject.name} still has {nameof(NetworkBehaviour)}s and Auto-Add NetworkObjects is enabled. A NetworkObject is being added back to {gameObject.name}.");

--- a/com.unity.netcode.gameobjects/Editor/NetworkObjectEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkObjectEditor.cs
@@ -100,5 +100,28 @@ namespace Unity.Netcode.Editor
                 GUI.enabled = guiEnabled;
             }
         }
+
+        private GameObject m_GameObject;
+
+        /// <summary>
+        /// Invoked once when a NetworkObject component is
+        /// displayed in the inspector view.
+        /// </summary>
+        private void OnEnable()
+        {
+            // We set the GameObject upon being enabled because when the
+            // NetworkObject component is removed (i.e. when OnDestroy is invoked)
+            // it is no longer valid/available.
+            m_GameObject = (target as NetworkObject).gameObject;
+        }
+
+        /// <summary>
+        /// Invoked when a NetworkObject component is removed from
+        /// a GameObject.
+        /// </summary>
+        private void OnDestroy()
+        {
+            NetworkBehaviourEditor.CheckForNetworkObject(m_GameObject, true);
+        }
     }
 }

--- a/com.unity.netcode.gameobjects/Editor/NetworkObjectEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkObjectEditor.cs
@@ -101,6 +101,7 @@ namespace Unity.Netcode.Editor
             }
         }
 
+        // Saved for use in OnDestroy
         private GameObject m_GameObject;
 
         /// <summary>
@@ -116,8 +117,7 @@ namespace Unity.Netcode.Editor
         }
 
         /// <summary>
-        /// Invoked when a NetworkObject component is removed from
-        /// a GameObject.
+        /// Invoked when a NetworkObject component is removed from a GameObject.
         /// </summary>
         private void OnDestroy()
         {

--- a/com.unity.netcode.gameobjects/Editor/NetworkObjectEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkObjectEditor.cs
@@ -117,10 +117,14 @@ namespace Unity.Netcode.Editor
         }
 
         /// <summary>
-        /// Invoked when a NetworkObject component is removed from a GameObject.
+        /// Invoked once when a NetworkObject component is
+        /// no longer displayed in the inspector view.
         /// </summary>
         private void OnDestroy()
         {
+            // Since this is also invoked when a NetworkObject component is removed
+            // from a GameObject, we go ahead and check for a NetworkObject when
+            // this custom editor is destroyed.
             NetworkBehaviourEditor.CheckForNetworkObject(m_GameObject, true);
         }
     }


### PR DESCRIPTION
This addresses the issue where a user could add a NetworkBehaviour to a GameObject and forget to not also include a NetworkObject and never be notified that NetworkBehaviours require a GameObject in order to function properly.  

[MTT-1353](https://jira.unity3d.com/browse/MTT-1353)

## Changelog
### com.unity.netcode.gameobjects
- Fixed: User never being notified in the editor that a NetworkBehaviour requires a NetworkObject to function properly.

## Testing and Documentation
* No tests have been added.

## Additional Information
The first time a user adds a NetworkBehaviour to a GameObject that doesn't have a NetworkObject they will be presented with the following dialog box:
![image](https://user-images.githubusercontent.com/73188597/158683452-33f4036f-ef7e-44b1-8e9a-414aa6620997.png)
If the user selects "Yes - Do not show me this message again on this machine", then from that point forward if a NetworkBehaviour is added to a GameObject that doesn't already have a NetworkObject...it will automatically add one.

This setting can be reset (i.e. dialog box will appear the next time) via this drop down menu item:
![image](https://user-images.githubusercontent.com/73188597/158683928-426eb0cf-c7c6-410f-bdb3-f9b412069690.png)
