### PR TITLE
refactor: remove animation, physics and physics2d dependencies

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -14,6 +14,10 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+### Removed
+
+- Removed `com.unity.modules.animation`, `com.unity.modules.physics` and `com.unity.modules.physics2d` dependencies from the package (#1812)
+
 ### Fixed
 
 - Fixed user never being notified in the editor that a NetworkBehaviour requires a NetworkObject to function properly. (#1808)

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -1,3 +1,4 @@
+#if COM_UNITY_MODULES_ANIMATION
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
@@ -427,3 +428,4 @@ namespace Unity.Netcode.Components
         }
     }
 }
+#endif // COM_UNITY_MODULES_ANIMATION

--- a/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
@@ -1,3 +1,4 @@
+#if COM_UNITY_MODULES_PHYSICS
 using UnityEngine;
 
 namespace Unity.Netcode.Components
@@ -78,3 +79,4 @@ namespace Unity.Netcode.Components
         }
     }
 }
+#endif // COM_UNITY_MODULES_PHYSICS

--- a/com.unity.netcode.gameobjects/Components/NetworkRigidbody2D.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkRigidbody2D.cs
@@ -1,3 +1,4 @@
+#if COM_UNITY_MODULES_PHYSICS2D
 using UnityEngine;
 
 namespace Unity.Netcode.Components
@@ -78,3 +79,4 @@ namespace Unity.Netcode.Components
         }
     }
 }
+#endif // COM_UNITY_MODULES_PHYSICS2D

--- a/com.unity.netcode.gameobjects/Components/com.unity.netcode.components.asmdef
+++ b/com.unity.netcode.gameobjects/Components/com.unity.netcode.components.asmdef
@@ -5,5 +5,22 @@
         "Unity.Netcode.Runtime",
         "Unity.Collections"
     ],
-    "allowUnsafeCode": true
+    "allowUnsafeCode": true,
+    "versionDefines": [
+        {
+            "name": "com.unity.modules.animation",
+            "expression": "",
+            "define": "COM_UNITY_MODULES_ANIMATION"
+        },
+        {
+            "name": "com.unity.modules.physics",
+            "expression": "",
+            "define": "COM_UNITY_MODULES_PHYSICS"
+        },
+        {
+            "name": "com.unity.modules.physics2d",
+            "expression": "",
+            "define": "COM_UNITY_MODULES_PHYSICS2D"
+        }
+    ]
 }

--- a/com.unity.netcode.gameobjects/Editor/NetworkTransformEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkTransformEditor.cs
@@ -112,6 +112,7 @@ namespace Unity.Netcode.Editor
             EditorGUILayout.PropertyField(m_InLocalSpaceProperty);
             EditorGUILayout.PropertyField(m_InterpolateProperty);
 
+#if COM_UNITY_MODULES_PHYSICS
             // if rigidbody is present but network rigidbody is not present
             var go = ((NetworkTransform)target).gameObject;
             if (go.TryGetComponent<Rigidbody>(out _) && go.TryGetComponent<NetworkRigidbody>(out _) == false)
@@ -119,12 +120,15 @@ namespace Unity.Netcode.Editor
                 EditorGUILayout.HelpBox("This GameObject contains a Rigidbody but no NetworkRigidbody.\n" +
                     "Add a NetworkRigidbody component to improve Rigidbody synchronization.", MessageType.Warning);
             }
+#endif // COM_UNITY_MODULES_PHYSICS
 
+#if COM_UNITY_MODULES_PHYSICS2D
             if (go.TryGetComponent<Rigidbody2D>(out _) && go.TryGetComponent<NetworkRigidbody2D>(out _) == false)
             {
                 EditorGUILayout.HelpBox("This GameObject contains a Rigidbody2D but no NetworkRigidbody2D.\n" +
                     "Add a NetworkRigidbody2D component to improve Rigidbody2D synchronization.", MessageType.Warning);
             }
+#endif // COM_UNITY_MODULES_PHYSICS2D
 
             serializedObject.ApplyModifiedProperties();
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/NetworkAnimatorTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator/NetworkAnimatorTests.cs
@@ -1,3 +1,4 @@
+#if COM_UNITY_MODULES_ANIMATION
 using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework;
@@ -235,3 +236,4 @@ namespace Unity.Netcode.RuntimeTests
         }
     }
 }
+#endif // COM_UNITY_MODULES_ANIMATION

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbody2DTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbody2DTest.cs
@@ -1,3 +1,4 @@
+#if COM_UNITY_MODULES_PHYSICS2D
 using System.Collections;
 using NUnit.Framework;
 using Unity.Netcode.Components;
@@ -76,3 +77,4 @@ namespace Unity.Netcode.RuntimeTests
         }
     }
 }
+#endif // COM_UNITY_MODULES_PHYSICS2D

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbodyTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbodyTest.cs
@@ -1,3 +1,4 @@
+#if COM_UNITY_MODULES_PHYSICS
 using System.Collections;
 using NUnit.Framework;
 using Unity.Netcode.Components;
@@ -75,3 +76,4 @@ namespace Unity.Netcode.RuntimeTests
         }
     }
 }
+#endif // COM_UNITY_MODULES_PHYSICS

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -5,9 +5,6 @@
     "version": "1.0.0-pre.6",
     "unity": "2020.3",
     "dependencies": {
-        "com.unity.modules.animation": "1.0.0",
-        "com.unity.modules.physics": "1.0.0",
-        "com.unity.modules.physics2d": "1.0.0",
         "com.unity.nuget.mono-cecil": "1.10.1",
         "com.unity.collections": "1.1.0"
     }

--- a/minimalproject/Packages/packages-lock.json
+++ b/minimalproject/Packages/packages-lock.json
@@ -38,9 +38,6 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.modules.animation": "1.0.0",
-        "com.unity.modules.physics": "1.0.0",
-        "com.unity.modules.physics2d": "1.0.0",
         "com.unity.nuget.mono-cecil": "1.10.1",
         "com.unity.collections": "1.1.0"
       }
@@ -63,12 +60,6 @@
       },
       "url": "https://packages.unity.com"
     },
-    "com.unity.modules.animation": {
-      "version": "1.0.0",
-      "depth": 1,
-      "source": "builtin",
-      "dependencies": {}
-    },
     "com.unity.modules.imgui": {
       "version": "1.0.0",
       "depth": 3,
@@ -78,18 +69,6 @@
     "com.unity.modules.jsonserialize": {
       "version": "1.0.0",
       "depth": 3,
-      "source": "builtin",
-      "dependencies": {}
-    },
-    "com.unity.modules.physics": {
-      "version": "1.0.0",
-      "depth": 1,
-      "source": "builtin",
-      "dependencies": {}
-    },
-    "com.unity.modules.physics2d": {
-      "version": "1.0.0",
-      "depth": 1,
       "source": "builtin",
       "dependencies": {}
     }

--- a/testproject/Packages/packages-lock.json
+++ b/testproject/Packages/packages-lock.json
@@ -70,8 +70,8 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.netcode.gameobjects": "1.0.0-pre.5",
-        "com.unity.transport": "1.0.0-pre.13"
+        "com.unity.netcode.gameobjects": "1.0.0-pre.6",
+        "com.unity.transport": "1.0.0-pre.15"
       }
     },
     "com.unity.netcode.gameobjects": {
@@ -79,9 +79,6 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.modules.animation": "1.0.0",
-        "com.unity.modules.physics": "1.0.0",
-        "com.unity.modules.physics2d": "1.0.0",
         "com.unity.nuget.mono-cecil": "1.10.1",
         "com.unity.collections": "1.1.0"
       }
@@ -188,7 +185,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.transport": {
-      "version": "1.0.0-pre.13",
+      "version": "1.0.0-pre.15",
       "depth": 1,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
- removing `com.unity.modules.animation`, `com.unity.modules.physics` and `com.unity.modules.physics2d` hard dependencies from the SDK
- defining macros based on package presence and `#if <macro>` guarding `NetworkAnimator`, `NetworkRigidbody`, `NetworkRigidbody2D` and related tests and editor code
- `testproject` has all these 3 packages in its `manifest.json` file and is running `NetworkAnimatorTests`, `NetworkRigidbodyTests` and `NetworkRigidbody2DTests`
- `minimalproject` doesn't have any of these 3 packages and validating the absence of these packages not causing any dependency issues
- note: we're thinking of modifying some yamato jobs with `unity-config` CLI to progressively add/remove packages during `testproject` tests (run testproject & sdk tests with and without these packages) — but that'll be addressed later

FYI @JesseOlmer @lpmaurice @mattwalsh-unity 

MTT-2702