### PR TITLE
fix: Track RTT in seconds rather than milliseconds

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
@@ -462,15 +462,15 @@ namespace Unity.Netcode
 #endif
         }
 
-        public void TrackRttToServer(int rtt)
+        public void TrackRttToServer(int rttMilliseconds)
         {
 #if MULTIPLAYER_TOOLS_1_0_0_PRE_7
             if (!CanSendMetrics)
             {
                 return;
             }
-
-            m_RttToServerGauge.Set(rtt);
+            var rttSeconds = rttMilliseconds * 1e-3;
+            m_RttToServerGauge.Set(rttSeconds);
 #endif
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/RttMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/RttMetricsTests.cs
@@ -92,7 +92,7 @@ namespace Unity.Netcode.RuntimeTests.Metrics
             foreach (var clientGaugeMetricValue in clientGaugeMetricValues)
             {
                 var rttValue = clientGaugeMetricValue.AssertMetricValueHaveBeenFound();
-                Assert.That(rttValue, Is.GreaterThanOrEqualTo(1f));
+                Assert.That(rttValue, Is.GreaterThanOrEqualTo(1e-3f));
             }
         }
     }


### PR DESCRIPTION
To maintain compatibility with the RNSM, which has been modified to only
accept metrics in base units such as Bytes and Seconds, and not units
with a metric prefix such as milliseconds.

https://jira.unity3d.com/browse/MTT-2906

<!-- Add RFC link here if applicable. -->