### PR TITLE
fix: Fixed NetworkVar assignment of the same value triggering replication

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using System;
+using System.Runtime.CompilerServices;
 using Unity.Collections.LowLevel.Unsafe;
 
 namespace Unity.Netcode
@@ -106,6 +107,7 @@ namespace Unity.Netcode
         // Compares two values of the same unmanaged type by underlying memory
         // Ignoring any overriden value checks
         // Size is fixed
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe bool ValueEquals(ref T a, ref T b)
         {
             // get unmanaged pointers

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using System;
+using Unity.Collections.LowLevel.Unsafe;
 
 namespace Unity.Netcode
 {
@@ -88,7 +89,7 @@ namespace Unity.Netcode
             set
             {
                 // Compare bitwise
-                if (ValueEquals(m_InternalValue, value))
+                if (ValueEquals(ref m_InternalValue, ref value))
                 {
                     return;
                 }
@@ -105,27 +106,14 @@ namespace Unity.Netcode
         // Compares two values of the same unmanaged type bitwise
         // Ignoring any overriden value checks
         // Size is fixed
-        private static unsafe bool ValueEquals(in T a, in T b)
+        private static unsafe bool ValueEquals(ref T a, ref T b)
         {
-            // get native type pointer
-            fixed (T* pa = &a)
-            fixed (T* pb = &b)
-            {
-                // convert to byte pointer type
-                var aptr = (byte*)pa;
-                var bptr = (byte*)pb;
+            // get unmanaged pointers
+            var aptr = UnsafeUtility.AddressOf(ref a);
+            var bptr = UnsafeUtility.AddressOf(ref b);
 
-                // compare
-                for (var i = 0; i < sizeof(T); i++)
-                {
-                    if (aptr[i] != bptr[i])
-                    {
-                        return false;
-                    }
-                }
-            }
-
-            return true;
+            // compare addresses
+            return UnsafeUtility.MemCmp(aptr, bptr, sizeof(T)) == 0;
         }
 
 

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -88,7 +88,8 @@ namespace Unity.Netcode
             get => m_InternalValue;
             set
             {
-                if (EqualityComparer<T>.Default.Equals(m_InternalValue, value))
+                // Compare bitwise
+                if (ValueEquals(m_InternalValue, value))
                 {
                     return;
                 }
@@ -101,6 +102,33 @@ namespace Unity.Netcode
                 Set(value);
             }
         }
+
+        // Compares two values of the same unmanaged type bitwise
+        // Ignoring any overriden value checks
+        // Size is fixed
+        private static unsafe bool ValueEquals(in T a, in T b)
+        {
+            // get native type pointer
+            fixed (T* pa = &a)
+            fixed (T* pb = &b)
+            {
+                // convert to byte pointer type
+                var aptr = (byte*)pa;
+                var bptr = (byte*)pb;
+
+                // compare
+                for (var i = 0; i < sizeof(T); i++)
+                {
+                    if (aptr[i] != bptr[i])
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
 
         private protected void Set(T value)
         {

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -103,7 +103,7 @@ namespace Unity.Netcode
             }
         }
 
-        // Compares two values of the same unmanaged type bitwise
+        // Compares two values of the same unmanaged type by underlying memory
         // Ignoring any overriden value checks
         // Size is fixed
         private static unsafe bool ValueEquals(ref T a, ref T b)

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -1,6 +1,5 @@
 using UnityEngine;
 using System;
-using System.Collections.Generic;
 
 namespace Unity.Netcode
 {

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using System;
+using System.Collections.Generic;
 
 namespace Unity.Netcode
 {
@@ -87,6 +88,11 @@ namespace Unity.Netcode
             get => m_InternalValue;
             set
             {
+                if (EqualityComparer<T>.Default.Equals(m_InternalValue, value))
+                {
+                    return;
+                }
+
                 if (m_NetworkBehaviour && !CanClientWrite(m_NetworkBehaviour.NetworkManager.LocalClientId))
                 {
                     throw new InvalidOperationException("Client is not allowed to write to this NetworkVariable");

--- a/com.unity.netcode.gameobjects/Tests/Editor/NetworkVar.meta
+++ b/com.unity.netcode.gameobjects/Tests/Editor/NetworkVar.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ed3be13d96c34bc4b8676ce550cee041
+timeCreated: 1647861659

--- a/com.unity.netcode.gameobjects/Tests/Editor/NetworkVar/NetworkVarTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/NetworkVar/NetworkVarTests.cs
@@ -7,7 +7,7 @@ namespace Unity.Netcode.EditorTests.NetworkVar
         [Test]
         public void TestAssignmentUnchanged()
         {
-            NetworkVariable<int> intVar = new NetworkVariable<int>();
+            var intVar = new NetworkVariable<int>();
 
             intVar.Value = 314159265;
 
@@ -22,11 +22,11 @@ namespace Unity.Netcode.EditorTests.NetworkVar
         [Test]
         public void TestAssignmentChanged()
         {
-            NetworkVariable<int> intVar = new NetworkVariable<int>();
+            var intVar = new NetworkVariable<int>();
 
             intVar.Value = 314159265;
 
-            bool changed = false;
+            var changed = false;
 
             intVar.OnValueChanged += (value, newValue) =>
             {

--- a/com.unity.netcode.gameobjects/Tests/Editor/NetworkVar/NetworkVarTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/NetworkVar/NetworkVarTests.cs
@@ -1,0 +1,41 @@
+using NUnit.Framework;
+
+namespace Unity.Netcode.EditorTests.NetworkVar
+{
+    public class NetworkVarTests
+    {
+        [Test]
+        public void TestAssignmentUnchanged()
+        {
+            NetworkVariable<int> intVar = new NetworkVariable<int>();
+
+            intVar.Value = 314159265;
+
+            intVar.OnValueChanged += (value, newValue) =>
+            {
+                Assert.Fail("OnValueChanged was invoked when setting the same value");
+            };
+
+            intVar.Value = 314159265;
+        }
+
+        [Test]
+        public void TestAssignmentChanged()
+        {
+            NetworkVariable<int> intVar = new NetworkVariable<int>();
+
+            intVar.Value = 314159265;
+
+            bool changed = false;
+
+            intVar.OnValueChanged += (value, newValue) =>
+            {
+                changed = true;
+            };
+
+            intVar.Value = 314159266;
+
+            Assert.True(changed);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Editor/NetworkVar/NetworkVarTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Editor/NetworkVar/NetworkVarTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a7cdd8c1251f4352b1f1d4825dc85182
+timeCreated: 1647861669


### PR DESCRIPTION


<!-- Replace this line with what this PR does and why.  Describe what you'd like reviewers to know, how you applied the Engineering principles, and any interesting tradeoffs made.  Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

Setting the value of a NetworkVar to the same value it's currently set to no longer triggers replication.

<!-- Add JIRA link here. Short version (e.g. MTT-123) also works and gets auto-linked. -->
MTT-2882

<!-- Add RFC link here if applicable. -->

## Changelog

### com.unity.netcode.gameobjects
- Fixed: NetworkVar assignment of the same value no longer triggers replication

## Testing and Documentation

* Includes unit tests.
* No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->