### PR TITLE
fix: key not found exception when client never connects

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -19,13 +19,14 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Removed `com.unity.modules.animation`, `com.unity.modules.physics` and `com.unity.modules.physics2d` dependencies from the package (#1812)
 
 ### Fixed
+- Fixed client throws a key not found exception when it times out using UNet or UTP. (#1821)
+- Fixed network variable updates are no longer limited to 32,768 bytes when NetworkConfig.EnsureNetworkVariableLengthSafety is enabled. The limits are now determined by what the transport can send in a message. (#1811)
 - Fixed in-scene NetworkObjects get destroyed if a client fails to connect and shuts down the NetworkManager. (#1809)
 - Fixed user never being notified in the editor that a NetworkBehaviour requires a NetworkObject to function properly. (#1808)
 - Fixed PlayerObjects and dynamically spawned NetworkObjects not being added to the NetworkClient's OwnedObjects (#1801)
 - Fixed issue where NetworkManager would continue starting even if the NetworkTransport selected failed. (#1780)
 - Fixed issue when spawning new player if an already existing player exists it does not remove IsPlayer from the previous player (#1779)
 - Fixed lack of notification that NetworkManager and NetworkObject cannot be added to the same GameObject with in-editor notifications (#1777)
-- Network variable updates are no longer limited to 32,768 bytes when NetworkConfig.EnsureNetworkVariableLengthSafety is enabled. The limits are now determined by what the transport can send in a message. (#1811)
 
 ## [1.0.0-pre.6] - 2022-03-02
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1436,17 +1436,30 @@ namespace Unity.Netcode
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
                     s_TransportDisconnect.Begin();
 #endif
-                    clientId = TransportIdToClientId(clientId);
-
-                    OnClientDisconnectCallback?.Invoke(clientId);
-
-                    m_TransportIdToClientIdMap.Remove(transportId);
-                    m_ClientIdToTransportIdMap.Remove(clientId);
-
                     if (NetworkLog.CurrentLogLevel <= LogLevel.Developer)
                     {
                         NetworkLog.LogInfo($"Disconnect Event From {clientId}");
                     }
+
+                    if (!IsServer && !m_TransportIdToClientIdMap.ContainsKey(clientId))
+                    {
+                        // We just use the transport ID assigned if we never connected
+                        OnClientDisconnectCallback?.Invoke(clientId);
+                        Shutdown();
+#if DEVELOPMENT_BUILD || UNITY_EDITOR
+                        s_TransportDisconnect.End();
+#endif
+                        break;
+                    }
+
+                    clientId = TransportIdToClientId(clientId);
+
+                    m_TransportIdToClientIdMap.Remove(transportId);
+                    m_ClientIdToTransportIdMap.Remove(clientId);
+
+
+                    OnClientDisconnectCallback?.Invoke(clientId);
+
 
                     if (IsServer)
                     {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1471,11 +1471,11 @@ namespace Unity.Netcode
             // This check is for clients that attempted to connect but failed.
             // When this happens, the client will not have an entry within the
             // m_TransportIdToClientIdMap or m_ClientIdToTransportIdMap lookup
-            // tables so we exit early and just use the transport clientId
-            // for the disconnect event.
+            // tables so we exit early and just return 0 to be used for the
+            // disconnect event.
             if (!IsServer && !m_TransportIdToClientIdMap.ContainsKey(clientId))
             {
-                return clientId;
+                return 0;
             }
 
             clientId = TransportIdToClientId(clientId);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ClientFailsToConnectTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ClientFailsToConnectTest.cs
@@ -1,0 +1,76 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Unity.Netcode.TestHelpers.Runtime;
+#if UNITY_UNET_PRESENT
+using Unity.Netcode.Transports.UNET;
+#endif
+
+namespace Unity.Netcode.RuntimeTests
+{
+    public class ClientOnlyConnectionTests
+    {
+        private NetworkManager m_ClientNetworkManager;
+        private GameObject m_NetworkManagerGameObject;
+        private WaitForSeconds m_DefaultWaitForTick = new WaitForSeconds(1.0f / 30);
+        private bool m_WasDisconnected;
+        private TimeoutHelper m_TimeoutHelper;
+
+        [SetUp]
+        public void Setup()
+        {
+            m_WasDisconnected = false;
+            m_NetworkManagerGameObject = new GameObject();
+            m_ClientNetworkManager = m_NetworkManagerGameObject.AddComponent<NetworkManager>();
+            m_ClientNetworkManager.NetworkConfig = new NetworkConfig();
+#if UNITY_UNET_PRESENT
+            m_TimeoutHelper = new TimeoutHelper(30);
+            m_ClientNetworkManager.NetworkConfig.NetworkTransport = m_NetworkManagerGameObject.AddComponent<UNetTransport>();
+#else
+            // Default is 1000ms per connection attempt and 60 connection attempts (60s)
+            // Currently there is no easy way to set these values other than in-editor
+            m_TimeoutHelper = new TimeoutHelper(70);
+            m_ClientNetworkManager.NetworkConfig.NetworkTransport = m_NetworkManagerGameObject.AddComponent<UnityTransport>();
+#endif
+        }
+
+        [UnityTest]
+        public IEnumerator ClientFailsToConnect()
+        {
+            // Wait for the disconnected event
+            m_ClientNetworkManager.OnClientDisconnectCallback += M_ClientNetworkManager_OnClientDisconnectCallback;
+
+            // Only start the client (so it will timeout)
+            m_ClientNetworkManager.StartClient();
+
+#if !UNITY_UNET_PRESENT
+            // Unity Transport throws an error when it times out
+            LogAssert.Expect(LogType.Error, "Failed to connect to server.");
+#endif
+            yield return NetcodeIntegrationTest.WaitForConditionOrTimeOut(() => m_WasDisconnected, m_TimeoutHelper);
+            Assert.False(m_TimeoutHelper.TimedOut, "Timed out waiting for client to timeout waiting to connect!");
+
+            // Shutdown the client
+            m_ClientNetworkManager.Shutdown();
+
+            // Wait for a tick
+            yield return m_DefaultWaitForTick;
+        }
+
+        private void M_ClientNetworkManager_OnClientDisconnectCallback(ulong obj)
+        {
+            m_WasDisconnected = true;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (m_NetworkManagerGameObject != null)
+            {
+                Object.DestroyImmediate(m_NetworkManagerGameObject);
+            }
+        }
+    }
+}
+

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ClientFailsToConnectTest.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ClientFailsToConnectTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 639fe2161ab25c54f94ce6eb991e668a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This fixes the issue where when a client would try to connect to a server but never established a connection it would throw a key not found exception.

[NCCBUG-130](https://jira.unity3d.com/browse/NCCBUG-130)

## Changelog
### com.unity.netcode.gameobjects
- Fixed: Client throws a key not found exception when it times out using UNet or UTP.

## Testing and Documentation
* Includes integration tests.