### PR TITLE
fix: utp connectiontests serverdisconnectwithdatainqueue wait for client connect

### DIFF
--- a/com.unity.netcode.adapter.utp/Tests/Runtime/ConnectionTests.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/ConnectionTests.cs
@@ -294,7 +294,7 @@ namespace Unity.Netcode.UTP.RuntimeTests
             m_Server.StartServer();
             m_Clients[0].StartClient();
 
-            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ServerEvents);
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[0]);
 
             var data = new ArraySegment<byte>(new byte[] { 42 });
             m_Server.Send(m_ServerEvents[0].ClientID, data, NetworkDelivery.Unreliable);

--- a/com.unity.netcode.adapter.utp/Tests/Runtime/ConnectionTests.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/ConnectionTests.cs
@@ -294,6 +294,7 @@ namespace Unity.Netcode.UTP.RuntimeTests
             m_Server.StartServer();
             m_Clients[0].StartClient();
 
+            // Wait for the client before we disconnect the client
             yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[0]);
 
             var data = new ArraySegment<byte>(new byte[] { 42 });

--- a/com.unity.netcode.adapter.utp/Tests/Runtime/ConnectionTests.cs
+++ b/com.unity.netcode.adapter.utp/Tests/Runtime/ConnectionTests.cs
@@ -294,7 +294,7 @@ namespace Unity.Netcode.UTP.RuntimeTests
             m_Server.StartServer();
             m_Clients[0].StartClient();
 
-            // Wait for the client before we disconnect the client
+            // Wait for the client to connect before we disconnect the client
             yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[0]);
 
             var data = new ArraySegment<byte>(new byte[] { 42 });


### PR DESCRIPTION
Fix for potential instability in the ServerDisconnectWithDataInQueue

## Testing and Documentation
* Includes integration test fix
