### PR TITLE
chore: Update PR template to remind people to add JIRA ticket to PR title [skipci]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 <!-- Replace this line with what this PR does and why.  Describe what you'd like reviewers to know, how you applied the Engineering principles, and any interesting tradeoffs made.  Delete bullet points below that don't apply, and update the changelog section as appropriate. -->
 
-<!-- Add JIRA link to PR title. Short version (e.g. MTT-123) works and gets auto-linked. -->
+<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->
 
 <!-- Add RFC link here if applicable. -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 <!-- Replace this line with what this PR does and why.  Describe what you'd like reviewers to know, how you applied the Engineering principles, and any interesting tradeoffs made.  Delete bullet points below that don't apply, and update the changelog section as appropriate. -->
 
-<!-- Add JIRA link here. Short version (e.g. MTT-123) also works and gets auto-linked. -->
+<!-- Add JIRA link to PR title. Short version (e.g. MTT-123) works and gets auto-linked. -->
 
 <!-- Add RFC link here if applicable. -->
 


### PR DESCRIPTION
Changing a note in the PR template to remind people to add the jira ticket to the PR title. Adding it to the title ensures the PR is automatically associated with the JIRA ticket. Adding the ticket to the body of the PR doesn't do anything (it just creates a hyperlink in the body...)

This policy will also make changelog generation "easier" since the JIRA ticket will automatically be included in auto-generated logs.

## Changelog

## Testing and Documentation

* No tests have been added.
* No documentation changes or additions were necessary.