### PR TITLE
feat: UTP Packet Loss tracking [MTT-1654]

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Metrics/INetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/INetworkMetrics.cs
@@ -87,11 +87,13 @@ namespace Unity.Netcode
 
         void TrackPacketReceived(uint packetCount);
 
-        void TrackRttToServer(int rtt);
+        void UpdateRttToServer(int rtt);
 
         void UpdateNetworkObjectsCount(int count);
 
         void UpdateConnectionsCount(int count);
+
+        void UpdatePacketLoss(float count);
 
         void DispatchFrame();
     }

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/INetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/INetworkMetrics.cs
@@ -93,7 +93,7 @@ namespace Unity.Netcode
 
         void UpdateConnectionsCount(int count);
 
-        void UpdatePacketLoss(float count);
+        void UpdatePacketLoss(float packetLoss);
 
         void DispatchFrame();
     }

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
@@ -500,7 +500,7 @@ namespace Unity.Netcode
 #endif
         }
 
-        public void UpdatePacketLoss(float count)
+        public void UpdatePacketLoss(float packetLoss)
         {
 #if MULTIPLAYER_TOOLS_1_0_0_PRE_7
             if (!CanSendMetrics)
@@ -508,7 +508,7 @@ namespace Unity.Netcode
                 return;
             }
 
-            m_PacketLossGauge.Set(count);
+            m_PacketLossGauge.Set(packetLoss);
 #endif
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
@@ -87,6 +87,7 @@ namespace Unity.Netcode
         {
             ShouldResetOnDispatch = true,
         };
+        private readonly Gauge m_PacketLossGauge = new Gauge(NetworkMetricTypes.PacketLoss.Id);
 #endif
 
         private ulong m_NumberOfMetricsThisFrame;
@@ -110,6 +111,7 @@ namespace Unity.Netcode
                 .WithGauges(m_RttToServerGauge)
                 .WithGauges(m_NetworkObjectsGauge)
                 .WithGauges(m_ConnectionsGauge)
+                .WithGauges(m_PacketLossGauge)
 #endif
                 .Build();
 
@@ -462,7 +464,7 @@ namespace Unity.Netcode
 #endif
         }
 
-        public void TrackRttToServer(int rttMilliseconds)
+        public void UpdateRttToServer(int rttMilliseconds)
         {
 #if MULTIPLAYER_TOOLS_1_0_0_PRE_7
             if (!CanSendMetrics)
@@ -495,6 +497,18 @@ namespace Unity.Netcode
             }
 
             m_ConnectionsGauge.Set(count);
+#endif
+        }
+
+        public void UpdatePacketLoss(float count)
+        {
+#if MULTIPLAYER_TOOLS_1_0_0_PRE_7
+            if (!CanSendMetrics)
+            {
+                return;
+            }
+
+            m_PacketLossGauge.Set(count);
 #endif
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/NullNetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/NullNetworkMetrics.cs
@@ -157,7 +157,7 @@ namespace Unity.Netcode
         {
         }
 
-        public void UpdatePacketLoss(float count)
+        public void UpdatePacketLoss(float packetLoss)
         {
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/NullNetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/NullNetworkMetrics.cs
@@ -145,7 +145,7 @@ namespace Unity.Netcode
         {
         }
 
-        public void TrackRttToServer(int rtt)
+        public void UpdateRttToServer(int rtt)
         {
         }
 
@@ -154,6 +154,10 @@ namespace Unity.Netcode
         }
 
         public void UpdateConnectionsCount(int count)
+        {
+        }
+
+        public void UpdatePacketLoss(float count)
         {
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -781,7 +781,7 @@ namespace Unity.Netcode.Transports.UTP
 
                 var packetReceived = (float)sharedContext->stats.PacketsReceived;
                 var packetDropped = (float)sharedContext->stats.PacketsDropped;
-                var packetLoss = packetReceived > 0 ? packetDropped/packetReceived*100 : 0;
+                var packetLoss = packetReceived > 0 ? packetDropped/packetReceived : 0;
 
                 return packetLoss;
             }

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -781,7 +781,7 @@ namespace Unity.Netcode.Transports.UTP
 
                 var packetReceived = (float)sharedContext->stats.PacketsReceived;
                 var packetDropped = (float)sharedContext->stats.PacketsDropped;
-                var packetLoss = packetReceived > 0 ? packetDropped/packetReceived : 0;
+                var packetLoss = packetReceived > 0 ? packetDropped / packetReceived : 0;
 
                 return packetLoss;
             }

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -710,7 +710,10 @@ namespace Unity.Netcode.Transports.UTP
             ExtractNetworkMetricsFromPipeline(m_ReliableSequencedPipeline, networkConnection);
 
             var rttValue = NetworkManager.IsServer ? 0 : ExtractRtt(networkConnection);
-            NetworkMetrics.TrackRttToServer(rttValue);
+            NetworkMetrics.UpdateRttToServer(rttValue);
+
+            var packetLoss = NetworkManager.IsServer ? 0 : ExtractPacketLoss(networkConnection);
+            NetworkMetrics.UpdatePacketLoss(packetLoss);
         }
 
         private void ExtractNetworkMetricsFromPipeline(NetworkPipeline pipeline, NetworkConnection networkConnection)
@@ -755,6 +758,32 @@ namespace Unity.Netcode.Transports.UTP
                 var sharedContext = (ReliableUtility.SharedContext*)sharedBuffer.GetUnsafePtr();
 
                 return sharedContext->RttInfo.LastRtt;
+            }
+        }
+
+        private float ExtractPacketLoss(NetworkConnection networkConnection)
+        {
+            if (m_Driver.GetConnectionState(networkConnection) != NetworkConnection.State.Connected)
+            {
+                return 0f;
+            }
+
+            m_Driver.GetPipelineBuffers(m_ReliableSequencedPipeline,
+                NetworkPipelineStageCollection.GetStageId(typeof(ReliableSequencedPipelineStage)),
+                networkConnection,
+                out _,
+                out _,
+                out var sharedBuffer);
+
+            unsafe
+            {
+                var sharedContext = (ReliableUtility.SharedContext*)sharedBuffer.GetUnsafePtr();
+
+                var packetReceived = (float)sharedContext->stats.PacketsReceived;
+                var packetDropped = (float)sharedContext->stats.PacketsDropped;
+                var packetLoss = packetReceived > 0 ? packetDropped/packetReceived*100 : 0;
+
+                return packetLoss;
             }
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/PacketLossMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/PacketLossMetricsTests.cs
@@ -17,7 +17,7 @@ namespace Unity.Netcode.RuntimeTests.Metrics
     public class PacketLossMetricsTests : NetcodeIntegrationTest
     {
         protected override int NumberOfClients => 1;
-
+        private readonly int m_PacketLossRate = 25;
         private int m_DropInterval = 5;
 
         public PacketLossMetricsTests()
@@ -32,7 +32,7 @@ namespace Unity.Netcode.RuntimeTests.Metrics
         protected override void OnServerAndClientsCreated()
         {
             var clientTransport = (UnityTransport)m_ClientNetworkManagers[0].NetworkConfig.NetworkTransport;
-            clientTransport.SetDebugSimulatorParameters(0, 0, 25);
+            clientTransport.SetDebugSimulatorParameters(0, 0, m_PacketLossRate);
 
             base.OnServerAndClientsCreated();
         }
@@ -62,7 +62,7 @@ namespace Unity.Netcode.RuntimeTests.Metrics
         [UnityTest]
         public IEnumerator TrackPacketLossAsClient()
         {
-            const double packetLossRate = 0.25;
+            double packetLossRate = m_PacketLossRate/100d;
             var clientNetworkManager = m_ClientNetworkManagers[0];
             var waitForPacketLossMetric = new WaitForGaugeMetricValues((clientNetworkManager.NetworkMetrics as NetworkMetrics).Dispatcher,
                 NetworkMetricTypes.PacketLoss,

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/PacketLossMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/PacketLossMetricsTests.cs
@@ -62,7 +62,7 @@ namespace Unity.Netcode.RuntimeTests.Metrics
         [UnityTest]
         public IEnumerator TrackPacketLossAsClient()
         {
-            const double packetLossRate = 25d;
+            const double packetLossRate = 0.25;
             var clientNetworkManager = m_ClientNetworkManagers[0];
             var waitForPacketLossMetric = new WaitForGaugeMetricValues((clientNetworkManager.NetworkMetrics as NetworkMetrics).Dispatcher,
                 NetworkMetricTypes.PacketLoss,

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/PacketLossMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/PacketLossMetricsTests.cs
@@ -1,3 +1,6 @@
+#if MULTIPLAYER_TOOLS
+#if MULTIPLAYER_TOOLS_1_0_0_PRE_7
+
 using System;
 using System.Collections;
 using NUnit.Framework;
@@ -81,3 +84,6 @@ namespace Unity.Netcode.RuntimeTests.Metrics
         }
     }
 }
+
+#endif
+#endif

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/PacketLossMetricsTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/PacketLossMetricsTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 12e64da4670d49a4a89da38d18e64396
+timeCreated: 1648133968

--- a/testproject-tools-integration/Packages/manifest.json
+++ b/testproject-tools-integration/Packages/manifest.json
@@ -2,7 +2,7 @@
     "registry": "https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-candidates",
     "dependencies": {
         "com.unity.ide.rider": "3.0.7",
-        "com.unity.multiplayer.tools": "https://github.com/Unity-Technologies/com.unity.multiplayer.tools.git#cfb8fd305c3e46bb1251b40ec5f6cb621a267e7f",
+        "com.unity.multiplayer.tools": "https://github.com/Unity-Technologies/com.unity.multiplayer.tools.git#f935904741c349dc41ba24fda6639041128e8f19",
         "com.unity.netcode.gameobjects": "file:../../com.unity.netcode.gameobjects",
         "com.unity.test-framework": "1.1.31",
         "com.unity.test-framework.performance": "2.8.0-preview",


### PR DESCRIPTION
This PR add packet loss tracking from the UTP Transport.
Currently server tracking is 0 until we have a proper way to handle the values per connection on the receiving side.

MTT-1654

## Testing and Documentation

- Includes integration tests.
