### PR TITLE
chore: Update UTP dependency to 1.0.0-pre.16

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -14,6 +14,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Added `NetworkVariableWritePermission` to `NetworkVariableBase` and implemented `Owner` client writable netvars. (#1762)
 
 ### Changed
+- Updated `UnityTransport` dependency on `com.unity.transport` to 1.0.0-pre.16.
 
 ### Removed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -14,7 +14,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Added `NetworkVariableWritePermission` to `NetworkVariableBase` and implemented `Owner` client writable netvars. (#1762)
 
 ### Changed
-- Updated `UnityTransport` dependency on `com.unity.transport` to 1.0.0-pre.16.
+- Updated `UnityTransport` dependency on `com.unity.transport` to 1.0.0-pre.16. (#1834)
 
 ### Removed
 

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -7,6 +7,6 @@
     "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",
         "com.unity.collections": "1.1.0",
-        "com.unity.transport": "1.0.0-pre.15"
+        "com.unity.transport": "1.0.0-pre.16"
     }
 }


### PR DESCRIPTION
PR title says it all.

No JIRA issue since this is just a small basic chore.

## Changelog

- Changed: Updated `UnityTransport` dependency on `com.unity.transport` to 1.0.0-pre.16.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.