### PR TITLE
chore: update `packages-lock.json` files

### DIFF
--- a/minimalproject/Packages/packages-lock.json
+++ b/minimalproject/Packages/packages-lock.json
@@ -10,12 +10,12 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collections": {
-      "version": "1.1.0",
-      "depth": 1,
+      "version": "1.2.3",
+      "depth": 2,
       "source": "registry",
       "dependencies": {
-        "com.unity.burst": "1.5.4",
-        "com.unity.test-framework": "1.1.29"
+        "com.unity.burst": "1.6.4",
+        "com.unity.test-framework": "1.1.31"
       },
       "url": "https://packages.unity.com"
     },
@@ -40,7 +40,7 @@
       "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",
         "com.unity.collections": "1.1.0",
-        "com.unity.transport": "1.0.0-pre.15"
+        "com.unity.transport": "1.0.0-pre.16"
       }
     },
     "com.unity.nuget.mono-cecil": {
@@ -51,8 +51,8 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.29",
-      "depth": 2,
+      "version": "1.1.31",
+      "depth": 3,
       "source": "registry",
       "dependencies": {
         "com.unity.ext.nunit": "1.0.6",
@@ -62,11 +62,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.transport": {
-      "version": "1.0.0-pre.15",
+      "version": "1.0.0-pre.16",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.collections": "1.1.0",
+        "com.unity.collections": "1.2.3",
         "com.unity.burst": "1.6.4",
         "com.unity.mathematics": "1.2.5"
       },

--- a/testproject-tools-integration/Packages/packages-lock.json
+++ b/testproject-tools-integration/Packages/packages-lock.json
@@ -10,12 +10,12 @@
       "url": "https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-candidates"
     },
     "com.unity.collections": {
-      "version": "1.1.0",
-      "depth": 1,
+      "version": "1.2.3",
+      "depth": 2,
       "source": "registry",
       "dependencies": {
-        "com.unity.burst": "1.5.4",
-        "com.unity.test-framework": "1.1.29"
+        "com.unity.burst": "1.6.4",
+        "com.unity.test-framework": "1.1.31"
       },
       "url": "https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-candidates"
     },
@@ -62,7 +62,7 @@
       "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",
         "com.unity.collections": "1.1.0",
-        "com.unity.transport": "1.0.0-pre.15"
+        "com.unity.transport": "1.0.0-pre.16"
       }
     },
     "com.unity.nuget.mono-cecil": {
@@ -108,11 +108,11 @@
       "url": "https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-candidates"
     },
     "com.unity.transport": {
-      "version": "1.0.0-pre.15",
+      "version": "1.0.0-pre.16",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.collections": "1.1.0",
+        "com.unity.collections": "1.2.3",
         "com.unity.burst": "1.6.4",
         "com.unity.mathematics": "1.2.5"
       },

--- a/testproject/Packages/packages-lock.json
+++ b/testproject/Packages/packages-lock.json
@@ -17,12 +17,12 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collections": {
-      "version": "1.1.0",
-      "depth": 1,
+      "version": "1.2.3",
+      "depth": 2,
       "source": "registry",
       "dependencies": {
-        "com.unity.burst": "1.5.4",
-        "com.unity.test-framework": "1.1.29"
+        "com.unity.burst": "1.6.4",
+        "com.unity.test-framework": "1.1.31"
       },
       "url": "https://packages.unity.com"
     },
@@ -72,7 +72,7 @@
       "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",
         "com.unity.collections": "1.1.0",
-        "com.unity.transport": "1.0.0-pre.15"
+        "com.unity.transport": "1.0.0-pre.16"
       }
     },
     "com.unity.nuget.mono-cecil": {
@@ -177,11 +177,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.transport": {
-      "version": "1.0.0-pre.15",
+      "version": "1.0.0-pre.16",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.collections": "1.1.0",
+        "com.unity.collections": "1.2.3",
         "com.unity.burst": "1.6.4",
         "com.unity.mathematics": "1.2.5"
       },


### PR DESCRIPTION
we bumped UTP with PR #1834 but didn't update `packages-lock.json` files in projects, we should.