### PR TITLE
fix: ClientRpcs ignores NetworkObject's observer list [MTT-2878]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -21,6 +21,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Removed `com.unity.modules.animation`, `com.unity.modules.physics` and `com.unity.modules.physics2d` dependencies from the package (#1812)
 
 ### Fixed
+- Fixed ClientRpcs would always send to all connected clients by default as opposed to only sending to the NetworkObject's Observers list by default. (#1836)
 - Fixed clarity for NetworkSceneManager client side notification when it receives a scene hash value that does not exist in its local hash table. (#1828)
 - Fixed client throws a key not found exception when it times out using UNet or UTP. (#1821)
 - Fixed network variable updates are no longer limited to 32,768 bytes when NetworkConfig.EnsureNetworkVariableLengthSafety is enabled. The limits are now determined by what the transport can send in a message. (#1811)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -158,7 +158,6 @@ namespace Unity.Netcode
             // We check to see if we need to shortcut for the case where we are the host/server and we can send a clientRPC
             // to ourself. Sadly we have to figure that out from the list of clientIds :(
             bool shouldSendToHost = false;
-            var logLevel = NetworkManager.LogLevel;
             if (clientRpcParams.Send.TargetClientIds != null)
             {
                 foreach (var targetClientId in clientRpcParams.Send.TargetClientIds)
@@ -170,7 +169,7 @@ namespace Unity.Netcode
                     }
 
                     // Check to make sure we are sending to only observers, if not log an error.
-                    if (!NetworkObject.Observers.Contains(targetClientId) && logLevel >= LogLevel.Error)
+                    if (NetworkManager.LogLevel >= LogLevel.Error && !NetworkObject.Observers.Contains(targetClientId))
                     {
                         NetworkLog.LogError(GenerateObserverErrorMessage(clientRpcParams, targetClientId));
                     }
@@ -189,7 +188,7 @@ namespace Unity.Netcode
                     }
 
                     // Check to make sure we are sending to only observers, if not log an error.
-                    if (!NetworkObject.Observers.Contains(targetClientId) && logLevel >= LogLevel.Error)
+                    if (NetworkManager.LogLevel >= LogLevel.Error && !NetworkObject.Observers.Contains(targetClientId))
                     {
                         NetworkLog.LogError(GenerateObserverErrorMessage(clientRpcParams, targetClientId));
                     }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using UnityEngine;
 using System.Reflection;
 using Unity.Collections;
-using System.Runtime.CompilerServices;
 
 namespace Unity.Netcode
 {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -268,7 +268,6 @@ namespace Unity.Netcode
 #endif
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal string GenerateObserverErrorMessage(ClientRpcParams clientRpcParams, ulong targetClientId)
         {
             var containerNameHoldingId = clientRpcParams.Send.TargetClientIds != null ? nameof(ClientRpcParams.Send.TargetClientIds) : nameof(ClientRpcParams.Send.TargetClientIdsNativeArray);

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -207,23 +207,28 @@ namespace Unity.Netcode
                 {
                     observerAllocateCount--;
                 }
-                // Allocate native array large enough to hold the remaining observers' clientIds.
-                var observerClientIds = new NativeArray<ulong>(observerAllocateCount, Allocator.Temp);
-                var observerEnumerator = NetworkObject.Observers.GetEnumerator();
-                var observerCount = 0;
-                while (observerEnumerator.MoveNext())
-                {
-                    // Skip over the host
-                    if (IsHost && observerEnumerator.Current == NetworkManager.LocalClientId)
-                    {
-                        shouldSendToHost = true;
-                        continue;
-                    }
-                    observerClientIds[observerCount++] = observerEnumerator.Current;
-                }
 
-                rpcWriteSize = NetworkManager.SendMessage(ref clientRpcMessage, networkDelivery, observerClientIds);
-                observerClientIds.Dispose();
+                // Only if at least 1 connected client or more to send to
+                if (observerAllocateCount > 0)
+                {
+                    // Allocate native array large enough to hold the remaining observers' clientIds.
+                    var observerClientIds = new NativeArray<ulong>(observerAllocateCount, Allocator.Temp);
+                    var observerEnumerator = NetworkObject.Observers.GetEnumerator();
+                    var observerCount = 0;
+                    while (observerEnumerator.MoveNext())
+                    {
+                        // Skip over the host
+                        if (IsHost && observerEnumerator.Current == NetworkManager.LocalClientId)
+                        {
+                            shouldSendToHost = true;
+                            continue;
+                        }
+                        observerClientIds[observerCount++] = observerEnumerator.Current;
+                    }
+
+                    rpcWriteSize = NetworkManager.SendMessage(ref clientRpcMessage, networkDelivery, observerClientIds);
+                    observerClientIds.Dispose();
+                }
             }
 
             // If we are a server/host then we just no op and send to ourself

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -170,7 +170,7 @@ namespace Unity.Netcode
                     }
 
                     // Check to make sure we are sending to only observers, if not log an error.
-                    if (!NetworkObject.Observers.Contains(targetClientId) && logLevel == LogLevel.Error)
+                    if (!NetworkObject.Observers.Contains(targetClientId) && logLevel >= LogLevel.Error)
                     {
                         NetworkLog.LogError(GenerateObserverErrorMessage(clientRpcParams, targetClientId));
                     }
@@ -189,7 +189,7 @@ namespace Unity.Netcode
                     }
 
                     // Check to make sure we are sending to only observers, if not log an error.
-                    if (!NetworkObject.Observers.Contains(targetClientId) && logLevel == LogLevel.Error)
+                    if (!NetworkObject.Observers.Contains(targetClientId) && logLevel >= LogLevel.Error)
                     {
                         NetworkLog.LogError(GenerateObserverErrorMessage(clientRpcParams, targetClientId));
                     }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using UnityEngine;
 using System.Reflection;
 using Unity.Collections;
+using System.Runtime.CompilerServices;
 
 namespace Unity.Netcode
 {
@@ -172,7 +173,7 @@ namespace Unity.Netcode
                     // Check to make sure we are sending to only observers, if not log an error.
                     if (!NetworkObject.Observers.Contains(targetClientId))
                     {
-                        Debug.LogError($"Sending ClientRpc to non-observer! {nameof(ClientRpcParams.Send.TargetClientIds)} contains clientId {targetClientId} that is not an observer!");
+                        Debug.LogError(GenerateObserverErrorMessage(clientRpcParams, targetClientId));
                     }
                 }
 
@@ -191,7 +192,7 @@ namespace Unity.Netcode
                     // Check to make sure we are sending to only observers, if not log an error.
                     if (!NetworkObject.Observers.Contains(targetClientId))
                     {
-                        Debug.LogError($"Sending ClientRpc to non-observer!  {nameof(ClientRpcParams.Send.TargetClientIdsNativeArray)} contains clientId {targetClientId} that is not an observer!");
+                        Debug.LogError(GenerateObserverErrorMessage(clientRpcParams, targetClientId));
                     }
                 }
 
@@ -260,6 +261,13 @@ namespace Unity.Netcode
                 }
             }
 #endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal string GenerateObserverErrorMessage(ClientRpcParams clientRpcParams, ulong targetClientId)
+        {
+            var containerNameHoldingId = clientRpcParams.Send.TargetClientIds != null ? nameof(ClientRpcParams.Send.TargetClientIds) : nameof(ClientRpcParams.Send.TargetClientIdsNativeArray);
+            return $"Sending ClientRpc to non-observer! {containerNameHoldingId} contains clientId {targetClientId} that is not an observer!";
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -170,7 +170,7 @@ namespace Unity.Netcode
                     }
 
                     // Check to make sure we are sending to only observers, if not log an error.
-                    if (!NetworkObject.Observers.Contains(targetClientId) && logLevel == LogLevel.Developer)
+                    if (!NetworkObject.Observers.Contains(targetClientId) && logLevel == LogLevel.Error)
                     {
                         NetworkLog.LogError(GenerateObserverErrorMessage(clientRpcParams, targetClientId));
                     }
@@ -189,7 +189,7 @@ namespace Unity.Netcode
                     }
 
                     // Check to make sure we are sending to only observers, if not log an error.
-                    if (!NetworkObject.Observers.Contains(targetClientId) && logLevel == LogLevel.Developer)
+                    if (!NetworkObject.Observers.Contains(targetClientId) && logLevel == LogLevel.Error)
                     {
                         NetworkLog.LogError(GenerateObserverErrorMessage(clientRpcParams, targetClientId));
                     }

--- a/testproject/Assets/Tests/Runtime/RpcObserverTests.cs
+++ b/testproject/Assets/Tests/Runtime/RpcObserverTests.cs
@@ -82,7 +82,8 @@ namespace TestProject.RuntimeTests
             var clientRpcParams = new ClientRpcParams();
             // Verify that we get an error message when we try to send to a non-observer using TargetClientIds
             clientRpcParams.Send.TargetClientIds = new List<ulong>() { nonObservers[0] };
-            LogAssert.Expect(LogType.Error, m_ServerRpcObserverObject.GenerateObserverErrorMessage(clientRpcParams, nonObservers[0]));
+            m_ServerNetworkManager.LogLevel = LogLevel.Error;
+            LogAssert.Expect(LogType.Error, "[Netcode] " + m_ServerRpcObserverObject.GenerateObserverErrorMessage(clientRpcParams, nonObservers[0]));
             m_ServerRpcObserverObject.ObserverMessageClientRpc(clientRpcParams);
             yield return s_DefaultWaitForTick;
 
@@ -94,7 +95,7 @@ namespace TestProject.RuntimeTests
 
             // Now verify that we get an error message when we try to send to a non-observer using TargetClientIdsNativeArray
             clientRpcParams.Send.TargetClientIdsNativeArray = m_NonObserverArrayError;
-            LogAssert.Expect(LogType.Error, m_ServerRpcObserverObject.GenerateObserverErrorMessage(clientRpcParams, nonObservers[0]));
+            LogAssert.Expect(LogType.Error, "[Netcode] " + m_ServerRpcObserverObject.GenerateObserverErrorMessage(clientRpcParams, nonObservers[0]));
             m_ServerRpcObserverObject.ObserverMessageClientRpc(clientRpcParams);
             yield return s_DefaultWaitForTick;
 
@@ -117,6 +118,8 @@ namespace TestProject.RuntimeTests
                 Assert.True(m_ServerRpcObserverObject.HostReceivedMessage, "Host failed to receive the ClientRpc when no clients were connected!");
                 Assert.False(m_ServerRpcObserverObject.NonObserversReceivedRPC(nonObservers), $"Non-observers ({m_ServerRpcObserverObject.GetClientIdsAsString(nonObservers)}) received the RPC message!");
             }
+
+            m_ServerNetworkManager.LogLevel = LogLevel.Normal;
         }
 
         /// <summary>

--- a/testproject/Assets/Tests/Runtime/RpcObserverTests.cs
+++ b/testproject/Assets/Tests/Runtime/RpcObserverTests.cs
@@ -61,6 +61,7 @@ namespace TestProject.RuntimeTests
             yield return RunRpcObserverTest(nonObservers);
 
             // This hides the test prefab from one client and then runs the test
+            // and repeats until all clients are no longer observers
             foreach (var clientId in m_ServerNetworkManager.ConnectedClientsIds)
             {
                 if (clientId == m_ServerNetworkManager.LocalClientId)
@@ -137,7 +138,7 @@ namespace TestProject.RuntimeTests
             // Always verify the host received the RPC
             if (m_UseHost)
             {
-                Assert.True(m_ServerRpcObserverObject.HostReceivedMessage, "Host failed to receive the ClientRpc when no clients were connected!");
+                Assert.True(m_ServerRpcObserverObject.HostReceivedMessage, $"Host failed to receive the ClientRpc with the following observers: {m_ServerRpcObserverObject.GetClientIdsAsString()}!");
             }
         }
 

--- a/testproject/Assets/Tests/Runtime/RpcObserverTests.cs
+++ b/testproject/Assets/Tests/Runtime/RpcObserverTests.cs
@@ -1,0 +1,238 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Unity.Netcode.TestHelpers.Runtime;
+using Unity.Netcode;
+
+namespace TestProject.RuntimeTests
+{
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    public class RpcObserverTests : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 9;
+
+        private GameObject m_TestPrefab;
+
+        private GameObject m_ServerPrefabInstance;
+        private RpcObserverObject m_ServerRpcObserverObject;
+
+        public RpcObserverTests(HostOrServer hostOrServer) : base(hostOrServer) { }
+
+        protected override void OnOneTimeSetup()
+        {
+            m_NetworkTransport = NetcodeIntegrationTestHelpers.InstanceTransport.UTP;
+        }
+
+        protected override void OnServerAndClientsCreated()
+        {
+            m_TestPrefab = CreateNetworkObjectPrefab($"{nameof(RpcObserverObject)}");
+            m_TestPrefab.AddComponent<RpcObserverObject>();
+        }
+
+        protected override IEnumerator OnServerAndClientsConnected()
+        {
+            m_ServerPrefabInstance = SpawnObject(m_TestPrefab, m_ServerNetworkManager);
+            m_ServerRpcObserverObject = m_ServerPrefabInstance.GetComponent<RpcObserverObject>();
+            return base.OnServerAndClientsConnected();
+        }
+
+        [UnityTest]
+        public IEnumerator ClientRpcObserverTest()
+        {
+            // Wait for all clients to report they have spawned an instance of our test prefab
+            yield return WaitForConditionOrTimeOut(m_ServerRpcObserverObject.AllClientsSpawned);
+
+            var nonObservers = new List<ulong>();
+
+            // We start out with all clients being observers of the test prefab
+            // Test that all clients receive the RPC
+            yield return RunRpcObserverTest(nonObservers);
+
+            // This hides the test prefab from one client and then runs the test
+            foreach (var clientId in m_ServerNetworkManager.ConnectedClientsIds)
+            {
+                if (clientId == m_ServerNetworkManager.LocalClientId)
+                {
+                    continue;
+                }
+                // Hide it from the client
+                m_ServerRpcObserverObject.NetworkObject.NetworkHide(clientId);
+                nonObservers.Add(clientId);
+                // Provide 1 tick for the client to hide the NetworkObject
+                yield return s_DefaultWaitForTick;
+
+                // Run the test
+                yield return RunRpcObserverTest(nonObservers);
+            }
+        }
+
+        /// <summary>
+        /// This will send an RPC to all observers of the test prefab and check
+        /// to see if the observer clients receive the message and also confirms
+        /// that the non-observer clients did not receive the message.
+        /// </summary>
+        private IEnumerator RunRpcObserverTest(List<ulong> nonObservers)
+        {
+            m_ServerRpcObserverObject.ResetTest();
+
+            m_ServerRpcObserverObject.ObserverMessageClientRpc();
+
+            yield return WaitForConditionOrTimeOut(m_ServerRpcObserverObject.AllObserversReceivedRPC);
+            Assert.False(s_GlobalTimeoutHelper.TimedOut, $"Timed out waiting for all clients to receive message!\n" +
+                $"Clients that received the message:{m_ServerRpcObserverObject.GetClientIdsAsString()}");
+
+            Assert.False(m_ServerRpcObserverObject.NonObserversReceivedRPC(nonObservers),$"Non-observers ({m_ServerRpcObserverObject.GetClientIdsAsString(nonObservers)}) received the RPC message!");
+        }
+
+    }
+
+    public class RpcObserverObject : NetworkBehaviour
+    {
+        public readonly List<ulong> ObserversThatReceivedRPC = new List<ulong>();
+
+        public static readonly List<ulong>  ClientInstancesSpawned = new List<ulong>();
+
+        protected bool m_NotifyClientReceivedMessage;
+
+        public string GetClientIdsAsString(List<ulong> clientIds = null)
+        {
+            if (clientIds == null)
+            {
+                clientIds = ObserversThatReceivedRPC;
+            }
+            var clientIdsAsString = string.Empty;
+            foreach (var clientId in clientIds)
+            {
+                clientIdsAsString += $"({clientId})";
+            }
+            return clientIdsAsString;
+        }
+
+        /// <summary>
+        /// Returns true if all connected clients have spawned the test prefab
+        /// </summary>
+        public bool AllClientsSpawned()
+        {
+            if (!IsServer)
+            {
+                return false;
+            }
+
+            foreach(var clientId in NetworkManager.ConnectedClientsIds)
+            {
+                if (clientId == NetworkManager.LocalClientId)
+                {
+                    continue;
+                }
+
+                if (!ClientInstancesSpawned.Contains(clientId))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Returns true if all observers have received the RPC
+        /// </summary>
+        public bool AllObserversReceivedRPC()
+        {
+            if (!IsServer)
+            {
+                return false;
+            }
+
+            foreach (var clientId in NetworkObject.Observers)
+            {
+                if (clientId == NetworkManager.LocalClientId)
+                {
+                    continue;
+                }
+                if (!ObserversThatReceivedRPC.Contains(clientId))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Returns true if any clientId in the nonObservers list received the RPC
+        /// </summary>
+        /// <param name="nonObservers">list of clientIds that should not have received the RPC message</param>
+        public bool NonObserversReceivedRPC(List<ulong> nonObservers)
+        {
+            foreach (var clientId in nonObservers)
+            {
+                // return false if a non-observer received the RPC
+                if (ObserversThatReceivedRPC.Contains(clientId))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Clears the received
+        /// </summary>
+        public void ResetTest()
+        {
+            ObserversThatReceivedRPC.Clear();
+        }
+
+        /// <summary>
+        /// Called from server-host once per test run
+        /// </summary>
+        [ClientRpc]
+        public void ObserverMessageClientRpc()
+        {
+            m_NotifyClientReceivedMessage = true;
+        }
+
+        /// <summary>
+        /// Called by each observer client that received the ObserverMessageClientRpc message
+        /// The sender id is added to the ObserversThatReceivedRPC list
+        /// </summary>
+        [ServerRpc(RequireOwnership = false)]
+        public void ObserverMessageServerRpc(ServerRpcParams serverRpcParams = default)
+        {
+            ObserversThatReceivedRPC.Add(serverRpcParams.Receive.SenderClientId);
+        }
+
+        public override void OnNetworkSpawn()
+        {
+            if (IsClient)
+            {
+                ClientInstancesSpawned.Add(NetworkManager.LocalClientId);
+            }
+        }
+
+        public override void OnNetworkDespawn()
+        {
+            if (IsClient)
+            {
+                ClientInstancesSpawned.Remove(NetworkManager.LocalClientId);
+            }
+        }
+
+        private void Update()
+        {
+            if (IsServer)
+            {
+                return;
+            }
+
+            if (m_NotifyClientReceivedMessage)
+            {
+                m_NotifyClientReceivedMessage = false;
+                ObserverMessageServerRpc();
+            }
+        }
+    }
+
+}

--- a/testproject/Assets/Tests/Runtime/RpcObserverTests.cs.meta
+++ b/testproject/Assets/Tests/Runtime/RpcObserverTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 93cca52e92a2ccd48aed09a9b717ddce
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This fixes the issue where NetworkBehaviour.__endSendClientRpc ignored the associated NetworkObject's Observers list and would send to all connected clients (including non-observers which would not have that NetworkObject instance).

## Changelog
- Fixed: ClientRpcs would always send to all connected clients by default as opposed to only sending to the NetworkObject's Observers list by default.

## Testing and Documentation
- Includes an integration test.
