### PR TITLE
fix: Ownership table entries not being removed on clients [MTT-2974]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -21,7 +21,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Removed `com.unity.modules.animation`, `com.unity.modules.physics` and `com.unity.modules.physics2d` dependencies from the package (#1812)
 
 ### Fixed
-- Fixed issue where entries were not being removed from the NetworkSpawnManager.OwnershipToObjectsTable.
+- Fixed issue where entries were not being removed from the NetworkSpawnManager.OwnershipToObjectsTable. (#1838)
 - Fixed clarity for NetworkSceneManager client side notification when it receives a scene hash value that does not exist in its local hash table. (#1828)
 - Fixed client throws a key not found exception when it times out using UNet or UTP. (#1821)
 - Fixed network variable updates are no longer limited to 32,768 bytes when NetworkConfig.EnsureNetworkVariableLengthSafety is enabled. The limits are now determined by what the transport can send in a message. (#1811)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -21,6 +21,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Removed `com.unity.modules.animation`, `com.unity.modules.physics` and `com.unity.modules.physics2d` dependencies from the package (#1812)
 
 ### Fixed
+- Fixed issue where entries were not being removed from the NetworkSpawnManager.OwnershipToObjectsTable.
 - Fixed clarity for NetworkSceneManager client side notification when it receives a scene hash value that does not exist in its local hash table. (#1828)
 - Fixed client throws a key not found exception when it times out using UNet or UTP. (#1821)
 - Fixed network variable updates are no longer limited to 32,768 bytes when NetworkConfig.EnsureNetworkVariableLengthSafety is enabled. The limits are now determined by what the transport can send in a message. (#1811)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -515,8 +515,8 @@ namespace Unity.Netcode
 
         internal void InvokeBehaviourOnLostOwnership()
         {
-            // Server already handles this earlier, hosts should ignore
-            if (!NetworkManager.IsServer && NetworkManager.LocalClientId == OwnerClientId)
+            // Server already handles this earlier, hosts should ignore, all clients should update
+            if (!NetworkManager.IsServer)
             {
                 NetworkManager.SpawnManager.UpdateOwnershipTable(this, OwnerClientId, true);
             }
@@ -529,7 +529,7 @@ namespace Unity.Netcode
 
         internal void InvokeBehaviourOnGainedOwnership()
         {
-            // Server already handles this earlier, hosts should ignore
+            // Server already handles this earlier, hosts should ignore and only client owners should update
             if (!NetworkManager.IsServer && NetworkManager.LocalClientId == OwnerClientId)
             {
                 NetworkManager.SpawnManager.UpdateOwnershipTable(this, OwnerClientId);

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -113,6 +113,10 @@ namespace Unity.Netcode
                     networkObject.InvokeBehaviourOnGainedOwnership();
                 }
             }
+            else if (isRemoving)
+            {
+                OwnershipToObjectsTable[previousOwner].Remove(networkObject.NetworkObjectId);
+            }
             else if (NetworkManager.LogLevel == LogLevel.Developer)
             {
                 NetworkLog.LogWarning($"Setting ownership twice? Client-ID {previousOwner} already owns NetworkObject ID {networkObject.NetworkObjectId}!");

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOwnershipTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOwnershipTests.cs
@@ -207,10 +207,7 @@ namespace Unity.Netcode.RuntimeTests
                     Assert.That(previousClientComponent.OnLostOwnershipFired);
                     Assert.That(previousClientComponent.OwnerClientId, Is.EqualTo(clientId));
                 }
-                if (previousNetworkManager.SpawnManager.OwnershipToObjectsTable[previousNetworkManager.LocalClientId].ContainsKey(serverObject.NetworkObjectId))
-                {
-                    Debug.Log("Bad things happen!");
-                }
+
                 // Assure the previous owner is no longer in the local table of the previous owner.
                 Assert.That(!previousNetworkManager.SpawnManager.OwnershipToObjectsTable[previousNetworkManager.LocalClientId].ContainsKey(serverObject.NetworkObjectId));
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOwnershipTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOwnershipTests.cs
@@ -192,18 +192,28 @@ namespace Unity.Netcode.RuntimeTests
                 Assert.That(m_ServerNetworkManager.ConnectedClients.ContainsKey(clientId));
                 serverObject.ChangeOwnership(clientId);
                 yield return s_DefaultWaitForTick;
-
                 Assert.That(serverComponent.OnLostOwnershipFired);
                 Assert.That(serverComponent.OwnerClientId, Is.EqualTo(clientId));
                 // Wait for all clients to receive the CreateObjectMessage
                 yield return WaitForConditionOrTimeOut(ownershipMessageHooks);
                 Assert.False(s_GlobalTimeoutHelper.TimedOut, $"Timed out waiting for all clients to receive the {nameof(ChangeOwnershipMessage)} message.");
 
+                var previousNetworkManager = m_ServerNetworkManager;
                 if (previousClientComponent != null)
                 {
+                    // Once we have a previousClientComponent, we want to verify the server is keeping track for the removal of ownership in the OwnershipToObjectsTable
+                    Assert.That(!m_ServerNetworkManager.SpawnManager.OwnershipToObjectsTable[m_ServerNetworkManager.LocalClientId].ContainsKey(serverObject.NetworkObjectId));
+                    previousNetworkManager = previousClientComponent.NetworkManager;
                     Assert.That(previousClientComponent.OnLostOwnershipFired);
                     Assert.That(previousClientComponent.OwnerClientId, Is.EqualTo(clientId));
                 }
+                if (previousNetworkManager.SpawnManager.OwnershipToObjectsTable[previousNetworkManager.LocalClientId].ContainsKey(serverObject.NetworkObjectId))
+                {
+                    Debug.Log("Bad things happen!");
+                }
+                // Assure the previous owner is no longer in the local table of the previous owner.
+                Assert.That(!previousNetworkManager.SpawnManager.OwnershipToObjectsTable[previousNetworkManager.LocalClientId].ContainsKey(serverObject.NetworkObjectId));
+
                 var currentClientComponent = clientObjects[clientIndex].GetComponent<NetworkObjectOwnershipComponent>();
                 Assert.That(currentClientComponent.OnGainedOwnershipFired);
 


### PR DESCRIPTION
This addresses the issue where entries were not being removed from the NetworkSpawnManager.OwnershipToObjectsTable when UpdateOwnershipTable's isRemoving parameter was true and clients were not invoking the UpdateOwnershipTable method when they lost ownership.

[MTT-2974](https://jira.unity3d.com/browse/MTT-2974)

## Changelog
- Fixed issue where entries were not being removed from the NetworkSpawnManager.OwnershipToObjectsTable.

## Testing and Documentation
- Includes an update to an integration test.
