### PR TITLE
fix: network variables were reporting the incorrect sizes

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkVariableDeltaMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkVariableDeltaMessage.cs
@@ -48,6 +48,7 @@ namespace Unity.Netcode
                     continue;
                 }
 
+                var startingSize = writer.Length;
                 var networkVariable = NetworkBehaviour.NetworkVariableFields[i];
                 var shouldWrite = networkVariable.IsDirty() &&
                     networkVariable.CanClientRead(TargetClientId) &&
@@ -96,7 +97,7 @@ namespace Unity.Netcode
                         NetworkBehaviour.NetworkObject,
                         networkVariable.Name,
                         NetworkBehaviour.__getTypeName(),
-                        writer.Length);
+                        writer.Length - startingSize);
                 }
             }
         }


### PR DESCRIPTION
Network variable payloads were reporting the full size of the writer, rather than the size of the individual network variables. This means that each network variable on a given object reports sequentially higher values that include all previously serialized values, rather than the size of the individual network variable. This simple fix ensure we only report the size that was actually written to the buffer for that individual network variable.

https://jira.unity3d.com/browse/MTT-2982

## Changelog

- Fixed: Network Variable metrics reporting incorrect sizes

## Testing and Documentation

- No tests have been added. Tech Debt https://jira.unity3d.com/browse/MTT-2983 added to improve test coverage in this area.