### PR TITLE
fix: MTT-2991: Flush UnityTransport send queues on disconnect

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -21,6 +21,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Removed `com.unity.modules.animation`, `com.unity.modules.physics` and `com.unity.modules.physics2d` dependencies from the package (#1812)
 
 ### Fixed
+- Fixed issue where `UnityTransport` send queues were not flushed when calling `DisconnectLocalClient` or `DisconnectRemoteClient`. (#1847)
 - Fixed NetworkBehaviour dependency verification check for an existing NetworkObject not searching from root parent transform relative GameObject. (#1841)
 - Fixed issue where entries were not being removed from the NetworkSpawnManager.OwnershipToObjectsTable. (#1838)
 - Fixed clarity for NetworkSceneManager client side notification when it receives a scene hash value that does not exist in its local hash table. (#1828)
@@ -32,7 +33,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed issue where NetworkManager would continue starting even if the NetworkTransport selected failed. (#1780)
 - Fixed issue when spawning new player if an already existing player exists it does not remove IsPlayer from the previous player (#1779)
 - Fixed lack of notification that NetworkManager and NetworkObject cannot be added to the same GameObject with in-editor notifications (#1777)
-- `UnityTransport` send queues are now flushed when calling `DisconnectLocalClient` or `DisconnectRemoteClient`. (#1847)
 
 ## [1.0.0-pre.6] - 2022-03-02
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -32,7 +32,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed issue where NetworkManager would continue starting even if the NetworkTransport selected failed. (#1780)
 - Fixed issue when spawning new player if an already existing player exists it does not remove IsPlayer from the previous player (#1779)
 - Fixed lack of notification that NetworkManager and NetworkObject cannot be added to the same GameObject with in-editor notifications (#1777)
-- `UnityTransport` send queues are now flushed when calling `DisconnectLocalClient` or `DisconnectRemoteClient`.
+- `UnityTransport` send queues are now flushed when calling `DisconnectLocalClient` or `DisconnectRemoteClient`. (#1847)
 
 ## [1.0.0-pre.6] - 2022-03-02
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -32,6 +32,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed issue where NetworkManager would continue starting even if the NetworkTransport selected failed. (#1780)
 - Fixed issue when spawning new player if an already existing player exists it does not remove IsPlayer from the previous player (#1779)
 - Fixed lack of notification that NetworkManager and NetworkObject cannot be added to the same GameObject with in-editor notifications (#1777)
+- `UnityTransport` send queues are now flushed when calling `DisconnectLocalClient` or `DisconnectRemoteClient`.
 
 ## [1.0.0-pre.6] - 2022-03-02
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportConnectionTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportConnectionTests.cs
@@ -303,7 +303,16 @@ namespace Unity.Netcode.RuntimeTests
 
             m_Server.DisconnectRemoteClient(m_ServerEvents[0].ClientID);
 
-            yield return WaitForNetworkEvent(NetworkEvent.Disconnect, m_ClientsEvents[0]);
+            yield return WaitForNetworkEvent(NetworkEvent.Data, m_ClientsEvents[0]);
+
+            if (m_ClientsEvents[0].Count >= 3)
+            {
+                Assert.AreEqual(NetworkEvent.Disconnect, m_ClientsEvents[0][2].Type);
+            }
+            else
+            {
+                yield return WaitForNetworkEvent(NetworkEvent.Disconnect, m_ClientsEvents[0]);
+            }
         }
 
         // Check client disconnection with data in send queue.
@@ -323,7 +332,16 @@ namespace Unity.Netcode.RuntimeTests
 
             m_Clients[0].DisconnectLocalClient();
 
-            yield return WaitForNetworkEvent(NetworkEvent.Disconnect, m_ServerEvents);
+            yield return WaitForNetworkEvent(NetworkEvent.Data, m_ServerEvents);
+
+            if (m_ServerEvents.Count >= 3)
+            {
+                Assert.AreEqual(NetworkEvent.Disconnect, m_ServerEvents[2].Type);
+            }
+            else
+            {
+                yield return WaitForNetworkEvent(NetworkEvent.Disconnect, m_ServerEvents);
+            }
         }
 
         // Check that a server can disconnect a client after another client has disconnected.

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
@@ -283,7 +283,7 @@ namespace Unity.Netcode.RuntimeTests
 
             m_Server.Shutdown();
 
-            var numSends = (UnityTransport.InitialMaxSendQueueSize / 1024) + 1;
+            var numSends = (UnityTransport.InitialMaxSendQueueSize / 1024);
 
             for (int i = 0; i < numSends; i++)
             {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
@@ -415,5 +415,47 @@ namespace Unity.Netcode.RuntimeTests
 
             yield return null;
         }
+
+        [UnityTest]
+        public IEnumerator SendQueuesFlushedOnLocalClientDisconnect([ValueSource("k_DeliveryParameters")] NetworkDelivery delivery)
+        {
+            InitializeTransport(out m_Server, out m_ServerEvents);
+            InitializeTransport(out m_Client1, out m_Client1Events);
+
+            m_Server.StartServer();
+            m_Client1.StartClient();
+
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_Client1Events);
+
+            var data = new ArraySegment<byte>(new byte[] { 42 });
+            m_Client1.Send(m_Client1.ServerClientId, data, delivery);
+
+            m_Client1.DisconnectLocalClient();
+
+            yield return WaitForNetworkEvent(NetworkEvent.Data, m_ServerEvents);
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator SendQueuesFlushedOnRemoteClientDisconnect([ValueSource("k_DeliveryParameters")] NetworkDelivery delivery)
+        {
+            InitializeTransport(out m_Server, out m_ServerEvents);
+            InitializeTransport(out m_Client1, out m_Client1Events);
+
+            m_Server.StartServer();
+            m_Client1.StartClient();
+
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_Client1Events);
+
+            var data = new ArraySegment<byte>(new byte[] { 42 });
+            m_Server.Send(m_Client1.ServerClientId, data, delivery);
+
+            m_Server.DisconnectRemoteClient(m_ServerEvents[0].ClientID);
+
+            yield return WaitForNetworkEvent(NetworkEvent.Data, m_Client1Events);
+
+            yield return null;
+        }
     }
 }


### PR DESCRIPTION
Flush the `UnityTransport` send queues when calling `DisconnectLocalClient` or `DisconnectRemoteClient`. This brings the behavior more in line with what is happening on shutdown (it's weird to flush the queues on shutdown, but not on disconnect).

See MTT-2991 for more details.

## Changelog

- Fixed: `UnityTransport` send queues are now flushed when calling `DisconnectLocalClient` or `DisconnectRemoteClient`.

## Testing and Documentation

- Includes unit/integration tests.
- No documentation changes or additions were necessary.