### PR TITLE
fix: Make UnityTransport a partial class

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -67,7 +67,7 @@ namespace Unity.Netcode.Transports.UTP
         }
     }
 
-    public class UnityTransport : NetworkTransport, INetworkStreamDriverConstructor
+    public partial class UnityTransport : NetworkTransport, INetworkStreamDriverConstructor
     {
         public enum ProtocolType
         {


### PR DESCRIPTION
This change is kind of minor but important currently if a dev wants to override the creation of a driver they do not have access to the m_settings member variable which is pretty bad because the class assumes its usage. 

This change allows devs to use asmrefs to essentially extend the behavior of the UnityTransport class for custom network params and settings values in combination of a custom driver constructor. 

I think in the end it allow for better customization if required

```
public partial class UnityTransport 
{
   public void SetupSecureSettings() {
        m_settings.WithSecureParameters(...);
   }
}
```

## Changelog

- Made UnityTransport a partial class to allow for more customization from the developer side of things

## Testing and Documentation

- No tests have been added.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
