### PR TITLE
test: Added test to check mismatch shutdown

### DIFF
--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/Transport/SIPTransport.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/Transport/SIPTransport.cs
@@ -85,7 +85,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 });
 
                 // Remove the local connection on remote
-                m_Peers[clientId].Transport.m_LocalConnection = null;
+                m_Peers[clientId].Transport.m_Peers.Remove(m_LocalConnection.ConnectionId);
 
                 // Remove connection on server
                 m_Peers.Remove(clientId);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkConfigTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkConfigTests.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+using NUnit.Framework;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    public class NetworkConfigTests
+    {
+        [UnityTest]
+        public IEnumerator TestNetworkConfigMismatch()
+        {
+            NetcodeIntegrationTestHelpers.Create(1, out NetworkManager server, out NetworkManager[] clients);
+
+            // Make a diff in the network config
+            server.NetworkConfig.ProtocolVersion++;
+
+            NetcodeIntegrationTestHelpers.Start(true, server, clients);
+
+            // Wait for a full shutdown on the client
+            yield return NetcodeIntegrationTestHelpers.WaitForCondition(() => !clients[0].IsListening, null, 10);
+            Assert.False(clients[0].IsListening);
+
+            // If exception is thrown, test will fail
+
+            NetcodeIntegrationTestHelpers.Destroy();
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkConfigTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkConfigTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: aaafe712d20440fe91bfa5eb116ba98b
+timeCreated: 1648721124


### PR DESCRIPTION
The PR ensures a NetworkConfig mismatch is handled properly, no exceptions and correct shutdown. It had to include a fix for SIPTransport as it had a remote shutdown bug preventing the test.

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->
MTT-1344

<!-- Add RFC link here if applicable. -->
## Testing and Documentation

- Includes unit tests.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
