### PR TITLE
fix: check NetworkPrefabsList count before rendering GUI

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
@@ -135,9 +135,13 @@ namespace Unity.Netcode.Editor
             m_NetworkPrefabsList = new ReorderableList(serializedObject, serializedObject.FindProperty(nameof(NetworkManager.NetworkConfig)).FindPropertyRelative(nameof(NetworkConfig.NetworkPrefabs)), true, true, true, true);
             m_NetworkPrefabsList.elementHeightCallback = index =>
             {
-                var networkPrefab = m_NetworkPrefabsList.serializedProperty.GetArrayElementAtIndex(index);
-                var networkOverrideProp = networkPrefab.FindPropertyRelative(nameof(NetworkPrefab.Override));
-                var networkOverrideInt = networkOverrideProp.enumValueIndex;
+                var networkOverrideInt = 0;
+                if (m_NetworkPrefabsList.count > 0)
+                {
+                    var networkPrefab = m_NetworkPrefabsList.serializedProperty.GetArrayElementAtIndex(index);
+                    var networkOverrideProp = networkPrefab.FindPropertyRelative(nameof(NetworkPrefab.Override));
+                    networkOverrideInt = networkOverrideProp.enumValueIndex;
+                }
 
                 return 8 + (networkOverrideInt == 0 ? EditorGUIUtility.singleLineHeight : (EditorGUIUtility.singleLineHeight * 2) + 5);
             };


### PR DESCRIPTION
<!-- Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->

<!-- Add RFC link here if applicable. -->

If you drop `NetworkManager` component onto a `GameObject` for the first time, you'd get exceptions similar to below:

![image](https://user-images.githubusercontent.com/12574651/161799489-fee57038-5f6e-4015-919b-f891f45b579b.png)
