### PR TITLE
fix: changed link to Multiplayer Tools docs

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
@@ -363,7 +363,7 @@ namespace Unity.Netcode.Editor
             const string getToolsText = "Access additional tools for multiplayer development by installing the Multiplayer Tools package in the Package Manager.";
             const string openDocsButtonText = "Open Docs";
             const string dismissButtonText = "Dismiss";
-            const string targetUrl = "https://docs-multiplayer.unity3d.com/docs/tools/install-tools";
+            const string targetUrl = "https://docs-multiplayer.unity3d.com/netcode/current/tools/install-tools";
             const string infoIconName = "console.infoicon";
 
             if (PlayerPrefs.GetInt(InstallMultiplayerToolsTipDismissedPlayerPrefKey, 0) != 0)


### PR DESCRIPTION
Updates the URL pointing to the Multiplayer Tools package docs, current one doesn't exist anymore as pointed out here https://github.com/Unity-Technologies/com.unity.multiplayer.docs/issues/579

## Changelog

- Fixed: Change the tools install link so it redirects to the correct documentation page.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.