### PR TITLE
fix: NetworkRigidbody authority and ownership detection

### DIFF
--- a/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
@@ -75,7 +75,7 @@ namespace Unity.Netcode.Components
             }
         }
 
-        // Puts the Rigidbody in a kinematic non-interpolated mode on everyone but the server.
+        // Puts the Rigidbody in a kinematic non-interpolated mode on all non-authoritative instances
         private void UpdateRigidbodyKinematicMode()
         {
             if (m_IsAuthority == false)

--- a/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
@@ -5,50 +5,81 @@ namespace Unity.Netcode.Components
 {
     /// <summary>
     /// NetworkRigidbody allows for the use of <see cref="Rigidbody"/> on network objects. By controlling the kinematic
-    /// mode of the rigidbody and disabling it on all peers but the authoritative one.
+    /// mode of the <see cref="Rigidbody"/> and disabling it on all peers but the authoritative one.
     /// </summary>
     [RequireComponent(typeof(Rigidbody))]
     [RequireComponent(typeof(NetworkTransform))]
     public class NetworkRigidbody : NetworkBehaviour
     {
+        /// <summary>
+        /// Determines if we are server (true) or owner (false) authoritative
+        /// <see cref="NetworkTransform.IsServerAuthoritative"/>
+        /// </summary>
+        private bool m_IsServerAuthoritative;
+
         private Rigidbody m_Rigidbody;
         private NetworkTransform m_NetworkTransform;
 
         private bool m_OriginalKinematic;
         private RigidbodyInterpolation m_OriginalInterpolation;
 
-        // Used to cache the authority state of this rigidbody during the last frame
+        // Used to cache the authority state of this Rigidbody during the last frame
         private bool m_IsAuthority;
-
-        /// <summary>
-        /// Gets a bool value indicating whether this <see cref="NetworkRigidbody"/> on this peer currently holds authority.
-        /// </summary>
-        private bool HasAuthority => m_NetworkTransform.CanCommitToTransform;
 
         private void Awake()
         {
             m_Rigidbody = GetComponent<Rigidbody>();
+            // Store off the original kinematic state when instantiated
+            m_OriginalKinematic = m_Rigidbody.isKinematic;
+
+            // Turn off physics for the rigid body until spawned, otherwise
+            // clients can run fixed update before the first full
+            // NetworkTransform update
+            m_Rigidbody.isKinematic = true;
+
             m_NetworkTransform = GetComponent<NetworkTransform>();
+            m_IsServerAuthoritative = m_NetworkTransform.IsServerAuthoritative();
         }
 
-        private void FixedUpdate()
+        /// <summary>
+        /// For owner authoritative (i.e. ClientNetworkTransform)
+        /// we adjust our authority when we gain ownership
+        /// </summary>
+        public override void OnGainedOwnership()
         {
-            if (NetworkManager.IsListening)
+            UpdateOwnershipAuthority();
+        }
+
+        /// <summary>
+        /// For owner authoritative(i.e. ClientNetworkTransform)
+        /// we adjust our authority when we have lost ownership
+        /// </summary>
+        public override void OnLostOwnership()
+        {
+            UpdateOwnershipAuthority();
+        }
+
+        /// <summary>
+        /// Sets the authority differently depending upon
+        /// whether it is server or owner authoritative
+        /// </summary>
+        private void UpdateOwnershipAuthority()
+        {
+            if (m_IsServerAuthoritative)
             {
-                if (HasAuthority != m_IsAuthority)
-                {
-                    m_IsAuthority = HasAuthority;
-                    UpdateRigidbodyKinematicMode();
-                }
+                m_IsAuthority = NetworkManager.IsServer;
+            }
+            else
+            {
+                m_IsAuthority = IsOwner;
             }
         }
 
-        // Puts the rigidbody in a kinematic non-interpolated mode on everyone but the server.
+        // Puts the Rigidbody in a kinematic non-interpolated mode on everyone but the server.
         private void UpdateRigidbodyKinematicMode()
         {
             if (m_IsAuthority == false)
             {
-                m_OriginalKinematic = m_Rigidbody.isKinematic;
                 m_Rigidbody.isKinematic = true;
 
                 m_OriginalInterpolation = m_Rigidbody.interpolation;
@@ -57,7 +88,7 @@ namespace Unity.Netcode.Components
             }
             else
             {
-                // Resets the rigidbody back to it's non replication only state. Happens on shutdown and when authority is lost
+                // Resets the Rigidbody back to its non-replication only state. Happens on shutdown and when authority is lost
                 m_Rigidbody.isKinematic = m_OriginalKinematic;
                 m_Rigidbody.interpolation = m_OriginalInterpolation;
             }
@@ -66,9 +97,8 @@ namespace Unity.Netcode.Components
         /// <inheritdoc />
         public override void OnNetworkSpawn()
         {
-            m_IsAuthority = HasAuthority;
-            m_OriginalKinematic = m_Rigidbody.isKinematic;
             m_OriginalInterpolation = m_Rigidbody.interpolation;
+            UpdateOwnershipAuthority();
             UpdateRigidbodyKinematicMode();
         }
 

--- a/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
@@ -19,8 +19,6 @@ namespace Unity.Netcode.Components
 
         private Rigidbody m_Rigidbody;
         private NetworkTransform m_NetworkTransform;
-
-        private bool m_OriginalKinematic;
         private RigidbodyInterpolation m_OriginalInterpolation;
 
         // Used to cache the authority state of this Rigidbody during the last frame
@@ -32,8 +30,6 @@ namespace Unity.Netcode.Components
             m_IsServerAuthoritative = m_NetworkTransform.IsServerAuthoritative();
 
             m_Rigidbody = GetComponent<Rigidbody>();
-            // Store off the original kinematic state when instantiated
-            m_OriginalKinematic = m_Rigidbody.isKinematic;
             m_OriginalInterpolation = m_Rigidbody.interpolation;
 
             // Set interpolation to none if NetworkTransform is handling interpolation, otherwise it sets it to the original value
@@ -96,7 +92,7 @@ namespace Unity.Netcode.Components
         {
             m_Rigidbody.interpolation = m_OriginalInterpolation;
             // Turn off physics for the rigid body until spawned, otherwise
-            // clients can run fixed update before the first full
+            // non-owners can run fixed updates before the first full
             // NetworkTransform update and physics will be applied (i.e. gravity, etc)
             m_Rigidbody.isKinematic = true;
         }

--- a/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
@@ -13,7 +13,6 @@ namespace Unity.Netcode.Components
     {
         /// <summary>
         /// Determines if we are server (true) or owner (false) authoritative
-        /// <see cref="NetworkTransform.IsServerAuthoritative"/>
         /// </summary>
         private bool m_IsServerAuthoritative;
 

--- a/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
@@ -76,8 +76,10 @@ namespace Unity.Netcode.Components
             // If you have authority then you are not kinematic
             m_Rigidbody.isKinematic = !m_IsAuthority;
 
-            // Set interpolation to none if NetworkTransform is handling interpolation, otherwise it sets it to the original value
-            m_Rigidbody.interpolation = m_NetworkTransform.Interpolate ? RigidbodyInterpolation.None : m_OriginalInterpolation;
+            // Set interpolation of the Rigidbody based on authority
+            // With authority: let local transform handle interpolation
+            // Without authority: let the NetworkTransform handle interpolation
+            m_Rigidbody.interpolation = m_IsAuthority ? m_OriginalInterpolation : RigidbodyInterpolation.None;
         }
 
         /// <inheritdoc />

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -971,9 +971,9 @@ namespace Unity.Netcode.Components
         }
 
         /// <summary>
-        /// Determines if the <see cref="NetworkTransform"/> is server or owner authoritative.
+        /// Used by <see cref="NetworkRigidbody"/> to determines if this is server or owner authoritative.
         /// </summary>
-        public bool IsServerAuthoritative()
+        internal bool IsServerAuthoritative()
         {
             return OnIsServerAuthoritatitive();
         }

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -960,5 +960,16 @@ namespace Unity.Netcode.Components
             TryCommitValuesToServer(newPosition, newRotationEuler, newScale, m_CachedNetworkManager.LocalTime.Time);
             m_LocalAuthoritativeNetworkState.IsTeleportingNextFrame = false;
         }
+
+        protected virtual bool OnIsServerAuthoritatitive()
+        {
+            return true;
+        }
+
+        public bool IsServerAuthoritative()
+        {
+            return OnIsServerAuthoritatitive();
+        }
+
     }
 }

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -961,15 +961,21 @@ namespace Unity.Netcode.Components
             m_LocalAuthoritativeNetworkState.IsTeleportingNextFrame = false;
         }
 
+        /// <summary>
+        /// Override this and return false to follow the owner authoritative
+        /// Otherwise, it defaults to server authoritative
+        /// </summary>
         protected virtual bool OnIsServerAuthoritatitive()
         {
             return true;
         }
 
+        /// <summary>
+        /// Determines if the <see cref="NetworkTransform"/> is server or owner authoritative.
+        /// </summary>
         public bool IsServerAuthoritative()
         {
             return OnIsServerAuthoritatitive();
         }
-
     }
 }

--- a/com.unity.netcode.gameobjects/Samples/ClientNetworkTransform/Scripts/ClientNetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Samples/ClientNetworkTransform/Scripts/ClientNetworkTransform.cs
@@ -36,5 +36,10 @@ namespace Unity.Netcode.Samples
                 }
             }
         }
+
+        protected override bool OnIsServerAuthoritatitive()
+        {
+            return false;
+        }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
@@ -1,0 +1,213 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Unity.Netcode.Components;
+using NUnit.Framework;
+using Unity.Netcode.Samples;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Unity.Netcode.TestHelpers.Runtime;
+namespace Unity.Netcode.RuntimeTests
+{
+    public class NetworkTransformOwnershipTests : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 1;
+
+        private GameObject m_ClientNetworkTransformPrefab;
+        private GameObject m_NetworkTransformPrefab;
+
+        protected override void OnServerAndClientsCreated()
+        {
+            VerifyObjectIsSpawnedOnClient.ResetObjectTable();
+            m_ClientNetworkTransformPrefab = CreateNetworkObjectPrefab("OwnerAuthorityTest");
+            var clientNetworkTransform = m_ClientNetworkTransformPrefab.AddComponent<ClientNetworkTransform>();
+            clientNetworkTransform.Interpolate = false;
+            m_ClientNetworkTransformPrefab.AddComponent<Rigidbody>();
+            m_ClientNetworkTransformPrefab.AddComponent<NetworkRigidbody>();
+            m_ClientNetworkTransformPrefab.AddComponent<SphereCollider>();
+            m_ClientNetworkTransformPrefab.AddComponent<VerifyObjectIsSpawnedOnClient>();
+
+            m_NetworkTransformPrefab = CreateNetworkObjectPrefab("ServerAuthorityTest");
+            var networkTransform = m_NetworkTransformPrefab.AddComponent<NetworkTransform>();
+            m_NetworkTransformPrefab.AddComponent<Rigidbody>();
+            m_NetworkTransformPrefab.AddComponent<NetworkRigidbody>();
+            m_NetworkTransformPrefab.AddComponent<SphereCollider>();
+            m_NetworkTransformPrefab.AddComponent<VerifyObjectIsSpawnedOnClient>();
+            networkTransform.Interpolate = false;
+
+            base.OnServerAndClientsCreated();
+        }
+
+        public enum StartingOwnership
+        {
+            HostStartsAsOwner,
+            ClientStartsAsOwner,
+        }
+
+        /// <summary>
+        /// This verifies that when authority is owner authoritative that
+        /// we can switch between owners and the owner can update the transform.
+        /// </summary>
+        /// <param name="spawnWithHostOwnership">determines who starts as the owner (true): host | (false): client</param>
+        [UnityTest]
+        public IEnumerator OwnerAuthoritativeTest([Values] StartingOwnership spawnWithHostOwnership)
+        {
+            // Get the current ownership layout
+            var networkManagerOwner = spawnWithHostOwnership == StartingOwnership.HostStartsAsOwner ? m_ServerNetworkManager : m_ClientNetworkManagers[0];
+            var networkManagerNonOwner = spawnWithHostOwnership == StartingOwnership.HostStartsAsOwner ? m_ClientNetworkManagers[0] : m_ServerNetworkManager;
+
+            // Spawn the m_ClientNetworkTransformPrefab and wait for the client-side to spawn the object
+            var serverSideInstance = SpawnObject(m_ClientNetworkTransformPrefab, networkManagerOwner);
+            yield return WaitForConditionOrTimeOut(() => VerifyObjectIsSpawnedOnClient.GetClientsThatSpawnedThisPrefab().Contains(m_ClientNetworkManagers[0].LocalClientId));
+
+            // Get owner relative instances
+            var ownerInstance = VerifyObjectIsSpawnedOnClient.GetClientInstance(networkManagerOwner.LocalClientId);
+            var nonOwnerInstance = VerifyObjectIsSpawnedOnClient.GetClientInstance(networkManagerNonOwner.LocalClientId);
+            Assert.NotNull(ownerInstance);
+            Assert.NotNull(nonOwnerInstance);
+
+            // Owner changes transform values
+            var valueSetByOwner = Vector3.one * 2;
+            ownerInstance.transform.position = valueSetByOwner;
+            ownerInstance.transform.localScale = valueSetByOwner;
+            var rotation = new Quaternion();
+            rotation.eulerAngles = valueSetByOwner;
+            ownerInstance.transform.rotation = rotation;
+            var transformToTest = nonOwnerInstance.transform;
+            yield return WaitForConditionOrTimeOut(() => transformToTest.position == valueSetByOwner && transformToTest.localScale == valueSetByOwner && transformToTest.rotation == rotation);
+            Assert.False(s_GlobalTimeoutHelper.TimedOut, $"Timed out waiting for {networkManagerNonOwner.name}'s object instance {nonOwnerInstance.name} to change its transform!\n" +
+                $"Expected Position: {valueSetByOwner} | Current Position: {transformToTest.position}\n" +
+                $"Expected Rotation: {valueSetByOwner} | Current Rotation: {transformToTest.rotation.eulerAngles}\n" +
+                $"Expected Scale: {valueSetByOwner} | Current Scale: {transformToTest.localScale}");
+
+            // Verify non-owners cannot change transform values
+            nonOwnerInstance.transform.position = Vector3.zero;
+            yield return s_DefaultWaitForTick;
+            Assert.True(nonOwnerInstance.transform.position == valueSetByOwner, $"{networkManagerNonOwner.name}'s object instance {nonOwnerInstance.name} was allowed to change its position! Expected: {Vector3.one} Is Currently:{nonOwnerInstance.transform.position}");
+
+            // Change ownership and wait for the non-owner to reflect the change
+            VerifyObjectIsSpawnedOnClient.ResetObjectTable();
+            m_ServerNetworkManager.SpawnManager.ChangeOwnership(serverSideInstance.GetComponent<NetworkObject>(), networkManagerNonOwner.LocalClientId);
+            yield return WaitForConditionOrTimeOut(() => nonOwnerInstance.GetComponent<NetworkObject>().OwnerClientId == networkManagerNonOwner.LocalClientId);
+            Assert.False(s_GlobalTimeoutHelper.TimedOut, $"Timed out waiting for {networkManagerNonOwner.name}'s object instance {nonOwnerInstance.name} to change ownership!");
+
+            // Re-assign the ownership references and wait for the non-owner instance to be notified of ownership change
+            networkManagerOwner = spawnWithHostOwnership == StartingOwnership.HostStartsAsOwner ? m_ClientNetworkManagers[0] : m_ServerNetworkManager;
+            networkManagerNonOwner = spawnWithHostOwnership == StartingOwnership.HostStartsAsOwner ? m_ServerNetworkManager : m_ClientNetworkManagers[0];
+            ownerInstance = VerifyObjectIsSpawnedOnClient.GetClientInstance(networkManagerOwner.LocalClientId);
+            Assert.NotNull(ownerInstance);
+            yield return WaitForConditionOrTimeOut(() => VerifyObjectIsSpawnedOnClient.GetClientInstance(networkManagerNonOwner.LocalClientId) != null);
+            nonOwnerInstance = VerifyObjectIsSpawnedOnClient.GetClientInstance(networkManagerNonOwner.LocalClientId);
+            Assert.NotNull(nonOwnerInstance);
+
+            // Have the new owner change transform values and wait for those values to be applied on the non-owner side.
+            valueSetByOwner = Vector3.one * 50;
+            ownerInstance.transform.position = valueSetByOwner;
+            ownerInstance.transform.localScale = valueSetByOwner;
+            rotation.eulerAngles = valueSetByOwner;
+            ownerInstance.transform.rotation = rotation;
+            transformToTest = nonOwnerInstance.transform;
+            yield return WaitForConditionOrTimeOut(() => transformToTest.position == valueSetByOwner && transformToTest.localScale == valueSetByOwner && transformToTest.rotation == rotation);
+            Assert.False(s_GlobalTimeoutHelper.TimedOut, $"Timed out waiting for {networkManagerNonOwner.name}'s object instance {nonOwnerInstance.name} to change its transform!\n" +
+                $"Expected Position: {valueSetByOwner} | Current Position: {transformToTest.position}\n" +
+                $"Expected Rotation: {valueSetByOwner} | Current Rotation: {transformToTest.rotation.eulerAngles}\n" +
+                $"Expected Scale: {valueSetByOwner} | Current Scale: {transformToTest.localScale}");
+
+            // The last check is to verify non-owners cannot change transform values after ownership has changed
+            nonOwnerInstance.transform.position = Vector3.zero;
+            yield return s_DefaultWaitForTick;
+            Assert.True(nonOwnerInstance.transform.position == valueSetByOwner, $"{networkManagerNonOwner.name}'s object instance {nonOwnerInstance.name} was allowed to change its position! Expected: {Vector3.one} Is Currently:{nonOwnerInstance.transform.position}");
+        }
+
+        [UnityTest]
+        public IEnumerator ServerAuthoritativeTest()
+        {
+            // Spawn the m_NetworkTransformPrefab and wait for the client-side to spawn the object
+            var serverSideInstance = SpawnObject(m_NetworkTransformPrefab, m_ServerNetworkManager);
+            yield return WaitForConditionOrTimeOut(() => VerifyObjectIsSpawnedOnClient.GetClientsThatSpawnedThisPrefab().Contains(m_ClientNetworkManagers[0].LocalClientId));
+
+            var ownerInstance = VerifyObjectIsSpawnedOnClient.GetClientInstance(m_ServerNetworkManager.LocalClientId);
+            var nonOwnerInstance = VerifyObjectIsSpawnedOnClient.GetClientInstance(m_ClientNetworkManagers[0].LocalClientId);
+
+            // Server changes transform values
+            var valueSetByOwner = Vector3.one * 2;
+            ownerInstance.transform.position = valueSetByOwner;
+            ownerInstance.transform.localScale = valueSetByOwner;
+            var rotation = new Quaternion();
+            rotation.eulerAngles = valueSetByOwner;
+            ownerInstance.transform.rotation = rotation;
+            var transformToTest = nonOwnerInstance.transform;
+            yield return WaitForConditionOrTimeOut(() => transformToTest.position == valueSetByOwner && transformToTest.localScale == valueSetByOwner && transformToTest.rotation == rotation);
+            Assert.False(s_GlobalTimeoutHelper.TimedOut, $"Timed out waiting for {m_ClientNetworkManagers[0].name}'s object instance {nonOwnerInstance.name} to change its transform!\n" +
+                $"Expected Position: {valueSetByOwner} | Current Position: {transformToTest.position}\n" +
+                $"Expected Rotation: {valueSetByOwner} | Current Rotation: {transformToTest.rotation.eulerAngles}\n" +
+                $"Expected Scale: {valueSetByOwner} | Current Scale: {transformToTest.localScale}");
+
+
+            // The last check is to verify clients cannot change transform values
+            nonOwnerInstance.transform.position = Vector3.zero;
+            yield return s_DefaultWaitForTick;
+            Assert.True(nonOwnerInstance.transform.position == valueSetByOwner, $"{m_ClientNetworkManagers[0].name}'s object instance {nonOwnerInstance.name} was allowed to change its position! Expected: {Vector3.one} Is Currently:{nonOwnerInstance.transform.position}");
+        }
+
+        public class VerifyObjectIsSpawnedOnClient : NetworkBehaviour
+        {
+            private static Dictionary<ulong, VerifyObjectIsSpawnedOnClient> s_NetworkManagerRelativeSpawnedObjects = new Dictionary<ulong, VerifyObjectIsSpawnedOnClient>();
+
+            public static void ResetObjectTable ()
+            {
+                s_NetworkManagerRelativeSpawnedObjects.Clear();
+            }
+
+            public override void OnGainedOwnership()
+            {
+                if (!s_NetworkManagerRelativeSpawnedObjects.ContainsKey(NetworkManager.LocalClientId))
+                {
+                    s_NetworkManagerRelativeSpawnedObjects.Add(NetworkManager.LocalClientId, this);
+                }
+                base.OnGainedOwnership();
+            }
+
+            public override void OnLostOwnership()
+            {
+                if (!s_NetworkManagerRelativeSpawnedObjects.ContainsKey(NetworkManager.LocalClientId))
+                {
+                    s_NetworkManagerRelativeSpawnedObjects.Add(NetworkManager.LocalClientId, this);
+                }
+                base.OnLostOwnership();
+            }
+
+            public static List<ulong> GetClientsThatSpawnedThisPrefab()
+            {
+                return s_NetworkManagerRelativeSpawnedObjects.Keys.ToList();
+            }
+
+            public static VerifyObjectIsSpawnedOnClient GetClientInstance(ulong clientId)
+            {
+                if(s_NetworkManagerRelativeSpawnedObjects.ContainsKey(clientId))
+                {
+                    return s_NetworkManagerRelativeSpawnedObjects[clientId];
+                }
+                return null;
+            }
+
+            public override void OnNetworkSpawn()
+            {
+                if (!s_NetworkManagerRelativeSpawnedObjects.ContainsKey(NetworkManager.LocalClientId))
+                {
+                    s_NetworkManagerRelativeSpawnedObjects.Add(NetworkManager.LocalClientId, this);
+                }
+                base.OnNetworkSpawn();
+            }
+
+            public override void OnNetworkDespawn()
+            {
+                if (s_NetworkManagerRelativeSpawnedObjects.ContainsKey(NetworkManager.LocalClientId))
+                {
+                    s_NetworkManagerRelativeSpawnedObjects.Remove(NetworkManager.LocalClientId);
+                }
+                base.OnNetworkDespawn();
+            }
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
@@ -273,7 +273,5 @@ namespace Unity.Netcode.RuntimeTests
             }
         }
     }
-
-
 }
 #endif

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
@@ -218,7 +218,7 @@ namespace Unity.Netcode.RuntimeTests
             public override void OnNetworkSpawn()
             {
                 // This makes sure that the NetworkManager relative NetworkObject instances don't collide with each other
-                // and skew the position testing
+                // and skew the expected changes to the transforms
                 foreach (var entry in s_NetworkManagerRelativeSpawnedObjects)
                 {
                     Physics.IgnoreCollision(entry.Value.GetComponent<SphereCollider>(), GetComponent<SphereCollider>());

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
@@ -178,7 +178,7 @@ namespace Unity.Netcode.RuntimeTests
         {
             private static Dictionary<ulong, VerifyObjectIsSpawnedOnClient> s_NetworkManagerRelativeSpawnedObjects = new Dictionary<ulong, VerifyObjectIsSpawnedOnClient>();
 
-            public static void ResetObjectTable ()
+            public static void ResetObjectTable()
             {
                 s_NetworkManagerRelativeSpawnedObjects.Clear();
             }
@@ -208,7 +208,7 @@ namespace Unity.Netcode.RuntimeTests
 
             public static VerifyObjectIsSpawnedOnClient GetClientInstance(ulong clientId)
             {
-                if(s_NetworkManagerRelativeSpawnedObjects.ContainsKey(clientId))
+                if (s_NetworkManagerRelativeSpawnedObjects.ContainsKey(clientId))
                 {
                     return s_NetworkManagerRelativeSpawnedObjects[clientId];
                 }
@@ -219,7 +219,7 @@ namespace Unity.Netcode.RuntimeTests
             {
                 // This makes sure that the NetworkManager relative NetworkObject instances don't collide with each other
                 // and skew the position testing
-                foreach(var entry in s_NetworkManagerRelativeSpawnedObjects)
+                foreach (var entry in s_NetworkManagerRelativeSpawnedObjects)
                 {
                     Physics.IgnoreCollision(entry.Value.GetComponent<SphereCollider>(), GetComponent<SphereCollider>());
                 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
@@ -54,11 +54,11 @@ namespace Unity.Netcode.RuntimeTests
         /// </summary>
         /// <param name="spawnWithHostOwnership">determines who starts as the owner (true): host | (false): client</param>
         [UnityTest]
-        public IEnumerator OwnerAuthoritativeTest([Values] StartingOwnership spawnWithHostOwnership)
+        public IEnumerator OwnerAuthoritativeTest([Values] StartingOwnership startingOwnership)
         {
             // Get the current ownership layout
-            var networkManagerOwner = spawnWithHostOwnership == StartingOwnership.HostStartsAsOwner ? m_ServerNetworkManager : m_ClientNetworkManagers[0];
-            var networkManagerNonOwner = spawnWithHostOwnership == StartingOwnership.HostStartsAsOwner ? m_ClientNetworkManagers[0] : m_ServerNetworkManager;
+            var networkManagerOwner = startingOwnership == StartingOwnership.HostStartsAsOwner ? m_ServerNetworkManager : m_ClientNetworkManagers[0];
+            var networkManagerNonOwner = startingOwnership == StartingOwnership.HostStartsAsOwner ? m_ClientNetworkManagers[0] : m_ServerNetworkManager;
 
             // Spawn the m_ClientNetworkTransformPrefab and wait for the client-side to spawn the object
             var serverSideInstance = SpawnObject(m_ClientNetworkTransformPrefab, networkManagerOwner);
@@ -100,8 +100,8 @@ namespace Unity.Netcode.RuntimeTests
             Assert.False(s_GlobalTimeoutHelper.TimedOut, $"Timed out waiting for {networkManagerNonOwner.name}'s object instance {nonOwnerInstance.name} to change ownership!");
 
             // Re-assign the ownership references and wait for the non-owner instance to be notified of ownership change
-            networkManagerOwner = spawnWithHostOwnership == StartingOwnership.HostStartsAsOwner ? m_ClientNetworkManagers[0] : m_ServerNetworkManager;
-            networkManagerNonOwner = spawnWithHostOwnership == StartingOwnership.HostStartsAsOwner ? m_ServerNetworkManager : m_ClientNetworkManagers[0];
+            networkManagerOwner = startingOwnership == StartingOwnership.HostStartsAsOwner ? m_ClientNetworkManagers[0] : m_ServerNetworkManager;
+            networkManagerNonOwner = startingOwnership == StartingOwnership.HostStartsAsOwner ? m_ServerNetworkManager : m_ClientNetworkManagers[0];
             ownerInstance = VerifyObjectIsSpawnedOnClient.GetClientInstance(networkManagerOwner.LocalClientId);
             Assert.NotNull(ownerInstance);
             yield return WaitForConditionOrTimeOut(() => VerifyObjectIsSpawnedOnClient.GetClientInstance(networkManagerNonOwner.LocalClientId) != null);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
@@ -1,3 +1,4 @@
+#if COM_UNITY_MODULES_PHYSICS
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -275,3 +276,4 @@ namespace Unity.Netcode.RuntimeTests
 
 
 }
+#endif

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b2f8cf0e06334cb4f9f7d4ca3c2d19e3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbodyTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbodyTest.cs
@@ -8,21 +8,9 @@ using Unity.Netcode.TestHelpers.Runtime;
 
 namespace Unity.Netcode.RuntimeTests
 {
-    public class NetworkRigidbodyDynamicTest : NetworkRigidbodyTestBase
-    {
-        public override bool Kinematic => false;
-    }
-
-    public class NetworkRigidbodyKinematicTest : NetworkRigidbodyTestBase
-    {
-        public override bool Kinematic => true;
-    }
-
-    public abstract class NetworkRigidbodyTestBase : NetcodeIntegrationTest
+    public class NetworkRigidbodyTest : NetcodeIntegrationTest
     {
         protected override int NumberOfClients => 1;
-
-        public abstract bool Kinematic { get; }
 
         protected override void OnCreatePlayerPrefab()
         {
@@ -30,7 +18,6 @@ namespace Unity.Netcode.RuntimeTests
             m_PlayerPrefab.AddComponent<Rigidbody>();
             m_PlayerPrefab.AddComponent<NetworkRigidbody>();
             m_PlayerPrefab.GetComponent<Rigidbody>().interpolation = RigidbodyInterpolation.Interpolate;
-            m_PlayerPrefab.GetComponent<Rigidbody>().isKinematic = Kinematic;
         }
 
         /// <summary>
@@ -55,8 +42,8 @@ namespace Unity.Netcode.RuntimeTests
 
             yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ServerNetworkManager, 3);
 
-            // server rigidbody has authority and should have a kinematic mode of false
-            Assert.True(serverPlayer.GetComponent<Rigidbody>().isKinematic == Kinematic, "serverPlayer kinematic");
+            // server rigidbody has authority and should not be kinematic
+            Assert.True(serverPlayer.GetComponent<Rigidbody>().isKinematic == false, "serverPlayer kinematic");
             Assert.AreEqual(RigidbodyInterpolation.Interpolate, serverPlayer.GetComponent<Rigidbody>().interpolation, "server equal interpolate");
 
             // client rigidbody has no authority and should have a kinematic mode of true
@@ -68,7 +55,8 @@ namespace Unity.Netcode.RuntimeTests
 
             yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ServerNetworkManager, 3);
 
-            Assert.IsTrue(serverPlayer.GetComponent<Rigidbody>().isKinematic == Kinematic, "serverPlayer second kinematic");
+            // When despawned, we should always be kinematic (i.e. don't apply physics when despawned)
+            Assert.IsTrue(serverPlayer.GetComponent<Rigidbody>().isKinematic == true, "serverPlayer second kinematic");
 
             yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ServerNetworkManager, 3);
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/com.unity.netcode.runtimetests.asmdef
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/com.unity.netcode.runtimetests.asmdef
@@ -11,20 +11,10 @@
         "Unity.Multiplayer.Tools.NetStats",
         "Unity.Networking.Transport",
         "ClientNetworkTransform",
-        "Unity.Netcode.TestHelpers.Runtime",
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner"
+        "Unity.Netcode.TestHelpers.Runtime"
     ],
-    "includePlatforms": [],
-    "excludePlatforms": [],
-    "allowUnsafeCode": false,
-    "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll"
-    ],
-    "autoReferenced": false,
-    "defineConstraints": [
-        "UNITY_INCLUDE_TESTS"
+     "optionalUnityReferences": [
+        "TestAssemblies"
     ],
     "versionDefines": [
         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/com.unity.netcode.runtimetests.asmdef
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/com.unity.netcode.runtimetests.asmdef
@@ -37,6 +37,5 @@
             "expression": "",
             "define": "COM_UNITY_MODULES_PHYSICS"
         }
-    ],
-    "noEngineReferences": false
+    ]
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/com.unity.netcode.runtimetests.asmdef
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/com.unity.netcode.runtimetests.asmdef
@@ -13,7 +13,7 @@
         "ClientNetworkTransform",
         "Unity.Netcode.TestHelpers.Runtime"
     ],
-     "optionalUnityReferences": [
+    "optionalUnityReferences": [
         "TestAssemblies"
     ],
     "versionDefines": [

--- a/com.unity.netcode.gameobjects/Tests/Runtime/com.unity.netcode.runtimetests.asmdef
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/com.unity.netcode.runtimetests.asmdef
@@ -11,10 +11,20 @@
         "Unity.Multiplayer.Tools.NetStats",
         "Unity.Networking.Transport",
         "ClientNetworkTransform",
-        "Unity.Netcode.TestHelpers.Runtime"
+        "Unity.Netcode.TestHelpers.Runtime",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
     ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
     ],
     "versionDefines": [
         {
@@ -31,6 +41,12 @@
             "name": "com.unity.multiplayer.tools",
             "expression": "1.0.0-pre.7",
             "define": "MULTIPLAYER_TOOLS_1_0_0_PRE_7"
+        },
+        {
+            "name": "com.unity.modules.physics",
+            "expression": "",
+            "define": "COM_UNITY_MODULES_PHYSICS"
         }
-    ]
+    ],
+    "noEngineReferences": false
 }


### PR DESCRIPTION
This is a minor refactor of NetworkRigidbody and NetworkTranaform to elminate constant FixedUpdate polling in NetworkRigidBody to detect changes in ownership.
This also fixes an issue where both authoritative and non-authoritative Rigidbodies were not kinematic until spawned, now all instances are set to kinematic until authority is determined and applied (this happens during OnNetworkSpawn and OnGainedOwnership/OnLostOwnership).

[MTT-3374](https://jira.unity3d.com/browse/MTT-3374)

## Testing and Documentation
- No tests have been added.
