### PR TITLE
feat: Added way to get GlobalObjectIdHash from a NetworkPrefab [MTT-1645]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -8,6 +8,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ## Unreleased
 
 ### Added
+- Added a way to get the `GlobalObjectIdHash` from a GameObject for use in `ConnectionApproval`. (#1893)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionRequestMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionRequestMessage.cs
@@ -102,10 +102,10 @@ namespace Unity.Netcode
                 // Note: Delegate creation allocates.
                 // Note: ToArray() also allocates. :(
                 networkManager.InvokeConnectionApproval(ConnectionData, senderId,
-                    (createPlayerObject, playerPrefabHash, approved, position, rotation) =>
+                    (createPlayerObject, playerPrefab, approved, position, rotation) =>
                     {
                         var localCreatePlayerObject = createPlayerObject;
-                        networkManager.HandleApproval(senderId, localCreatePlayerObject, playerPrefabHash, approved, position, rotation);
+                        networkManager.HandleApproval(senderId, localCreatePlayerObject, playerPrefab, approved, position, rotation);
                     });
             }
             else

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -210,6 +210,46 @@ namespace Unity.Netcode
         }
 
         /// <summary>
+        /// Gets the GlobalObjectIdHash from a NetworkPrefab.
+        /// This can be used to properly pass the GlobalObjectIdHash in the ConnectionApproval callback.
+        /// </summary>
+        /// <param name="gameObject">The GameObject you want to resolve a GlobalObjectIdHash for</param>
+        /// <returns>The GlobalObjectIdHash for the passed GameObject</returns>
+        public uint GetGlobalObjectIdHash(GameObject gameObject)
+        {
+            if (gameObject == null)
+            {
+                throw new ArgumentNullException(nameof(gameObject));
+            }
+
+            var isInPrefabsList = false;
+
+            // Doesn't use LINQ for performance ( GC )
+            for (int i = 0; i < NetworkManager.NetworkConfig.NetworkPrefabs.Count; i++)
+            {
+                if (NetworkManager.NetworkConfig.NetworkPrefabs[i].Prefab == gameObject)
+                {
+                    isInPrefabsList = true;
+                    break;
+                }
+            }
+
+            if (!isInPrefabsList)
+            {
+                throw new Exception("The gameObject is not registered as a NetworkPrefab");
+            }
+
+            var netObj = gameObject.GetComponent<NetworkObject>();
+
+            if (netObj == null)
+            {
+                throw new Exception("The gameObject does not have a NetworkObject component");
+            }
+
+            return netObj.GlobalObjectIdHash;
+        }
+
+        /// <summary>
         /// Defers processing of a message until the moment a specific networkObjectId is spawned.
         /// This is to handle situations where an RPC or other object-specific message arrives before the spawn does,
         /// either due to it being requested in OnNetworkSpawn before the spawn call has been executed

--- a/com.unity.netcode.gameobjects/Tests/Editor/SpawnManagerTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/SpawnManagerTests.cs
@@ -1,0 +1,32 @@
+using NUnit.Framework;
+using Unity.Netcode.Transports.UTP;
+using UnityEngine;
+
+namespace Unity.Netcode.EditorTests
+{
+    public class SpawnManagerTests
+    {
+        [Test]
+        public void TestGetGlobalObjectIdHash()
+        {
+            var prefab = new GameObject();
+            prefab.AddComponent<NetworkObject>();
+
+            var go = new GameObject();
+            var nm = go.AddComponent<NetworkManager>();
+            nm.NetworkConfig = new NetworkConfig();
+            nm.NetworkConfig.NetworkPrefabs.Add(new NetworkPrefab()
+            {
+                Prefab = prefab
+            });
+            nm.NetworkConfig.NetworkTransport = go.AddComponent<UnityTransport>();
+
+            // Start to populate the SpawnManager
+            nm.StartHost();
+
+            Assert.True(nm.SpawnManager.GetGlobalObjectIdHash(prefab) == prefab.GetComponent<NetworkObject>().GlobalObjectIdHash);
+
+            nm.Shutdown();
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Editor/SpawnManagerTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Editor/SpawnManagerTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0df00395bdae494faa4dddb2e6f7e869
+timeCreated: 1650537066

--- a/testproject/Assets/Tests/Manual/ConnectionApproval/ConnectionApprovalTest.unity
+++ b/testproject/Assets/Tests/Manual/ConnectionApproval/ConnectionApprovalTest.unity
@@ -296,6 +296,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1033031600}
   - {fileID: 839387550}
@@ -399,6 +400,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 6
@@ -416,10 +418,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_ApprovalToken: MyApprovalToken
-  m_GlobalObjectIdHashOverride: 1477363480
+  m_PlayerPrefabOverride: {fileID: 8685790303553767886, guid: 96e0a72e30d0c46c8a5c9a750e8f5807,
+    type: 3}
   m_ConnectionMessageToDisplay: {fileID: 1394268806}
   m_SimulateFailure: {fileID: 344942972}
-  m_PlayerPrefabOverride: {fileID: 1493186929}
+  m_OverridePlayerPrefab: {fileID: 1493186929}
   m_ClientDisconnectButton: {fileID: 1357994470}
   m_ConnectionModeButtons: {fileID: 1931383346}
 --- !u!1 &609255385
@@ -450,6 +453,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1357994469}
   m_RootOrder: 0
@@ -600,7 +604,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 593a2fe42fa9d37498c96f9a383b6521, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  DontDestroy: 1
   RunInBackground: 1
   LogLevel: 1
   NetworkConfig:
@@ -621,7 +624,6 @@ MonoBehaviour:
     ConnectionData: 
     EnableTimeResync: 0
     TimeResyncInterval: 30
-    EnableNetworkVariable: 1
     EnsureNetworkVariableLengthSafety: 0
     EnableSceneManagement: 1
     ForceSamePrefabs: 1
@@ -649,7 +651,6 @@ MonoBehaviour:
   ConnectAddress: 127.0.0.1
   ConnectPort: 7777
   ServerListenPort: 7777
-  Channels: []
   MessageSendMode: 0
 --- !u!4 &697639108
 Transform:
@@ -661,6 +662,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 2
@@ -693,6 +695,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 344942971}
   m_RootOrder: 1
@@ -806,6 +809,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 4
@@ -838,6 +842,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1068621167}
   m_Father: {fileID: 344942971}
@@ -914,6 +919,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1033031600}
   m_RootOrder: 0
@@ -989,6 +995,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.7183, y: 0.7183, z: 0.7183}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1907934187}
   m_RootOrder: 2
@@ -1069,6 +1076,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 609255386}
   m_Father: {fileID: 1907934187}
@@ -1202,6 +1210,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1907934187}
   m_RootOrder: 4
@@ -1280,6 +1289,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1890361339}
   - {fileID: 1760562150}
@@ -1492,6 +1502,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1493186928}
   m_RootOrder: 1
@@ -1571,6 +1582,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1890361339}
   m_RootOrder: 0
@@ -1697,6 +1709,7 @@ Transform:
   m_LocalRotation: {x: 0.09027468, y: -0, z: -0, w: 0.99591696}
   m_LocalPosition: {x: 0.4, y: 18.4, z: -49.9}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -1790,6 +1803,7 @@ Transform:
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
   m_LocalPosition: {x: 0, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
@@ -1822,6 +1836,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1794718018}
   m_Father: {fileID: 1493186928}
@@ -1960,6 +1975,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1357994469}
   - {fileID: 274528836}

--- a/testproject/Assets/Tests/Manual/Scripts/ConnectionApprovalComponent.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/ConnectionApprovalComponent.cs
@@ -16,7 +16,7 @@ namespace TestProject.ManualTests
         private string m_ApprovalToken;
 
         [SerializeField]
-        private uint m_GlobalObjectIdHashOverride;
+        private GameObject m_PlayerPrefabOverride;
 
         [SerializeField]
         private Text m_ConnectionMessageToDisplay;
@@ -25,7 +25,7 @@ namespace TestProject.ManualTests
         private Toggle m_SimulateFailure;
 
         [SerializeField]
-        private Toggle m_PlayerPrefabOverride;
+        private Toggle m_OverridePlayerPrefab;
 
         [SerializeField]
         private Button m_ClientDisconnectButton;
@@ -43,9 +43,9 @@ namespace TestProject.ManualTests
 
         private void Start()
         {
-            if (m_PlayerPrefabOverride)
+            if (m_OverridePlayerPrefab)
             {
-                m_PlayerPrefabOverride.gameObject.SetActive(false);
+                m_OverridePlayerPrefab.gameObject.SetActive(false);
             }
 
             if (m_SimulateFailure)
@@ -126,9 +126,9 @@ namespace TestProject.ManualTests
                 m_SimulateFailure.gameObject.SetActive(IsServer);
             }
 
-            if (m_PlayerPrefabOverride)
+            if (m_OverridePlayerPrefab)
             {
-                m_PlayerPrefabOverride.gameObject.SetActive(IsServer);
+                m_OverridePlayerPrefab.gameObject.SetActive(IsServer);
             }
         }
 
@@ -163,9 +163,9 @@ namespace TestProject.ManualTests
                 isTokenValid = false;
             }
 
-            if (m_GlobalObjectIdHashOverride != 0 && m_PlayerPrefabOverride && m_PlayerPrefabOverride.isOn)
+            if (m_PlayerPrefabOverride != null && m_OverridePlayerPrefab && m_OverridePlayerPrefab.isOn)
             {
-                aprovalCallback.Invoke(true, m_GlobalObjectIdHashOverride, isTokenValid, null, null);
+                aprovalCallback.Invoke(true, m_PlayerPrefabOverride.GetComponent<NetworkObject>(), isTokenValid, null, null);
             }
             else
             {

--- a/testproject/Assets/Tests/Runtime/MultiClientConnectionApproval.cs
+++ b/testproject/Assets/Tests/Runtime/MultiClientConnectionApproval.cs
@@ -15,7 +15,7 @@ namespace TestProject.RuntimeTests
         private string m_ConnectionToken;
         private uint m_SuccessfulConnections;
         private uint m_FailedConnections;
-        private uint m_PrefabOverrideGlobalObjectIdHash;
+        private NetworkObject m_PrefabOverride;
 
         private GameObject m_PlayerPrefab;
         private GameObject m_PlayerPrefabOverride;
@@ -83,7 +83,7 @@ namespace TestProject.RuntimeTests
                 // This assures that if a client is shutdown it will not destroy the prefab
                 networkObjectOverride.NetworkManagerOwner = server;
                 NetcodeIntegrationTestHelpers.MakeNetworkObjectTestPrefab(networkObjectOverride);
-                m_PrefabOverrideGlobalObjectIdHash = networkObjectOverride.GlobalObjectIdHash;
+                m_PrefabOverride = networkObjectOverride;
 
                 server.NetworkConfig.NetworkPrefabs.Add(new NetworkPrefab { Prefab = m_PlayerPrefabOverride });
                 foreach (var client in clients)
@@ -93,7 +93,7 @@ namespace TestProject.RuntimeTests
             }
             else
             {
-                m_PrefabOverrideGlobalObjectIdHash = 0;
+                m_PrefabOverride = null;
             }
 
             // [Host-Side] Set the player prefab
@@ -148,7 +148,7 @@ namespace TestProject.RuntimeTests
                 foreach (var networkClient in server.ConnectedClientsList)
                 {
                     Assert.IsNotNull(networkClient.PlayerObject);
-                    Assert.AreEqual(networkClient.PlayerObject.GlobalObjectIdHash, m_PrefabOverrideGlobalObjectIdHash);
+                    Assert.AreEqual(networkClient.PlayerObject.GlobalObjectIdHash, m_PrefabOverride.GlobalObjectIdHash);
                 }
             }
 
@@ -187,13 +187,13 @@ namespace TestProject.RuntimeTests
                 m_FailedConnections++;
             }
 
-            if (m_PrefabOverrideGlobalObjectIdHash == 0)
+            if (m_PrefabOverride == null)
             {
                 callback.Invoke(true, null, isApproved, null, null);
             }
             else
             {
-                callback.Invoke(true, m_PrefabOverrideGlobalObjectIdHash, isApproved, null, null);
+                callback.Invoke(true, m_PrefabOverride, isApproved, null, null);
             }
         }
 


### PR DESCRIPTION
<!-- Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->
MTT-1645

<!-- Add RFC link here if applicable. -->

## Changelog

- Added a way to get the `GlobalObjectIdHash` from a GameObject for use in `ConnectionApproval`.

## Testing and Documentation

- Includes unit tests.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
