### PR TITLE
fix:  TestTimeIntegrationTest can skip the required shutdown and clean up if it asserts

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeMultiInstanceTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeMultiInstanceTest.cs
@@ -93,7 +93,7 @@ namespace Unity.Netcode.RuntimeTests
 
         protected override IEnumerator OnTearDown()
         {
-
+            // Always "shutdown in a tear-down" otherwise you can cause all proceeding tests to fail
             ShutdownAndCleanUp();
             yield return base.OnTearDown();
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeMultiInstanceTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeMultiInstanceTest.cs
@@ -89,8 +89,13 @@ namespace Unity.Netcode.RuntimeTests
                 // compares the two client times, only difference should be based on buffering.
                 m_Client1State.AssertCheckDifference(m_Client2State, 0.2 - tickInterval, (0.1 - tickInterval), tickInterval * 2 + frameInterval * 2 + k_AdditionalTimeTolerance);
             }
+        }
+
+        protected override IEnumerator OnTearDown()
+        {
 
             ShutdownAndCleanUp();
+            yield return base.OnTearDown();
         }
 
         // This is from NetcodeIntegrationTest but we need a custom version of this to modifiy the config


### PR DESCRIPTION
This fixes the issue where if the TestTimeIntegrationTest asserts it will cause all tests that proceed it to fail because the NetworkManager instances never get properly cleaned up.

## Testing and Documentation
- No tests have been added.
