### PR TITLE
fix: Fix build tests when target support is not installed/supported

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Editor/Build/BuildTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Build/BuildTests.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using UnityEditor;
 using UnityEditor.Build.Reporting;
 using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace Unity.Netcode.EditorTests
 {
@@ -16,13 +17,25 @@ namespace Unity.Netcode.EditorTests
         {
             var execAssembly = Assembly.GetExecutingAssembly();
             var packagePath = UnityEditor.PackageManager.PackageInfo.FindForAssembly(execAssembly).assetPath;
+            var buildTarget = EditorUserBuildSettings.activeBuildTarget;
+            var buildTargetGroup = BuildPipeline.GetBuildTargetGroup(buildTarget);
+            var buildTargetSupported = BuildPipeline.IsBuildTargetSupported(buildTargetGroup, buildTarget);
+
             var buildReport = BuildPipeline.BuildPlayer(
                 new[] { Path.Combine(packagePath, DefaultBuildScenePath) },
                 Path.Combine(Path.GetDirectoryName(Application.dataPath), "Builds", nameof(BuildTests)),
-                EditorUserBuildSettings.activeBuildTarget,
+                buildTarget,
                 BuildOptions.None
             );
-            Assert.AreEqual(BuildResult.Succeeded, buildReport.summary.result);
+
+            if (buildTargetSupported)
+            {
+                Assert.AreEqual(BuildResult.Succeeded, buildReport.summary.result);
+            }
+            else
+            {
+                LogAssert.Expect(LogType.Error, "Error building player because build target was unsupported");
+            }
         }
     }
 }


### PR DESCRIPTION
On Katana, [APackageVerification for EditorTests](https://katana.ds.unity3d.com/projects/Unity%20(Git)/builders/proj10-Test%20EditorTests%20-%20MacEditor%20%28Isolated%20Packages%20Verified%20-%2010.14%29/builds/72?unity-github_branch=mutiplayer-rc-package-test) only downloads the Editor. It does not pull down Standalone supports. 
`BasicBuildTest` fails with error `Error building player because build target was unsupported`. 
The fix handles the case when build target supports are not found/installed. 

Fixes: 
<img width="1446" alt="image" src="https://user-images.githubusercontent.com/36935028/164917234-0841ff0c-a3eb-4198-a536-bd0f6fc910aa.png">


## Changelog

n/a

## Testing and Documentation

n/a

