### PR TITLE
fix: Use pinned Ubuntu version - must be reverted to stable when Ubuntu issues are fixed

### DIFF
--- a/.yamato/package-tests.yml
+++ b/.yamato/package-tests.yml
@@ -17,6 +17,9 @@ test_{{project.name}}_{{  package.name }}_{{ editor }}_{{ platform.name }}:
     flavor: {{ platform.flavor}}
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+{% if platform.name == "ubuntu" %}
+    - sudo apt install xvfb
+{% endif %}
     - {% if platform.name == "centos" %}DISPLAY=:0 {% endif %}{% if platform.name == "ubuntu" %}xvfb-run -s "-screen 0 1280x1024x24" {% endif %}upm-ci project test -u {{ editor }} --type package-tests --project-path {{ project.name }} --package-filter {{ package.name }}
   artifacts:
     logs:

--- a/.yamato/package-tests.yml
+++ b/.yamato/package-tests.yml
@@ -17,7 +17,7 @@ test_{{project.name}}_{{  package.name }}_{{ editor }}_{{ platform.name }}:
     flavor: {{ platform.flavor}}
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - {% if platform.name == "centos" %}DISPLAY=:0 {% endif %}upm-ci project test -u {{ editor }} --type package-tests --project-path {{ project.name }} --package-filter {{ package.name }}
+    - {% if platform.name == "centos" %}DISPLAY=:0 {% endif %}{% if platform.name == "ubuntu" %}xvfb-run -s "-screen 0 1280x1024x24" {% endif %}upm-ci project test -u {{ editor }} --type package-tests --project-path {{ project.name }} --package-filter {{ package.name }}
   artifacts:
     logs:
       paths:

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -21,7 +21,7 @@ test_platforms:
     utr: ./utr
   - name: ubuntu
     type: Unity::VM
-    image: package-ci/ubuntu:v3.3.0
+    image: package-ci/ubuntu:pre-stable
     flavor: b1.large
     pathsep: /
     standalone: StandaloneLinux64

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -21,7 +21,7 @@ test_platforms:
     utr: ./utr
   - name: ubuntu
     type: Unity::VM
-    image: package-ci/ubuntu:stable
+    image: package-ci/ubuntu:v3.3.0
     flavor: b1.large
     pathsep: /
     standalone: StandaloneLinux64

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -21,7 +21,7 @@ test_platforms:
     utr: ./utr
   - name: ubuntu
     type: Unity::VM
-    image: package-ci/ubuntu:pre-stable
+    image: package-ci/ubuntu:stable
     flavor: b1.large
     pathsep: /
     standalone: StandaloneLinux64


### PR DESCRIPTION
fix: Use pinned Ubuntu version - must be reverted to stable when Ubuntu issues are fixed