### PR TITLE
fix: Fixes an ILPP crash when a NetworkBehaviour had a field of a type with no base type (an interface or `object`)

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkSerializableILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkSerializableILPP.cs
@@ -114,6 +114,10 @@ namespace Unity.Netcode.Editor.CodeGen
                                     // Get the field type and its base type
                                     var fieldType = field.FieldType;
                                     var baseType = fieldType.Resolve().BaseType;
+                                    if (baseType == null)
+                                    {
+                                        continue;
+                                    }
                                     // This type stack is used for resolving NetworkVariableSerialization's T value
                                     // When looking at base types, we get the type definition rather than the
                                     // type reference... which means that we get the generic definition with an


### PR DESCRIPTION
## Changelog

No changelog necessary as this is a fix for an unreleased bug.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.