### PR TITLE
chore: Add validation jobs as dependency of Publish and Promote [skip ci]

### DIFF
--- a/.yamato/project-promotion.yml
+++ b/.yamato/project-promotion.yml
@@ -40,6 +40,7 @@ promote_{{ project.name }}_{{ package.name }}:
         - "upm-ci~/packages/*.tgz"
   dependencies:
     - .yamato/project-pack.yml#pack_{{ project.name }}
+    - .yamato/project-promotion.yml#promotion_validate_{{ project.name }}_{{ package.name }}_{{ test_platforms.first.name }}_{{ validation_editor }}
     - .yamato/project-promotion.yml#promote_{{ project.name }}_{{ package.name }}_dry_run
 
 promote_{{ project.name }}_{{ package.name }}_dry_run:

--- a/.yamato/project-publish.yml
+++ b/.yamato/project-publish.yml
@@ -18,6 +18,7 @@ publish_{{ project.name }}_{{ package.name }}:
         - "upm-ci~/packages/*.tgz"
   dependencies:
     - .yamato/project-pack.yml#pack_{{ project.name }}
+    - .yamato/project-tests.yml#validate_{{ package.name }}_{{ test_platforms.first.name }}_{{ validation_editor }}
     - .yamato/project-publish.yml#publish_{{ project.name }}_{{ package.name }}_dry_run
 
 publish_{{ project.name }}_{{ package.name }}_dry_run:


### PR DESCRIPTION
Publish and Promote require validation jobs to be a direct dependency. This change is already made on `release/1.0.0` for pre.8

Skipping CI because these changes don't affect PR CI. 

Tested on release/1.0.0 for pre.8 - [CI](https://yamato.cds.internal.unity3d.com/jobs/1201-Unity%2520Netcode%2520for%2520GameObjects/tree/release%252F1.0.0/.yamato%252Fproject-promotion.yml%2523promote_testproject_com.unity.netcode.gameobjects/13376334/job/pipeline)