### PR TITLE
fix: shutting down properly, when failing to StartHost or StartClient

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1047,7 +1047,12 @@ namespace Unity.Netcode.Transports.UTP
                 return false;
             }
 
-            return ClientBindAndConnect();
+            var succeeded = ClientBindAndConnect();
+            if (!succeeded)
+            {
+                Shutdown();
+            }
+            return succeeded;
         }
 
         public override bool StartServer()
@@ -1057,12 +1062,23 @@ namespace Unity.Netcode.Transports.UTP
                 return false;
             }
 
+            bool succeeded;
             switch (m_ProtocolType)
             {
                 case ProtocolType.UnityTransport:
-                    return ServerBindAndListen(ConnectionData.ListenEndPoint);
+                    succeeded = ServerBindAndListen(ConnectionData.ListenEndPoint);
+                    if (!succeeded)
+                    {
+                        Shutdown();
+                    }
+                    return succeeded;
                 case ProtocolType.RelayUnityTransport:
-                    return StartRelayServer();
+                    succeeded = StartRelayServer();
+                    if (!succeeded)
+                    {
+                        Shutdown();
+                    }
+                    return succeeded;
                 default:
                     return false;
             }


### PR DESCRIPTION
Shutting down properly, when failing to StartHost or StartClient. This allows the next attempt to not fail automatically.

[MTT-3421](https://jira.unity3d.com/browse/MTT-3421)