### PR TITLE
fix: Fixed compile failure when compiled against com.unity.nuget.mono-cecil >= 1.11.4

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -22,6 +22,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed issue during client synchronization if 'ValidateSceneBeforeLoading' returned false it would halt the client synchronization process resulting in a client that was approved but not synchronized or fully connected with the server. (#1883)
 - Fixed an issue where UNetTransport.StartServer would return success even if the underlying transport failed to start (#854)
 - Passing generic types to RPCs no longer causes a native crash (#1901)
+- Fixed a compile failure when compiling against com.unity.nuget.mono-cecil >= 1.11.4 (#1920)
 
 ## [Unreleased]
 

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -607,7 +607,11 @@ namespace Unity.Netcode.Editor.CodeGen
                             var meetsConstraints = true;
                             foreach (var constraint in method.GenericParameters[0].Constraints)
                             {
+#if UNITY_CECIL_CONSTRAINTS_ARE_TYPE_REFERENCES
                                 var resolvedConstraint = constraint.Resolve();
+#else
+                                var resolvedConstraint = constraint.ConstraintType.Resolve();
+#endif
 
                                 var resolvedConstraintName = resolvedConstraint.FullNameWithGenericParameters(new[] { method.GenericParameters[0] }, new[] { checkType });
                                 if ((resolvedConstraint.IsInterface && !checkType.HasInterface(resolvedConstraintName)) ||
@@ -737,7 +741,12 @@ namespace Unity.Netcode.Editor.CodeGen
                             var meetsConstraints = true;
                             foreach (var constraint in method.GenericParameters[0].Constraints)
                             {
+#if UNITY_CECIL_CONSTRAINTS_ARE_TYPE_REFERENCES
                                 var resolvedConstraint = constraint.Resolve();
+#else
+                                var resolvedConstraint = constraint.ConstraintType.Resolve();
+#endif
+
 
                                 var resolvedConstraintName = resolvedConstraint.FullNameWithGenericParameters(new[] { method.GenericParameters[0] }, new[] { checkType });
 

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -607,7 +607,7 @@ namespace Unity.Netcode.Editor.CodeGen
                             var meetsConstraints = true;
                             foreach (var constraint in method.GenericParameters[0].Constraints)
                             {
-#if UNITY_CECIL_CONSTRAINTS_ARE_TYPE_REFERENCES
+#if CECIL_CONSTRAINTS_ARE_TYPE_REFERENCES
                                 var resolvedConstraint = constraint.Resolve();
 #else
                                 var resolvedConstraint = constraint.ConstraintType.Resolve();
@@ -741,7 +741,7 @@ namespace Unity.Netcode.Editor.CodeGen
                             var meetsConstraints = true;
                             foreach (var constraint in method.GenericParameters[0].Constraints)
                             {
-#if UNITY_CECIL_CONSTRAINTS_ARE_TYPE_REFERENCES
+#if CECIL_CONSTRAINTS_ARE_TYPE_REFERENCES
                                 var resolvedConstraint = constraint.Resolve();
 #else
                                 var resolvedConstraint = constraint.ConstraintType.Resolve();

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/com.unity.netcode.editor.codegen.asmdef
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/com.unity.netcode.editor.codegen.asmdef
@@ -15,5 +15,12 @@
         "Mono.Cecil.Pdb.dll",
         "Mono.Cecil.Rocks.dll"
     ],
-    "autoReferenced": false
+    "autoReferenced": false,
+    "versionDefines": [
+        {
+            "name": "Unity",
+            "expression": "(0,2022.2.0a11)",
+            "define": "UNITY_CECIL_CONSTRAINTS_ARE_TYPE_REFERENCES"
+        }
+    ]
 }

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/com.unity.netcode.editor.codegen.asmdef
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/com.unity.netcode.editor.codegen.asmdef
@@ -7,6 +7,7 @@
     "includePlatforms": [
         "Editor"
     ],
+    "excludePlatforms": [],
     "allowUnsafeCode": true,
     "overrideReferences": true,
     "precompiledReferences": [
@@ -16,11 +17,13 @@
         "Mono.Cecil.Rocks.dll"
     ],
     "autoReferenced": false,
+    "defineConstraints": [],
     "versionDefines": [
         {
-            "name": "Unity",
-            "expression": "(0,2022.2.0a11)",
-            "define": "UNITY_CECIL_CONSTRAINTS_ARE_TYPE_REFERENCES"
+            "name": "com.unity.nuget.mono-cecil",
+            "expression": "(0,1.11.4)",
+            "define": "CECIL_CONSTRAINTS_ARE_TYPE_REFERENCES"
         }
-    ]
+    ],
+    "noEngineReferences": false
 }


### PR DESCRIPTION
In cecil version 1.11.4 (a patch version), a change was made to the return type for MethodDefinition.GenericParameters from `Collection<TypeReference>` to `Collection<GenericParameterConstraint>`. This causes compilation to fail because of trying to call a method that doesn't exist on `GenericParameterConstraint`. The version of Cecil was updated in Unity 2022.0.0a12, causing compiles against that version to fail; this PR updates the code with conditional compilation based on the version.

## Changelog

- Fixed: Fixed a compile failure when compiling against com.unity.nuget.mono-cecil >= 1.11.4 

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.