### PR TITLE
chore: Separate trunk tests and trigger weekly

### DIFF
--- a/.yamato/_run-all.yml
+++ b/.yamato/_run-all.yml
@@ -10,10 +10,28 @@ run_all_tests:
 {% for platform in test_platforms -%}
 {% for project in projects -%}
 {% for editor in project.test_editors -%}
+{% if editor != "trunk" -%}
 {% for package in project.packages -%}
     - .yamato/package-tests.yml#test_{{ project.name}}_{{ package.name }}_{{ editor }}_{{ platform.name }}
 {% endfor -%}
     - .yamato/project-tests.yml#test_{{ project.name }}_{{ editor }}_{{ platform.name }}
+{% endif -%}
+{% endfor -%}
+{% endfor -%}
+{% endfor -%}
+
+run_all_tests_trunk:
+  name: Run All Package and Project Tests [Trunk]
+  dependencies:
+{% for platform in test_platforms -%}
+{% for project in projects -%}
+{% for editor in project.test_editors -%}
+{% if editor == "trunk" -%}
+{% for package in project.packages -%}
+    - .yamato/package-tests.yml#test_{{ project.name}}_{{ package.name }}_{{ editor }}_{{ platform.name }}
+{% endfor -%}
+    - .yamato/project-tests.yml#test_{{ project.name }}_{{ editor }}_{{ platform.name }}
+{% endif -%}
 {% endfor -%}
 {% endfor -%}
 {% endfor -%}

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -87,9 +87,11 @@ badges_test_trigger:
     - .yamato/project-tests.yml#validate_{{ package.name }}_{{ test_platforms.first.name }}_{{ validation_editor }}
 {% endif -%}
 {% for editor in project.test_editors -%}
+{% if editor != "trunk" -%}
 {% for platform in test_platforms -%}
     - .yamato/package-tests.yml#test_{{ project.name }}_{{ package.name }}_{{ editor }}_{{ platform.name }}
 {% endfor -%}
+{% endif -%}
 {% endfor -%}
 {% endfor -%}
 {% endfor -%}

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -13,8 +13,8 @@ develop_nightly:
     - .yamato/code-coverage.yml#code_coverage_win_{{ project.name }}
 {% endfor -%}
 
-develop_nightly_trunk:
-  name: "[Nightly] Run All Tests [Trunk]"
+develop_weekly_trunk:
+  name: "[Weekly] Run All Tests [Trunk]"
   triggers:
     recurring:
     - branch: develop

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -13,6 +13,16 @@ develop_nightly:
     - .yamato/code-coverage.yml#code_coverage_win_{{ project.name }}
 {% endfor -%}
 
+develop_nightly_trunk:
+  name: "[Nightly] Run All Tests [Trunk]"
+  triggers:
+    recurring:
+    - branch: develop
+      frequency: weekly
+      rerun: always
+  dependencies:
+    - .yamato/_run-all.yml#run_all_tests_trunk
+
 multiprocess_nightly:
   name: "[Nightly] Run Multiprocess Tests"
   triggers:

--- a/.yamato/code-coverage.yml
+++ b/.yamato/code-coverage.yml
@@ -1,8 +1,8 @@
 {% metadata_file .yamato/project.metafile %}
 ---
 {% for project in projects -%}
-code_coverage_win_{{ project.name }}:
-  name: Code Coverage Report - Windows - {{ project.name }}
+code_coverage_win_{{ project.name }}_{{ validation_editor }}:
+  name: Code Coverage Report - Windows - {{ project.name }} - {{ validation_editor }}
   agent:
     type: Unity::VM
     image: package-ci/win10:stable
@@ -10,7 +10,7 @@ code_coverage_win_{{ project.name }}:
   commands:
     - pip install unity-downloader-cli --upgrade --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - unity-downloader-cli -u trunk -c editor --wait --fast
+    - unity-downloader-cli -u {{ validation_editor }} -c editor --wait --fast
     - upm-ci package test -u .Editor --package-path com.unity.netcode.gameobjects --enable-code-coverage --code-coverage-options 'enableCyclomaticComplexity;generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Netcode.Editor,+Unity.Netcode.Runtime,+Unity.Netcode.Components'
   artifacts:
     logs:


### PR DESCRIPTION
Separate trunk tests and trigger weekly.

[Trunk runs](https://yamato.cds.internal.unity3d.com/jobs/1201-Unity%2520Netcode%2520for%2520GameObjects/tree/chore%252Fseparate-trunk-runs/.yamato%252F_run-all.yml%2523run_all_tests_trunk/13515078/job/pipeline)

[Weekly Trigger](https://yamato.cds.internal.unity3d.com/jobs/1201-Unity%2520Netcode%2520for%2520GameObjects/tree/chore%252Fseparate-trunk-runs/.yamato%252F_triggers.yml%2523develop_weekly_trunk/13515116/job/pipeline)

[Nightly](https://yamato.cds.internal.unity3d.com/jobs/1201-Unity%2520Netcode%2520for%2520GameObjects/tree/chore%252Fseparate-trunk-runs/.yamato%252F_triggers.yml%2523develop_nightly/13515271/job/pipeline)

Update Code Coverage Tests to run on `validation editor` - 2020.3 at the moment.

## Changelog

n/a

## Testing and Documentation

n/a
