### PR TITLE
docs: NetworkConfig.ClientConnectionBufferTimeout [skip ci]

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkConfig.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkConfig.cs
@@ -53,9 +53,18 @@ namespace Unity.Netcode
         public uint TickRate = 30;
 
         /// <summary>
-        /// The amount of seconds to wait for handshake to complete before timing out a client
+        /// The amount of seconds for the server to wait for the connection approval handshake to complete before the client is disconnected.
+        ///
+        /// If the timeout is reached before approval is completed the client will be disconnected.
         /// </summary>
-        [Tooltip("The amount of seconds to wait for the handshake to complete before the client times out")]
+        /// <remarks>
+        /// The period begins after the <see cref="NetworkEvent.Connect"/> is received on the server.
+        /// The period ends once the server finishes processing a <see cref="ConnectionRequestMessage"/> from the client.
+        ///
+        /// This setting is independent of any Transport-level timeouts that may be in effect.
+        ///
+        /// This setting is server-side only.</remarks>
+        [Tooltip("The amount of seconds for the server to wait for the connection approval handshake to complete before the client is disconnected")]
         public int ClientConnectionBufferTimeout = 10;
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkConfig.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkConfig.cs
@@ -61,9 +61,12 @@ namespace Unity.Netcode
         /// The period begins after the <see cref="NetworkEvent.Connect"/> is received on the server.
         /// The period ends once the server finishes processing a <see cref="ConnectionRequestMessage"/> from the client.
         ///
-        /// This setting is independent of any Transport-level timeouts that may be in effect.
+        /// This setting is independent of any Transport-level timeouts that may be in effect. It covers the time between
+        /// the connection being established on the Transport layer, the client sending a
+        /// <see cref="ConnectionRequestMessage"/>, and the server processing that message through <see cref="ConnectionApproval"/>.
         ///
-        /// This setting is server-side only.</remarks>
+        /// This setting is server-side only.
+        /// </remarks>
         [Tooltip("The amount of seconds for the server to wait for the connection approval handshake to complete before the client is disconnected")]
         public int ClientConnectionBufferTimeout = 10;
 


### PR DESCRIPTION
Add more detail to where in the process the setting takes effect, how it relates to transport-level timeouts and indicates that it's a server-side setting only.

Note that in documenting this, I discovered that connection approval timeout appears bugged/inoperable on the client-side and has been that way for a very long time. Will file a follow-up issue.

## Changelog

- Docs: Updated ClientConnectionBufferTimeout documentation to be more helpful about its uses and caveats.

## Testing and Documentation

- No tests have been added.
- Includes edits to existing public API documentation.