### PR TITLE
chore: backport #1917 and #1918 into release/1.0.0 (second attempt)

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -11,6 +11,7 @@ namespace Unity.Netcode
     public class NetworkList<T> : NetworkVariableSerialization<T> where T : unmanaged, IEquatable<T>
     {
         private NativeList<T> m_List = new NativeList<T>(64, Allocator.Persistent);
+        private NativeList<T> m_ListAtLastReset = new NativeList<T>(64, Allocator.Persistent);
         private NativeList<NetworkListEvent<T>> m_DirtyEvents = new NativeList<NetworkListEvent<T>>(64, Allocator.Persistent);
 
         /// <summary>
@@ -41,7 +42,11 @@ namespace Unity.Netcode
         public override void ResetDirty()
         {
             base.ResetDirty();
-            m_DirtyEvents.Clear();
+            if (m_DirtyEvents.Length > 0)
+            {
+                m_DirtyEvents.Clear();
+                m_ListAtLastReset.CopyFrom(m_List);
+            }
         }
 
         /// <inheritdoc />
@@ -109,10 +114,10 @@ namespace Unity.Netcode
         /// <inheritdoc />
         public override void WriteField(FastBufferWriter writer)
         {
-            writer.WriteValueSafe((ushort)m_List.Length);
-            for (int i = 0; i < m_List.Length; i++)
+            writer.WriteValueSafe((ushort)m_ListAtLastReset.Length);
+            for (int i = 0; i < m_ListAtLastReset.Length; i++)
             {
-                Write(writer, m_List[i]);
+                Write(writer, m_ListAtLastReset[i]);
             }
         }
 
@@ -454,6 +459,7 @@ namespace Unity.Netcode
         public override void Dispose()
         {
             m_List.Dispose();
+            m_ListAtLastReset.Dispose();
             m_DirtyEvents.Dispose();
         }
     }

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1047,7 +1047,12 @@ namespace Unity.Netcode.Transports.UTP
                 return false;
             }
 
-            return ClientBindAndConnect();
+            var succeeded = ClientBindAndConnect();
+            if (!succeeded)
+            {
+                Shutdown();
+            }
+            return succeeded;
         }
 
         public override bool StartServer()
@@ -1057,12 +1062,23 @@ namespace Unity.Netcode.Transports.UTP
                 return false;
             }
 
+            bool succeeded;
             switch (m_ProtocolType)
             {
                 case ProtocolType.UnityTransport:
-                    return ServerBindAndListen(ConnectionData.ListenEndPoint);
+                    succeeded = ServerBindAndListen(ConnectionData.ListenEndPoint);
+                    if (!succeeded)
+                    {
+                        Shutdown();
+                    }
+                    return succeeded;
                 case ProtocolType.RelayUnityTransport:
-                    return StartRelayServer();
+                    succeeded = StartRelayServer();
+                    if (!succeeded)
+                    {
+                        Shutdown();
+                    }
+                    return succeeded;
                 default:
                     return false;
             }


### PR DESCRIPTION
Backporting  #1917 and #1918, but without taking 2de6754211c1741a69f48ac8be67b565d4128c41 which seemed to be breaking Yamato build