### PR TITLE
fix: Fix code coverage config name in nightly trigger [skip ci]

### DIFF
--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -10,7 +10,7 @@ develop_nightly:
   dependencies:
     - .yamato/_run-all.yml#run_all_tests
 {% for project in projects -%}
-    - .yamato/code-coverage.yml#code_coverage_win_{{ project.name }}
+    - .yamato/code-coverage.yml#code_coverage_win_{{ project.name }}_{{ validation_editor }}
 {% endfor -%}
 
 develop_weekly_trunk:


### PR DESCRIPTION
Fix code coverage config name in nightly trigger. 
Skipping CI since I ran the [Nightly on CI](https://yamato.cds.internal.unity3d.com/jobs/1201-Unity%2520Netcode%2520for%2520GameObjects/tree/fix%252Fnightly-code-cov/.yamato%252F_triggers.yml%2523develop_nightly/13541735/job) on this branch.