### PR TITLE
fix: Clearing TransportEvent delegate event when failing to host. [MTT-3421] (backport #1938)

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
+### Fixed
+
+- Fixed: Hosting again after failing to host now works correctly
+
 ## [1.0.0-pre.8] - 2022-04-27
 
 ### Changed

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1175,6 +1175,8 @@ namespace Unity.Netcode
                 m_ShuttingDown = true;
                 m_StopProcessingMessages = discardMessageQueue;
             }
+
+            NetworkConfig.NetworkTransport.OnTransportEvent -= HandleRawTransportPoll;
         }
 
         internal void ShutdownInternal()


### PR DESCRIPTION
* fix: Clearing TransportEvent delegate event when failing to host. Fixes an issue where hosting again after hosting with invalid params would result in doubly-delivered messages followed by time-out

* fix: Clearing TransportEvent delegate (changelog)

[MTT-3421]
