### PR TITLE
fix: allowing quick NetworkHide and NetworkShow [MTT-3488]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,6 +10,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 - Fixed: Hosting again after failing to host now works correctly
 
+- Fixed: NetworkHide followed by NetworkShow on the same frame works correctly (#1940)
+
 ## [1.0.0-pre.8] - 2022-04-27
 
 ### Changed

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -352,7 +352,10 @@ namespace Unity.Netcode
             if (NetworkManager != null && NetworkManager.SpawnManager != null &&
                 NetworkManager.SpawnManager.SpawnedObjects.TryGetValue(NetworkObjectId, out var networkObject))
             {
-                NetworkManager.SpawnManager.OnDespawnObject(networkObject, false);
+                if (this == networkObject)
+                {
+                    NetworkManager.SpawnManager.OnDespawnObject(networkObject, false);
+                }
             }
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
@@ -74,7 +74,7 @@ namespace Unity.Netcode.RuntimeTests
             int count = 0;
             do
             {
-                yield return new WaitForSeconds(0.1f);
+                yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ServerNetworkManager, 5);
                 count++;
 
                 if (count > 20)
@@ -196,11 +196,11 @@ namespace Unity.Netcode.RuntimeTests
                 // hide them on one client
                 Show(mode == 0, false);
 
-                yield return new WaitForSeconds(1.0f);
+                yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ServerNetworkManager, 5);
 
                 m_NetSpawnedObject1.GetComponent<ShowHideObject>().MyNetworkVariable.Value = 3;
 
-                yield return new WaitForSeconds(1.0f);
+                yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ServerNetworkManager, 5);
 
                 // verify they got hidden
                 yield return CheckVisible(false);
@@ -244,9 +244,9 @@ namespace Unity.Netcode.RuntimeTests
                 Show(mode == 0, false);
                 Show(mode == 0, true);
 
-                yield return new WaitForSeconds(0.5f);
+                yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ServerNetworkManager, 5);
                 yield return RefreshNetworkObjects();
-                yield return new WaitForSeconds(0.5f);
+                yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ServerNetworkManager, 5);
 
                 // verify they become visible
                 yield return CheckVisible(true);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
@@ -140,18 +140,18 @@ namespace Unity.Netcode.RuntimeTests
         {
             var serverClientPlayerResult = new NetcodeIntegrationTestHelpers.ResultWrapper<NetworkObject>();
             yield return NetcodeIntegrationTestHelpers.GetNetworkObjectByRepresentation(
-                    x => x.NetworkObjectId == m_NetSpawnedObject1.NetworkObjectId,
+                    x => x.NetworkObjectId == m_NetSpawnedObject1.NetworkObjectId && x.IsSpawned,
                     m_ClientNetworkManagers[0],
                     serverClientPlayerResult);
             m_Object1OnClient0 = serverClientPlayerResult.Result;
             yield return NetcodeIntegrationTestHelpers.GetNetworkObjectByRepresentation(
-                    x => x.NetworkObjectId == m_NetSpawnedObject2.NetworkObjectId,
+                    x => x.NetworkObjectId == m_NetSpawnedObject2.NetworkObjectId && x.IsSpawned,
                     m_ClientNetworkManagers[0],
                     serverClientPlayerResult);
             m_Object2OnClient0 = serverClientPlayerResult.Result;
             serverClientPlayerResult = new NetcodeIntegrationTestHelpers.ResultWrapper<NetworkObject>();
             yield return NetcodeIntegrationTestHelpers.GetNetworkObjectByRepresentation(
-                    x => x.NetworkObjectId == m_NetSpawnedObject3.NetworkObjectId,
+                    x => x.NetworkObjectId == m_NetSpawnedObject3.NetworkObjectId && x.IsSpawned,
                     m_ClientNetworkManagers[0],
                     serverClientPlayerResult);
             m_Object3OnClient0 = serverClientPlayerResult.Result;
@@ -208,6 +208,45 @@ namespace Unity.Netcode.RuntimeTests
                 // show them to that client
                 Show(mode == 0, true);
                 yield return RefreshNetworkObjects();
+
+                // verify they become visible
+                yield return CheckVisible(true);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator NetworkShowHideQuickTest()
+        {
+            m_ClientId0 = m_ClientNetworkManagers[0].LocalClientId;
+
+            var spawnedObject1 = UnityEngine.Object.Instantiate(m_PrefabToSpawn);
+            var spawnedObject2 = UnityEngine.Object.Instantiate(m_PrefabToSpawn);
+            var spawnedObject3 = UnityEngine.Object.Instantiate(m_PrefabToSpawn);
+            m_NetSpawnedObject1 = spawnedObject1.GetComponent<NetworkObject>();
+            m_NetSpawnedObject2 = spawnedObject2.GetComponent<NetworkObject>();
+            m_NetSpawnedObject3 = spawnedObject3.GetComponent<NetworkObject>();
+            m_NetSpawnedObject1.NetworkManagerOwner = m_ServerNetworkManager;
+            m_NetSpawnedObject2.NetworkManagerOwner = m_ServerNetworkManager;
+            m_NetSpawnedObject3.NetworkManagerOwner = m_ServerNetworkManager;
+            m_NetSpawnedObject1.Spawn();
+            m_NetSpawnedObject2.Spawn();
+            m_NetSpawnedObject3.Spawn();
+
+            for (int mode = 0; mode < 2; mode++)
+            {
+                // get the NetworkObject on a client instance
+                yield return RefreshNetworkObjects();
+
+                // check object start visible
+                yield return CheckVisible(true);
+
+                // hide and show them on one client, during the same frame
+                Show(mode == 0, false);
+                Show(mode == 0, true);
+
+                yield return new WaitForSeconds(0.5f);
+                yield return RefreshNetworkObjects();
+                yield return new WaitForSeconds(0.5f);
 
                 // verify they become visible
                 yield return CheckVisible(true);


### PR DESCRIPTION
Verifies which object got OnDestroyed, to prevent confusion on quick  NetworkHide and NetworkShow.

Addresses https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/1940

