### PR TITLE
fix: Endless warning dialogs when NetworkBehaviour is added to NetworkManager - MTT-3252 

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -5,10 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
+### Added
+
+### Changed
+
+### Removed
 
 ### Fixed
 
 - Fixed: Hosting again after failing to host now works correctly
+- Fixed endless dialog boxes when adding a NetworkBehaviour to a NetworkManager or vice-versa. (#1947)
 
 ## [1.0.0-pre.8] - 2022-04-27
 

--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -249,6 +249,38 @@ namespace Unity.Netcode.Editor
 
             // Now get the root parent transform to the current GameObject (or itself)
             var rootTransform = GetRootParentTransform(gameObject.transform);
+            var networkManager = rootTransform.GetComponent<NetworkManager>();
+            if (networkManager == null)
+            {
+                networkManager = rootTransform.GetComponentInChildren<NetworkManager>();
+            }
+
+            if (networkManager != null)
+            {
+                var networkBehaviours = networkManager.gameObject.GetComponents<NetworkBehaviour>();
+                var networkBehavioursChildren = networkManager.gameObject.GetComponentsInChildren<NetworkBehaviour>();
+                if (networkBehaviours.Length > 0 || networkBehavioursChildren.Length > 0)
+                {
+                    if (EditorUtility.DisplayDialog("NetworkBehaviour Cannot Be Added", $"{nameof(NetworkManager)}s cannot have {nameof(NetworkBehaviour)} components added to the root parent or any of its children." +
+                        $" Would you like to remove the NetworkManager or NetworkBehaviour?", "NetworkManager", "NetworkBehaviour"))
+                    {
+                        DestroyImmediate(networkManager);
+                    }
+                    else
+                    {
+                        foreach (var networkBehaviour in networkBehaviours)
+                        {
+                            DestroyImmediate(networkBehaviour);
+                        }
+
+                        foreach (var networkBehaviour in networkBehaviours)
+                        {
+                            DestroyImmediate(networkBehaviour);
+                        }
+                    }
+                    return;
+                }
+            }
 
             // Otherwise, check to see if there is any NetworkObject from the root GameObject down to all children.
             // If not, notify the user that NetworkBehaviours require that the relative GameObject has a NetworkObject component.

--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -255,13 +255,14 @@ namespace Unity.Netcode.Editor
                 networkManager = rootTransform.GetComponentInChildren<NetworkManager>();
             }
 
+            // If there is a NetworkManager, then notify the user that a NetworkManager cannot have NetworkBehaviour components
             if (networkManager != null)
             {
                 var networkBehaviours = networkManager.gameObject.GetComponents<NetworkBehaviour>();
                 var networkBehavioursChildren = networkManager.gameObject.GetComponentsInChildren<NetworkBehaviour>();
                 if (networkBehaviours.Length > 0 || networkBehavioursChildren.Length > 0)
                 {
-                    if (EditorUtility.DisplayDialog("NetworkBehaviour Cannot Be Added", $"{nameof(NetworkManager)}s cannot have {nameof(NetworkBehaviour)} components added to the root parent or any of its children." +
+                    if (EditorUtility.DisplayDialog("NetworkBehaviour or NetworkManager Cannot Be Added", $"{nameof(NetworkManager)}s cannot have {nameof(NetworkBehaviour)} components added to the root parent or any of its children." +
                         $" Would you like to remove the NetworkManager or NetworkBehaviour?", "NetworkManager", "NetworkBehaviour"))
                     {
                         DestroyImmediate(networkManager);


### PR DESCRIPTION
Based on issue #1904, this fixes the endless dialog loops if you add a NetworkBehaviour to a NetworkManager or vice versa.

[MTT-3252](https://jira.unity3d.com/browse/MTT-3252)

## Changelog
- Fixed: endless dialog boxes when adding a NetworkBehaviour to a NetworkManager or vice-versa.

## Testing and Documentation
- No tests have been added.

## Additional Information
Now, when a user places a NetworkBehaviour component on a GameObject with a NetworkManager or vice-versa they will be presented with the following dialog:
![image](https://user-images.githubusercontent.com/73188597/167480192-cd86608e-2b5c-4b84-a91e-6f660077c79f.png)
Depending upon whether they were adding the NetworkBehaviour or NetworkManager, the user is presented with the option to remove either the NetworkManager or NetworkBehaviour.