### PR TITLE
fix: allowing quick NetworkHide and NetworkShow [MTT-3488] (backport #1944)

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,6 +10,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 - Fixed: Hosting again after failing to host now works correctly
 
+- Fixed: NetworkHide followed by NetworkShow on the same frame works correctly (#1940)
+
 ## [1.0.0-pre.8] - 2022-04-27
 
 ### Changed

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -352,7 +352,10 @@ namespace Unity.Netcode
             if (NetworkManager != null && NetworkManager.SpawnManager != null &&
                 NetworkManager.SpawnManager.SpawnedObjects.TryGetValue(NetworkObjectId, out var networkObject))
             {
-                NetworkManager.SpawnManager.OnDespawnObject(networkObject, false);
+                if (this == networkObject)
+                {
+                    NetworkManager.SpawnManager.OnDespawnObject(networkObject, false);
+                }
             }
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
@@ -140,18 +140,18 @@ namespace Unity.Netcode.RuntimeTests
         {
             var serverClientPlayerResult = new NetcodeIntegrationTestHelpers.ResultWrapper<NetworkObject>();
             yield return NetcodeIntegrationTestHelpers.GetNetworkObjectByRepresentation(
-                    x => x.NetworkObjectId == m_NetSpawnedObject1.NetworkObjectId,
+                    x => x.NetworkObjectId == m_NetSpawnedObject1.NetworkObjectId && x.IsSpawned,
                     m_ClientNetworkManagers[0],
                     serverClientPlayerResult);
             m_Object1OnClient0 = serverClientPlayerResult.Result;
             yield return NetcodeIntegrationTestHelpers.GetNetworkObjectByRepresentation(
-                    x => x.NetworkObjectId == m_NetSpawnedObject2.NetworkObjectId,
+                    x => x.NetworkObjectId == m_NetSpawnedObject2.NetworkObjectId && x.IsSpawned,
                     m_ClientNetworkManagers[0],
                     serverClientPlayerResult);
             m_Object2OnClient0 = serverClientPlayerResult.Result;
             serverClientPlayerResult = new NetcodeIntegrationTestHelpers.ResultWrapper<NetworkObject>();
             yield return NetcodeIntegrationTestHelpers.GetNetworkObjectByRepresentation(
-                    x => x.NetworkObjectId == m_NetSpawnedObject3.NetworkObjectId,
+                    x => x.NetworkObjectId == m_NetSpawnedObject3.NetworkObjectId && x.IsSpawned,
                     m_ClientNetworkManagers[0],
                     serverClientPlayerResult);
             m_Object3OnClient0 = serverClientPlayerResult.Result;


### PR DESCRIPTION
Backport to release/1.0.0 of:
Verifies which object got OnDestroyed, to prevent confusion on quick NetworkHide and NetworkShow.

Addresses https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/1940

