### PR TITLE
fix: cleaning up connected clients upon shutdown [MTT-1573] (backport #1945)

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,7 +10,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 - Fixed: Hosting again after failing to host now works correctly
 
-- Fixed: NetworkManager properly cleaning up its clientlists upon shutdown (#1945)
+- Fixed NetworkManager to cleanup connected client lists after stopping (#1945)
+- Fixed: NetworkHide followed by NetworkShow on the same frame works correctly (#1940)
 
 ## [1.0.0-pre.8] - 2022-04-27
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -8,7 +8,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed: Hosting again after failing to host now works correctly (#1938)
+- Fixed Hosting again after failing to host now works correctly (#1938)
 - Fixed NetworkManager to cleanup connected client lists after stopping (#1945)
 - Fixed NetworkHide followed by NetworkShow on the same frame works correctly (#1940)
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,6 +10,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 - Fixed: Hosting again after failing to host now works correctly
 
+- Fixed: NetworkManager properly cleaning up its clientlists upon shutdown (#1945)
+
 ## [1.0.0-pre.8] - 2022-04-27
 
 ### Changed

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -765,12 +765,7 @@ namespace Unity.Netcode
 #endif
             LocalClientId = ulong.MaxValue;
 
-            PendingClients.Clear();
-            m_ConnectedClients.Clear();
-            m_ConnectedClientsList.Clear();
-            m_ConnectedClientIds.Clear();
-            LocalClient = null;
-            NetworkObject.OrphanChildren.Clear();
+            ClearClients();
 
             // Create spawn manager instance
             SpawnManager = new NetworkSpawnManager(this);
@@ -860,6 +855,16 @@ namespace Unity.Netcode
             NetworkConfig.NetworkTransport.OnTransportEvent += HandleRawTransportPoll;
 
             NetworkConfig.NetworkTransport.Initialize(this);
+        }
+
+        private void ClearClients()
+        {
+            PendingClients.Clear();
+            m_ConnectedClients.Clear();
+            m_ConnectedClientsList.Clear();
+            m_ConnectedClientIds.Clear();
+            LocalClient = null;
+            NetworkObject.OrphanChildren.Clear();
         }
 
         /// <summary>
@@ -1301,6 +1306,8 @@ namespace Unity.Netcode
             IsListening = false;
             m_ShuttingDown = false;
             m_StopProcessingMessages = false;
+
+            ClearClients();
         }
 
         // INetworkUpdateSystem


### PR DESCRIPTION
Backport of:
This cleans up the connected clients upon shutdown. Proper clean-up.

Doesn't change much for the customers, though, since recent Netcode for GameObjects would throw an exception, anyway, if trying to access connected clients while not hosting.

https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/416