### PR TITLE
perf: Improved performance for large number of NetworkObjects

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
@@ -5,11 +5,16 @@ namespace Unity.Netcode
 {
     public class NetworkBehaviourUpdater
     {
-        private HashSet<NetworkObject> m_Touched = new HashSet<NetworkObject>();
+        private HashSet<NetworkObject> m_DirtyNetworkObjects = new HashSet<NetworkObject>();
 
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
         private ProfilerMarker m_NetworkBehaviourUpdate = new ProfilerMarker($"{nameof(NetworkBehaviour)}.{nameof(NetworkBehaviourUpdate)}");
 #endif
+
+        internal void AddForUpdate(NetworkObject networkObject)
+        {
+            m_DirtyNetworkObjects.Add(networkObject);
+        }
 
         internal void NetworkBehaviourUpdate(NetworkManager networkManager)
         {
@@ -20,38 +25,42 @@ namespace Unity.Netcode
             {
                 if (networkManager.IsServer)
                 {
-                    m_Touched.Clear();
-                    for (int i = 0; i < networkManager.ConnectedClientsList.Count; i++)
+                    foreach (var dirtyObj in m_DirtyNetworkObjects)
                     {
-                        var client = networkManager.ConnectedClientsList[i];
-                        var spawnedObjs = networkManager.SpawnManager.SpawnedObjectsList;
-                        m_Touched.UnionWith(spawnedObjs);
-                        foreach (var sobj in spawnedObjs)
+                        for (int i = 0; i < networkManager.ConnectedClientsList.Count; i++)
                         {
-                            if (sobj.IsNetworkVisibleTo(client.ClientId))
+                            var client = networkManager.ConnectedClientsList[i];
+                            if (networkManager.IsHost && client.ClientId == networkManager.LocalClientId)
+                            {
+                                continue;
+                            }
+
+                            if (dirtyObj.IsNetworkVisibleTo(client.ClientId))
                             {
                                 // Sync just the variables for just the objects this client sees
-                                for (int k = 0; k < sobj.ChildNetworkBehaviours.Count; k++)
+                                for (int k = 0; k < dirtyObj.ChildNetworkBehaviours.Count; k++)
                                 {
-                                    sobj.ChildNetworkBehaviours[k].VariableUpdate(client.ClientId);
+                                    dirtyObj.ChildNetworkBehaviours[k].VariableUpdate(client.ClientId);
                                 }
                             }
+                            
                         }
                     }
 
                     // Now, reset all the no-longer-dirty variables
-                    foreach (var sobj in m_Touched)
+                    foreach (var dirtyObj in m_DirtyNetworkObjects)
                     {
-                        for (int k = 0; k < sobj.ChildNetworkBehaviours.Count; k++)
+                        for (int k = 0; k < dirtyObj.ChildNetworkBehaviours.Count; k++)
                         {
-                            sobj.ChildNetworkBehaviours[k].PostNetworkVariableWrite();
+                            dirtyObj.ChildNetworkBehaviours[k].PostNetworkVariableWrite();
                         }
                     }
+                    m_DirtyNetworkObjects.Clear();
                 }
                 else
                 {
                     // when client updates the server, it tells it about all its objects
-                    foreach (var sobj in networkManager.SpawnManager.SpawnedObjectsList)
+                    foreach (var sobj in m_DirtyNetworkObjects)
                     {
                         if (sobj.IsOwner)
                         {
@@ -63,13 +72,14 @@ namespace Unity.Netcode
                     }
 
                     // Now, reset all the no-longer-dirty variables
-                    foreach (var sobj in networkManager.SpawnManager.SpawnedObjectsList)
+                    foreach (var sobj in m_DirtyNetworkObjects)
                     {
                         for (int k = 0; k < sobj.ChildNetworkBehaviours.Count; k++)
                         {
                             sobj.ChildNetworkBehaviours[k].PostNetworkVariableWrite();
                         }
                     }
+                    m_DirtyNetworkObjects.Clear();
                 }
             }
             finally

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -56,6 +56,11 @@ namespace Unity.Netcode
 
         internal NetworkBehaviourUpdater BehaviourUpdater { get; private set; }
 
+        internal void MarkNetworkObjectDirty(NetworkObject networkObject)
+        {
+            BehaviourUpdater.AddForUpdate(networkObject);
+        }
+
         internal MessagingSystem MessagingSystem { get; private set; }
 
         private NetworkPrefabHandler m_PrefabHandler;

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -74,7 +74,7 @@ namespace Unity.Netcode
 
         private protected void Set(T value)
         {
-            m_IsDirty = true;
+            SetDirty(true);
             T previousValue = m_InternalValue;
             m_InternalValue = value;
             OnValueChanged?.Invoke(previousValue, m_InternalValue);
@@ -106,7 +106,7 @@ namespace Unity.Netcode
 
             if (keepDirtyDelta)
             {
-                m_IsDirty = true;
+                SetDirty(true);
             }
 
             OnValueChanged?.Invoke(previousValue, m_InternalValue);

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
@@ -30,7 +30,7 @@ namespace Unity.Netcode
             WritePerm = writePerm;
         }
 
-        private protected bool m_IsDirty;
+        private bool m_IsDirty;
 
         /// <summary>
         /// Gets or sets the name of the network variable's instance
@@ -51,6 +51,7 @@ namespace Unity.Netcode
         public virtual void SetDirty(bool isDirty)
         {
             m_IsDirty = isDirty;
+            m_NetworkBehaviour.NetworkManager.MarkNetworkObjectDirty(m_NetworkBehaviour.NetworkObject);
         }
 
         /// <summary>


### PR DESCRIPTION
Presently every NetworkObject is checked for each client every tick to see if it has dirty NetworkVariables that require syncing. This causes poor performance with large numbers of NetworkObjects as they all are checked multiple times per frame regardless of whether or not they have changed.

This PR changes the behaviour of NetworkVariables such that they register themselves with the NetworkManager for updating when they are marked dirty so there are no redundant checks.