### PR TITLE
fix: DestroyGameObject message changes updated for NetworkObject.NetworkHide - MTT-3552

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -285,7 +285,8 @@ namespace Unity.Netcode
 
             var message = new DestroyObjectMessage
             {
-                NetworkObjectId = NetworkObjectId
+                NetworkObjectId = NetworkObjectId,
+                DestroyGameObject = true
             };
             // Send destroy call
             var size = NetworkManager.SendMessage(ref message, NetworkDelivery.ReliableSequenced, clientId);


### PR DESCRIPTION
This fixes the issue introduced by PR-1898 that updated the DestroyGameObject to be able to "soft destroy" a NetworkObject.
This also adds additional NetworkShowHide integration test checks to make sure the GameObject on the client-side is indeed destroyed.

[MTT-3552](https://jira.unity3d.com/browse/MTT-3552)

## Testing and Documentation
- Includes integration test update for NetworkShowHideTests