### PR TITLE
chore: allowing multiple Connection Approval handlers. [MTT-3496]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,9 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+- [breaking] Allow multiple Connection Approval handlers. 
+  `public delegate void ConnectionApprovalDelegate(byte[] payload, ulong clientId, ConnectionApprovalDecision decision);` now receives a `ConnectionApprovalDecision` class that must be filled, instead of calling a second callback. This allows having multiple Connection Approval handlers. (#1941)
+  
 ### Removed
 
 ### Fixed

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionRequestMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionRequestMessage.cs
@@ -97,20 +97,21 @@ namespace Unity.Netcode
                 client.ConnectionState = PendingClient.State.PendingApproval;
             }
 
+            var decision = new NetworkManager.ConnectionApprovalDecision();
+
             if (networkManager.NetworkConfig.ConnectionApproval)
             {
                 // Note: Delegate creation allocates.
                 // Note: ToArray() also allocates. :(
-                networkManager.InvokeConnectionApproval(ConnectionData, senderId,
-                    (createPlayerObject, playerPrefabHash, approved, position, rotation) =>
-                    {
-                        var localCreatePlayerObject = createPlayerObject;
-                        networkManager.HandleApproval(senderId, localCreatePlayerObject, playerPrefabHash, approved, position, rotation);
-                    });
+                networkManager.ConnectionApprovalCallback?.Invoke(ConnectionData, senderId, decision);
+
+                networkManager.HandleApproval(senderId, decision);
             }
             else
             {
-                networkManager.HandleApproval(senderId, networkManager.NetworkConfig.PlayerPrefab != null, null, true, null, null);
+                decision.Approved = true;
+                decision.CreatePlayerObject = networkManager.NetworkConfig.PlayerPrefab != null;
+                networkManager.HandleApproval(senderId, decision);
             }
         }
     }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApproval.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApproval.cs
@@ -47,14 +47,16 @@ namespace Unity.Netcode.RuntimeTests
             Assert.True(m_IsValidated);
         }
 
-        private void NetworkManagerObject_ConnectionApprovalCallback(byte[] connectionData, ulong clientId, NetworkManager.ConnectionApprovedDelegate callback)
+        private void NetworkManagerObject_ConnectionApprovalCallback(byte[] connectionData, ulong clientId, NetworkManager.ConnectionApprovalDecision decision)
         {
             var stringGuid = Encoding.UTF8.GetString(connectionData);
             if (m_ValidationToken.ToString() == stringGuid)
             {
                 m_IsValidated = true;
             }
-            callback(false, null, m_IsValidated, null, null);
+
+            decision.CreatePlayerObject = false;
+            decision.Approved = m_IsValidated;
         }
 
         [TearDown]

--- a/testproject/Assets/Tests/Manual/Scripts/ConnectionApprovalComponent.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/ConnectionApprovalComponent.cs
@@ -154,7 +154,7 @@ namespace TestProject.ManualTests
         /// <param name="dataToken">key or password to get approval</param>
         /// <param name="clientId">client identifier being approved</param>
         /// <param name="aprovalCallback">callback that should be invoked once it is determined if client is approved or not</param>
-        private void ConnectionApprovalCallback(byte[] dataToken, ulong clientId, NetworkManager.ConnectionApprovedDelegate aprovalCallback)
+        private void ConnectionApprovalCallback(byte[] dataToken, ulong clientId, NetworkManager.ConnectionApprovalDecision decision)
         {
             string approvalToken = Encoding.ASCII.GetString(dataToken);
             var isTokenValid = approvalToken == m_ApprovalToken;
@@ -165,13 +165,16 @@ namespace TestProject.ManualTests
 
             if (m_GlobalObjectIdHashOverride != 0 && m_PlayerPrefabOverride && m_PlayerPrefabOverride.isOn)
             {
-                aprovalCallback.Invoke(true, m_GlobalObjectIdHashOverride, isTokenValid, null, null);
+                decision.Approved = isTokenValid;
+                decision.PlayerPrefabHash = m_GlobalObjectIdHashOverride;
+                decision.CreatePlayerObject = true;
             }
             else
             {
-                aprovalCallback.Invoke(true, null, isTokenValid, null, null);
+                decision.Approved = isTokenValid;
+                decision.PlayerPrefabHash = null;
+                decision.CreatePlayerObject = true;
             }
-
 
             if (m_ConnectionMessageToDisplay)
             {

--- a/testproject/Assets/Tests/Runtime/MultiClientConnectionApproval.cs
+++ b/testproject/Assets/Tests/Runtime/MultiClientConnectionApproval.cs
@@ -173,7 +173,7 @@ namespace TestProject.RuntimeTests
         /// <param name="connectionData">the NetworkConfig.ConnectionData sent from the client being approved</param>
         /// <param name="clientId">the client id being approved</param>
         /// <param name="callback">the callback invoked to handle approval</param>
-        private void ConnectionApprovalCallback(byte[] connectionData, ulong clientId, NetworkManager.ConnectionApprovedDelegate callback)
+        private void ConnectionApprovalCallback(byte[] connectionData, ulong clientId, NetworkManager.ConnectionApprovalDecision decision)
         {
             string approvalToken = Encoding.ASCII.GetString(connectionData);
             var isApproved = approvalToken == m_ConnectionToken;
@@ -189,11 +189,14 @@ namespace TestProject.RuntimeTests
 
             if (m_PrefabOverrideGlobalObjectIdHash == 0)
             {
-                callback.Invoke(true, null, isApproved, null, null);
+                decision.CreatePlayerObject = true;
+                decision.Approved = isApproved;
             }
             else
             {
-                callback.Invoke(true, m_PrefabOverrideGlobalObjectIdHash, isApproved, null, null);
+                decision.CreatePlayerObject = true;
+                decision.Approved = isApproved;
+                decision.PlayerPrefabHash = m_PrefabOverrideGlobalObjectIdHash;
             }
         }
 


### PR DESCRIPTION
chore: allowing multiple Connection Approval handlers. Using the decision after they all got a chance to decide

[MTT-3496]

## Changelog

- [breaking] Allow multiple Connection Approval handlers. 
  `public delegate void ConnectionApprovalDelegate(byte[] payload, ulong clientId, ConnectionApprovalDecision decision);` now receives a `ConnectionApprovalDecision` class that must be filled, instead of calling a second callback. This allows having multiple Connection Approval handlers. (#1941)
  