### PR TITLE
fix: NetworkSceneManager does not synchronize despawned in-scene placed NetworkObjects [MTT-2924] (backport #1898)

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -26,7 +26,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Removed `ClientNetworkTransform` from the package samples and moved to Boss Room's Utilities package which can be found [here](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/blob/main/Packages/com.unity.multiplayer.samples.coop/Utilities/Net/ClientAuthority/ClientNetworkTransform.cs) (#1912).
 
 ### Fixed
-- Fixed `NetworkSceneManager` does not synchronize despawned in-scene placed NetworkObjects.
+- Fixed `NetworkSceneManager` does not synchronize despawned in-scene placed NetworkObjects. (#1898)
 - Fixed `NetworkTransform` generating false positive rotation delta checks when rolling over between 0 and 360 degrees. (#1890)
 - Fixed client throwing an exception if it has messages in the outbound queue when processing the `NetworkEvent.Disconnect` event and is using UTP. (#1884)
 - Fixed issue during client synchronization if 'ValidateSceneBeforeLoading' returned false it would halt the client synchronization process resulting in a client that was approved but not synchronized or fully connected with the server. (#1883)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -26,7 +26,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Removed `ClientNetworkTransform` from the package samples and moved to Boss Room's Utilities package which can be found [here](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/blob/main/Packages/com.unity.multiplayer.samples.coop/Utilities/Net/ClientAuthority/ClientNetworkTransform.cs) (#1912).
 
 ### Fixed
-- Fixed `NetworkSceneManager` does not synchronize despawned in-scene placed NetworkObjects. (#1898)
+- Fixed `NetworkSceneManager` does not synchronize despawned in-scene placed NetworkObjects nor do they have to register them to re-spawn them. (#1898)
 - Fixed `NetworkTransform` generating false positive rotation delta checks when rolling over between 0 and 360 degrees. (#1890)
 - Fixed client throwing an exception if it has messages in the outbound queue when processing the `NetworkEvent.Disconnect` event and is using UTP. (#1884)
 - Fixed issue during client synchronization if 'ValidateSceneBeforeLoading' returned false it would halt the client synchronization process resulting in a client that was approved but not synchronized or fully connected with the server. (#1883)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -26,7 +26,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Removed `ClientNetworkTransform` from the package samples and moved to Boss Room's Utilities package which can be found [here](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/blob/main/Packages/com.unity.multiplayer.samples.coop/Utilities/Net/ClientAuthority/ClientNetworkTransform.cs) (#1912).
 
 ### Fixed
-
+- Fixed `NetworkSceneManager` does not synchronize despawned in-scene placed NetworkObjects.
 - Fixed `NetworkTransform` generating false positive rotation delta checks when rolling over between 0 and 360 degrees. (#1890)
 - Fixed client throwing an exception if it has messages in the outbound queue when processing the `NetworkEvent.Disconnect` event and is using UTP. (#1884)
 - Fixed issue during client synchronization if 'ValidateSceneBeforeLoading' returned false it would halt the client synchronization process resulting in a client that was approved but not synchronized or fully connected with the server. (#1883)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -26,7 +26,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Removed `ClientNetworkTransform` from the package samples and moved to Boss Room's Utilities package which can be found [here](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/blob/main/Packages/com.unity.multiplayer.samples.coop/Utilities/Net/ClientAuthority/ClientNetworkTransform.cs) (#1912).
 
 ### Fixed
-- Fixed `NetworkSceneManager` does not synchronize despawned in-scene placed NetworkObjects nor do they have to register them to re-spawn them. (#1898)
+- Fixed issue where `NetworkSceneManager` did not synchronize despawned in-scene placed NetworkObjects. (#1898)
 - Fixed `NetworkTransform` generating false positive rotation delta checks when rolling over between 0 and 360 degrees. (#1890)
 - Fixed client throwing an exception if it has messages in the outbound queue when processing the `NetworkEvent.Disconnect` event and is using UTP. (#1884)
 - Fixed issue during client synchronization if 'ValidateSceneBeforeLoading' returned false it would halt the client synchronization process resulting in a client that was approved but not synchronized or fully connected with the server. (#1883)
@@ -47,6 +47,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - When `ForceSamePrefabs` is false, a configurable delay (default 1 second, configurable via `NetworkConfig.SpawnTimeout`) has been introduced to gracefully handle race conditions where a spawn call has been received for an object whose prefab is still being loaded. (#1882)
 
 ### Changed
+- Changed requirement to register in-scene placed NetworkObjects with `NetworkManager` in order to respawn them.  In-scene placed NetworkObjects are now automatically tracked during runtime and no longer need to be registered as a NetworkPrefab.  (#1898)
 
 - Changed `NetcodeIntegrationTestHelpers` to use `UnityTransport` (#1870)
 - Updated `UnityTransport` dependency on `com.unity.transport` to 1.0.0 (#1849)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -19,6 +19,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Changed
 
 - `unmanaged` structs are no longer universally accepted as RPC parameters because some structs (i.e., structs with pointers in them, such as `NativeList<T>`) can't be supported by the default memcpy struct serializer. Structs that are intended to be serialized across the network must add `INetworkSerializeByMemcpy` to the interface list (i.e., `struct Foo : INetworkSerializeByMemcpy`). This interface is empty and just serves to mark the struct as compatible with memcpy serialization. For external structs you can't edit, you can pass them to RPCs by wrapping them in `ForceNetworkSerializeByMemcpy<T>`. (#1901)
+- Changed requirement to register in-scene placed NetworkObjects with `NetworkManager` in order to respawn them.  In-scene placed NetworkObjects are now automatically tracked during runtime and no longer need to be registered as a NetworkPrefab.  (#1898)
 
 ### Removed
 
@@ -38,6 +39,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ## [1.0.0-pre.7] - 2022-04-06
 
 ### Added
+
 - Added editor only check prior to entering into play mode if the currently open and active scene is in the build list and if not displays a dialog box asking the user if they would like to automatically add it prior to entering into play mode. (#1828)
 - Added `UnityTransport` implementation and `com.unity.transport` package dependency (#1823)
 - Added `NetworkVariableWritePermission` to `NetworkVariableBase` and implemented `Owner` client writable netvars. (#1762)
@@ -47,7 +49,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - When `ForceSamePrefabs` is false, a configurable delay (default 1 second, configurable via `NetworkConfig.SpawnTimeout`) has been introduced to gracefully handle race conditions where a spawn call has been received for an object whose prefab is still being loaded. (#1882)
 
 ### Changed
-- Changed requirement to register in-scene placed NetworkObjects with `NetworkManager` in order to respawn them.  In-scene placed NetworkObjects are now automatically tracked during runtime and no longer need to be registered as a NetworkPrefab.  (#1898)
 
 - Changed `NetcodeIntegrationTestHelpers` to use `UnityTransport` (#1870)
 - Updated `UnityTransport` dependency on `com.unity.transport` to 1.0.0 (#1849)

--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -218,6 +218,11 @@ namespace Unity.Netcode.Editor
         /// </summary>
         private void OnEnable()
         {
+            // This can be null and throw an exception when running in test runner
+            if (target == null)
+            {
+                return;
+            }
             // When we first add a NetworkBehaviour this editor will be enabled
             // so we go ahead and check for an already existing NetworkObject here
             CheckForNetworkObject((target as NetworkBehaviour).gameObject);

--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -218,7 +218,7 @@ namespace Unity.Netcode.Editor
         /// </summary>
         private void OnEnable()
         {
-            // This can be null and throw an exception when running in test runner
+            // This can be null and throw an exception when running test runner in the editor
             if (target == null)
             {
                 return;

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1838,7 +1838,7 @@ namespace Unity.Netcode
 
                 if (createPlayerObject)
                 {
-                    var networkObject = SpawnManager.CreateLocalNetworkObject(false, playerPrefabHash ?? NetworkConfig.PlayerPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash, ownerClientId, null, position, rotation);
+                    var networkObject = SpawnManager.CreateLocalNetworkObject(false, playerPrefabHash ?? NetworkConfig.PlayerPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash, ownerClientId, null, null, position, rotation);
                     SpawnManager.SpawnNetworkObjectLocally(networkObject, SpawnManager.GetNetworkObjectId(), false, true, ownerClientId, false);
 
                     ConnectedClients[ownerClientId].PlayerObject = networkObject;

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -16,6 +16,10 @@ namespace Unity.Netcode
         [SerializeField]
         internal uint GlobalObjectIdHash;
 
+        /// <summary>
+        /// For in-scene placed NetworkObjects, this is used to uniquely identify the
+        /// NetworkObject relative to the NetworkSceneHandle.
+        /// </summary>
         internal int NetworkSceneHandle;
 #if UNITY_EDITOR
         private void OnValidate()
@@ -903,6 +907,11 @@ namespace Unity.Netcode
                     }
                 }
 
+                // In-Scene NetworkObjects are uniquely identified NetworkPrefabs defined by their
+                // NetworkSceneHandle and GlobalObjectIdHash. Since each loaded scene has a unique
+                // handle, it provides us with a unique and persistent "scene prefab asset" instance.
+                // This is only set on in-scene placed NetworkObjects to reduce the over-all packet
+                // sizes for dynamically spawned NetworkObjects.
                 if (Header.IsSceneObject)
                 {
                     writer.WriteValue(OwnerObject.NetworkSceneHandle);
@@ -948,6 +957,11 @@ namespace Unity.Netcode
                     }
                 }
 
+                // In-Scene NetworkObjects are uniquely identified NetworkPrefabs defined by their
+                // NetworkSceneHandle and GlobalObjectIdHash. Since each loaded scene has a unique
+                // handle, it provides us with a unique and persistent "scene prefab asset" instance.
+                // Client-side NetworkSceneManagers use this to locate their local instance of the
+                // NetworkObject instance.
                 if (Header.IsSceneObject)
                 {
                     reader.ReadValue(out NetworkSceneHandle);

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -373,7 +373,7 @@ namespace Unity.Netcode
                 throw new NotServerException($"Only server can spawn {nameof(NetworkObject)}s");
             }
 
-            NetworkManager.SpawnManager.SpawnNetworkObjectLocally(this, NetworkManager.SpawnManager.GetNetworkObjectId(), IsSceneObject.HasValue && IsSceneObject.Value == true, playerObject, ownerClientId, destroyWithScene);
+            NetworkManager.SpawnManager.SpawnNetworkObjectLocally(this, NetworkManager.SpawnManager.GetNetworkObjectId(), IsSceneObject.HasValue && IsSceneObject.Value, playerObject, ownerClientId, destroyWithScene);
 
             for (int i = 0; i < NetworkManager.ConnectedClientsList.Count; i++)
             {
@@ -964,7 +964,7 @@ namespace Unity.Netcode
                     IsPlayerObject = IsPlayerObject,
                     NetworkObjectId = NetworkObjectId,
                     OwnerClientId = OwnerClientId,
-                    IsSceneObject = IsSceneObject != false,
+                    IsSceneObject = IsSceneObject ?? true,
                     Hash = HostCheckForGlobalObjectIdHashOverride(),
                 },
                 OwnerObject = this,

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -16,6 +16,7 @@ namespace Unity.Netcode
         [SerializeField]
         internal uint GlobalObjectIdHash;
 
+        internal int NetworkSceneHandle;
 #if UNITY_EDITOR
         private void OnValidate()
         {
@@ -372,7 +373,7 @@ namespace Unity.Netcode
                 throw new NotServerException($"Only server can spawn {nameof(NetworkObject)}s");
             }
 
-            NetworkManager.SpawnManager.SpawnNetworkObjectLocally(this, NetworkManager.SpawnManager.GetNetworkObjectId(), false, playerObject, ownerClientId, destroyWithScene);
+            NetworkManager.SpawnManager.SpawnNetworkObjectLocally(this, NetworkManager.SpawnManager.GetNetworkObjectId(), IsSceneObject.HasValue && IsSceneObject.Value == true, playerObject, ownerClientId, destroyWithScene);
 
             for (int i = 0; i < NetworkManager.ConnectedClientsList.Count; i++)
             {
@@ -834,6 +835,7 @@ namespace Unity.Netcode
                 public ulong NetworkObjectId;
                 public ulong OwnerClientId;
                 public uint Hash;
+                public int NetworkSceneHandle;
 
                 public bool IsPlayerObject;
                 public bool HasParent;
@@ -865,16 +867,17 @@ namespace Unity.Netcode
             public NetworkObject OwnerObject;
             public ulong TargetClientId;
 
+            public int NetworkSceneHandle;
+
             public unsafe void Serialize(FastBufferWriter writer)
             {
-                if (!writer.TryBeginWrite(
-                    sizeof(HeaderData) +
-                    (Header.HasParent ? FastBufferWriter.GetWriteSize(ParentObjectId) : 0) +
-                    (Header.HasTransform ? FastBufferWriter.GetWriteSize(Transform) : 0) +
-                    (Header.IsReparented
-                        ? FastBufferWriter.GetWriteSize(IsLatestParentSet) +
-                          (IsLatestParentSet ? FastBufferWriter.GetWriteSize<ulong>() : 0)
-                        : 0)))
+                var writeSize = sizeof(HeaderData);
+                writeSize += Header.HasParent ? FastBufferWriter.GetWriteSize(ParentObjectId) : 0;
+                writeSize += Header.HasTransform ? FastBufferWriter.GetWriteSize(Transform) : 0;
+                writeSize += Header.IsReparented ? FastBufferWriter.GetWriteSize(IsLatestParentSet) + (IsLatestParentSet ? FastBufferWriter.GetWriteSize<ulong>() : 0) : 0 ;
+                writeSize += Header.IsSceneObject ? FastBufferWriter.GetWriteSize<int>() : 0;
+
+                if (!writer.TryBeginWrite(writeSize))
                 {
                     throw new OverflowException("Could not serialize SceneObject: Out of buffer space.");
                 }
@@ -900,6 +903,11 @@ namespace Unity.Netcode
                     }
                 }
 
+                if (Header.IsSceneObject)
+                {
+                    writer.WriteValue(OwnerObject.NetworkSceneHandle);
+                }
+
                 OwnerObject.WriteNetworkVariableData(writer, TargetClientId);
             }
 
@@ -910,10 +918,12 @@ namespace Unity.Netcode
                     throw new OverflowException("Could not deserialize SceneObject: Out of buffer space.");
                 }
                 reader.ReadValue(out Header);
-                if (!reader.TryBeginRead(
-                    (Header.HasParent ? FastBufferWriter.GetWriteSize(ParentObjectId) : 0) +
-                    (Header.HasTransform ? FastBufferWriter.GetWriteSize(Transform) : 0) +
-                    (Header.IsReparented ? FastBufferWriter.GetWriteSize(IsLatestParentSet) : 0)))
+                var readSize = Header.HasParent ? FastBufferWriter.GetWriteSize(ParentObjectId) : 0;
+                readSize += Header.HasTransform ? FastBufferWriter.GetWriteSize(Transform) : 0;
+                readSize += Header.IsReparented ? FastBufferWriter.GetWriteSize(IsLatestParentSet) + (IsLatestParentSet ? FastBufferWriter.GetWriteSize<ulong>() : 0) : 0;
+                readSize += Header.IsSceneObject ? FastBufferWriter.GetWriteSize<int>() : 0;
+
+                if (!reader.TryBeginRead(readSize))
                 {
                     throw new OverflowException("Could not deserialize SceneObject: Out of buffer space.");
                 }
@@ -937,6 +947,11 @@ namespace Unity.Netcode
                         LatestParent = latestParent;
                     }
                 }
+
+                if (Header.IsSceneObject)
+                {
+                    reader.ReadValue(out NetworkSceneHandle);
+                }
             }
         }
 
@@ -949,7 +964,7 @@ namespace Unity.Netcode
                     IsPlayerObject = IsPlayerObject,
                     NetworkObjectId = NetworkObjectId,
                     OwnerClientId = OwnerClientId,
-                    IsSceneObject = IsSceneObject ?? true,
+                    IsSceneObject = IsSceneObject != false,
                     Hash = HostCheckForGlobalObjectIdHashOverride(),
                 },
                 OwnerObject = this,
@@ -1006,6 +1021,7 @@ namespace Unity.Netcode
             Vector3? position = null;
             Quaternion? rotation = null;
             ulong? parentNetworkId = null;
+            int? networkSceneHandle = null;
 
             if (sceneObject.Header.HasTransform)
             {
@@ -1018,10 +1034,15 @@ namespace Unity.Netcode
                 parentNetworkId = sceneObject.ParentObjectId;
             }
 
+            if (sceneObject.Header.IsSceneObject)
+            {
+                networkSceneHandle = sceneObject.NetworkSceneHandle;
+            }
+
             //Attempt to create a local NetworkObject
             var networkObject = networkManager.SpawnManager.CreateLocalNetworkObject(
                 sceneObject.Header.IsSceneObject, sceneObject.Header.Hash,
-                sceneObject.Header.OwnerClientId, parentNetworkId, position, rotation, sceneObject.Header.IsReparented);
+                sceneObject.Header.OwnerClientId, parentNetworkId, networkSceneHandle, position, rotation, sceneObject.Header.IsReparented);
 
             networkObject?.SetNetworkParenting(sceneObject.Header.IsReparented, sceneObject.LatestParent);
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -16,11 +16,6 @@ namespace Unity.Netcode
         [SerializeField]
         internal uint GlobalObjectIdHash;
 
-        /// <summary>
-        /// For in-scene placed NetworkObjects, this is used to uniquely identify the
-        /// NetworkObject relative to the NetworkSceneHandle.
-        /// </summary>
-        internal int NetworkSceneHandle;
 #if UNITY_EDITOR
         private void OnValidate()
         {
@@ -839,7 +834,6 @@ namespace Unity.Netcode
                 public ulong NetworkObjectId;
                 public ulong OwnerClientId;
                 public uint Hash;
-                public int NetworkSceneHandle;
 
                 public bool IsPlayerObject;
                 public bool HasParent;
@@ -914,7 +908,7 @@ namespace Unity.Netcode
                 // sizes for dynamically spawned NetworkObjects.
                 if (Header.IsSceneObject)
                 {
-                    writer.WriteValue(OwnerObject.NetworkSceneHandle);
+                    writer.WriteValue(OwnerObject.gameObject.scene.handle);
                 }
 
                 OwnerObject.WriteNetworkVariableData(writer, TargetClientId);

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -874,7 +874,7 @@ namespace Unity.Netcode
                 var writeSize = sizeof(HeaderData);
                 writeSize += Header.HasParent ? FastBufferWriter.GetWriteSize(ParentObjectId) : 0;
                 writeSize += Header.HasTransform ? FastBufferWriter.GetWriteSize(Transform) : 0;
-                writeSize += Header.IsReparented ? FastBufferWriter.GetWriteSize(IsLatestParentSet) + (IsLatestParentSet ? FastBufferWriter.GetWriteSize<ulong>() : 0) : 0 ;
+                writeSize += Header.IsReparented ? FastBufferWriter.GetWriteSize(IsLatestParentSet) + (IsLatestParentSet ? FastBufferWriter.GetWriteSize<ulong>() : 0) : 0;
                 writeSize += Header.IsSceneObject ? FastBufferWriter.GetWriteSize<int>() : 0;
 
                 if (!writer.TryBeginWrite(writeSize))

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -152,6 +152,7 @@ namespace Unity.Netcode
 #endif
         }
 
+        private readonly HashSet<ulong> m_EmptyULongHashSet = new HashSet<ulong>();
         /// <summary>
         /// Returns Observers enumerator
         /// </summary>
@@ -160,7 +161,7 @@ namespace Unity.Netcode
         {
             if (!IsSpawned)
             {
-                throw new SpawnStateException("Object is not spawned");
+                return m_EmptyULongHashSet.GetEnumerator();
             }
 
             return Observers.GetEnumerator();
@@ -175,9 +176,8 @@ namespace Unity.Netcode
         {
             if (!IsSpawned)
             {
-                throw new SpawnStateException("Object is not spawned");
+                return false;
             }
-
             return Observers.Contains(clientId);
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/CreateObjectMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/CreateObjectMessage.cs
@@ -19,7 +19,6 @@ namespace Unity.Netcode
             }
 
             ObjectInfo.Deserialize(reader);
-
             if (!networkManager.NetworkConfig.ForceSamePrefabs && !networkManager.SpawnManager.HasPrefab(ObjectInfo))
             {
                 networkManager.DeferredMessageManager.DeferMessage(IDeferredMessageManager.TriggerType.OnAddPrefab, ObjectInfo.Header.Hash, reader, ref context);

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/CreateObjectMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/CreateObjectMessage.cs
@@ -19,7 +19,8 @@ namespace Unity.Netcode
             }
 
             ObjectInfo.Deserialize(reader);
-            if (!networkManager.NetworkConfig.ForceSamePrefabs && !networkManager.SpawnManager.HasPrefab(ObjectInfo.Header.IsSceneObject, ObjectInfo.Header.Hash))
+
+            if (!networkManager.NetworkConfig.ForceSamePrefabs && !networkManager.SpawnManager.HasPrefab(ObjectInfo))
             {
                 networkManager.DeferredMessageManager.DeferMessage(IDeferredMessageManager.TriggerType.OnAddPrefab, ObjectInfo.Header.Hash, reader, ref context);
                 return false;

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/DestroyObjectMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/DestroyObjectMessage.cs
@@ -3,6 +3,7 @@ namespace Unity.Netcode
     internal struct DestroyObjectMessage : INetworkMessage, INetworkSerializeByMemcpy
     {
         public ulong NetworkObjectId;
+        public bool DestroyGameObject;
 
         public void Serialize(FastBufferWriter writer)
         {
@@ -37,7 +38,7 @@ namespace Unity.Netcode
             }
 
             networkManager.NetworkMetrics.TrackObjectDestroyReceived(context.SenderId, networkObject, context.MessageSize);
-            networkManager.SpawnManager.OnDespawnObject(networkObject, true);
+            networkManager.SpawnManager.OnDespawnObject(networkObject, DestroyGameObject);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs
@@ -15,8 +15,10 @@ namespace Unity.Netcode
         {
             internal uint SceneEventId;
             internal Action<uint> EventAction;
+            internal Action Completed;
             internal void Invoke()
             {
+                Completed?.Invoke();
                 EventAction.Invoke(SceneEventId);
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs
@@ -15,6 +15,10 @@ namespace Unity.Netcode
         {
             internal uint SceneEventId;
             internal Action<uint> EventAction;
+            /// <summary>
+            /// Used server-side for integration testing in order to
+            /// invoke the SceneEventProgress once done loading
+            /// </summary>
             internal Action Completed;
             internal void Invoke()
             {

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -720,18 +720,18 @@ namespace Unity.Netcode
         /// </summary>
         /// <param name="globalObjectIdHash"></param>
         /// <returns></returns>
-        internal NetworkObject GetSceneRelativeInSceneNetworkObject(uint globalObjectIdHash)
+        internal NetworkObject GetSceneRelativeInSceneNetworkObject(uint globalObjectIdHash, int? networkSceneHandle)
         {
             if (ScenePlacedObjects.ContainsKey(globalObjectIdHash))
             {
                 if (ScenePlacedObjects[globalObjectIdHash].ContainsKey(SceneBeingSynchronized.handle))
                 {
-                    var inScenePlacedNetworkObject = ScenePlacedObjects[globalObjectIdHash][SceneBeingSynchronized.handle];
-
-                    // We can only have 1 duplicated globalObjectIdHash per scene instance, so remove it once it has been returned
-                    ScenePlacedObjects[globalObjectIdHash].Remove(SceneBeingSynchronized.handle);
-
-                    return inScenePlacedNetworkObject;
+                    var sceneHandle = SceneBeingSynchronized.handle;
+                    if (networkSceneHandle.HasValue && networkSceneHandle.Value != 0)
+                    {
+                        sceneHandle = ServerSceneHandleToClientSceneHandle[networkSceneHandle.Value];
+                    }
+                    return ScenePlacedObjects[globalObjectIdHash][sceneHandle];
                 }
             }
             return null;

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1411,6 +1411,7 @@ namespace Unity.Netcode
             }
 
             sceneEventData.AddSpawnedNetworkObjects();
+            sceneEventData.AddDespawnedInSceneNetworkObjects();
 
             var message = new SceneEventMessage
             {

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -632,7 +632,10 @@ namespace Unity.Netcode
             return validated;
         }
 
-        // WIP: Might be used for integration tests
+        /// <summary>
+        /// Used for NetcodeIntegrationTest testing in order to properly
+        /// assign the right loaded scene to the right client's ScenesLoaded list
+        /// </summary>
         internal Func<string, Scene> OverrideGetAndAddNewlyLoadedSceneByName;
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -734,13 +734,13 @@ namespace Unity.Netcode
         {
             if (ScenePlacedObjects.ContainsKey(globalObjectIdHash))
             {
-                if (ScenePlacedObjects[globalObjectIdHash].ContainsKey(SceneBeingSynchronized.handle))
+                var sceneHandle = SceneBeingSynchronized.handle;
+                if (networkSceneHandle.HasValue && networkSceneHandle.Value != 0)
                 {
-                    var sceneHandle = SceneBeingSynchronized.handle;
-                    if (networkSceneHandle.HasValue && networkSceneHandle.Value != 0)
-                    {
-                        sceneHandle = ServerSceneHandleToClientSceneHandle[networkSceneHandle.Value];
-                    }
+                    sceneHandle = ServerSceneHandleToClientSceneHandle[networkSceneHandle.Value];
+                }
+                if (ScenePlacedObjects[globalObjectIdHash].ContainsKey(sceneHandle))
+                {
                     return ScenePlacedObjects[globalObjectIdHash][sceneHandle];
                 }
             }
@@ -1458,7 +1458,7 @@ namespace Unity.Netcode
             var loadSceneMode = sceneHash == sceneEventData.SceneHash ? sceneEventData.LoadSceneMode : LoadSceneMode.Additive;
 
             // Store the sceneHandle and hash
-            sceneEventData.ClientSceneHandle = sceneHandle;
+            sceneEventData.NetworkSceneHandle = sceneHandle;
             sceneEventData.ClientSceneHash = sceneHash;
 
             // If this is the beginning of the synchronization event, then send client a notification that synchronization has begun
@@ -1547,9 +1547,9 @@ namespace Unity.Netcode
                 SceneManager.SetActiveScene(nextScene);
             }
 
-            if (!ServerSceneHandleToClientSceneHandle.ContainsKey(sceneEventData.ClientSceneHandle))
+            if (!ServerSceneHandleToClientSceneHandle.ContainsKey(sceneEventData.NetworkSceneHandle))
             {
-                ServerSceneHandleToClientSceneHandle.Add(sceneEventData.ClientSceneHandle, nextScene.handle);
+                ServerSceneHandleToClientSceneHandle.Add(sceneEventData.NetworkSceneHandle, nextScene.handle);
             }
             else
             {

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -961,6 +961,7 @@ namespace Unity.Netcode
             var sceneEventAction = new ISceneManagerHandler.SceneEventAction() { SceneEventId = sceneEventData.SceneEventId, EventAction = OnSceneUnloaded };
             var sceneUnload = SceneManagerHandler.UnloadSceneAsync(scene, sceneEventAction);
 
+            // If integration testing, IntegrationTestSceneHandler returns null
             if (sceneUnload == null)
             {
                 sceneEventProgress.SetSceneLoadOperation(sceneEventAction);
@@ -1168,6 +1169,8 @@ namespace Unity.Netcode
             // Now start loading the scene
             var sceneEventAction = new ISceneManagerHandler.SceneEventAction() { SceneEventId = sceneEventId, EventAction = OnSceneLoaded };
             var sceneLoad = SceneManagerHandler.LoadSceneAsync(sceneName, loadSceneMode, sceneEventAction);
+
+            // If integration testing, IntegrationTestSceneHandler returns null
             if (sceneLoad == null)
             {
                 sceneEventProgress.SetSceneLoadOperation(sceneEventAction);

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
@@ -249,7 +249,7 @@ namespace Unity.Netcode
         internal void AddDespawnedInSceneNetworkObjects()
         {
             m_DespawnedInSceneObjectsSync.Clear();
-            var inSceneNetworkObjects = UnityEngine.Object.FindObjectsOfType<NetworkObject>().Where((c)=>c.NetworkManager == m_NetworkManager);
+            var inSceneNetworkObjects = UnityEngine.Object.FindObjectsOfType<NetworkObject>().Where((c) => c.NetworkManager == m_NetworkManager);
             foreach (var sobj in inSceneNetworkObjects)
             {
                 if (sobj.IsSceneObject.HasValue && sobj.IsSceneObject.Value && !sobj.IsSpawned)

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
@@ -744,7 +744,7 @@ namespace Unity.Netcode
                     // We just need to get the scene
                     InternalBuffer.ReadValueSafe(out int networkSceneHandle);
                     InternalBuffer.ReadValueSafe(out uint globalObjectIdHash);
-                    var sceneRelativeNetworkObjects = new Dictionary<uint,NetworkObject>();
+                    var sceneRelativeNetworkObjects = new Dictionary<uint, NetworkObject>();
                     if (!sceneCache.ContainsKey(networkSceneHandle))
                     {
                         if (m_NetworkManager.SceneManager.ServerSceneHandleToClientSceneHandle.ContainsKey(networkSceneHandle))
@@ -756,7 +756,7 @@ namespace Unity.Netcode
                                 var inSceneNetworkObjects = UnityEngine.Object.FindObjectsOfType<NetworkObject>().Where((c) => c.gameObject.scene == objectRelativeScene &&
                                 c.gameObject.scene.handle == localSceneHandle && (c.IsSceneObject != false)).ToList();
 
-                                foreach(var inSceneObject in inSceneNetworkObjects)
+                                foreach (var inSceneObject in inSceneNetworkObjects)
                                 {
                                     sceneRelativeNetworkObjects.Add(inSceneObject.GlobalObjectIdHash, inSceneObject);
                                 }
@@ -779,7 +779,7 @@ namespace Unity.Netcode
                     }
 
                     // Now find the in-scene NetworkObject with the current GlobalObjectIdHash we are looking for
-                    if(sceneRelativeNetworkObjects.ContainsKey(globalObjectIdHash))
+                    if (sceneRelativeNetworkObjects.ContainsKey(globalObjectIdHash))
                     {
                         // Since this is a NetworkObject that was never spawned, we just need to send a notification
                         // out that it was despawned so users can make adjustments

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
@@ -784,6 +784,16 @@ namespace Unity.Netcode
                         // Since this is a NetworkObject that was never spawned, we just need to send a notification
                         // out that it was despawned so users can make adjustments
                         sceneRelativeNetworkObjects[globalObjectIdHash].InvokeBehaviourNetworkDespawn();
+                        if (!m_NetworkManager.SceneManager.ScenePlacedObjects.ContainsKey(globalObjectIdHash))
+                        {
+                            m_NetworkManager.SceneManager.ScenePlacedObjects.Add(globalObjectIdHash, new Dictionary<int, NetworkObject>());
+                        }
+
+                        if (!m_NetworkManager.SceneManager.ScenePlacedObjects[globalObjectIdHash].ContainsKey(sceneRelativeNetworkObjects[globalObjectIdHash].gameObject.scene.handle))
+                        {
+                            m_NetworkManager.SceneManager.ScenePlacedObjects[globalObjectIdHash].Add(sceneRelativeNetworkObjects[globalObjectIdHash].gameObject.scene.handle, sceneRelativeNetworkObjects[globalObjectIdHash]);
+                        }
+
                     }
                     else
                     {

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
@@ -754,7 +754,7 @@ namespace Unity.Netcode
                             {
                                 var objectRelativeScene = m_NetworkManager.SceneManager.ScenesLoaded[localSceneHandle];
                                 var inSceneNetworkObjects = UnityEngine.Object.FindObjectsOfType<NetworkObject>().Where((c) => c.gameObject.scene == objectRelativeScene &&
-                                c.gameObject.scene.handle == localSceneHandle && (!c.IsSceneObject.HasValue || c.IsSceneObject.HasValue && c.IsSceneObject.Value == true)).ToList();
+                                c.gameObject.scene.handle == localSceneHandle && (c.IsSceneObject != false)).ToList();
 
                                 foreach(var inSceneObject in inSceneNetworkObjects)
                                 {

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
@@ -100,7 +100,7 @@ namespace Unity.Netcode
 
         // Used by the client during synchronization
         internal uint ClientSceneHash;
-        internal int ClientSceneHandle;
+        internal int NetworkSceneHandle;
 
         /// Only used for <see cref="SceneEventType.Synchronize"/> scene events, this assures permissions when writing
         /// NetworkVariable information.  If that process changes, then we need to update this
@@ -249,10 +249,10 @@ namespace Unity.Netcode
         internal void AddDespawnedInSceneNetworkObjects()
         {
             m_DespawnedInSceneObjectsSync.Clear();
-            var inSceneNetworkObjects = UnityEngine.Object.FindObjectsOfType<NetworkObject>();
+            var inSceneNetworkObjects = UnityEngine.Object.FindObjectsOfType<NetworkObject>().Where((c)=>c.NetworkManager == m_NetworkManager);
             foreach (var sobj in inSceneNetworkObjects)
             {
-                if (sobj.Observers.Contains(TargetClientId) && sobj.IsSceneObject.HasValue && sobj.IsSceneObject.Value && !sobj.IsSpawned)
+                if (sobj.IsSceneObject.HasValue && sobj.IsSceneObject.Value && !sobj.IsSpawned)
                 {
                     m_DespawnedInSceneObjectsSync.Add(sobj);
                 }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
@@ -137,29 +137,28 @@ namespace Unity.Netcode
 
         internal void SetSceneLoadOperation(AsyncOperation sceneLoadOperation)
         {
-            try
-            {
-                m_SceneLoadOperation = sceneLoadOperation;
-                m_SceneLoadOperation.completed += operation => CheckCompletion();
-            }
-            catch (Exception ex)
-            {
-                Debug.LogException(ex);
-            }
+            m_SceneLoadOperation = sceneLoadOperation;
+            m_SceneLoadOperation.completed += operation => CheckCompletion();
         }
 
+        /// <summary>
+        /// Called only on the server-side during integration test (NetcodeIntegrationTest specific)
+        /// scene loading and unloading.
+        ///
+        /// Note: During integration testing we must queue all scene loading and unloading requests for
+        /// both the server and all clients so they can be processed in a FIFO/linear fashion to avoid
+        /// conflicts when the  <see cref="SceneManager.sceneLoaded"/> and <see cref="SceneManager.sceneUnloaded"/>
+        /// events are triggered. The Completed action simulates the <see cref="AsyncOperation.completed"/> event.
+        /// (See: Unity.Netcode.TestHelpers.Runtime.IntegrationTestSceneHandler)
+        /// </summary>
         internal void SetSceneLoadOperation(ISceneManagerHandler.SceneEventAction sceneEventAction)
         {
-            try
-            {
-                sceneEventAction.Completed = SetComplete;
-            }
-            catch (Exception ex)
-            {
-                Debug.LogException(ex);
-            }
+            sceneEventAction.Completed = SetComplete;
         }
 
+        /// <summary>
+        /// Finalizes the SceneEventProgress
+        /// </summary>
         internal void SetComplete()
         {
             IsCompleted = true;

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -358,27 +358,19 @@ namespace Unity.Netcode
                 {
                     // See if there is a valid registered NetworkPrefabOverrideLink associated with the provided prefabHash
                     GameObject networkPrefabReference = null;
-                    if (!isSceneObject)
+                    if (NetworkManager.NetworkConfig.NetworkPrefabOverrideLinks.ContainsKey(globalObjectIdHash))
                     {
-                        if (NetworkManager.NetworkConfig.NetworkPrefabOverrideLinks.ContainsKey(globalObjectIdHash))
+                        switch (NetworkManager.NetworkConfig.NetworkPrefabOverrideLinks[globalObjectIdHash].Override)
                         {
-                            switch (NetworkManager.NetworkConfig.NetworkPrefabOverrideLinks[globalObjectIdHash].Override)
-                            {
-                                default:
-                                case NetworkPrefabOverride.None:
-                                    networkPrefabReference = NetworkManager.NetworkConfig.NetworkPrefabOverrideLinks[globalObjectIdHash].Prefab;
-                                    break;
-                                case NetworkPrefabOverride.Hash:
-                                case NetworkPrefabOverride.Prefab:
-                                    networkPrefabReference = NetworkManager.NetworkConfig.NetworkPrefabOverrideLinks[globalObjectIdHash].OverridingTargetPrefab;
-                                    break;
-                            }
+                            default:
+                            case NetworkPrefabOverride.None:
+                                networkPrefabReference = NetworkManager.NetworkConfig.NetworkPrefabOverrideLinks[globalObjectIdHash].Prefab;
+                                break;
+                            case NetworkPrefabOverride.Hash:
+                            case NetworkPrefabOverride.Prefab:
+                                networkPrefabReference = NetworkManager.NetworkConfig.NetworkPrefabOverrideLinks[globalObjectIdHash].OverridingTargetPrefab;
+                                break;
                         }
-                    }
-                    else
-                    {
-                        // Find and return the already existing despawned in-scene object
-                        return NetworkManager.SceneManager.GetSceneRelativeInSceneNetworkObject(globalObjectIdHash, networkSceneHandle);
                     }
 
                     // If not, then there is an issue (user possibly didn't register the prefab properly?)
@@ -576,9 +568,9 @@ namespace Unity.Netcode
 
             if (networkObject.IsSceneObject != false)
             {
-                // This is used to distinguish between identical GlobalObjectIdhash values when
-                // the same scene is loaded multiple times additively.  This is only sent if the
-                // NetworkObject is an in-scene placed NetworkObject
+                // In-Scene NetworkObjects are uniquely identified NetworkPrefabs defined by their
+                // NetworkSceneHandle and GlobalObjectIdHash. Since each loaded scene has a unique
+                // handle, it provides us with a unique and persistent "scene prefab asset" instance.
                 networkObject.NetworkSceneHandle = networkObject.gameObject.scene.handle;
             }
 

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -377,6 +377,7 @@ namespace Unity.Netcode
                     }
                     else
                     {
+                        // Find and return the already existing despawned in-scene object
                         return NetworkManager.SceneManager.GetSceneRelativeInSceneNetworkObject(globalObjectIdHash, networkSceneHandle);
                     }
 
@@ -493,6 +494,13 @@ namespace Unity.Netcode
             //  the current design banks on getting the network behaviour set and then only reading from it after the
             //  below initialization code. However cowardice compels me to hold off on moving this until that commit
             networkObject.IsSceneObject = sceneObject;
+
+            // For integration testing, this makes sure that the appropriate NetworkManager is assigned to
+            // the NetworkObject since it uses the NetworkManager.Singleton when not set
+            if (networkObject.NetworkManagerOwner != NetworkManager)
+            {
+                networkObject.NetworkManagerOwner = NetworkManager;
+            }
 
             networkObject.NetworkObjectId = networkId;
 

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -283,7 +283,7 @@ namespace Unity.Netcode
             }
         }
 
-        internal bool HasPrefab(NetworkObject.SceneObject sceneObject)//bool isSceneObject, uint globalObjectIdHash)
+        internal bool HasPrefab(NetworkObject.SceneObject sceneObject)
         {
             if (!NetworkManager.NetworkConfig.EnableSceneManagement || !sceneObject.Header.IsSceneObject)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -306,7 +306,7 @@ namespace Unity.Netcode
 
                 return false;
             }
-            var networkObject = NetworkManager.SceneManager.GetSceneRelativeInSceneNetworkObject(sceneObject.Header.Hash, sceneObject.Header.NetworkSceneHandle);
+            var networkObject = NetworkManager.SceneManager.GetSceneRelativeInSceneNetworkObject(sceneObject.Header.Hash, sceneObject.NetworkSceneHandle);
             return networkObject != null;
         }
 
@@ -564,14 +564,6 @@ namespace Unity.Netcode
             if (clientId == NetworkManager.ServerClientId)
             {
                 return;
-            }
-
-            if (networkObject.IsSceneObject != false)
-            {
-                // In-Scene NetworkObjects are uniquely identified NetworkPrefabs defined by their
-                // NetworkSceneHandle and GlobalObjectIdHash. Since each loaded scene has a unique
-                // handle, it provides us with a unique and persistent "scene prefab asset" instance.
-                networkObject.NetworkSceneHandle = networkObject.gameObject.scene.handle;
             }
 
             var message = new CreateObjectMessage

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -313,7 +313,7 @@ namespace Unity.Netcode
         /// <summary>
         /// Should only run on the client
         /// </summary>
-        internal NetworkObject CreateLocalNetworkObject(bool isSceneObject, uint globalObjectIdHash, ulong ownerClientId, ulong? parentNetworkId, Vector3? position, Quaternion? rotation, bool isReparented = false)
+        internal NetworkObject CreateLocalNetworkObject(bool isSceneObject, uint globalObjectIdHash, ulong ownerClientId, ulong? parentNetworkId, int? networkSceneHandle, Vector3? position, Quaternion? rotation, bool isReparented = false)
         {
             NetworkObject parentNetworkObject = null;
 
@@ -358,19 +358,26 @@ namespace Unity.Netcode
                 {
                     // See if there is a valid registered NetworkPrefabOverrideLink associated with the provided prefabHash
                     GameObject networkPrefabReference = null;
-                    if (NetworkManager.NetworkConfig.NetworkPrefabOverrideLinks.ContainsKey(globalObjectIdHash))
+                    if (!isSceneObject)
                     {
-                        switch (NetworkManager.NetworkConfig.NetworkPrefabOverrideLinks[globalObjectIdHash].Override)
+                        if (NetworkManager.NetworkConfig.NetworkPrefabOverrideLinks.ContainsKey(globalObjectIdHash))
                         {
-                            default:
-                            case NetworkPrefabOverride.None:
-                                networkPrefabReference = NetworkManager.NetworkConfig.NetworkPrefabOverrideLinks[globalObjectIdHash].Prefab;
-                                break;
-                            case NetworkPrefabOverride.Hash:
-                            case NetworkPrefabOverride.Prefab:
-                                networkPrefabReference = NetworkManager.NetworkConfig.NetworkPrefabOverrideLinks[globalObjectIdHash].OverridingTargetPrefab;
-                                break;
+                            switch (NetworkManager.NetworkConfig.NetworkPrefabOverrideLinks[globalObjectIdHash].Override)
+                            {
+                                default:
+                                case NetworkPrefabOverride.None:
+                                    networkPrefabReference = NetworkManager.NetworkConfig.NetworkPrefabOverrideLinks[globalObjectIdHash].Prefab;
+                                    break;
+                                case NetworkPrefabOverride.Hash:
+                                case NetworkPrefabOverride.Prefab:
+                                    networkPrefabReference = NetworkManager.NetworkConfig.NetworkPrefabOverrideLinks[globalObjectIdHash].OverridingTargetPrefab;
+                                    break;
+                            }
                         }
+                    }
+                    else
+                    {
+                        return NetworkManager.SceneManager.GetSceneRelativeInSceneNetworkObject(globalObjectIdHash, networkSceneHandle);
                     }
 
                     // If not, then there is an issue (user possibly didn't register the prefab properly?)
@@ -404,7 +411,7 @@ namespace Unity.Netcode
             }
             else
             {
-                var networkObject = NetworkManager.SceneManager.GetSceneRelativeInSceneNetworkObject(globalObjectIdHash);
+                var networkObject = NetworkManager.SceneManager.GetSceneRelativeInSceneNetworkObject(globalObjectIdHash, networkSceneHandle);
 
                 if (networkObject == null)
                 {
@@ -486,6 +493,7 @@ namespace Unity.Netcode
             //  the current design banks on getting the network behaviour set and then only reading from it after the
             //  below initialization code. However cowardice compels me to hold off on moving this until that commit
             networkObject.IsSceneObject = sceneObject;
+
             networkObject.NetworkObjectId = networkId;
 
             networkObject.DestroyWithScene = sceneObject || destroyWithScene;
@@ -552,11 +560,18 @@ namespace Unity.Netcode
 
         internal void SendSpawnCallForObject(ulong clientId, NetworkObject networkObject)
         {
-            //Currently, if this is called and the clientId (destination) is the server's client Id, this case will be checked
-            // within the below Send function.  To avoid unwarranted allocation of a PooledNetworkBuffer placing this check here. [NSS]
-            if (NetworkManager.IsServer && clientId == NetworkManager.ServerClientId)
+            // If we are a host and sending to the host's client id, then we can skip sending ourselves the spawn message.
+            if (clientId == NetworkManager.ServerClientId)
             {
                 return;
+            }
+
+            if (networkObject.IsSceneObject != false)
+            {
+                // This is used to distinguish between identical GlobalObjectIdhash values when
+                // the same scene is loaded multiple times additively.  This is only sent if the
+                // NetworkObject is an in-scene placed NetworkObject
+                networkObject.NetworkSceneHandle = networkObject.gameObject.scene.handle;
             }
 
             var message = new CreateObjectMessage
@@ -785,7 +800,8 @@ namespace Unity.Netcode
 
                         var message = new DestroyObjectMessage
                         {
-                            NetworkObjectId = networkObject.NetworkObjectId
+                            NetworkObjectId = networkObject.NetworkObjectId,
+                            DestroyGameObject = networkObject.IsSceneObject != false ? destroyGameObject : true
                         };
                         var size = NetworkManager.SendMessage(ref message, NetworkDelivery.ReliableSequenced, m_TargetClientIds);
                         foreach (var targetClientId in m_TargetClientIds)

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -283,15 +283,15 @@ namespace Unity.Netcode
             }
         }
 
-        internal bool HasPrefab(bool isSceneObject, uint globalObjectIdHash)
+        internal bool HasPrefab(NetworkObject.SceneObject sceneObject)//bool isSceneObject, uint globalObjectIdHash)
         {
-            if (!NetworkManager.NetworkConfig.EnableSceneManagement || !isSceneObject)
+            if (!NetworkManager.NetworkConfig.EnableSceneManagement || !sceneObject.Header.IsSceneObject)
             {
-                if (NetworkManager.PrefabHandler.ContainsHandler(globalObjectIdHash))
+                if (NetworkManager.PrefabHandler.ContainsHandler(sceneObject.Header.Hash))
                 {
                     return true;
                 }
-                if (NetworkManager.NetworkConfig.NetworkPrefabOverrideLinks.TryGetValue(globalObjectIdHash, out var networkPrefab))
+                if (NetworkManager.NetworkConfig.NetworkPrefabOverrideLinks.TryGetValue(sceneObject.Header.Hash, out var networkPrefab))
                 {
                     switch (networkPrefab.Override)
                     {
@@ -306,7 +306,7 @@ namespace Unity.Netcode
 
                 return false;
             }
-            var networkObject = NetworkManager.SceneManager.GetSceneRelativeInSceneNetworkObject(globalObjectIdHash);
+            var networkObject = NetworkManager.SceneManager.GetSceneRelativeInSceneNetworkObject(sceneObject.Header.Hash, sceneObject.Header.NetworkSceneHandle);
             return networkObject != null;
         }
 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/Components/ObjectNameIdentifier.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/Components/ObjectNameIdentifier.cs
@@ -42,7 +42,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
                         continue;
                     }
                     var segment = nameSegment;
-                    if (nameSegment.Contains(k_TagInfoStart) && nameSegment.Contains(k_TagInfoStop))
+                    if (nameSegment.Contains($"{k_TagInfoStart}") && nameSegment.Contains($"{k_TagInfoStop}"))
                     {
                         var startPos = nameSegment.IndexOf(k_TagInfoStart);
                         var stopPos = nameSegment.IndexOf(k_TagInfoStop);

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
@@ -111,6 +111,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
             {
                 yield return s_WaitForSeconds;
             }
+            yield return s_WaitForSeconds;
+            CurrentQueuedSceneJob.SceneAction.Invoke();
         }
 
         /// <summary>
@@ -127,7 +129,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
                 ProcessInSceneObjects(scene, CurrentQueuedSceneJob.IntegrationTestSceneHandler.NetworkManager);
 
-                CurrentQueuedSceneJob.SceneAction.Invoke();
                 CurrentQueuedSceneJob.JobType = QueuedSceneJob.JobTypes.Completed;
             }
         }
@@ -186,6 +187,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
             {
                 yield return s_WaitForSeconds;
             }
+            yield return s_WaitForSeconds;
+            CurrentQueuedSceneJob.SceneAction.Invoke();
         }
 
         /// <summary>
@@ -196,7 +199,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             if (CurrentQueuedSceneJob.JobType != QueuedSceneJob.JobTypes.Completed && CurrentQueuedSceneJob.Scene.name == scene.name)
             {
                 SceneManager.sceneUnloaded -= SceneManager_sceneUnloaded;
-                CurrentQueuedSceneJob.SceneAction.Invoke();
+
                 CurrentQueuedSceneJob.JobType = QueuedSceneJob.JobTypes.Completed;
             }
         }
@@ -207,7 +210,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// </summary>
         static internal IEnumerator JobQueueProcessor()
         {
-            var waitforJob = new WaitForSeconds(0.25f);
             while (true)
             {
                 while (QueuedSceneJobs.Count != 0)
@@ -224,7 +226,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
                     }
                     VerboseDebug($"[ITSH-STOP] {CurrentQueuedSceneJob.IntegrationTestSceneHandler.NetworkManager.name} processing {CurrentQueuedSceneJob.JobType} for scene {CurrentQueuedSceneJob.SceneName}.");
                 }
-                yield return waitforJob;
+                yield return s_WaitForSeconds;
             }
         }
 
@@ -361,7 +363,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             NetworkManagers.Add(networkManager);
             if (s_WaitForSeconds == null)
             {
-                s_WaitForSeconds = new WaitForSeconds(0.01f);
+                s_WaitForSeconds = new WaitForSeconds(0.075f);
             }
             NetworkManager = networkManager;
             if (CoroutineRunner == null)
@@ -376,8 +378,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
             if (SceneJobProcessor != null)
             {
                 CoroutineRunner.StopCoroutine(SceneJobProcessor);
+                SceneJobProcessor = null;
             }
-            CoroutineRunner.StopAllCoroutines();
 
             foreach (var job in QueuedSceneJobs)
             {

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
@@ -90,7 +90,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
         static internal IEnumerator ProcessLoadingSceneJob(QueuedSceneJob queuedSceneJob)
         {
             var itegrationTestSceneHandler = queuedSceneJob.IntegrationTestSceneHandler;
-            yield return s_WaitForSeconds;
             while (!itegrationTestSceneHandler.OnCanClientsLoad())
             {
                 yield return s_WaitForSeconds;
@@ -139,7 +138,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
         static internal IEnumerator ProcessUnloadingSceneJob(QueuedSceneJob queuedSceneJob)
         {
             var itegrationTestSceneHandler = queuedSceneJob.IntegrationTestSceneHandler;
-            yield return s_WaitForSeconds;
             while (!itegrationTestSceneHandler.OnCanClientsUnload())
             {
                 yield return s_WaitForSeconds;

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
@@ -178,7 +178,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
             }
             else
             {
-                CurrentQueuedSceneJob.SceneAction.Invoke();
                 CurrentQueuedSceneJob.JobType = QueuedSceneJob.JobTypes.Completed;
             }
 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
@@ -9,13 +9,15 @@ namespace Unity.Netcode.TestHelpers.Runtime
 {
     /// <summary>
     /// The default SceneManagerHandler used for all NetcodeIntegrationTest derived children.
+    /// Original class -- will be removed if the new IntegrationTestSceneHandler cannot load
+    /// scenes for all clients.
     /// </summary>
-    internal class IntegrationTestSceneHandler : ISceneManagerHandler, IDisposable
+    internal class OldIntegrationTestSceneHandler : ISceneManagerHandler, IDisposable
     {
         internal CoroutineRunner CoroutineRunner;
 
         // Default client simulated delay time
-        protected const float k_ClientLoadingSimulatedDelay = 0.02f;
+        protected const float k_ClientLoadingSimulatedDelay = 0.016f;
 
         // Controls the client simulated delay time
         protected float m_ClientLoadingSimulatedDelay = k_ClientLoadingSimulatedDelay;
@@ -93,7 +95,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             return new AsyncOperation();
         }
 
-        public IntegrationTestSceneHandler()
+        public OldIntegrationTestSceneHandler()
         {
             if (CoroutineRunner == null)
             {
@@ -109,6 +111,271 @@ namespace Unity.Netcode.TestHelpers.Runtime
             }
             CoroutineRunner.StopAllCoroutines();
 
+            Object.Destroy(CoroutineRunner.gameObject);
+        }
+    }
+
+    internal class IntegrationTestSceneHandler : ISceneManagerHandler, IDisposable
+    {
+        internal static CoroutineRunner CoroutineRunner;
+
+        // Default client simulated delay time
+        protected const float k_ClientLoadingSimulatedDelay = 0.006f;
+
+        // Controls the client simulated delay time
+        protected static float s_ClientLoadingSimulatedDelay = k_ClientLoadingSimulatedDelay;
+
+
+        internal static List<QueuedSceneJob> QueuedSceneJobs = new List<QueuedSceneJob>();
+        internal List<Coroutine> CoroutinesRunning = new List<Coroutine>();
+        internal static Coroutine SceneJobProcessor;
+        internal static QueuedSceneJob CurrentQueuedSceneJob;
+        protected static WaitForSeconds s_WaitForSeconds;
+
+
+        public delegate bool CanClientsLoadUnloadDelegateHandler();
+        public static event CanClientsLoadUnloadDelegateHandler CanClientsLoad;
+        public static event CanClientsLoadUnloadDelegateHandler CanClientsUnload;
+
+        internal class QueuedSceneJob
+        {
+            public enum JobTypes
+            {
+                Loading,
+                Unloading,
+                Completed
+            }
+            public JobTypes JobType;
+            public string SceneName;
+            public Scene Scene;
+            public ISceneManagerHandler.SceneEventAction SceneAction;
+            public IntegrationTestSceneHandler IntegrationTestSceneHandler;
+        }
+
+        internal NetworkManager NetworkManager;
+
+        /// <summary>
+        /// Used to control when clients should attempt to fake-load a scene
+        /// Note: Unit/Integration tests that only use <see cref="NetcodeIntegrationTestHelpers"/>
+        /// need to subscribe to the CanClientsLoad and CanClientsUnload events
+        /// in order to control when clients can fake-load.
+        /// Tests that derive from <see cref="NetcodeIntegrationTest"/> already have integrated
+        /// support and you can override <see cref="NetcodeIntegrationTest.CanClientsLoad"/> and
+        /// <see cref="NetcodeIntegrationTest.CanClientsUnload"/>.
+        /// </summary>
+        protected bool OnCanClientsLoad()
+        {
+            if (CanClientsLoad != null)
+            {
+                return CanClientsLoad.Invoke();
+            }
+            return true;
+        }
+
+        protected bool OnCanClientsUnload()
+        {
+            if (CanClientsUnload != null)
+            {
+                return CanClientsUnload.Invoke();
+            }
+            return true;
+        }
+
+        static internal IEnumerator ProcessLoadingSceneJob(QueuedSceneJob queuedSceneJob)
+        {
+            var itegrationTestSceneHandler = queuedSceneJob.IntegrationTestSceneHandler;
+            yield return s_WaitForSeconds;
+            while (!itegrationTestSceneHandler.OnCanClientsLoad())
+            {
+                yield return s_WaitForSeconds;
+            }
+
+            //SceneManager.sceneLoaded += SceneManager_sceneLoaded;
+            //// We always load additively for all scenes during integration tests
+            //SceneManager.LoadSceneAsync(queuedSceneJob.SceneName, LoadSceneMode.Additive);
+
+            CurrentQueuedSceneJob.SceneAction.Invoke();
+            CurrentQueuedSceneJob.JobType = QueuedSceneJob.JobTypes.Completed;
+
+            // Wait for it to finish
+            while (queuedSceneJob.JobType != QueuedSceneJob.JobTypes.Completed)
+            {
+                yield return s_WaitForSeconds;
+            }
+        }
+
+
+        private static void SceneManager_sceneLoaded(Scene scene, LoadSceneMode loadSceneMode)
+        {
+            if (CurrentQueuedSceneJob.SceneName == scene.name)
+            {
+                SceneManager.sceneLoaded -= SceneManager_sceneLoaded;
+                //scene.name += $"-OnClient({CurrentQueuedSceneJob.IntegrationTestSceneHandler.NetworkManager.LocalClientId})";
+                CurrentQueuedSceneJob.SceneAction.Invoke();
+                CurrentQueuedSceneJob.JobType = QueuedSceneJob.JobTypes.Completed;
+            }
+        }
+
+        static internal IEnumerator ProcessUnloadingSceneJob(QueuedSceneJob queuedSceneJob)
+        {
+            var itegrationTestSceneHandler = queuedSceneJob.IntegrationTestSceneHandler;
+            yield return s_WaitForSeconds;
+            while (!itegrationTestSceneHandler.OnCanClientsUnload())
+            {
+                yield return s_WaitForSeconds;
+            }
+
+            //SceneManager.sceneUnloaded += SceneManager_sceneUnloaded;
+            //if (queuedSceneJob.Scene.IsValid() && queuedSceneJob.Scene.isLoaded)
+            //{
+            //    SceneManager.UnloadSceneAsync(queuedSceneJob.Scene);
+            //}
+            //else
+            //{
+            //    CurrentQueuedSceneJob.SceneAction.Invoke();
+            //    CurrentQueuedSceneJob.JobType = QueuedSceneJob.JobTypes.Completed;
+            //}
+
+            CurrentQueuedSceneJob.SceneAction.Invoke();
+            CurrentQueuedSceneJob.JobType = QueuedSceneJob.JobTypes.Completed;
+            // Wait for it to finish
+            while (queuedSceneJob.JobType != QueuedSceneJob.JobTypes.Completed)
+            {
+                yield return s_WaitForSeconds;
+            }
+        }
+
+        private static void SceneManager_sceneUnloaded(Scene scene)
+        {
+            if (CurrentQueuedSceneJob.Scene.name == scene.name)
+            {
+                SceneManager.sceneUnloaded -= SceneManager_sceneUnloaded;
+                CurrentQueuedSceneJob.SceneAction.Invoke();
+                CurrentQueuedSceneJob.JobType = QueuedSceneJob.JobTypes.Completed;
+            }
+        }
+
+        static internal IEnumerator JobQueueProcessor()
+        {
+            var nextJob = QueuedSceneJobs[0];
+            while (nextJob != null)
+            {
+                CurrentQueuedSceneJob = nextJob;
+                if (nextJob.JobType == QueuedSceneJob.JobTypes.Loading)
+                {
+                    yield return ProcessLoadingSceneJob(nextJob);
+                }
+                else if (nextJob.JobType == QueuedSceneJob.JobTypes.Unloading)
+                {
+                    yield return ProcessUnloadingSceneJob(nextJob);
+                }
+                QueuedSceneJobs.Remove(nextJob);
+                nextJob = QueuedSceneJobs.Count > 0 ? QueuedSceneJobs[0] : null;
+            }
+            SceneJobProcessor = null;
+            yield break;
+        }
+
+        private void AddJobToQueue(QueuedSceneJob queuedSceneJob)
+        {
+            QueuedSceneJobs.Add(queuedSceneJob);
+            if (SceneJobProcessor == null)
+            {
+                SceneJobProcessor = CoroutineRunner.StartCoroutine(JobQueueProcessor());
+            }
+        }
+
+        public AsyncOperation LoadSceneAsync(string sceneName, LoadSceneMode loadSceneMode, ISceneManagerHandler.SceneEventAction sceneEventAction)
+        {
+            AddJobToQueue(new QueuedSceneJob() { IntegrationTestSceneHandler = this, SceneName = sceneName, SceneAction = sceneEventAction, JobType = QueuedSceneJob.JobTypes.Loading });
+            // This is OK to return a "nothing" AsyncOperation since we are simulating client loading
+            return new AsyncOperation();
+        }
+
+        public AsyncOperation UnloadSceneAsync(Scene scene, ISceneManagerHandler.SceneEventAction sceneEventAction)
+        {
+            AddJobToQueue(new QueuedSceneJob() { IntegrationTestSceneHandler = this, Scene = scene, SceneAction = sceneEventAction, JobType = QueuedSceneJob.JobTypes.Unloading });
+            // This is OK to return a "nothing" AsyncOperation since we are simulating client loading
+            return new AsyncOperation();
+        }
+
+        internal Scene GetAndAddNewlyLoadedSceneByName(string sceneName)
+        {
+            var otherNetworkManagers = NetworkManagers;
+            otherNetworkManagers.Remove(NetworkManager);
+            for (int i = 0; i < SceneManager.sceneCount; i++)
+            {
+                var sceneLoaded = SceneManager.GetSceneAt(i);
+                if (sceneLoaded.name == sceneName)
+                {
+                    var skip = false;
+                    foreach (var otherNetworkManager in otherNetworkManagers)
+                    {
+                        if (otherNetworkManager.SceneManager.ScenesLoaded.ContainsKey(sceneLoaded.handle))
+                        {
+                            skip = true;
+                            break;
+                        }
+                    }
+                    if (skip)
+                    {
+                        continue;
+                    }
+
+                    if (!NetworkManager.SceneManager.ScenesLoaded.ContainsKey(sceneLoaded.handle))
+                    {
+                        NetworkManager.SceneManager.ScenesLoaded.Add(sceneLoaded.handle, sceneLoaded);
+                        return sceneLoaded;
+                    }
+                }
+            }
+
+            throw new Exception($"Failed to find any loaded scene named {sceneName}!");
+        }
+
+
+        internal static List<NetworkManager> NetworkManagers = new List<NetworkManager>();
+
+        public IntegrationTestSceneHandler(NetworkManager networkManager)
+        {
+            networkManager.SceneManager.OverrideGetAndAddNewlyLoadedSceneByName = GetAndAddNewlyLoadedSceneByName;
+            NetworkManagers.Add(networkManager);
+            if (s_WaitForSeconds == null)
+            {
+                s_WaitForSeconds = new WaitForSeconds(s_ClientLoadingSimulatedDelay);
+            }
+            NetworkManager = networkManager;
+            if (CoroutineRunner == null)
+            {
+                CoroutineRunner = new GameObject("UnitTestSceneHandlerCoroutine").AddComponent<CoroutineRunner>();
+            }
+        }
+
+        public void Dispose()
+        {
+            NetworkManagers.Clear();
+            if (SceneJobProcessor != null)
+            {
+                CoroutineRunner.StopCoroutine(SceneJobProcessor);
+            }
+            CoroutineRunner.StopAllCoroutines();
+
+            foreach (var job in QueuedSceneJobs)
+            {
+                if (job.JobType != QueuedSceneJob.JobTypes.Completed)
+                {
+                    if (job.JobType == QueuedSceneJob.JobTypes.Loading)
+                    {
+                        SceneManager.sceneLoaded -= SceneManager_sceneLoaded;
+                    }
+                    else
+                    {
+                        SceneManager.sceneUnloaded -= SceneManager_sceneUnloaded;
+                    }
+                    job.JobType = QueuedSceneJob.JobTypes.Completed;
+                }
+            }
+            QueuedSceneJobs.Clear();
             Object.Destroy(CoroutineRunner.gameObject);
         }
     }

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
@@ -187,7 +187,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
             {
                 yield return s_WaitForSeconds;
             }
-            yield return s_WaitForSeconds;
             CurrentQueuedSceneJob.SceneAction.Invoke();
         }
 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
@@ -280,7 +280,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         public AsyncOperation LoadSceneAsync(string sceneName, LoadSceneMode loadSceneMode, ISceneManagerHandler.SceneEventAction sceneEventAction)
         {
             // Server and non NetcodeIntegrationTest tests use the generic load scene method
-            if (NetworkManager.IsServer || !NetcodeIntegrationTest.IsRunning)
+            if (!NetcodeIntegrationTest.IsRunning)
             {
                 return GenericLoadSceneAsync(sceneName, loadSceneMode, sceneEventAction);
             }
@@ -288,14 +288,14 @@ namespace Unity.Netcode.TestHelpers.Runtime
             {
                 AddJobToQueue(new QueuedSceneJob() { IntegrationTestSceneHandler = this, SceneName = sceneName, SceneAction = sceneEventAction, JobType = QueuedSceneJob.JobTypes.Loading });
             }
-            // This is OK to return a "nothing" AsyncOperation since we are simulating client loading
-            return new AsyncOperation();
+
+            return null;
         }
 
         public AsyncOperation UnloadSceneAsync(Scene scene, ISceneManagerHandler.SceneEventAction sceneEventAction)
         {
             // Server and non NetcodeIntegrationTest tests use the generic unload scene method
-            if (NetworkManager.IsServer || !NetcodeIntegrationTest.IsRunning)
+            if (!NetcodeIntegrationTest.IsRunning)
             {
                 return GenericUnloadSceneAsync(scene, sceneEventAction);
             }
@@ -304,7 +304,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 AddJobToQueue(new QueuedSceneJob() { IntegrationTestSceneHandler = this, Scene = scene, SceneAction = sceneEventAction, JobType = QueuedSceneJob.JobTypes.Unloading });
             }
             // This is OK to return a "nothing" AsyncOperation since we are simulating client loading
-            return new AsyncOperation();
+            return null;
         }
 
         /// <summary>
@@ -359,7 +359,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             NetworkManagers.Add(networkManager);
             if (s_WaitForSeconds == null)
             {
-                s_WaitForSeconds = new WaitForSeconds(0.032f);
+                s_WaitForSeconds = new WaitForSeconds(1.0f / networkManager.NetworkConfig.TickRate);
             }
             NetworkManager = networkManager;
             if (CoroutineRunner == null)

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -173,7 +173,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         {
             IsRunning = true;
             m_EnableVerboseDebug = OnSetVerboseDebug();
-
+            IntegrationTestSceneHandler.VerboseDebugMode = m_EnableVerboseDebug;
             VerboseDebug($"Entering {nameof(OneTimeSetup)}");
 
             m_NetworkManagerInstatiationMode = OnSetIntegrationTestMode();
@@ -531,6 +531,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
+            IntegrationTestSceneHandler.VerboseDebugMode = false;
             VerboseDebug($"Entering {nameof(OneTimeTearDown)}");
             OnOneTimeTearDown();
 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -17,7 +17,11 @@ namespace Unity.Netcode.TestHelpers.Runtime
     /// </summary>
     public abstract class NetcodeIntegrationTest
     {
-        public static bool IsRunning { get; private set; }
+        /// <summary>
+        /// Used to determine if a NetcodeIntegrationTest is currently running to
+        /// determine how clients will load scenes
+        /// </summary>
+        internal static bool IsRunning { get; private set; }
         protected static TimeoutHelper s_GlobalTimeoutHelper = new TimeoutHelper(4.0f);
         protected static WaitForSeconds s_DefaultWaitForTick = new WaitForSeconds(1.0f / k_DefaultTickRate);
 
@@ -278,10 +282,11 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
             // Set the player prefab for the server and clients
             m_ServerNetworkManager.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
-            int count = 0;
+
+            // Renaming client NetworkManagers to match player identification tags
             foreach (var client in m_ClientNetworkManagers)
             {
-                client.name = $"NetworkManager - Client - {++count}";
+                client.name = $"NetworkManager - Client - {client.LocalClientId + 1}";
                 client.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
             }
 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -409,11 +409,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// </summary>
         protected void DeRegisterSceneManagerHandler()
         {
-            if (NetcodeIntegrationTestHelpers.ClientSceneHandler != null)
-            {
-                NetcodeIntegrationTestHelpers.ClientSceneHandler.CanClientsLoad -= ClientSceneHandler_CanClientsLoad;
-                NetcodeIntegrationTestHelpers.ClientSceneHandler.CanClientsUnload -= ClientSceneHandler_CanClientsUnload;
-            }
+            IntegrationTestSceneHandler.CanClientsLoad -= ClientSceneHandler_CanClientsLoad;
+            IntegrationTestSceneHandler.CanClientsUnload -= ClientSceneHandler_CanClientsUnload;
         }
 
         /// <summary>
@@ -423,11 +420,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// </summary>
         protected void RegisterSceneManagerHandler()
         {
-            if (NetcodeIntegrationTestHelpers.ClientSceneHandler != null)
-            {
-                NetcodeIntegrationTestHelpers.ClientSceneHandler.CanClientsLoad += ClientSceneHandler_CanClientsLoad;
-                NetcodeIntegrationTestHelpers.ClientSceneHandler.CanClientsUnload += ClientSceneHandler_CanClientsUnload;
-            }
+            IntegrationTestSceneHandler.CanClientsLoad += ClientSceneHandler_CanClientsLoad;
+            IntegrationTestSceneHandler.CanClientsUnload += ClientSceneHandler_CanClientsUnload;
         }
 
         private bool ClientSceneHandler_CanClientsUnload()
@@ -452,11 +446,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             // Shutdown and clean up both of our NetworkManager instances
             try
             {
-                if (NetcodeIntegrationTestHelpers.ClientSceneHandler != null)
-                {
-                    NetcodeIntegrationTestHelpers.ClientSceneHandler.CanClientsLoad -= ClientSceneHandler_CanClientsLoad;
-                    NetcodeIntegrationTestHelpers.ClientSceneHandler.CanClientsUnload -= ClientSceneHandler_CanClientsUnload;
-                }
+                DeRegisterSceneManagerHandler();
 
                 NetcodeIntegrationTestHelpers.Destroy();
 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -470,8 +470,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
                 m_PlayerNetworkObjects.Clear();
                 s_GlobalNetworkObjects.Clear();
-
-                UnloadRemainingScenes();
             }
             catch (Exception e) { throw e; }
             finally
@@ -485,6 +483,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
             // Cleanup any remaining NetworkObjects
             DestroySceneNetworkObjects();
+
+            UnloadRemainingScenes();
 
             // reset the m_ServerWaitForTick for the next test to initialize
             s_DefaultWaitForTick = new WaitForSeconds(1.0f / k_DefaultTickRate);
@@ -821,7 +821,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
                     continue;
                 }
                 VerboseDebug($"Unloading scene {scene.name}-{scene.handle}");
-                var asyncOperation = SceneManager.UnloadSceneAsync(i);
+                var asyncOperation = SceneManager.UnloadSceneAsync(scene);
             }
         }
     }

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -283,10 +283,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
             // Set the player prefab for the server and clients
             m_ServerNetworkManager.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
 
-            // Renaming client NetworkManagers to match player identification tags
             foreach (var client in m_ClientNetworkManagers)
             {
-                client.name = $"NetworkManager - Client - {client.LocalClientId + 1}";
                 client.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
             }
 
@@ -330,6 +328,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             // This provides a simpler way to get a specific player instance relative to a client instance
             foreach (var networkManager in m_ClientNetworkManagers)
             {
+                networkManager.name = $"NetworkManager - Client - {networkManager.LocalClientId}";
                 Assert.NotNull(networkManager.LocalClient.PlayerObject, $"{nameof(StartServerAndClients)} detected that client {networkManager.LocalClientId} does not have an assigned player NetworkObject!");
 
                 // Get all player instances for the current client NetworkManager instance

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -125,7 +125,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
         private NetworkManagerInstatiationMode m_NetworkManagerInstatiationMode;
 
-        private bool m_EnableVerboseDebug;
+        protected bool m_EnableVerboseDebug { get; private set; }
 
         /// <summary>
         /// Used to display the various integration test

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -275,9 +275,10 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
             // Set the player prefab for the server and clients
             m_ServerNetworkManager.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
-
+            int count = 0;
             foreach (var client in m_ClientNetworkManagers)
             {
+                client.name = $"NetworkManager - Client - {++count}";
                 client.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
             }
 
@@ -411,6 +412,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         {
             IntegrationTestSceneHandler.CanClientsLoad -= ClientSceneHandler_CanClientsLoad;
             IntegrationTestSceneHandler.CanClientsUnload -= ClientSceneHandler_CanClientsUnload;
+            IntegrationTestSceneHandler.NetworkManagers.Clear();
         }
 
         /// <summary>
@@ -422,6 +424,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         {
             IntegrationTestSceneHandler.CanClientsLoad += ClientSceneHandler_CanClientsLoad;
             IntegrationTestSceneHandler.CanClientsUnload += ClientSceneHandler_CanClientsUnload;
+            NetcodeIntegrationTestHelpers.RegisterSceneManagerHandler(m_ServerNetworkManager, true);
         }
 
         private bool ClientSceneHandler_CanClientsUnload()

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
@@ -146,7 +146,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// </summary>
         public static void CleanUpHandlers()
         {
-            foreach(var handler in ClientSceneHandlers)
+            foreach (var handler in ClientSceneHandlers)
             {
                 handler.Dispose();
             }

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
@@ -16,7 +16,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
     public static class NetcodeIntegrationTestHelpers
     {
         public const int DefaultMinFrames = 1;
-        public const float DefaultTimeout = 1f;
+        public const float DefaultTimeout = 2f;
         private static List<NetworkManager> s_NetworkManagerInstances = new List<NetworkManager>();
         private static Dictionary<NetworkManager, MultiInstanceHooks> s_Hooks = new Dictionary<NetworkManager, MultiInstanceHooks>();
         private static bool s_IsStarted;
@@ -118,7 +118,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             }
         }
 
-        private const string k_FirstPartOfTestRunnerSceneName = "InitTestScene";
+        internal const string FirstPartOfTestRunnerSceneName = "InitTestScene";
 
         public static List<NetworkManager> NetworkManagerInstances => s_NetworkManagerInstances;
 
@@ -271,6 +271,19 @@ namespace Unity.Netcode.TestHelpers.Runtime
         }
 
         /// <summary>
+        /// Starts one single client and makes sure to register the required hooks and handlers
+        /// </summary>
+        /// <param name="clientToStart"></param>
+        public static void StartOneClient(NetworkManager clientToStart)
+        {
+            clientToStart.StartClient();
+            s_Hooks[clientToStart] = new MultiInstanceHooks();
+            clientToStart.MessagingSystem.Hook(s_Hooks[clientToStart]);
+            // if set, then invoke this for the client
+            RegisterHandlers(clientToStart);
+        }
+
+        /// <summary>
         /// Should always be invoked when finished with a single unit test
         /// (i.e. during TearDown)
         /// </summary>
@@ -313,7 +326,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         private static bool VerifySceneIsValidForClientsToLoad(int sceneIndex, string sceneName, LoadSceneMode loadSceneMode)
         {
             // exclude test runner scene
-            if (sceneName.StartsWith(k_FirstPartOfTestRunnerSceneName))
+            if (sceneName.StartsWith(FirstPartOfTestRunnerSceneName))
             {
                 return false;
             }
@@ -340,7 +353,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             // warning about using the currently active scene
             var scene = SceneManager.GetActiveScene();
             // As long as this is a test runner scene (or most likely a test runner scene)
-            if (scene.name.StartsWith(k_FirstPartOfTestRunnerSceneName))
+            if (scene.name.StartsWith(FirstPartOfTestRunnerSceneName))
             {
                 // Register the test runner scene just so we avoid another warning about not being able to find the
                 // scene to synchronize NetworkObjects.  Next, add the currently active test runner scene to the scenes

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
@@ -122,7 +122,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
         public static List<NetworkManager> NetworkManagerInstances => s_NetworkManagerInstances;
 
-        internal static IntegrationTestSceneHandler ClientSceneHandler = null;
+        internal static List<IntegrationTestSceneHandler> ClientSceneHandlers = new List<IntegrationTestSceneHandler>();
 
         /// <summary>
         /// Registers the IntegrationTestSceneHandler for integration tests.
@@ -132,11 +132,9 @@ namespace Unity.Netcode.TestHelpers.Runtime
         {
             if (!networkManager.IsServer)
             {
-                if (ClientSceneHandler == null)
-                {
-                    ClientSceneHandler = new IntegrationTestSceneHandler();
-                }
-                networkManager.SceneManager.SceneManagerHandler = ClientSceneHandler;
+                var handler = new IntegrationTestSceneHandler(networkManager);
+                ClientSceneHandlers.Add(handler);
+                networkManager.SceneManager.SceneManagerHandler = handler;
             }
         }
 
@@ -148,11 +146,11 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// </summary>
         public static void CleanUpHandlers()
         {
-            if (ClientSceneHandler != null)
+            foreach(var handler in ClientSceneHandlers)
             {
-                ClientSceneHandler.Dispose();
-                ClientSceneHandler = null;
+                handler.Dispose();
             }
+            ClientSceneHandlers.Clear();
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
@@ -128,9 +128,9 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// Registers the IntegrationTestSceneHandler for integration tests.
         /// The default client behavior is to not load scenes on the client side.
         /// </summary>
-        private static void RegisterSceneManagerHandler(NetworkManager networkManager)
+        internal static void RegisterSceneManagerHandler(NetworkManager networkManager, bool allowServer = false)
         {
-            if (!networkManager.IsServer)
+            if (!networkManager.IsServer || networkManager.IsServer && allowServer)
             {
                 var handler = new IntegrationTestSceneHandler(networkManager);
                 ClientSceneHandlers.Add(handler);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/HiddenVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/HiddenVariableTests.cs
@@ -138,7 +138,7 @@ namespace Unity.Netcode.RuntimeTests
             {
                 if (id != otherClientId)
                 {
-                    if (HiddenVariableObject.ValueOnClient[id] != value)
+                    if (!HiddenVariableObject.ValueOnClient.ContainsKey(id) || HiddenVariableObject.ValueOnClient[id] != value)
                     {
                         return false;
                     }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/HiddenVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/HiddenVariableTests.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 using Unity.Netcode.TestHelpers.Runtime;
@@ -12,6 +13,8 @@ namespace Unity.Netcode.RuntimeTests
 
     public class HiddenVariableObject : NetworkBehaviour
     {
+        public static List<NetworkObject> ClientInstancesSpawned = new List<NetworkObject>();
+
         public NetworkVariable<int> MyNetworkVariable = new NetworkVariable<int>();
         public NetworkList<int> MyNetworkList = new NetworkList<int>();
 
@@ -21,6 +24,10 @@ namespace Unity.Netcode.RuntimeTests
 
         public override void OnNetworkSpawn()
         {
+            if (!IsServer)
+            {
+                ClientInstancesSpawned.Add(NetworkObject);
+            }
             Debug.Log($"{nameof(HiddenVariableObject)}.{nameof(OnNetworkSpawn)}() with value {MyNetworkVariable.Value}");
 
             MyNetworkVariable.OnValueChanged += Changed;
@@ -28,6 +35,15 @@ namespace Unity.Netcode.RuntimeTests
             SpawnCount++;
 
             base.OnNetworkSpawn();
+        }
+
+        public override void OnNetworkDespawn()
+        {
+            if (!IsServer)
+            {
+                ClientInstancesSpawned.Remove(NetworkObject);
+            }
+            base.OnNetworkDespawn();
         }
 
         public void Changed(int before, int after)
@@ -71,50 +87,75 @@ namespace Unity.Netcode.RuntimeTests
             }
         }
 
-        public void VerifyLists()
+        public bool VerifyLists()
         {
             NetworkList<int> prev = null;
             int numComparison = 0;
-
+            var prevObject = (NetworkObject)null;
             // for all the instances of NetworkList
-            foreach (var gameObject in m_NetSpawnedObjectOnClient)
+            foreach (var networkObject in m_NetSpawnedObjectOnClient)
             {
                 // this skips despawned/hidden objects
-                if (gameObject != null)
+                if (networkObject != null)
                 {
                     // if we've seen another one before
                     if (prev != null)
                     {
-                        var curr = gameObject.GetComponent<HiddenVariableObject>().MyNetworkList;
+                        var curr = networkObject.GetComponent<HiddenVariableObject>().MyNetworkList;
 
                         // check that the two lists are identical
-                        Debug.Assert(curr.Count == prev.Count);
+                        if (curr.Count != prev.Count)
+                        {
+                            return false;
+                        }
                         for (int index = 0; index < curr.Count; index++)
                         {
-                            Debug.Assert(curr[index] == prev[index]);
+                            if (curr[index] != prev[index])
+                            {
+                                return false;
+                            }
                         }
                         numComparison++;
                     }
+                    prevObject = networkObject;
                     // store the list
-                    prev = gameObject.GetComponent<HiddenVariableObject>().MyNetworkList;
+                    prev = networkObject.GetComponent<HiddenVariableObject>().MyNetworkList;
                 }
             }
-            Debug.Log($"{numComparison} comparisons done.");
+            return true;
         }
 
-        public IEnumerator RefreshGameObects()
+        public IEnumerator RefreshGameObects(int numberToExpect)
         {
-            m_NetSpawnedObjectOnClient.Clear();
+            yield return WaitForConditionOrTimeOut(() => numberToExpect == HiddenVariableObject.ClientInstancesSpawned.Count);
+            Assert.False(s_GlobalTimeoutHelper.TimedOut, $"Timed out waiting for total spawned count to reach {numberToExpect} but is currently {HiddenVariableObject.ClientInstancesSpawned.Count}");
+            m_NetSpawnedObjectOnClient = HiddenVariableObject.ClientInstancesSpawned;
+        }
 
-            foreach (var netMan in m_ClientNetworkManagers)
+        private bool CheckValueOnClient(ulong otherClientId, int value)
+        {
+            foreach (var id in m_ServerNetworkManager.ConnectedClientsIds)
             {
-                var serverClientPlayerResult = new NetcodeIntegrationTestHelpers.ResultWrapper<NetworkObject>();
-                yield return NetcodeIntegrationTestHelpers.GetNetworkObjectByRepresentation(
-                        x => x.NetworkObjectId == m_NetSpawnedObject.NetworkObjectId,
-                        netMan,
-                        serverClientPlayerResult);
-                m_NetSpawnedObjectOnClient.Add(serverClientPlayerResult.Result);
+                if (id != otherClientId)
+                {
+                    if (HiddenVariableObject.ValueOnClient[id] != value)
+                    {
+                        return false;
+                    }
+                }
             }
+            return true;
+        }
+
+        private IEnumerator SetAndCheckValueSet(ulong otherClientId, int value)
+        {
+            yield return WaitForConditionOrTimeOut(() => CheckValueOnClient(otherClientId, value));
+            Assert.IsFalse(s_GlobalTimeoutHelper.TimedOut, $"Timed out waiting for all clients to have a value of {value}");
+
+            yield return WaitForConditionOrTimeOut(VerifyLists);
+            Assert.IsFalse(s_GlobalTimeoutHelper.TimedOut, "Timed out waiting for all clients to have identical values!");
+
+            Debug.Log("Value changed");
         }
 
         [UnityTest]
@@ -127,15 +168,14 @@ namespace Unity.Netcode.RuntimeTests
 
             Debug.Log("Running test");
 
-
             // ==== Spawn object with ownership on one client
             var client = m_ServerNetworkManager.ConnectedClientsList[1];
             var otherClient = m_ServerNetworkManager.ConnectedClientsList[2];
             m_NetSpawnedObject = SpawnObject(m_TestNetworkPrefab, m_ClientNetworkManagers[1]).GetComponent<NetworkObject>();
 
-            yield return RefreshGameObects();
+            yield return RefreshGameObects(4);
 
-            // === Check spawn occured
+            // === Check spawn occurred
             yield return WaitForSpawnCount(NumberOfClients + 1);
             Debug.Assert(HiddenVariableObject.SpawnCount == NumberOfClients + 1);
             Debug.Log("Objects spawned");
@@ -143,41 +183,22 @@ namespace Unity.Netcode.RuntimeTests
             // ==== Set the NetworkVariable value to 2
             HiddenVariableObject.ExpectedSize = 1;
             HiddenVariableObject.SpawnCount = 0;
+            var currentValueSet = 2;
 
-            m_NetSpawnedObject.GetComponent<HiddenVariableObject>().MyNetworkVariable.Value = 2;
-            m_NetSpawnedObject.GetComponent<HiddenVariableObject>().MyNetworkList.Add(2);
+            m_NetSpawnedObject.GetComponent<HiddenVariableObject>().MyNetworkVariable.Value = currentValueSet;
+            m_NetSpawnedObject.GetComponent<HiddenVariableObject>().MyNetworkList.Add(currentValueSet);
 
-            yield return new WaitForSeconds(1.0f);
-
-            foreach (var id in m_ServerNetworkManager.ConnectedClientsIds)
-            {
-                Debug.Assert(HiddenVariableObject.ValueOnClient[id] == 2);
-            }
-
-            VerifyLists();
-
-            Debug.Log("Value changed");
+            yield return SetAndCheckValueSet(otherClient.ClientId, currentValueSet);
 
             // ==== Hide our object to a different client
             HiddenVariableObject.ExpectedSize = 2;
             m_NetSpawnedObject.NetworkHide(otherClient.ClientId);
 
-            // ==== Change the NetworkVariable value
-            // we should get one less notification of value changing and no errors or exception
-            m_NetSpawnedObject.GetComponent<HiddenVariableObject>().MyNetworkVariable.Value = 3;
-            m_NetSpawnedObject.GetComponent<HiddenVariableObject>().MyNetworkList.Add(3);
+            currentValueSet = 3;
+            m_NetSpawnedObject.GetComponent<HiddenVariableObject>().MyNetworkVariable.Value = currentValueSet;
+            m_NetSpawnedObject.GetComponent<HiddenVariableObject>().MyNetworkList.Add(currentValueSet);
 
-            yield return new WaitForSeconds(1.0f);
-            foreach (var id in m_ServerNetworkManager.ConnectedClientsIds)
-            {
-                if (id != otherClient.ClientId)
-                {
-                    Debug.Assert(HiddenVariableObject.ValueOnClient[id] == 3);
-                }
-            }
-
-            VerifyLists();
-            Debug.Log("Values changed");
+            yield return SetAndCheckValueSet(otherClient.ClientId, currentValueSet);
 
             // ==== Show our object again to this client
             HiddenVariableObject.ExpectedSize = 3;
@@ -189,22 +210,13 @@ namespace Unity.Netcode.RuntimeTests
             Debug.Log("Object spawned");
 
             // ==== We need a refresh for the newly re-spawned object
-            yield return RefreshGameObects();
+            yield return RefreshGameObects(4);
 
-            // ==== Change the NetworkVariable value
-            // we should get all notifications of value changing and no errors or exception
-            m_NetSpawnedObject.GetComponent<HiddenVariableObject>().MyNetworkVariable.Value = 4;
-            m_NetSpawnedObject.GetComponent<HiddenVariableObject>().MyNetworkList.Add(4);
+            currentValueSet = 4;
+            m_NetSpawnedObject.GetComponent<HiddenVariableObject>().MyNetworkVariable.Value = currentValueSet;
+            m_NetSpawnedObject.GetComponent<HiddenVariableObject>().MyNetworkList.Add(currentValueSet);
 
-            yield return new WaitForSeconds(1.0f);
-
-            foreach (var id in m_ServerNetworkManager.ConnectedClientsIds)
-            {
-                Debug.Assert(HiddenVariableObject.ValueOnClient[id] == 4);
-            }
-
-            VerifyLists();
-            Debug.Log("Values changed");
+            yield return SetAndCheckValueSet(otherClient.ClientId, currentValueSet);
 
             // ==== Hide our object to that different client again, and then destroy it
             m_NetSpawnedObject.NetworkHide(otherClient.ClientId);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -365,6 +365,7 @@ namespace Unity.Netcode.RuntimeTests
 
             // Wait for connection on client and server side
             yield return WaitForClientsConnectedOrTimeOut();
+            AssertOnTimeout($"Timed-out waiting for all clients to connect!");
 
             // These are the *SERVER VERSIONS* of the *CLIENT PLAYER 1 & 2*
             var result = new NetcodeIntegrationTestHelpers.ResultWrapper<NetworkObject>();

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeMultiInstanceTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeMultiInstanceTest.cs
@@ -145,6 +145,7 @@ namespace Unity.Netcode.RuntimeTests
 
             // Wait for connection on client and server side
             yield return WaitForClientsConnectedOrTimeOut();
+            AssertOnTimeout($"Timed-out waiting for all clients to connect!");
         }
 
         private readonly struct NetworkTimeState : IEquatable<NetworkTimeState>

--- a/testproject-tools-integration/Assets/Tests/Runtime/SceneEventTests.cs
+++ b/testproject-tools-integration/Assets/Tests/Runtime/SceneEventTests.cs
@@ -298,7 +298,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
         public IEnumerator TestS2CUnloadSent()
         {
             // Load a scene so that we can unload it
-            yield return LoadTestScene(k_SimpleSceneName);
+            yield return LoadTestScene(k_SimpleSceneName, true);
 
             var serverSceneUnloaded = false;
             // Register a callback so we can notify the test when the scene has finished unloading server side
@@ -316,6 +316,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
                 NetworkMetricTypes.SceneEventSent,
                 metric => metric.SceneEventType.Equals(SceneEventType.Unload.ToString()));
 
+            yield return s_DefaultWaitForTick;
             // Unload the scene to trigger the messages
             StartServerUnloadScene();
 
@@ -384,7 +385,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
         public IEnumerator TestC2SUnloadCompleteSent()
         {
             // Load a scene so that we can unload it
-            yield return LoadTestScene(k_SimpleSceneName);
+            yield return LoadTestScene(k_SimpleSceneName, true);
 
             // Register a callback so we can notify the test when the scene has finished unloading client side
             // as this is when the message is sent.
@@ -420,7 +421,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
         public IEnumerator TestC2SUnloadCompleteReceived()
         {
             // Load a scene so that we can unload it
-            yield return LoadTestScene(k_SimpleSceneName);
+            yield return LoadTestScene(k_SimpleSceneName, true);
 
             // Register a callback we can notify the test when the scene has finished unloading client side
             // as this is when the message is sent
@@ -495,7 +496,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
         public IEnumerator TestS2CUnloadCompleteReceived()
         {
             // Load a scene so that we can unload it
-            yield return LoadTestScene(k_SimpleSceneName, true);
+            yield return LoadTestScene(k_SimpleSceneName);
 
             // Register a callback so we can notify the test when the scene has finished unloading server side
             // as this is when the message is sent
@@ -682,7 +683,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             m_ClientNetworkSceneManager.OnSceneEvent += sceneEvent =>
             {
                 var clientIdToWaitFor = waitForClient == true ? m_ClientNetworkManagers[0].LocalClientId : m_ServerNetworkManager.LocalClientId;
-                if (sceneEvent.SceneEventType == SceneEventType.LoadEventCompleted)
+                if (sceneEvent.SceneEventType == SceneEventType.LoadComplete)
                 {
                     sceneLoadComplete = true;
                 }

--- a/testproject-tools-integration/Assets/Tests/Runtime/SceneEventTests.cs
+++ b/testproject-tools-integration/Assets/Tests/Runtime/SceneEventTests.cs
@@ -348,10 +348,9 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             // as this is when the message is sent
             m_ServerNetworkSceneManager.OnSceneEvent += sceneEvent =>
             {
-                if (sceneEvent.SceneEventType.Equals(SceneEventType.Unload))
+                if (sceneEvent.SceneEventType.Equals(SceneEventType.Unload) && sceneEvent.ClientId == Server.LocalClientId)
                 {
-                    serverSceneUnloaded = sceneEvent.AsyncOperation.isDone;
-                    sceneEvent.AsyncOperation.completed += _ => serverSceneUnloaded = true;
+                    serverSceneUnloaded = true;
                 }
             };
 

--- a/testproject-tools-integration/Assets/Tests/Runtime/SceneEventTests.cs
+++ b/testproject-tools-integration/Assets/Tests/Runtime/SceneEventTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using Unity.Multiplayer.Tools.MetricTypes;
@@ -23,8 +24,16 @@ namespace TestProject.ToolsIntegration.RuntimeTests
 
         protected override IEnumerator OnSetup()
         {
+            SceneManager.sceneLoaded += SceneManager_sceneLoaded;
             m_CreateServerFirst = false;
             return base.OnSetup();
+        }
+
+        private List<Scene> m_AllScenesLoaded = new List<Scene>();
+
+        private void SceneManager_sceneLoaded(Scene arg0, LoadSceneMode arg1)
+        {
+            m_AllScenesLoaded.Add(arg0);
         }
 
         protected override void OnServerAndClientsCreated()
@@ -47,7 +56,19 @@ namespace TestProject.ToolsIntegration.RuntimeTests
 
         protected override IEnumerator OnTearDown()
         {
-            yield return UnloadTestScene(m_LoadedScene);
+            if (!m_AllScenesLoaded.Contains(m_LoadedScene))
+            {
+                m_AllScenesLoaded.Add(m_LoadedScene);
+            }
+
+            foreach (var sceneLoaded in m_AllScenesLoaded)
+            {
+                if (sceneLoaded.IsValid())
+                {
+                    yield return UnloadTestScene(sceneLoaded);
+                }
+            }
+
             yield return base.OnTearDown();
         }
 
@@ -474,7 +495,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
         public IEnumerator TestS2CUnloadCompleteReceived()
         {
             // Load a scene so that we can unload it
-            yield return LoadTestScene(k_SimpleSceneName);
+            yield return LoadTestScene(k_SimpleSceneName, true);
 
             // Register a callback so we can notify the test when the scene has finished unloading server side
             // as this is when the message is sent
@@ -646,8 +667,11 @@ namespace TestProject.ToolsIntegration.RuntimeTests
 
         private void StartServerUnloadScene()
         {
-            var unloadSceneResult = m_ServerNetworkSceneManager.UnloadScene(m_LoadedScene);
-            Assert.AreEqual(SceneEventProgressStatus.Started, unloadSceneResult);
+            if (m_LoadedScene.IsValid() && m_LoadedScene.isLoaded)
+            {
+                var unloadSceneResult = m_ServerNetworkSceneManager.UnloadScene(m_LoadedScene);
+                Assert.AreEqual(SceneEventProgressStatus.Started, unloadSceneResult);
+            }
         }
 
         // Loads a scene, then waits for the client to notify the server
@@ -657,7 +681,7 @@ namespace TestProject.ToolsIntegration.RuntimeTests
             var sceneLoadComplete = false;
             m_ClientNetworkSceneManager.OnSceneEvent += sceneEvent =>
             {
-                var clientIdToWaitFor = waitForClient == true ? m_ClientNetworkManagers[1].LocalClientId : m_ServerNetworkManager.LocalClientId;
+                var clientIdToWaitFor = waitForClient == true ? m_ClientNetworkManagers[0].LocalClientId : m_ServerNetworkManager.LocalClientId;
                 if (sceneEvent.SceneEventType == SceneEventType.LoadEventCompleted)
                 {
                     sceneLoadComplete = true;
@@ -680,7 +704,6 @@ namespace TestProject.ToolsIntegration.RuntimeTests
                 // This is called after everything is done and destroyed.
                 // Just use the normal scene manager to unload the scene.
                 var asyncResults = SceneManager.UnloadSceneAsync(scene);
-
                 yield return WaitForCondition(() => asyncResults.isDone);
 
             }

--- a/testproject/Assets/Scenes/EmptyScene.unity
+++ b/testproject/Assets/Scenes/EmptyScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -148,7 +148,7 @@ AudioListener:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 213356910}
-  m_Enabled: 1
+  m_Enabled: 0
 --- !u!20 &213356912
 Camera:
   m_ObjectHideFlags: 0
@@ -202,6 +202,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -295,6 +296,7 @@ Transform:
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
   m_LocalPosition: {x: 0, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1

--- a/testproject/Assets/Tests/Manual/IntegrationTestScenes/InSceneNetworkObject.unity
+++ b/testproject/Assets/Tests/Manual/IntegrationTestScenes/InSceneNetworkObject.unity
@@ -133,7 +133,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1633685739}
   - component: {fileID: 1633685738}
-  - component: {fileID: 1633685740}
+  - component: {fileID: 1633685742}
   m_Layer: 0
   m_Name: InSceneObject
   m_TagString: Untagged
@@ -172,7 +172,7 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1633685740
+--- !u!114 &1633685742
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -181,6 +181,6 @@ MonoBehaviour:
   m_GameObject: {fileID: 1633685737}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a915cfb2e4f748e4f9526a8bf5ee84f2, type: 3}
+  m_Script: {fileID: 11500000, guid: bd877da52a3b48f4f867ac2c973c0265, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/testproject/Assets/Tests/Manual/IntegrationTestScenes/UnitTestBaseScene.unity
+++ b/testproject/Assets/Tests/Manual/IntegrationTestScenes/UnitTestBaseScene.unity
@@ -133,6 +133,8 @@ GameObject:
   m_Component:
   - component: {fileID: 37242883}
   - component: {fileID: 37242882}
+  - component: {fileID: 37242885}
+  - component: {fileID: 37242884}
   m_Layer: 0
   m_Name: Directional Light
   m_TagString: Untagged
@@ -212,10 +214,39 @@ Transform:
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
   m_LocalPosition: {x: 0, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!114 &37242884
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 37242881}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 527659865
+  AlwaysReplicateAsRoot: 0
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1
+--- !u!114 &37242885
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 37242881}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4d81b6825f19f4746b8fa6485d7e43c3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &57392470
 GameObject:
   m_ObjectHideFlags: 0
@@ -308,6 +339,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -30.5, y: 0.49999994, z: 0}
   m_LocalScale: {x: 1, y: 3, z: 62}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1332123092}
   m_RootOrder: 3
@@ -404,6 +436,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: -0.50000006, z: 0}
   m_LocalScale: {x: 60, y: 1, z: 60}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1332123092}
   m_RootOrder: 0
@@ -478,6 +511,7 @@ Transform:
   m_LocalRotation: {x: 0.41890106, y: -0, z: -0, w: 0.9080319}
   m_LocalPosition: {x: 0, y: 42, z: -46}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -489,7 +523,7 @@ LightingSettings:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: 
-  serializedVersion: 3
+  serializedVersion: 4
   m_GIWorkflowMode: 1
   m_EnableBakedLightmaps: 1
   m_EnableRealtimeLightmaps: 0
@@ -502,7 +536,7 @@ LightingSettings:
   m_LightmapMaxSize: 1024
   m_BakeResolution: 40
   m_Padding: 2
-  m_TextureCompression: 1
+  m_LightmapCompression: 3
   m_AO: 0
   m_AOMaxDistance: 1
   m_CompAOExponent: 1
@@ -543,6 +577,7 @@ LightingSettings:
   m_PVRFilteringAtrousPositionSigmaDirect: 0.5
   m_PVRFilteringAtrousPositionSigmaIndirect: 2
   m_PVRFilteringAtrousPositionSigmaAO: 1
+  m_PVRTiledBaking: 0
 --- !u!1 &1332123091
 GameObject:
   m_ObjectHideFlags: 0
@@ -569,6 +604,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0.000000059604645, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 336568649}
   - {fileID: 2028091272}
@@ -670,6 +706,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 30.5, y: 0.49999994, z: 0}
   m_LocalScale: {x: 1, y: 3, z: 62}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1332123092}
   m_RootOrder: 4
@@ -766,6 +803,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0.49999994, z: -30.5}
   m_LocalScale: {x: 60, y: 3, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1332123092}
   m_RootOrder: 2
@@ -862,6 +900,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0.49999994, z: 30.5}
   m_LocalScale: {x: 60, y: 3, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1332123092}
   m_RootOrder: 1

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/DespawnInSceneNetworkObject.cs
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/DespawnInSceneNetworkObject.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections;
+using UnityEngine;
+using Unity.Netcode;
+
+namespace TestProject.ManualTests
+{
+    public class DespawnInSceneNetworkObject : NetworkBehaviour
+    {
+        private Coroutine m_ScanInputHandle;
+        private MeshRenderer m_MeshRenderer;
+
+        private void Start()
+        {
+            if (!IsSpawned)
+            {
+                m_MeshRenderer = GetComponent<MeshRenderer>();
+                if (m_MeshRenderer != null)
+                {
+                    m_MeshRenderer.enabled = false;
+                }
+            }
+        }
+
+        public override void OnNetworkSpawn()
+        {
+            Debug.Log($"{name} spawned!");
+            m_MeshRenderer = GetComponent<MeshRenderer>();
+            if (m_MeshRenderer != null)
+            {
+                m_MeshRenderer.enabled = true;
+            }
+            if (!IsServer)
+            {
+                return;
+            }
+            if (m_ScanInputHandle == null)
+            {
+                m_ScanInputHandle = StartCoroutine(ScanInput());
+            }
+        }
+
+        public override void OnNetworkDespawn()
+        {
+            if (m_MeshRenderer != null)
+            {
+                m_MeshRenderer.enabled = false;
+            }
+            Debug.Log($"{name} despawned!");
+            base.OnNetworkDespawn();
+        }
+
+        public override void OnDestroy()
+        {
+            if (m_ScanInputHandle != null)
+            {
+                StopCoroutine(m_ScanInputHandle);
+            }
+            m_ScanInputHandle = null;
+            base.OnDestroy();
+        }
+
+        private IEnumerator ScanInput()
+        {
+            while (true)
+            {
+                try
+                {
+                    if (IsSpawned)
+                    {
+                        if (Input.GetKeyDown(KeyCode.Backspace))
+                        {
+                            Debug.Log($"{name} should despawn.");
+                            NetworkObject.Despawn(false);
+                        }
+                    }
+                    else if (NetworkManager.Singleton && NetworkManager.Singleton.IsListening)
+                    {
+                        if (Input.GetKeyDown(KeyCode.Backspace))
+                        {
+                            Debug.Log($"{name} should spawn.");
+                            NetworkObject.Spawn();
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogException(ex);
+                }
+
+                yield return null;
+            }
+
+        }
+    }
+}

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/DespawnInSceneNetworkObject.cs
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/DespawnInSceneNetworkObject.cs
@@ -5,6 +5,15 @@ using Unity.Netcode;
 
 namespace TestProject.ManualTests
 {
+    /// <summary>
+    /// Used for manually testing spawning and despawning in-scene
+    /// placed NetworkObjects
+    ///
+    /// Note: We do not destroy in-scene placed NetworkObjects, but
+    /// users must handle visibility (rendering wise) when the in-scene
+    /// NetworkObject is spawned and despawned.  This class just enables
+    /// or disabled the mesh renderer.
+    /// </summary>
     public class DespawnInSceneNetworkObject : NetworkBehaviour
     {
         private Coroutine m_ScanInputHandle;

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/DespawnInSceneNetworkObject.cs.meta
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/DespawnInSceneNetworkObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 749242a913ab531489f639bd36d2b546
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/InSceneObjectToDespawn.prefab
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/InSceneObjectToDespawn.prefab
@@ -1,0 +1,115 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4518755925279129986
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4518755925279129984}
+  - component: {fileID: 4518755925279129985}
+  - component: {fileID: 4518755925279129999}
+  - component: {fileID: 8696681427671075077}
+  - component: {fileID: 3650101775111153601}
+  m_Layer: 0
+  m_Name: InSceneObjectToDespawn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4518755925279129984
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4518755925279129986}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 2, y: 2, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4518755925279129985
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4518755925279129986}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 951099334
+  AlwaysReplicateAsRoot: 0
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1
+--- !u!114 &4518755925279129999
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4518755925279129986}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 749242a913ab531489f639bd36d2b546, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!23 &8696681427671075077
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4518755925279129986}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 57796fc6c3e986f46ba5d137d44f5a3d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &3650101775111153601
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4518755925279129986}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/InSceneObjectToDespawn.prefab.meta
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/InSceneObjectToDespawn.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3a854a190ab5b1b4fb00bec725fdda9e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/SceneTransitioningBase1.unity
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/SceneTransitioningBase1.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657815, g: 0.49641192, b: 0.57481617, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -150,6 +150,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1351730454}
   m_Father: {fileID: 290861172}
@@ -202,6 +203,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1347823142}
   m_Father: {fileID: 290861172}
@@ -317,6 +319,7 @@ Transform:
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
   m_LocalPosition: {x: 0, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
@@ -355,6 +358,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1429502879}
   m_Father: {fileID: 362129048}
@@ -431,6 +435,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 362129048}
   m_RootOrder: 1
@@ -525,6 +530,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -573,6 +579,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -30.5, y: 0.49999994, z: 0}
   m_LocalScale: {x: 1, y: 3, z: 62}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1332123092}
   m_RootOrder: 3
@@ -604,6 +611,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1651938367}
   m_Father: {fileID: 290861172}
@@ -657,6 +665,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 615497064}
   m_Father: {fileID: 1351730454}
@@ -733,6 +742,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1640896166}
   m_RootOrder: 1
@@ -874,6 +884,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1865409449}
   m_Father: {fileID: 0}
@@ -974,6 +985,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1588117328}
   - {fileID: 34066665}
@@ -1022,6 +1034,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 362129048}
   m_Father: {fileID: 290861172}
@@ -1074,6 +1087,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1689223598}
   - {fileID: 1638885888}
@@ -1189,6 +1203,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -1237,6 +1252,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: -0.50000006, z: 0}
   m_LocalScale: {x: 60, y: 1, z: 60}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1332123092}
   m_RootOrder: 0
@@ -1268,6 +1284,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 44393280}
   - {fileID: 57065842}
@@ -1368,6 +1385,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 432733929}
   m_Father: {fileID: 1651938367}
@@ -1444,6 +1462,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 418148061}
   m_RootOrder: 0
@@ -1519,6 +1538,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2058276876}
   m_RootOrder: 3
@@ -1649,6 +1669,7 @@ Transform:
   m_LocalRotation: {x: 0.41890106, y: -0, z: -0, w: 0.9080319}
   m_LocalPosition: {x: 0, y: 42, z: -46}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -1681,6 +1702,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1588117328}
   m_RootOrder: 0
@@ -1760,6 +1782,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 125866603}
   m_RootOrder: 0
@@ -1835,6 +1858,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1290928583}
   m_RootOrder: 0
@@ -1910,6 +1934,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1398648428}
   m_RootOrder: 0
@@ -1984,6 +2009,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 300124662}
   m_Father: {fileID: 290861172}
@@ -2015,8 +2041,8 @@ LightingSettings:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name:
-  serializedVersion: 3
+  m_Name: 
+  serializedVersion: 4
   m_GIWorkflowMode: 1
   m_EnableBakedLightmaps: 1
   m_EnableRealtimeLightmaps: 0
@@ -2029,7 +2055,7 @@ LightingSettings:
   m_LightmapMaxSize: 1024
   m_BakeResolution: 40
   m_Padding: 2
-  m_TextureCompression: 1
+  m_LightmapCompression: 3
   m_AO: 0
   m_AOMaxDistance: 1
   m_CompAOExponent: 1
@@ -2070,6 +2096,7 @@ LightingSettings:
   m_PVRFilteringAtrousPositionSigmaDirect: 0.5
   m_PVRFilteringAtrousPositionSigmaIndirect: 2
   m_PVRFilteringAtrousPositionSigmaAO: 1
+  m_PVRTiledBaking: 0
 --- !u!1 &906714043
 GameObject:
   m_ObjectHideFlags: 0
@@ -2098,6 +2125,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2019086800}
   m_RootOrder: 1
@@ -2149,6 +2177,80 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 906714043}
   m_CullTransparentMesh: 1
+--- !u!1001 &960545998
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4518755925279129984, guid: 3a854a190ab5b1b4fb00bec725fdda9e,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4518755925279129984, guid: 3a854a190ab5b1b4fb00bec725fdda9e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4518755925279129984, guid: 3a854a190ab5b1b4fb00bec725fdda9e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4518755925279129984, guid: 3a854a190ab5b1b4fb00bec725fdda9e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4518755925279129984, guid: 3a854a190ab5b1b4fb00bec725fdda9e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4518755925279129984, guid: 3a854a190ab5b1b4fb00bec725fdda9e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4518755925279129984, guid: 3a854a190ab5b1b4fb00bec725fdda9e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4518755925279129984, guid: 3a854a190ab5b1b4fb00bec725fdda9e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4518755925279129984, guid: 3a854a190ab5b1b4fb00bec725fdda9e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4518755925279129984, guid: 3a854a190ab5b1b4fb00bec725fdda9e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4518755925279129984, guid: 3a854a190ab5b1b4fb00bec725fdda9e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4518755925279129985, guid: 3a854a190ab5b1b4fb00bec725fdda9e,
+        type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3537583461
+      objectReference: {fileID: 0}
+    - target: {fileID: 4518755925279129986, guid: 3a854a190ab5b1b4fb00bec725fdda9e,
+        type: 3}
+      propertyPath: m_Name
+      value: InSceneObjectToDespawn
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3a854a190ab5b1b4fb00bec725fdda9e, type: 3}
 --- !u!1 &1008611498
 GameObject:
   m_ObjectHideFlags: 0
@@ -2176,6 +2278,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1640896166}
   m_Father: {fileID: 290861172}
@@ -2291,6 +2394,12 @@ MonoBehaviour:
       SourcePrefabToOverride: {fileID: 0}
       SourceHashToOverride: 0
       OverridingTargetPrefab: {fileID: 0}
+    - Override: 2
+      Prefab: {fileID: 0}
+      SourcePrefabToOverride: {fileID: 0}
+      SourceHashToOverride: 3537583461
+      OverridingTargetPrefab: {fileID: 4518755925279129986, guid: 3a854a190ab5b1b4fb00bec725fdda9e,
+        type: 3}
     TickRate: 30
     ClientConnectionBufferTimeout: 10
     ConnectionApproval: 0
@@ -2335,6 +2444,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.000061035156, y: 0.000015258789, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 2
@@ -2419,6 +2529,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 5
@@ -2466,6 +2577,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2019086800}
   m_Father: {fileID: 290861172}
@@ -2519,6 +2631,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1651938367}
   m_RootOrder: 1
@@ -2598,6 +2711,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 833301795}
   m_Father: {fileID: 1640896166}
@@ -2672,6 +2786,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0.000000059604645, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 336568649}
   - {fileID: 2028091272}
@@ -2724,6 +2839,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -2772,6 +2888,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 30.5, y: 0.49999994, z: 0}
   m_LocalScale: {x: 1, y: 3, z: 62}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1332123092}
   m_RootOrder: 4
@@ -2804,6 +2921,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1351730454}
   m_RootOrder: 1
@@ -2884,6 +3002,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1846334315}
   m_Father: {fileID: 34066665}
@@ -3015,6 +3134,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 125866603}
   - {fileID: 1336892119}
@@ -3115,6 +3235,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 290861172}
   m_RootOrder: 5
@@ -3192,6 +3313,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1523424137}
   m_Father: {fileID: 2058276876}
@@ -3230,6 +3352,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 865202802}
   m_Father: {fileID: 2019086800}
@@ -3306,6 +3429,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 44393280}
   m_RootOrder: 0
@@ -3381,6 +3505,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1387688805}
   m_RootOrder: 0
@@ -3456,6 +3581,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1889006547}
   m_RootOrder: 0
@@ -3532,6 +3658,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 599972121}
   m_Father: {fileID: 290861172}
@@ -3664,6 +3791,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 300124662}
   m_RootOrder: 1
@@ -3742,6 +3870,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1290928583}
   - {fileID: 163541782}
@@ -3841,6 +3970,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 418148061}
   - {fileID: 1210784442}
@@ -3941,6 +4071,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1691305196}
   m_Father: {fileID: 300124662}
@@ -4017,6 +4148,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1689223598}
   m_RootOrder: 0
@@ -4126,6 +4258,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -431, y: -242.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 290861172}
   m_RootOrder: 3
@@ -4158,6 +4291,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1347823142}
   m_RootOrder: 0
@@ -4252,6 +4386,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -4300,6 +4435,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0.49999994, z: -30.5}
   m_LocalScale: {x: 60, y: 3, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1332123092}
   m_RootOrder: 2
@@ -4455,6 +4591,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1549858059}
   m_Father: {fileID: 2058276876}
@@ -4492,6 +4629,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1398648428}
   - {fileID: 906714044}
@@ -4592,6 +4730,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2058276876}
   m_RootOrder: 0
@@ -4682,6 +4821,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -4730,6 +4870,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0.49999994, z: 30.5}
   m_LocalScale: {x: 60, y: 3, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1332123092}
   m_RootOrder: 1
@@ -4761,6 +4902,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2021718439}
   - {fileID: 1889006547}
@@ -4865,6 +5007,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 318.45444, y: 110.697815, z: 216.79077}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 7

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/SceneTransitioningBase1.unity
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/SceneTransitioningBase1.unity
@@ -2394,12 +2394,6 @@ MonoBehaviour:
       SourcePrefabToOverride: {fileID: 0}
       SourceHashToOverride: 0
       OverridingTargetPrefab: {fileID: 0}
-    - Override: 2
-      Prefab: {fileID: 0}
-      SourcePrefabToOverride: {fileID: 0}
-      SourceHashToOverride: 3537583461
-      OverridingTargetPrefab: {fileID: 4518755925279129986, guid: 3a854a190ab5b1b4fb00bec725fdda9e,
-        type: 3}
     TickRate: 30
     ClientConnectionBufferTimeout: 10
     ConnectionApproval: 0

--- a/testproject/Assets/Tests/Manual/Scripts/IndependentMover.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/IndependentMover.cs
@@ -8,13 +8,21 @@ namespace TestProject.ManualTests
     /// </summary>
     public class IndependentMover : NetworkBehaviour
     {
+        public static bool EnableVerboseDebug;
         private Vector3 m_Direction;
         private Rigidbody m_Rigidbody;
 
+        private void VerboseDebug(string message)
+        {
+            if (EnableVerboseDebug)
+            {
+                Debug.Log(message);
+            }
+        }
 
         public override void OnNetworkSpawn()
         {
-            Debug.Log($"{nameof(IndependentMover)} NID: {NetworkObjectId}");
+            VerboseDebug($"{nameof(IndependentMover)} NID: {NetworkObjectId}");
             m_Rigidbody = GetComponent<Rigidbody>();
             if (NetworkObject != null && m_Rigidbody != null)
             {

--- a/testproject/Assets/Tests/Manual/Scripts/NetworkLight.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/NetworkLight.cs
@@ -1,0 +1,20 @@
+using Unity.Netcode;
+
+namespace TestProject.ManualTests
+{
+    /// <summary>
+    /// Only allows server to have the light enabled.
+    /// Used for integration testing
+    /// </summary>
+    public class NetworkLight : NetworkBehaviour
+    {
+        public override void OnNetworkSpawn()
+        {
+            if(!IsServer)
+            {
+                gameObject.SetActive(false);
+            }
+            base.OnNetworkSpawn();
+        }
+    }
+}

--- a/testproject/Assets/Tests/Manual/Scripts/NetworkLight.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/NetworkLight.cs
@@ -10,7 +10,7 @@ namespace TestProject.ManualTests
     {
         public override void OnNetworkSpawn()
         {
-            if(!IsServer)
+            if (!IsServer)
             {
                 gameObject.SetActive(false);
             }

--- a/testproject/Assets/Tests/Manual/Scripts/NetworkLight.cs.meta
+++ b/testproject/Assets/Tests/Manual/Scripts/NetworkLight.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4d81b6825f19f4746b8fa6485d7e43c3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/InScenePlacedNetworkObjectTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/InScenePlacedNetworkObjectTests.cs
@@ -1,0 +1,160 @@
+using System.Collections;
+using System.Linq;
+using UnityEngine;
+using NUnit.Framework;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+using Unity.Netcode;
+using Unity.Netcode.TestHelpers.Runtime;
+
+
+
+namespace TestProject.RuntimeTests
+{
+    public class InScenePlacedNetworkObjects : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 2;
+
+        private const string k_SceneToLoad = "InSceneNetworkObject";
+        private Scene m_ServerSideSceneLoaded;
+        private bool m_CanStartServerAndClients;
+
+        protected override bool OnSetVerboseDebug()
+        {
+            return true;
+        }
+
+        protected override IEnumerator OnSetup()
+        {
+            m_CanStartServerAndClients = false;
+            return base.OnSetup();
+        }
+
+        protected override bool CanStartServerAndClients()
+        {
+            return m_CanStartServerAndClients;
+        }
+
+        /// <summary>
+        /// This verifies that in-scene placed NetworkObjects will be properly
+        /// synchronized if:
+        /// 1.) Despawned prior to a client late-joining
+        /// 2.) Re-spawned after having been despawned without registering the in-scene
+        /// NetworkObject as a NetworkPrefab
+        /// </summary>
+        [UnityTest]
+        public IEnumerator InSceneNetworkObjectSynchAndSpawn()
+        {
+            // Because despawning a client will cause it to shutdown and clean everything in the
+            // scene hierarchy, we have to prevent one of the clients from spawning initially before
+            // we test synchronizing late joining clients with despawned in-scene placed NetworkObjects.
+            // So, we prevent the automatic starting of the server and clients, remove the client we
+            // will be targeting to join late from the m_ClientNetworkManagers array, start the server
+            // and the remaining client, despawn the in-scene NetworkObject, and then start and synchronize
+            // the clientToTest.
+            var clientToTest = m_ClientNetworkManagers[1];
+            var clients = m_ClientNetworkManagers.ToList();
+            clients.Remove(clientToTest);
+            m_ClientNetworkManagers = clients.ToArray();
+            m_CanStartServerAndClients = true;
+            yield return StartServerAndClients();
+            clients.Add(clientToTest);
+            m_ClientNetworkManagers = clients.ToArray();
+
+            NetworkObjectTestComponent.ServerNetworkObjectInstance = null;
+            m_ServerNetworkManager.SceneManager.OnSceneEvent += Server_OnSceneEvent;
+            var status = m_ServerNetworkManager.SceneManager.LoadScene(k_SceneToLoad, LoadSceneMode.Additive);
+            Assert.IsTrue(status == SceneEventProgressStatus.Started, $"When attempting to load scene {k_SceneToLoad} was returned the following progress status: {status}");
+
+            // This verifies the scene loaded and the in-scene placed NetworkObjects spawned.
+            yield return WaitForConditionOrTimeOut(() => NetworkObjectTestComponent.SpawnedInstances.Count == TotalClients - 1);
+            AssertOnTimeout($"Timed out waiting for total spawned in-scene placed NetworkObjects to reach a count of {TotalClients - 1} and is currently {NetworkObjectTestComponent.SpawnedInstances.Count}");
+
+            // Get the server-side instance of the in-scene NetworkObject
+            Assert.True(s_GlobalNetworkObjects.ContainsKey(m_ServerNetworkManager.LocalClientId), $"Could not find server instance of the test in-scene NetworkObject!");
+            var serverObject = NetworkObjectTestComponent.ServerNetworkObjectInstance;
+            Assert.IsNotNull(serverObject, $"Could not find server-side in-scene placed NetworkObject!");
+            Assert.IsTrue(serverObject.IsSpawned, $"{serverObject.name} is not spawned!");
+
+            // Despawn the in-scene placed NetworkObject
+            Debug.Log("Despawning In-Scene placed NetworkObject");
+            serverObject.Despawn(false);
+            yield return WaitForConditionOrTimeOut(() => NetworkObjectTestComponent.SpawnedInstances.Count == 0);
+            AssertOnTimeout($"Timed out waiting for all in-scene instances to be despawned!  Current spawned count: {NetworkObjectTestComponent.SpawnedInstances.Count()}");
+
+            // Now late join a client
+            NetworkObjectTestComponent.OnInSceneObjectDespawned += OnInSceneObjectDespawned;
+            NetcodeIntegrationTestHelpers.StartOneClient(clientToTest);
+            yield return WaitForConditionOrTimeOut(() => (clientToTest.IsConnectedClient && clientToTest.IsListening));
+            AssertOnTimeout($"Timed out waiting for {clientToTest.name} to reconnect!");
+
+            yield return s_DefaultWaitForTick;
+
+            // Make sure the late-joining client's in-scene placed NetworkObject received the despawn notification during synchronization
+            Assert.IsNotNull(m_JoinedClientDespawnedNetworkObject, $"{clientToTest.name} did not despawn the in-scene placed NetworkObject when connecting and synchronizing!");
+
+            // Update the newly joined client information
+            ClientNetworkManagerPostStartInit();
+
+            // We should still have no spawned in-scene placed NetworkObjects at this point
+            yield return WaitForConditionOrTimeOut(() => NetworkObjectTestComponent.SpawnedInstances.Count == 0);
+            AssertOnTimeout($"{clientToTest.name} spawned in-scene placed NetworkObject!");
+
+            // Now test that the despawned in-scene placed NetworkObject can be re-spawned (without having been registered as a NetworkPrefab)
+            serverObject.Spawn();
+
+            yield return WaitForConditionOrTimeOut(() => NetworkObjectTestComponent.SpawnedInstances.Count == TotalClients);
+            AssertOnTimeout($"Timed out waiting for all in-scene instances to be spawned!  Current spawned count: {NetworkObjectTestComponent.SpawnedInstances.Count()} | Expected spawn count: {TotalClients}");
+            CleanUpLoadedScene();
+        }
+
+        private NetworkObject m_JoinedClientDespawnedNetworkObject;
+
+        private void OnInSceneObjectDespawned(NetworkObject networkObject)
+        {
+            m_JoinedClientDespawnedNetworkObject = networkObject;
+            NetworkObjectTestComponent.OnInSceneObjectDespawned -= OnInSceneObjectDespawned;
+        }
+
+        private void Server_OnSceneEvent(SceneEvent sceneEvent)
+        {
+            if (sceneEvent.ClientId == m_ServerNetworkManager.LocalClientId && sceneEvent.SceneEventType == SceneEventType.LoadComplete
+                && sceneEvent.Scene.IsValid() && sceneEvent.Scene.isLoaded)
+            {
+                m_ServerSideSceneLoaded = sceneEvent.Scene;
+                m_ServerNetworkManager.SceneManager.OnSceneEvent -= Server_OnSceneEvent;
+            }
+        }
+
+        private IEnumerator CleanUpLoadedScene()
+        {
+            if (m_ServerSideSceneLoaded.IsValid() && m_ServerSideSceneLoaded.isLoaded)
+            {
+                Debug.Log("Unloading scene now");
+                m_ServerNetworkManager.SceneManager.OnSceneEvent += Unload_OnSceneEvent;
+                m_ServerNetworkManager.SceneManager.UnloadScene(m_ServerSideSceneLoaded);
+                yield return WaitForConditionOrTimeOut(() => m_ClientNetworkManagers.Where((c) => !c.IsListening).Count() == 0);
+                AssertOnTimeout($"[CleanUpLoadedScene] Timed out waiting for all in-scene instances to be despawned!  Current spawned count: {m_ClientNetworkManagers.Where((c) => !c.IsListening).Count()}");
+            }
+        }
+
+        private void Unload_OnSceneEvent(SceneEvent sceneEvent)
+        {
+            if (sceneEvent.ClientId == m_ServerNetworkManager.LocalClientId && sceneEvent.SceneEventType == SceneEventType.UnloadEventCompleted)
+            {
+                m_ServerNetworkManager.SceneManager.OnSceneEvent -= Unload_OnSceneEvent;
+            }
+        }
+
+        /// <summary>
+        /// Very important to always have a backup "unloading" catch
+        /// in the event your test fails it could not potentially unload
+        /// a scene and the proceeding tests could be impacted by this!
+        /// </summary>
+        /// <returns></returns>
+        protected override IEnumerator OnTearDown()
+        {
+            yield return CleanUpLoadedScene();
+        }
+    }
+}

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/InScenePlacedNetworkObjectTests.cs.meta
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/InScenePlacedNetworkObjectTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 692dcc72fdcf3aa49a3ba278b930ba15
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectTestComponent.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectTestComponent.cs
@@ -5,6 +5,11 @@ using Unity.Netcode;
 
 namespace TestProject.RuntimeTests
 {
+    /// <summary>
+    /// Used with Integration tests to track how many instances of the component
+    /// have been spawned with additional debug log information for spawn and despawn
+    /// events.
+    /// </summary>
     public class NetworkObjectTestComponent : NetworkBehaviour
     {
         public static NetworkObject ServerNetworkObjectInstance;

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectTestComponent.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectTestComponent.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Unity.Netcode;
+
+namespace TestProject.RuntimeTests
+{
+    public class NetworkObjectTestComponent : NetworkBehaviour
+    {
+        public static NetworkObject ServerNetworkObjectInstance;
+        public static List<NetworkObjectTestComponent> SpawnedInstances = new List<NetworkObjectTestComponent>();
+
+        public override void OnNetworkSpawn()
+        {
+            if (IsServer)
+            {
+                ServerNetworkObjectInstance = NetworkObject;
+            }
+            SpawnedInstances.Add(this);
+            base.OnNetworkSpawn();
+        }
+
+        public static Action<NetworkObject> OnInSceneObjectDespawned;
+
+        public override void OnNetworkDespawn()
+        {
+            OnInSceneObjectDespawned?.Invoke(NetworkObject);
+            m_HasNotifiedSpawned = false;
+            Debug.Log($"{NetworkManager.name} de-spawned {gameObject.name}.");
+            SpawnedInstances.Remove(this);
+            base.OnNetworkDespawn();
+        }
+
+        private bool m_HasNotifiedSpawned;
+        private void Update()
+        {
+            // We do this so the ObjectNameIdentifier has a chance to label it properly
+            if (IsSpawned && !m_HasNotifiedSpawned)
+            {
+                Debug.Log($"{NetworkManager.name} spawned {gameObject.name}.");
+                m_HasNotifiedSpawned = true;
+            }
+        }
+    }
+}

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectTestComponent.cs.meta
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectTestComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd877da52a3b48f4f867ac2c973c0265
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerDDOLTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerDDOLTests.cs
@@ -104,11 +104,11 @@ namespace TestProject.RuntimeTests
             ddolBehaviour.SetInScene(isInScene);
 
             networkObject.Spawn();
-            yield return new WaitForSeconds(0.03f);
+            yield return waitForFullNetworkTick;
+
             Assert.That(networkObject.IsSpawned);
 
             objectInstance.SetActive(isActive);
-
             m_ServerNetworkManager.SceneManager.MoveObjectsToDontDestroyOnLoad();
 
             yield return waitForFullNetworkTick;

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerDDOLTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerDDOLTests.cs
@@ -28,6 +28,8 @@ namespace TestProject.RuntimeTests
             m_DDOL_ObjectToSpawn = new GameObject();
             var networkObject = m_DDOL_ObjectToSpawn.AddComponent<NetworkObject>();
             m_DDOL_ObjectToSpawn.AddComponent<DDOLBehaviour>();
+            networkObject.DontDestroyWithOwner = true;
+            networkObject.DestroyWithScene = false;
 
             NetcodeIntegrationTestHelpers.MakeNetworkObjectTestPrefab(networkObject);
 
@@ -82,6 +84,7 @@ namespace TestProject.RuntimeTests
             [Values(MovedIntoDDOLBy.User, MovedIntoDDOLBy.NetworkSceneManager)] MovedIntoDDOLBy movedIntoDDOLBy,
             [Values(NetworkObjectType.InScenePlaced, NetworkObjectType.DynamicallySpawned)] NetworkObjectType networkObjectType)
         {
+            var waitForFullNetworkTick = new WaitForSeconds(1.0f / m_ServerNetworkManager.NetworkConfig.TickRate);
             var isActive = activeState == DefaultState.IsEnabled ? true : false;
             var isInScene = networkObjectType == NetworkObjectType.InScenePlaced ? true : false;
             var objectInstance = Object.Instantiate(m_DDOL_ObjectToSpawn);
@@ -101,21 +104,21 @@ namespace TestProject.RuntimeTests
             ddolBehaviour.SetInScene(isInScene);
 
             networkObject.Spawn();
-
+            yield return new WaitForSeconds(0.03f);
             Assert.That(networkObject.IsSpawned);
 
             objectInstance.SetActive(isActive);
 
             m_ServerNetworkManager.SceneManager.MoveObjectsToDontDestroyOnLoad();
 
-            yield return new WaitForSeconds(0.03f);
+            yield return waitForFullNetworkTick;
 
             // It should be isActive when MoveObjectsToDontDestroyOnLoad is called.
             Assert.That(networkObject.isActiveAndEnabled == isActive);
 
             m_ServerNetworkManager.SceneManager.MoveObjectsFromDontDestroyOnLoadToScene(SceneManager.GetActiveScene());
 
-            yield return new WaitForSeconds(0.03f);
+            yield return waitForFullNetworkTick;
 
             // It should be isActive when MoveObjectsFromDontDestroyOnLoadToScene is called.
             Assert.That(networkObject.isActiveAndEnabled == isActive);
@@ -129,6 +132,12 @@ namespace TestProject.RuntimeTests
             public void MoveToDDOL()
             {
                 DontDestroyOnLoad(gameObject);
+            }
+
+            public override void OnNetworkSpawn()
+            {
+                NetworkObject.DestroyWithScene = false;
+                base.OnNetworkSpawn();
             }
 
             public void SetInScene(bool isInScene)

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventCallbacks.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventCallbacks.cs
@@ -15,7 +15,7 @@ namespace TestProject.RuntimeTests
     public class NetworkSceneManagerEventCallbacks : NetcodeIntegrationTest
     {
         private const string k_SceneToLoad = "EmptyScene";
-        protected override int NumberOfClients => 1;
+        protected override int NumberOfClients => 4;
         private Scene m_CurrentScene;
         private bool m_CanStartServerOrClients = false;
 

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventCallbacks.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventCallbacks.cs
@@ -15,7 +15,7 @@ namespace TestProject.RuntimeTests
     public class NetworkSceneManagerEventCallbacks : NetcodeIntegrationTest
     {
         private const string k_SceneToLoad = "EmptyScene";
-        protected override int NumberOfClients => 4;
+        protected override int NumberOfClients => 1;
         private Scene m_CurrentScene;
         private bool m_CanStartServerOrClients = false;
 
@@ -92,15 +92,8 @@ namespace TestProject.RuntimeTests
             m_CanStartServerOrClients = true;
             yield return StartServerAndClients();
 
-            //////////////////////////////////////////
-            // Testing synchronize event notifications
-            var shouldWait = NotificationTestShouldWait();
-
-            while (shouldWait)
-            {
-                yield return new WaitForSeconds(0.01f);
-                shouldWait = NotificationTestShouldWait();
-            }
+            yield return WaitForConditionOrTimeOut(() => !NotificationTestShouldWait());
+            AssertOnTimeout($"Timed out waiting for client to synchronize!");
 
             // Reset for next test
             ResetNotificationInfo();
@@ -108,35 +101,21 @@ namespace TestProject.RuntimeTests
             //////////////////////////////////////////
             // Testing load event notifications
             Assert.That(m_ServerNetworkManager.SceneManager.LoadScene(k_SceneToLoad, LoadSceneMode.Additive) == SceneEventProgressStatus.Started);
-            shouldWait = NotificationTestShouldWait() || !m_CurrentScene.IsValid() || !m_CurrentScene.isLoaded;
 
-            while (shouldWait)
-            {
-                yield return new WaitForSeconds(0.01f);
-                shouldWait = NotificationTestShouldWait() || !m_CurrentScene.IsValid() || !m_CurrentScene.isLoaded;
-                if (!shouldWait)
-                {
-                    shouldWait = !ValidateCompletedNotifications();
-                }
-            }
+            yield return WaitForConditionOrTimeOut(() => (!NotificationTestShouldWait() && m_CurrentScene.IsValid() && m_CurrentScene.isLoaded) ? true : !ValidateCompletedNotifications());
+            AssertOnTimeout($"Timed out waiting for client to load the scene {k_SceneToLoad}!");
 
             // Reset for next test
             ResetNotificationInfo();
 
+            yield return s_DefaultWaitForTick;
+
             //////////////////////////////////////////
             // Testing unload event notifications
             Assert.That(m_ServerNetworkManager.SceneManager.UnloadScene(m_CurrentScene) == SceneEventProgressStatus.Started);
-            shouldWait = NotificationTestShouldWait() || m_CurrentScene.IsValid() || m_CurrentScene.isLoaded;
-            while (shouldWait)
-            {
-                yield return new WaitForSeconds(0.01f);
-                shouldWait = NotificationTestShouldWait() || m_CurrentScene.isLoaded;
-                if (!shouldWait)
-                {
-                    shouldWait = !ValidateCompletedNotifications();
-                }
-            }
-            yield break;
+
+            yield return WaitForConditionOrTimeOut(() => (!NotificationTestShouldWait() && !m_CurrentScene.isLoaded) ? true : !ValidateCompletedNotifications());
+            AssertOnTimeout($"Timed out waiting for client to unload the scene {k_SceneToLoad}!");
         }
 
 

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventCallbacks.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventCallbacks.cs
@@ -15,7 +15,7 @@ namespace TestProject.RuntimeTests
     public class NetworkSceneManagerEventCallbacks : NetcodeIntegrationTest
     {
         private const string k_SceneToLoad = "EmptyScene";
-        protected override int NumberOfClients => 9;
+        protected override int NumberOfClients => 4;
         private Scene m_CurrentScene;
         private bool m_CanStartServerOrClients = false;
 

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventCallbacks.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventCallbacks.cs
@@ -105,17 +105,18 @@ namespace TestProject.RuntimeTests
             yield return WaitForConditionOrTimeOut(() => (!NotificationTestShouldWait() && m_CurrentScene.IsValid() && m_CurrentScene.isLoaded) ? true : !ValidateCompletedNotifications());
             AssertOnTimeout($"Timed out waiting for client to load the scene {k_SceneToLoad}!");
 
-            // Reset for next test
-            ResetNotificationInfo();
-
             yield return s_DefaultWaitForTick;
 
+            // Reset for next test
+            ResetNotificationInfo();
             //////////////////////////////////////////
             // Testing unload event notifications
             Assert.That(m_ServerNetworkManager.SceneManager.UnloadScene(m_CurrentScene) == SceneEventProgressStatus.Started);
 
             yield return WaitForConditionOrTimeOut(() => (!NotificationTestShouldWait() && !m_CurrentScene.isLoaded) ? true : !ValidateCompletedNotifications());
             AssertOnTimeout($"Timed out waiting for client to unload the scene {k_SceneToLoad}!");
+
+            yield return s_DefaultWaitForTick;
         }
 
 

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
@@ -352,18 +352,6 @@ namespace TestProject.RuntimeTests
             }
         }
 
-        private bool AllClientsUnloadedScene()
-        {
-            foreach (var client in m_ClientNetworkManagers)
-            {
-                if (!m_ClientsThatUnloadedCurrentScene.Contains(client.LocalClientId))
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
-
         private IEnumerator UnloadAllScenes(bool shouldCheckClients = false)
         {
             if (m_ScenesLoaded.Count > 0)
@@ -378,17 +366,14 @@ namespace TestProject.RuntimeTests
                     {
                         m_ClientsThatUnloadedCurrentScene.Clear();
                         m_SceneBeingUnloaded = scene.name;
-                        yield return UnloadScene(scene);
-                        if (shouldCheckClients)
-                        {
-                            yield return WaitForConditionOrTimeOut(AllClientsUnloadedScene);
-                        }
+                        SceneManager.UnloadSceneAsync(scene);
                     }
                 }
                 SceneManager.SetActiveScene(m_OriginalActiveScene);
 
                 m_ScenesLoaded.Clear();
             }
+            yield return null;
         }
 
         protected override IEnumerator OnTearDown()

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
@@ -48,6 +48,7 @@ namespace TestProject.RuntimeTests
 
         protected override IEnumerator OnSetup()
         {
+            IntegrationTestSceneHandler.VerboseDebugMode = true;
             m_CanStartServerOrClients = false;
             m_ClientsReceivedSynchronize.Clear();
             m_ShouldWaitList.Clear();
@@ -240,7 +241,7 @@ namespace TestProject.RuntimeTests
             // Wait for all clients to load the scene
             yield return WaitForConditionOrTimeOut(ConditionPassed);
 
-            var errorMessage = $"Timed out waiting for clients to load the scene {m_CurrentSceneName}!\nShould Wait List:";
+            var errorMessage = $"Timed out waiting for clients to load the scene {m_CurrentSceneName}!\nShould Wait List:\n";
             if (s_GlobalTimeoutHelper.TimedOut)
             {
                 foreach (var entry in m_ShouldWaitList)
@@ -269,7 +270,7 @@ namespace TestProject.RuntimeTests
 
             // Wait for all clients to unload the scene
             yield return WaitForConditionOrTimeOut(ConditionPassed);
-            var errorMessage = $"Timed out waiting for clients to unload the scene {m_CurrentSceneName}!\nShould Wait List:";
+            var errorMessage = $"Timed out waiting for clients to unload the scene {m_CurrentSceneName}!\nShould Wait List:\n";
             if (s_GlobalTimeoutHelper.TimedOut)
             {
                 foreach (var entry in m_ShouldWaitList)
@@ -409,6 +410,7 @@ namespace TestProject.RuntimeTests
         protected override IEnumerator OnTearDown()
         {
             yield return UnloadAllScenes();
+            IntegrationTestSceneHandler.VerboseDebugMode = false;
         }
     }
 }

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
@@ -92,7 +92,7 @@ namespace TestProject.RuntimeTests
                             m_ScenesLoaded.Add(scene);
                         }
                         Assert.AreEqual(sceneEvent.SceneName, m_CurrentSceneName);
-                        Assert.IsTrue(ContainsClient(sceneEvent.ClientId),$"[{m_CurrentSceneName}]Client ID {sceneEvent.ClientId} is not in {nameof(m_ShouldWaitList)}");
+                        Assert.IsTrue(ContainsClient(sceneEvent.ClientId), $"[{m_CurrentSceneName}]Client ID {sceneEvent.ClientId} is not in {nameof(m_ShouldWaitList)}");
                         SetClientProcessedEvent(sceneEvent.ClientId);
                         break;
                     }

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
@@ -85,7 +85,6 @@ namespace TestProject.RuntimeTests
                     {
                         Assert.AreEqual(sceneEvent.SceneName, m_CurrentSceneName);
                         Assert.IsTrue(ContainsClient(sceneEvent.ClientId));
-                        Assert.IsNotNull(sceneEvent.AsyncOperation);
                         break;
                     }
                 case SceneEventType.LoadComplete:
@@ -242,9 +241,7 @@ namespace TestProject.RuntimeTests
                     errorMessage += $"ClientId: {entry.ClientId} | Processed: {entry.ProcessedEvent} | ShouldWait: {entry.ShouldWait}\n";
                 }
             }
-
             Assert.IsFalse(s_GlobalTimeoutHelper.TimedOut, errorMessage);
-            yield return s_DefaultWaitForTick;
         }
 
         private IEnumerator UnloadScene(Scene scene)
@@ -271,7 +268,6 @@ namespace TestProject.RuntimeTests
                 }
             }
             Assert.IsFalse(s_GlobalTimeoutHelper.TimedOut, errorMessage);
-            yield return s_DefaultWaitForTick;
         }
 
         /// <summary>
@@ -350,8 +346,6 @@ namespace TestProject.RuntimeTests
                 client.SceneManager.OnUnloadComplete -= SceneManager_OnUnloadComplete;
             }
             m_ServerNetworkManager.SceneManager.OnSceneEvent -= ServerSceneManager_OnSceneEvent;
-
-            yield return s_DefaultWaitForTick;
         }
 
         private string m_SceneBeingUnloaded;

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
@@ -236,7 +236,7 @@ namespace TestProject.RuntimeTests
             var errorMessage = $"Timed out waiting for clients to unload the scene {m_CurrentSceneName}!\nShould Wait List:";
             if (s_GlobalTimeoutHelper.TimedOut)
             {
-                foreach(var entry in m_ShouldWaitList)
+                foreach (var entry in m_ShouldWaitList)
                 {
                     errorMessage += $"ClientId: {entry.ClientId} | Processed: {entry.ProcessedEvent} | ShouldWait: {entry.ShouldWait}";
                 }

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
@@ -233,7 +233,16 @@ namespace TestProject.RuntimeTests
             // Wait for all clients to load the scene
             yield return WaitForConditionOrTimeOut(ConditionPassed);
 
-            Assert.IsFalse(s_GlobalTimeoutHelper.TimedOut, "Timed out waiting for clients to load the scene!");
+            var errorMessage = $"Timed out waiting for clients to unload the scene {m_CurrentSceneName}!\nShould Wait List:";
+            if (s_GlobalTimeoutHelper.TimedOut)
+            {
+                foreach(var entry in m_ShouldWaitList)
+                {
+                    errorMessage += $"ClientId: {entry.ClientId} | Processed: {entry.ProcessedEvent} | ShouldWait: {entry.ShouldWait}";
+                }
+            }
+
+            Assert.IsFalse(s_GlobalTimeoutHelper.TimedOut, errorMessage);
 
             yield return s_DefaultWaitForTick;
         }
@@ -250,6 +259,17 @@ namespace TestProject.RuntimeTests
 
             // Wait for all clients to unload the scene
             yield return WaitForConditionOrTimeOut(ConditionPassed);
+            var errorMessage = $"Timed out waiting for clients to unload the scene {m_CurrentSceneName}!\nShould Wait List:";
+            if (s_GlobalTimeoutHelper.TimedOut)
+            {
+                foreach (var entry in m_ShouldWaitList)
+                {
+                    errorMessage += $"ClientId: {entry.ClientId} | Processed: {entry.ProcessedEvent} | ShouldWait: {entry.ShouldWait}";
+                }
+            }
+
+            Assert.IsFalse(s_GlobalTimeoutHelper.TimedOut, errorMessage);
+
             Assert.IsFalse(s_GlobalTimeoutHelper.TimedOut, "Timed out waiting for clients to unload the scene!");
             yield return s_DefaultWaitForTick;
         }

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
@@ -375,7 +375,6 @@ namespace TestProject.RuntimeTests
                         m_SceneBeingUnloaded = scene.name;
 
                         yield return UnloadScene(scene);
-                        //SceneManager.UnloadSceneAsync(scene);
                     }
                 }
                 SceneManager.SetActiveScene(m_OriginalActiveScene);

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
@@ -13,7 +13,7 @@ namespace TestProject.RuntimeTests
     [TestFixture(HostOrServer.Server)]
     public class NetworkSceneManagerEventDataPoolTest : NetcodeIntegrationTest
     {
-        protected override int NumberOfClients => 9;
+        protected override int NumberOfClients => 1;
         public NetworkSceneManagerEventDataPoolTest(HostOrServer hostOrServer) : base(hostOrServer) { }
 
         private const string k_BaseUnitTestSceneName = "UnitTestBaseScene";
@@ -92,7 +92,7 @@ namespace TestProject.RuntimeTests
                             m_ScenesLoaded.Add(scene);
                         }
                         Assert.AreEqual(sceneEvent.SceneName, m_CurrentSceneName);
-                        Assert.IsTrue(ContainsClient(sceneEvent.ClientId));
+                        Assert.IsTrue(ContainsClient(sceneEvent.ClientId),$"[{m_CurrentSceneName}]Client ID {sceneEvent.ClientId} is not in {nameof(m_ShouldWaitList)}");
                         SetClientProcessedEvent(sceneEvent.ClientId);
                         break;
                     }
@@ -282,6 +282,7 @@ namespace TestProject.RuntimeTests
             yield return WaitForConditionOrTimeOut(() => m_ClientsReceivedSynchronize.Count == (m_ClientNetworkManagers.Length));
             Assert.False(s_GlobalTimeoutHelper.TimedOut, $"Timed out waiting for all clients to receive synchronization event! Received: {m_ClientsReceivedSynchronize.Count} | Expected: {m_ClientNetworkManagers.Length}");
 
+
             // Now prepare for the loading and unloading additive scene testing
             InitializeSceneTestInfo(clientSynchronizationMode, true);
 
@@ -299,6 +300,9 @@ namespace TestProject.RuntimeTests
             yield return s_DefaultWaitForTick;
 
             yield return UnloadAllScenes();
+            m_ServerNetworkManager.SceneManager.OnSceneEvent -= ServerSceneManager_OnSceneEvent;
+            yield return s_DefaultWaitForTick;
+
         }
 
         private IEnumerator UnloadAllScenes()
@@ -324,6 +328,7 @@ namespace TestProject.RuntimeTests
         protected override IEnumerator OnTearDown()
         {
             yield return UnloadAllScenes();
+            m_ServerNetworkManager.SceneManager.OnSceneEvent -= ServerSceneManager_OnSceneEvent;
         }
     }
 }

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
@@ -14,7 +14,7 @@ namespace TestProject.RuntimeTests
     [TestFixture(HostOrServer.Server)]
     public class NetworkSceneManagerEventDataPoolTest : NetcodeIntegrationTest
     {
-        protected override int NumberOfClients => 1;
+        protected override int NumberOfClients => 4;
         public NetworkSceneManagerEventDataPoolTest(HostOrServer hostOrServer) : base(hostOrServer) { }
 
         private const string k_BaseUnitTestSceneName = "UnitTestBaseScene";
@@ -48,11 +48,6 @@ namespace TestProject.RuntimeTests
             m_ScenesLoaded.Clear();
             m_CreateServerFirst = false;
             return base.OnSetup();
-        }
-
-        protected override void OnServerAndClientsCreated()
-        {
-            base.OnServerAndClientsCreated();
         }
 
         protected override IEnumerator OnStartedServerAndClients()
@@ -234,7 +229,7 @@ namespace TestProject.RuntimeTests
             yield return WaitForConditionOrTimeOut(ConditionPassed);
 
             var errorMessage = $"Timed out waiting for clients to load the scene {m_CurrentSceneName}!\nShould Wait List:\n";
-            if (s_GlobalTimeoutHelper.TimedOut)
+            if (m_EnableVerboseDebug && s_GlobalTimeoutHelper.TimedOut)
             {
                 foreach (var entry in m_ShouldWaitList)
                 {
@@ -259,8 +254,9 @@ namespace TestProject.RuntimeTests
 
             // Wait for all clients to unload the scene
             yield return WaitForConditionOrTimeOut(ConditionPassed);
+
             var errorMessage = $"Timed out waiting for clients to unload the scene {m_CurrentSceneName}!\nShould Wait List:\n";
-            if (s_GlobalTimeoutHelper.TimedOut)
+            if (m_EnableVerboseDebug && s_GlobalTimeoutHelper.TimedOut)
             {
                 foreach (var entry in m_ShouldWaitList)
                 {

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
@@ -15,7 +15,7 @@ namespace TestProject.RuntimeTests
     [TestFixture(HostOrServer.Server)]
     public class NetworkSceneManagerEventDataPoolTest : NetcodeIntegrationTest
     {
-        protected override int NumberOfClients => 4;
+        protected override int NumberOfClients => 1;
         public NetworkSceneManagerEventDataPoolTest(HostOrServer hostOrServer) : base(hostOrServer) { }
 
         private const string k_BaseUnitTestSceneName = "UnitTestBaseScene";
@@ -41,14 +41,8 @@ namespace TestProject.RuntimeTests
         private List<SceneTestInfo> m_ShouldWaitList = new List<SceneTestInfo>();
         private List<ulong> m_ClientsReceivedSynchronize = new List<ulong>();
 
-        protected override bool OnSetVerboseDebug()
-        {
-            return true;
-        }
-
         protected override IEnumerator OnSetup()
         {
-            IntegrationTestSceneHandler.VerboseDebugMode = true;
             m_CanStartServerOrClients = false;
             m_ClientsReceivedSynchronize.Clear();
             m_ShouldWaitList.Clear();
@@ -410,7 +404,6 @@ namespace TestProject.RuntimeTests
         protected override IEnumerator OnTearDown()
         {
             yield return UnloadAllScenes();
-            IntegrationTestSceneHandler.VerboseDebugMode = false;
         }
     }
 }

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
-using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 using Unity.Netcode;
@@ -245,7 +244,6 @@ namespace TestProject.RuntimeTests
             }
 
             Assert.IsFalse(s_GlobalTimeoutHelper.TimedOut, errorMessage);
-
             yield return s_DefaultWaitForTick;
         }
 
@@ -307,8 +305,6 @@ namespace TestProject.RuntimeTests
             m_LoadSceneMode = clientSynchronizationMode;
             m_CanStartServerOrClients = true;
 
-
-
             yield return StartServerAndClients();
 
             // Now prepare for the loading and unloading additive scene testing
@@ -316,8 +312,6 @@ namespace TestProject.RuntimeTests
 
             yield return WaitForConditionOrTimeOut(() => m_ClientsReceivedSynchronize.Count == (m_ClientNetworkManagers.Length));
             Assert.False(s_GlobalTimeoutHelper.TimedOut, $"Timed out waiting for all clients to receive synchronization event! Received: {m_ClientsReceivedSynchronize.Count} | Expected: {m_ClientNetworkManagers.Length}");
-
-
 
             m_OriginalActiveScene = SceneManager.GetActiveScene();
 
@@ -334,7 +328,7 @@ namespace TestProject.RuntimeTests
                     message += $"NetworkSceneHandle: {entry.Key} | ClientSceneHandle: {entry.Value}\n";
                 }
             }
-            Debug.Log($"{message}");
+            VerboseDebug($"{message}");
 
             SceneManager.SetActiveScene(m_CurrentScene);
             // Now load the scene(s)

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventNotifications.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventNotifications.cs
@@ -83,7 +83,6 @@ namespace TestProject.RuntimeTests
                     {
                         Assert.AreEqual(sceneEvent.SceneName, m_CurrentSceneName);
                         Assert.IsTrue(ContainsClient(sceneEvent.ClientId));
-                        Assert.IsNotNull(sceneEvent.AsyncOperation);
                         break;
                     }
                 case SceneEventType.LoadComplete:

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventNotifications.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventNotifications.cs
@@ -173,8 +173,6 @@ namespace TestProject.RuntimeTests
             // Check error status for trying to load an invalid scene name
             LogAssert.Expect(LogType.Error, $"Scene '{k_InvalidSceneName}' couldn't be loaded because it has not been added to the build settings scenes in build list.");
             Assert.AreEqual(m_ServerNetworkManager.SceneManager.LoadScene(k_InvalidSceneName, LoadSceneMode.Additive), SceneEventProgressStatus.InvalidSceneName);
-
-            ShutdownAndCleanUp();
         }
 
         /// <summary>

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventNotifications.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventNotifications.cs
@@ -16,7 +16,7 @@ namespace TestProject.RuntimeTests
     {
         private const string k_InvalidSceneName = "SomeInvalidSceneName";
         private const string k_SceneToLoad = "EmptyScene";
-        protected override int NumberOfClients => 9;
+        protected override int NumberOfClients => 4;
         private string m_CurrentSceneName;
         private Scene m_CurrentScene;
         private LoadSceneMode m_LoadSceneMode;
@@ -157,14 +157,14 @@ namespace TestProject.RuntimeTests
 
             // Wait for all clients to load the scene
             yield return WaitForConditionOrTimeOut(ConditionPassed);
-            Assert.IsFalse(s_GlobalTimeoutHelper.TimedOut, $"Timed out waiting for all clients to load {m_CurrentSceneName}");
+            AssertOnTimeout($"Timed out waiting for all clients to load {m_CurrentSceneName}!");
 
             // Test unloading additive scenes and the associated event messaging and notification pipelines
             ResetWait();
             Assert.AreEqual(m_ServerNetworkManager.SceneManager.UnloadScene(m_CurrentScene), SceneEventProgressStatus.Started);
 
             yield return WaitForConditionOrTimeOut(ConditionPassed);
-            Assert.IsFalse(s_GlobalTimeoutHelper.TimedOut, $"Timed out waiting for all clients to unload {m_CurrentSceneName}");
+            AssertOnTimeout($"Timed out waiting for all clients to unload {m_CurrentSceneName}!");
 
             // Check error status for trying to unloading something not loaded
             ResetWait();

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerSeneVerification.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerSeneVerification.cs
@@ -17,8 +17,8 @@ namespace TestProject.RuntimeTests
         protected override int NumberOfClients => 9;
         public NetworkSceneManagerSeneVerification(HostOrServer hostOrServer) : base(hostOrServer) { }
 
-        private const string k_AdditiveScene1 = "AdditiveScene1";
-        private const string k_AdditiveScene2 = "AdditiveScene2";
+        private const string k_AdditiveScene1 = "InSceneNetworkObject";
+        private const string k_AdditiveScene2 = "AdditiveSceneMultiInstance";
 
         private string m_CurrentSceneName;
         private Scene m_CurrentScene;

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerSeneVerification.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerSeneVerification.cs
@@ -14,7 +14,7 @@ namespace TestProject.RuntimeTests
     public class NetworkSceneManagerSeneVerification : NetcodeIntegrationTest
     {
 
-        protected override int NumberOfClients => 9;
+        protected override int NumberOfClients => 4;
         public NetworkSceneManagerSeneVerification(HostOrServer hostOrServer) : base(hostOrServer) { }
 
         private const string k_AdditiveScene1 = "InSceneNetworkObject";
@@ -291,14 +291,14 @@ namespace TestProject.RuntimeTests
 
             // Wait for all clients to load the scene
             yield return WaitForConditionOrTimeOut(ConditionPassed);
-            Assert.IsFalse(s_GlobalTimeoutHelper.TimedOut, $"Timed out waiting for all clients to load {m_CurrentSceneName}");
+            AssertOnTimeout($"Timed out waiting for all clients to load {m_CurrentSceneName}");
 
             // Unload the scene
             ResetWait();
             Assert.AreEqual(m_ServerNetworkManager.SceneManager.UnloadScene(m_CurrentScene), SceneEventProgressStatus.Started);
 
             yield return WaitForConditionOrTimeOut(ConditionPassed);
-            Assert.IsFalse(s_GlobalTimeoutHelper.TimedOut, $"Timed out waiting for all clients to unload {m_CurrentSceneName}");
+            AssertOnTimeout($"Timed out waiting for all clients to unload {m_CurrentSceneName}");
 
             // Test VerifySceneBeforeLoading with m_ServerVerifyScene set to false
             // Server will notify it failed scene verification and no client should load
@@ -321,7 +321,7 @@ namespace TestProject.RuntimeTests
 
             // Now wait for server to complete and all clients to fail
             yield return WaitForConditionOrTimeOut(ConditionPassed);
-            Assert.IsFalse(s_GlobalTimeoutHelper.TimedOut, $"Timed out waiting for all clients to load {m_CurrentSceneName}");
+            AssertOnTimeout($"Timed out waiting for all clients to load {m_CurrentSceneName}");
 
             // Now unload the scene the server loaded from last test
             ResetWait();
@@ -341,7 +341,7 @@ namespace TestProject.RuntimeTests
 
             // Now wait for server to unload and clients will fake unload
             yield return WaitForConditionOrTimeOut(ConditionPassed);
-            Assert.IsFalse(s_GlobalTimeoutHelper.TimedOut, $"Timed out waiting for all clients to unload {m_CurrentSceneName}");
+            AssertOnTimeout($"Timed out waiting for all clients to unload {m_CurrentSceneName}");
         }
     }
 }

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerSeneVerification.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerSeneVerification.cs
@@ -99,7 +99,6 @@ namespace TestProject.RuntimeTests
                             var scene = sceneEvent.Scene;
                             m_CurrentScene = scene;
                             m_ScenesLoaded.Add(scene);
-                            //m_ClientsAreOkToLoad = true;
                         }
                         Assert.AreEqual(sceneEvent.SceneName, m_CurrentSceneName);
                         Assert.IsTrue(ContainsClient(sceneEvent.ClientId));
@@ -301,14 +300,15 @@ namespace TestProject.RuntimeTests
 
             // Wait for all clients to load the scene
             yield return WaitForConditionOrTimeOut(ConditionPassed);
-            AssertOnTimeout($"Timed out waiting for all clients to load {m_CurrentSceneName}");
+            AssertOnTimeout($"Timed out waiting for all clients to load {m_CurrentSceneName}\n{PrintFailedCondition()}");
 
             // Unload the scene
             ResetWait();
             Assert.AreEqual(m_ServerNetworkManager.SceneManager.UnloadScene(m_CurrentScene), SceneEventProgressStatus.Started);
 
             yield return WaitForConditionOrTimeOut(ConditionPassed);
-            AssertOnTimeout($"Timed out waiting for all clients to unload {m_CurrentSceneName}");
+
+            AssertOnTimeout($"Timed out waiting for all clients to unload {m_CurrentSceneName}\n{PrintFailedCondition()}");
 
             // Test VerifySceneBeforeLoading with m_ServerVerifyScene set to false
             // Server will notify it failed scene verification and no client should load
@@ -331,7 +331,7 @@ namespace TestProject.RuntimeTests
 
             // Now wait for server to complete and all clients to fail
             yield return WaitForConditionOrTimeOut(ConditionPassed);
-            AssertOnTimeout($"Timed out waiting for all clients to load {m_CurrentSceneName}!\n");
+            AssertOnTimeout($"Timed out waiting for all clients to load {m_CurrentSceneName}!\n{PrintFailedCondition()}");
 
             // Now unload the scene the server loaded from last test
             ResetWait();
@@ -351,7 +351,7 @@ namespace TestProject.RuntimeTests
 
             // Now wait for scenes to unload
             yield return WaitForConditionOrTimeOut(ConditionPassed);
-            AssertOnTimeout($"Timed out waiting for all clients to unload {m_CurrentSceneName}!");
+            AssertOnTimeout($"Timed out waiting for all clients to unload {m_CurrentSceneName}!\n{PrintFailedCondition()}");
         }
     }
 }


### PR DESCRIPTION
**This is a backport of [PR-1898](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/1898)**

This resolves the issue where an in-scene placed NetworkObject could be despawned prior to a client joining and the client-side in-scene placed NetworkObject component's would not receive a despawn notification when synchronizing.

This also greatly reduces user pain by not requiring users to register in-scene placed NetworkObjets with the NetworkManager using prefab hash overrides.  Instead, it just uses the table of in-scene NetworkObjects that were already being tracked by the NetworkSceneManager.

[MTT-2924](https://jira.unity3d.com/browse/MTT-2924)

## Changelog
- Fixed: `NetworkSceneManager` does not synchronize despawned in-scene placed NetworkObjects.
- Changed: requirement to register in-scene placed NetworkObjects with `NetworkManager` in order to respawn them.  In-scene placed NetworkObjects are now automatically tracked during runtime and no longer need to be registered as a NetworkPrefab.

## Testing and Documentation
- Includes manual test (Additive Scene Loading: Backspace on server spawns/despawns the green in-scene NetworkObject)
- Includes integration test updates.
- Includes integration test: InScenePlacedNetworkObjects

## NetcodeIntegrationTest Updates:
![image](https://user-images.githubusercontent.com/73188597/165867537-b1019b31-9270-4647-834b-514a0d748c68.png)
The image above is an integration test that has two (2) clients and (1) host where the host loaded a scene that has in-scene placed NetworkObjects.  If the in-scene NetworkObject has the TestHelper ObjectNameIdentifier component, then like in the above image you will be able to visually distinguish between each relative instance.