### PR TITLE
fix: preventing issues with game code registering multiple `ConnectionApprovalCallback`s [MTT-3496]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,15 +12,14 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
-- [breaking] `ConnectionApprovalCallback` is now `ConnectionApprovalHandler`. Receives a `ConnectionApprovalRequest`, and returns a `ConnectionApprovalResult`. By virtue of being a `Func<>`, there cannot be multiple handlers registered.
+- (API Breaking) `ConnectionApprovalCallback` is no longer an `event` and will not allow more than 1 handler registered. Also, `ConnectionApprovalCallback` is now a `Func<>` taking `ConnectionApprovalRequest` in and returning `ConnectionApprovalResponse` back out (#1941)
 
 ### Removed
 
 ### Fixed
 
+- Fixed issues when multiple `ConnectionApprovalCallback`s were registered (#1941)
 - Fixed endless dialog boxes when adding a NetworkBehaviour to a NetworkManager or vice-versa (#1947)
-
-- Fixed issues when multiple Connection Approval callbacks were registered (#1941)
 
 ## [1.0.0-pre.9] - 2022-05-10
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,11 +12,15 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+- [breaking] `ConnectionApprovalCallback` is now `ConnectionApprovalHandler`. Receives a `ConnectionApprovalRequest`, and returns a `ConnectionApprovalResult`. By virtue of being a `Func<>`, there cannot be multiple handlers registered.
+
 ### Removed
 
 ### Fixed
 
 - Fixed endless dialog boxes when adding a NetworkBehaviour to a NetworkManager or vice-versa (#1947)
+
+- Fixed issues when multiple Connection Approval callbacks were registered (#1941)
 
 ## [1.0.0-pre.9] - 2022-05-10
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,13 +12,13 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
-- (API Breaking) `ConnectionApprovalCallback` is no longer an `event` and will not allow more than 1 handler registered. Also, `ConnectionApprovalCallback` is now a `Func<>` taking `ConnectionApprovalRequest` in and returning `ConnectionApprovalResponse` back out (#1941)
+- (API Breaking) `ConnectionApprovalCallback` is no longer an `event` and will not allow more than 1 handler registered at a time. Also, `ConnectionApprovalCallback` is now a `Func<>` taking `ConnectionApprovalRequest` in and returning `ConnectionApprovalResponse` back out (#1972)
 
 ### Removed
 
 ### Fixed
 
-- Fixed issues when multiple `ConnectionApprovalCallback`s were registered (#1941)
+- Fixed issues when multiple `ConnectionApprovalCallback`s were registered (#1972)
 - Fixed endless dialog boxes when adding a NetworkBehaviour to a NetworkManager or vice-versa (#1947)
 
 ## [1.0.0-pre.9] - 2022-05-10

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -395,9 +395,7 @@ namespace Unity.Netcode
             {
                 if (value != null && value.GetInvocationList().Length > 1)
                 {
-                    Debug.LogError(
-                        $"Only one connection approval handler is supported in {nameof(m_ConnectionApprovalCallback)}. Rejecting further adds.");
-                    throw (new InvalidOperationException());
+                    throw (new InvalidOperationException($"Only one connection approval handler is supported in {nameof(m_ConnectionApprovalCallback)}. Rejecting further adds."));
                 }
                 else
                 {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1881,10 +1881,10 @@ namespace Unity.Netcode
                     SpawnManager.SpawnNetworkObjectLocally(
                         networkObject,
                         SpawnManager.GetNetworkObjectId(),
-                        sceneObject:false,
-                        playerObject:true,
+                        sceneObject: false,
+                        playerObject: true,
                         ownerClientId,
-                        destroyWithScene:false);
+                        destroyWithScene: false);
 
                     ConnectedClients[ownerClientId].PlayerObject = networkObject;
                 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionRequestMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionRequestMessage.cs
@@ -101,17 +101,17 @@ namespace Unity.Netcode
             {
                 // Note: Delegate creation allocates.
                 // Note: ToArray() also allocates. :(
-                var decision = networkManager.ConnectionApprovalHandler(new NetworkManager.ConnectionApprovalRequest
+                var decision = networkManager.ConnectionApprovalCallback(new NetworkManager.ConnectionApprovalRequest
                 { Payload = ConnectionData, ClientNetworkId = senderId });
 
-                networkManager.HandleApproval(senderId, decision);
+                networkManager.HandleConnectionApproval(senderId, decision);
             }
             else
             {
-                var decision = new NetworkManager.ConnectionApprovalResult();
+                var decision = new NetworkManager.ConnectionApprovalResponse();
                 decision.Approved = true;
                 decision.CreatePlayerObject = networkManager.NetworkConfig.PlayerPrefab != null;
-                networkManager.HandleApproval(senderId, decision);
+                networkManager.HandleConnectionApproval(senderId, decision);
             }
         }
     }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionRequestMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionRequestMessage.cs
@@ -101,16 +101,17 @@ namespace Unity.Netcode
             {
                 // Note: Delegate creation allocates.
                 // Note: ToArray() also allocates. :(
-                networkManager.InvokeConnectionApproval(ConnectionData, senderId,
-                    (createPlayerObject, playerPrefabHash, approved, position, rotation) =>
-                    {
-                        var localCreatePlayerObject = createPlayerObject;
-                        networkManager.HandleApproval(senderId, localCreatePlayerObject, playerPrefabHash, approved, position, rotation);
-                    });
+                var decision = networkManager.ConnectionApprovalHandler(new NetworkManager.ConnectionApprovalRequest
+                { Payload = ConnectionData, ClientNetworkId = senderId });
+
+                networkManager.HandleApproval(senderId, decision);
             }
             else
             {
-                networkManager.HandleApproval(senderId, networkManager.NetworkConfig.PlayerPrefab != null, null, true, null, null);
+                var decision = new NetworkManager.ConnectionApprovalResult();
+                decision.Approved = true;
+                decision.CreatePlayerObject = networkManager.NetworkConfig.PlayerPrefab != null;
+                networkManager.HandleApproval(senderId, decision);
             }
         }
     }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionRequestMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionRequestMessage.cs
@@ -101,17 +101,22 @@ namespace Unity.Netcode
             {
                 // Note: Delegate creation allocates.
                 // Note: ToArray() also allocates. :(
-                var decision = networkManager.ConnectionApprovalCallback(new NetworkManager.ConnectionApprovalRequest
-                { Payload = ConnectionData, ClientNetworkId = senderId });
-
-                networkManager.HandleConnectionApproval(senderId, decision);
+                var response = networkManager.ConnectionApprovalCallback(
+                    new NetworkManager.ConnectionApprovalRequest
+                    {
+                        Payload = ConnectionData,
+                        ClientNetworkId = senderId
+                    });
+                networkManager.HandleConnectionApproval(senderId, response);
             }
             else
             {
-                var decision = new NetworkManager.ConnectionApprovalResponse();
-                decision.Approved = true;
-                decision.CreatePlayerObject = networkManager.NetworkConfig.PlayerPrefab != null;
-                networkManager.HandleConnectionApproval(senderId, decision);
+                var response = new NetworkManager.ConnectionApprovalResponse
+                {
+                    Approved = true,
+                    CreatePlayerObject = networkManager.NetworkConfig.PlayerPrefab != null
+                };
+                networkManager.HandleConnectionApproval(senderId, response);
             }
         }
     }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApproval.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApproval.cs
@@ -24,7 +24,7 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator ConnectionApproval()
         {
-            NetworkManagerHelper.NetworkManagerObject.ConnectionApprovalHandler += NetworkManagerObject_ConnectionApprovalCallback;
+            NetworkManagerHelper.NetworkManagerObject.ConnectionApprovalCallback += NetworkManagerObject_ConnectionApprovalCallback;
             NetworkManagerHelper.NetworkManagerObject.NetworkConfig.ConnectionApproval = true;
             NetworkManagerHelper.NetworkManagerObject.NetworkConfig.PlayerPrefab = null;
             NetworkManagerHelper.NetworkManagerObject.NetworkConfig.ConnectionData = Encoding.UTF8.GetBytes(m_ValidationToken.ToString());
@@ -47,9 +47,9 @@ namespace Unity.Netcode.RuntimeTests
             Assert.True(m_IsValidated);
         }
 
-        private NetworkManager.ConnectionApprovalResult NetworkManagerObject_ConnectionApprovalCallback(NetworkManager.ConnectionApprovalRequest request)
+        private NetworkManager.ConnectionApprovalResponse NetworkManagerObject_ConnectionApprovalCallback(NetworkManager.ConnectionApprovalRequest request)
         {
-            var decision = new NetworkManager.ConnectionApprovalResult();
+            var decision = new NetworkManager.ConnectionApprovalResponse();
             var stringGuid = Encoding.UTF8.GetString(request.Payload);
             if (m_ValidationToken.ToString() == stringGuid)
             {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApproval.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApproval.cs
@@ -24,7 +24,7 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator ConnectionApproval()
         {
-            NetworkManagerHelper.NetworkManagerObject.ConnectionApprovalCallback += NetworkManagerObject_ConnectionApprovalCallback;
+            NetworkManagerHelper.NetworkManagerObject.ConnectionApprovalHandler += NetworkManagerObject_ConnectionApprovalCallback;
             NetworkManagerHelper.NetworkManagerObject.NetworkConfig.ConnectionApproval = true;
             NetworkManagerHelper.NetworkManagerObject.NetworkConfig.PlayerPrefab = null;
             NetworkManagerHelper.NetworkManagerObject.NetworkConfig.ConnectionData = Encoding.UTF8.GetBytes(m_ValidationToken.ToString());
@@ -47,14 +47,22 @@ namespace Unity.Netcode.RuntimeTests
             Assert.True(m_IsValidated);
         }
 
-        private void NetworkManagerObject_ConnectionApprovalCallback(byte[] connectionData, ulong clientId, NetworkManager.ConnectionApprovedDelegate callback)
+        private NetworkManager.ConnectionApprovalResult NetworkManagerObject_ConnectionApprovalCallback(NetworkManager.ConnectionApprovalRequest request)
         {
-            var stringGuid = Encoding.UTF8.GetString(connectionData);
+            var decision = new NetworkManager.ConnectionApprovalResult();
+            var stringGuid = Encoding.UTF8.GetString(request.Payload);
             if (m_ValidationToken.ToString() == stringGuid)
             {
                 m_IsValidated = true;
             }
-            callback(false, null, m_IsValidated, null, null);
+
+            decision.Approved = m_IsValidated;
+            decision.CreatePlayerObject = false;
+            decision.Position = null;
+            decision.Rotation = null;
+            decision.PlayerPrefabHash = null;
+
+            return decision;
         }
 
         [TearDown]

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApproval.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApproval.cs
@@ -24,7 +24,7 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator ConnectionApproval()
         {
-            NetworkManagerHelper.NetworkManagerObject.ConnectionApprovalCallback += NetworkManagerObject_ConnectionApprovalCallback;
+            NetworkManagerHelper.NetworkManagerObject.ConnectionApprovalCallback = NetworkManagerObject_ConnectionApprovalCallback;
             NetworkManagerHelper.NetworkManagerObject.NetworkConfig.ConnectionApproval = true;
             NetworkManagerHelper.NetworkManagerObject.NetworkConfig.PlayerPrefab = null;
             NetworkManagerHelper.NetworkManagerObject.NetworkConfig.ConnectionData = Encoding.UTF8.GetBytes(m_ValidationToken.ToString());
@@ -49,20 +49,20 @@ namespace Unity.Netcode.RuntimeTests
 
         private NetworkManager.ConnectionApprovalResponse NetworkManagerObject_ConnectionApprovalCallback(NetworkManager.ConnectionApprovalRequest request)
         {
-            var decision = new NetworkManager.ConnectionApprovalResponse();
+            var response = new NetworkManager.ConnectionApprovalResponse();
             var stringGuid = Encoding.UTF8.GetString(request.Payload);
             if (m_ValidationToken.ToString() == stringGuid)
             {
                 m_IsValidated = true;
             }
 
-            decision.Approved = m_IsValidated;
-            decision.CreatePlayerObject = false;
-            decision.Position = null;
-            decision.Rotation = null;
-            decision.PlayerPrefabHash = null;
+            response.Approved = m_IsValidated;
+            response.CreatePlayerObject = false;
+            response.Position = null;
+            response.Rotation = null;
+            response.PlayerPrefabHash = null;
 
-            return decision;
+            return response;
         }
 
         [TearDown]

--- a/testproject/Assets/Tests/Manual/Scripts/ConnectionApprovalComponent.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/ConnectionApprovalComponent.cs
@@ -65,7 +65,7 @@ namespace TestProject.ManualTests
 
             if (NetworkManager != null && NetworkManager.NetworkConfig.ConnectionApproval)
             {
-                NetworkManager.ConnectionApprovalHandler += ConnectionApprovalCallback;
+                NetworkManager.ConnectionApprovalCallback = ConnectionApprovalCallback;
 
                 if (m_ApprovalToken != string.Empty)
                 {
@@ -153,9 +153,9 @@ namespace TestProject.ManualTests
         /// </summary>
         /// <param name="request">The connection approval request</param>
         /// <returns>ConnectionApprovalResult with the approval decision, with parameters</returns>
-        private NetworkManager.ConnectionApprovalResult ConnectionApprovalCallback(NetworkManager.ConnectionApprovalRequest request)
+        private NetworkManager.ConnectionApprovalResponse ConnectionApprovalCallback(NetworkManager.ConnectionApprovalRequest request)
         {
-            var decision = new NetworkManager.ConnectionApprovalResult();
+            var decision = new NetworkManager.ConnectionApprovalResponse();
             string approvalToken = Encoding.ASCII.GetString(request.Payload);
             var isTokenValid = approvalToken == m_ApprovalToken;
             if (m_SimulateFailure && m_SimulateFailure.isOn && IsServer && request.ClientNetworkId != NetworkManager.LocalClientId)

--- a/testproject/Assets/Tests/Manual/Scripts/ConnectionApprovalComponent.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/ConnectionApprovalComponent.cs
@@ -155,7 +155,7 @@ namespace TestProject.ManualTests
         /// <returns>ConnectionApprovalResult with the approval decision, with parameters</returns>
         private NetworkManager.ConnectionApprovalResponse ConnectionApprovalCallback(NetworkManager.ConnectionApprovalRequest request)
         {
-            var decision = new NetworkManager.ConnectionApprovalResponse();
+            var response = new NetworkManager.ConnectionApprovalResponse();
             string approvalToken = Encoding.ASCII.GetString(request.Payload);
             var isTokenValid = approvalToken == m_ApprovalToken;
             if (m_SimulateFailure && m_SimulateFailure.isOn && IsServer && request.ClientNetworkId != NetworkManager.LocalClientId)
@@ -165,19 +165,19 @@ namespace TestProject.ManualTests
 
             if (m_GlobalObjectIdHashOverride != 0 && m_PlayerPrefabOverride && m_PlayerPrefabOverride.isOn)
             {
-                decision.Approved = isTokenValid;
-                decision.PlayerPrefabHash = m_GlobalObjectIdHashOverride;
-                decision.Position = null;
-                decision.Rotation = null;
-                decision.CreatePlayerObject = true;
+                response.Approved = isTokenValid;
+                response.PlayerPrefabHash = m_GlobalObjectIdHashOverride;
+                response.Position = null;
+                response.Rotation = null;
+                response.CreatePlayerObject = true;
             }
             else
             {
-                decision.Approved = isTokenValid;
-                decision.PlayerPrefabHash = null;
-                decision.Position = null;
-                decision.Rotation = null;
-                decision.CreatePlayerObject = true;
+                response.Approved = isTokenValid;
+                response.PlayerPrefabHash = null;
+                response.Position = null;
+                response.Rotation = null;
+                response.CreatePlayerObject = true;
             }
 
             if (m_ConnectionMessageToDisplay)
@@ -194,7 +194,7 @@ namespace TestProject.ManualTests
                 m_ConnectionMessageToDisplay.gameObject.SetActive(true);
             }
 
-            return decision;
+            return response;
         }
 
         /// <summary>

--- a/testproject/Assets/Tests/Manual/Scripts/ConnectionApprovalComponent.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/ConnectionApprovalComponent.cs
@@ -65,7 +65,7 @@ namespace TestProject.ManualTests
 
             if (NetworkManager != null && NetworkManager.NetworkConfig.ConnectionApproval)
             {
-                NetworkManager.ConnectionApprovalCallback += ConnectionApprovalCallback;
+                NetworkManager.ConnectionApprovalHandler += ConnectionApprovalCallback;
 
                 if (m_ApprovalToken != string.Empty)
                 {
@@ -151,41 +151,50 @@ namespace TestProject.ManualTests
         /// <summary>
         /// Invoked only on the server, this will handle the various connection approval combinations
         /// </summary>
-        /// <param name="dataToken">key or password to get approval</param>
-        /// <param name="clientId">client identifier being approved</param>
-        /// <param name="aprovalCallback">callback that should be invoked once it is determined if client is approved or not</param>
-        private void ConnectionApprovalCallback(byte[] dataToken, ulong clientId, NetworkManager.ConnectionApprovedDelegate aprovalCallback)
+        /// <param name="request">The connection approval request</param>
+        /// <returns>ConnectionApprovalResult with the approval decision, with parameters</returns>
+        private NetworkManager.ConnectionApprovalResult ConnectionApprovalCallback(NetworkManager.ConnectionApprovalRequest request)
         {
-            string approvalToken = Encoding.ASCII.GetString(dataToken);
+            var decision = new NetworkManager.ConnectionApprovalResult();
+            string approvalToken = Encoding.ASCII.GetString(request.Payload);
             var isTokenValid = approvalToken == m_ApprovalToken;
-            if (m_SimulateFailure && m_SimulateFailure.isOn && IsServer && clientId != NetworkManager.LocalClientId)
+            if (m_SimulateFailure && m_SimulateFailure.isOn && IsServer && request.ClientNetworkId != NetworkManager.LocalClientId)
             {
                 isTokenValid = false;
             }
 
             if (m_GlobalObjectIdHashOverride != 0 && m_PlayerPrefabOverride && m_PlayerPrefabOverride.isOn)
             {
-                aprovalCallback.Invoke(true, m_GlobalObjectIdHashOverride, isTokenValid, null, null);
+                decision.Approved = isTokenValid;
+                decision.PlayerPrefabHash = m_GlobalObjectIdHashOverride;
+                decision.Position = null;
+                decision.Rotation = null;
+                decision.CreatePlayerObject = true;
             }
             else
             {
-                aprovalCallback.Invoke(true, null, isTokenValid, null, null);
+                decision.Approved = isTokenValid;
+                decision.PlayerPrefabHash = null;
+                decision.Position = null;
+                decision.Rotation = null;
+                decision.CreatePlayerObject = true;
             }
-
 
             if (m_ConnectionMessageToDisplay)
             {
                 if (isTokenValid)
                 {
-                    AddNewMessage($"Client id {clientId} is authorized!");
+                    AddNewMessage($"Client id {request.ClientNetworkId} is authorized!");
                 }
                 else
                 {
-                    AddNewMessage($"Client id {clientId} failed authorization!");
+                    AddNewMessage($"Client id {request.ClientNetworkId} failed authorization!");
                 }
 
                 m_ConnectionMessageToDisplay.gameObject.SetActive(true);
             }
+
+            return decision;
         }
 
         /// <summary>

--- a/testproject/Assets/Tests/Runtime/MultiClientConnectionApproval.cs
+++ b/testproject/Assets/Tests/Runtime/MultiClientConnectionApproval.cs
@@ -99,7 +99,7 @@ namespace TestProject.RuntimeTests
             // [Host-Side] Set the player prefab
             server.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
             server.NetworkConfig.ConnectionApproval = true;
-            server.ConnectionApprovalHandler += ConnectionApprovalCallback;
+            server.ConnectionApprovalCallback += ConnectionApprovalCallback;
             server.NetworkConfig.ConnectionData = Encoding.ASCII.GetBytes(m_ConnectionToken);
 
             // [Client-Side] Get all of the RpcQueueManualTests instances relative to each client
@@ -161,7 +161,7 @@ namespace TestProject.RuntimeTests
                 }
             }
 
-            server.ConnectionApprovalHandler -= ConnectionApprovalCallback;
+            server.ConnectionApprovalCallback -= ConnectionApprovalCallback;
             server.Shutdown();
 
             Debug.Log($"Total frames updated = {Time.frameCount - startFrameCount} within {Time.realtimeSinceStartup - startTime} seconds.");
@@ -173,9 +173,9 @@ namespace TestProject.RuntimeTests
         /// <param name="connectionData">the NetworkConfig.ConnectionData sent from the client being approved</param>
         /// <param name="clientId">the client id being approved</param>
         /// <param name="callback">the callback invoked to handle approval</param>
-        private NetworkManager.ConnectionApprovalResult ConnectionApprovalCallback(NetworkManager.ConnectionApprovalRequest request)
+        private NetworkManager.ConnectionApprovalResponse ConnectionApprovalCallback(NetworkManager.ConnectionApprovalRequest request)
         {
-            var decision = new NetworkManager.ConnectionApprovalResult();
+            var decision = new NetworkManager.ConnectionApprovalResponse();
             string approvalToken = Encoding.ASCII.GetString(request.Payload);
             var isApproved = approvalToken == m_ConnectionToken;
 

--- a/testproject/Assets/Tests/Runtime/MultiClientConnectionApproval.cs
+++ b/testproject/Assets/Tests/Runtime/MultiClientConnectionApproval.cs
@@ -99,7 +99,7 @@ namespace TestProject.RuntimeTests
             // [Host-Side] Set the player prefab
             server.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
             server.NetworkConfig.ConnectionApproval = true;
-            server.ConnectionApprovalCallback += ConnectionApprovalCallback;
+            server.ConnectionApprovalHandler += ConnectionApprovalCallback;
             server.NetworkConfig.ConnectionData = Encoding.ASCII.GetBytes(m_ConnectionToken);
 
             // [Client-Side] Get all of the RpcQueueManualTests instances relative to each client
@@ -161,7 +161,7 @@ namespace TestProject.RuntimeTests
                 }
             }
 
-            server.ConnectionApprovalCallback -= ConnectionApprovalCallback;
+            server.ConnectionApprovalHandler -= ConnectionApprovalCallback;
             server.Shutdown();
 
             Debug.Log($"Total frames updated = {Time.frameCount - startFrameCount} within {Time.realtimeSinceStartup - startTime} seconds.");
@@ -173,9 +173,10 @@ namespace TestProject.RuntimeTests
         /// <param name="connectionData">the NetworkConfig.ConnectionData sent from the client being approved</param>
         /// <param name="clientId">the client id being approved</param>
         /// <param name="callback">the callback invoked to handle approval</param>
-        private void ConnectionApprovalCallback(byte[] connectionData, ulong clientId, NetworkManager.ConnectionApprovedDelegate callback)
+        private NetworkManager.ConnectionApprovalResult ConnectionApprovalCallback(NetworkManager.ConnectionApprovalRequest request)
         {
-            string approvalToken = Encoding.ASCII.GetString(connectionData);
+            var decision = new NetworkManager.ConnectionApprovalResult();
+            string approvalToken = Encoding.ASCII.GetString(request.Payload);
             var isApproved = approvalToken == m_ConnectionToken;
 
             if (isApproved)
@@ -189,12 +190,22 @@ namespace TestProject.RuntimeTests
 
             if (m_PrefabOverrideGlobalObjectIdHash == 0)
             {
-                callback.Invoke(true, null, isApproved, null, null);
+                decision.CreatePlayerObject = true;
+                decision.Approved = isApproved;
+                decision.Position = null;
+                decision.Rotation = null;
+                decision.PlayerPrefabHash = null;
             }
             else
             {
-                callback.Invoke(true, m_PrefabOverrideGlobalObjectIdHash, isApproved, null, null);
+                decision.CreatePlayerObject = true;
+                decision.Approved = isApproved;
+                decision.Position = null;
+                decision.Rotation = null;
+                decision.PlayerPrefabHash = m_PrefabOverrideGlobalObjectIdHash;
             }
+
+            return decision;
         }
 
 

--- a/testproject/Assets/Tests/Runtime/MultiClientConnectionApproval.cs
+++ b/testproject/Assets/Tests/Runtime/MultiClientConnectionApproval.cs
@@ -99,7 +99,7 @@ namespace TestProject.RuntimeTests
             // [Host-Side] Set the player prefab
             server.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
             server.NetworkConfig.ConnectionApproval = true;
-            server.ConnectionApprovalCallback += ConnectionApprovalCallback;
+            server.ConnectionApprovalCallback = ConnectionApprovalCallback;
             server.NetworkConfig.ConnectionData = Encoding.ASCII.GetBytes(m_ConnectionToken);
 
             // [Client-Side] Get all of the RpcQueueManualTests instances relative to each client
@@ -161,7 +161,7 @@ namespace TestProject.RuntimeTests
                 }
             }
 
-            server.ConnectionApprovalCallback -= ConnectionApprovalCallback;
+            server.ConnectionApprovalCallback = null;
             server.Shutdown();
 
             Debug.Log($"Total frames updated = {Time.frameCount - startFrameCount} within {Time.realtimeSinceStartup - startTime} seconds.");
@@ -175,7 +175,7 @@ namespace TestProject.RuntimeTests
         /// <param name="callback">the callback invoked to handle approval</param>
         private NetworkManager.ConnectionApprovalResponse ConnectionApprovalCallback(NetworkManager.ConnectionApprovalRequest request)
         {
-            var decision = new NetworkManager.ConnectionApprovalResponse();
+            var response = new NetworkManager.ConnectionApprovalResponse();
             string approvalToken = Encoding.ASCII.GetString(request.Payload);
             var isApproved = approvalToken == m_ConnectionToken;
 
@@ -190,22 +190,22 @@ namespace TestProject.RuntimeTests
 
             if (m_PrefabOverrideGlobalObjectIdHash == 0)
             {
-                decision.CreatePlayerObject = true;
-                decision.Approved = isApproved;
-                decision.Position = null;
-                decision.Rotation = null;
-                decision.PlayerPrefabHash = null;
+                response.CreatePlayerObject = true;
+                response.Approved = isApproved;
+                response.Position = null;
+                response.Rotation = null;
+                response.PlayerPrefabHash = null;
             }
             else
             {
-                decision.CreatePlayerObject = true;
-                decision.Approved = isApproved;
-                decision.Position = null;
-                decision.Rotation = null;
-                decision.PlayerPrefabHash = m_PrefabOverrideGlobalObjectIdHash;
+                response.CreatePlayerObject = true;
+                response.Approved = isApproved;
+                response.Position = null;
+                response.Rotation = null;
+                response.PlayerPrefabHash = m_PrefabOverrideGlobalObjectIdHash;
             }
 
-            return decision;
+            return response;
         }
 
 


### PR DESCRIPTION
fix: preventing issues with game code registering multiple ConnectionApprovalCallback. Refactored the entire connection approval

## Changelog

- [breaking] `ConnectionApprovalCallback` is now `ConnectionApprovalHandler`. Receives a `ConnectionApprovalRequest`, and returns a `ConnectionApprovalResult`. By virtue of being a `Func<>`, there cannot be multiple handlers registered.

- Fixed issues when multiple Connection Approval callbacks were registered (#1941)