### PR TITLE
chore: making NetworkTransform's interpolation bounds configurable.

### DIFF
--- a/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
+++ b/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
@@ -10,6 +10,7 @@ namespace Unity.Netcode
     /// </summary>
     public abstract class BufferedLinearInterpolator<T> where T : struct
     {
+        internal float m_MaxInterpolationBound = 3.0f;
         private struct BufferedItem
         {
             public T Item;
@@ -203,10 +204,9 @@ namespace Unity.Netcode
                         t = 0.0f;
                     }
 
-                    if (t > 3.0f) // max extrapolation
+                    if (t > m_MaxInterpolationBound) // max extrapolation
                     {
                         // TODO this causes issues with teleport, investigate
-                        // todo make this configurable
                         t = 1.0f;
                     }
                 }

--- a/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
+++ b/com.unity.netcode.gameobjects/Components/Interpolator/BufferedLinearInterpolator.cs
@@ -10,7 +10,7 @@ namespace Unity.Netcode
     /// </summary>
     public abstract class BufferedLinearInterpolator<T> where T : struct
     {
-        internal float m_MaxInterpolationBound = 3.0f;
+        internal float MaxInterpolationBound = 3.0f;
         private struct BufferedItem
         {
             public T Item;
@@ -204,7 +204,7 @@ namespace Unity.Netcode
                         t = 0.0f;
                     }
 
-                    if (t > m_MaxInterpolationBound) // max extrapolation
+                    if (t > MaxInterpolationBound) // max extrapolation
                     {
                         // TODO this causes issues with teleport, investigate
                         t = 1.0f;

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -720,6 +720,17 @@ namespace Unity.Netcode.Components
             }
         }
 
+        public void SetMaxInterpolationBound(float maxInterpolationBound)
+        {
+            m_PositionXInterpolator.m_MaxInterpolationBound = maxInterpolationBound;
+            m_PositionYInterpolator.m_MaxInterpolationBound = maxInterpolationBound;
+            m_PositionZInterpolator.m_MaxInterpolationBound = maxInterpolationBound;
+            m_RotationInterpolator.m_MaxInterpolationBound = maxInterpolationBound;
+            m_ScaleXInterpolator.m_MaxInterpolationBound = maxInterpolationBound;
+            m_ScaleYInterpolator.m_MaxInterpolationBound = maxInterpolationBound;
+            m_ScaleZInterpolator.m_MaxInterpolationBound = maxInterpolationBound;
+        }
+
         private void Awake()
         {
             // we only want to create our interpolators during Awake so that, when pooled, we do not create tons

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -722,13 +722,13 @@ namespace Unity.Netcode.Components
 
         public void SetMaxInterpolationBound(float maxInterpolationBound)
         {
-            m_PositionXInterpolator.m_MaxInterpolationBound = maxInterpolationBound;
-            m_PositionYInterpolator.m_MaxInterpolationBound = maxInterpolationBound;
-            m_PositionZInterpolator.m_MaxInterpolationBound = maxInterpolationBound;
-            m_RotationInterpolator.m_MaxInterpolationBound = maxInterpolationBound;
-            m_ScaleXInterpolator.m_MaxInterpolationBound = maxInterpolationBound;
-            m_ScaleYInterpolator.m_MaxInterpolationBound = maxInterpolationBound;
-            m_ScaleZInterpolator.m_MaxInterpolationBound = maxInterpolationBound;
+            m_PositionXInterpolator.MaxInterpolationBound = maxInterpolationBound;
+            m_PositionYInterpolator.MaxInterpolationBound = maxInterpolationBound;
+            m_PositionZInterpolator.MaxInterpolationBound = maxInterpolationBound;
+            m_RotationInterpolator.MaxInterpolationBound = maxInterpolationBound;
+            m_ScaleXInterpolator.MaxInterpolationBound = maxInterpolationBound;
+            m_ScaleYInterpolator.MaxInterpolationBound = maxInterpolationBound;
+            m_ScaleZInterpolator.MaxInterpolationBound = maxInterpolationBound;
         }
 
         private void Awake()

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TransformInterpolationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TransformInterpolationTests.cs
@@ -33,11 +33,7 @@ namespace Unity.Netcode.RuntimeTests
             // Move the nested object on the server
             if (IsMoving)
             {
-                var y = Time.realtimeSinceStartup;
-                while (y > 10.0f)
-                {
-                    y -= 10.0f;
-                }
+                var y = Time.realtimeSinceStartup % 10.0f;
 
                 // change the space between local and global every second
                 GetComponent<NetworkTransform>().InLocalSpace = ((int)y % 2 == 0);
@@ -119,6 +115,7 @@ namespace Unity.Netcode.RuntimeTests
 
             baseObject.GetComponent<TransformInterpolationObject>().IsFixed = true;
             spawnedObject.GetComponent<TransformInterpolationObject>().IsMoving = true;
+            spawnedObject.GetComponent<NetworkTransform>().SetMaxInterpolationBound(1.0f);
 
             const float maxPlacementError = 0.01f;
 
@@ -131,6 +128,7 @@ namespace Unity.Netcode.RuntimeTests
                 yield return new WaitForSeconds(0.01f);
             }
 
+            m_SpawnedObjectOnClient.GetComponent<NetworkTransform>().SetMaxInterpolationBound(1.0f);
             m_SpawnedObjectOnClient.GetComponent<TransformInterpolationObject>().CheckPosition = true;
 
             // Test that interpolation works correctly for 10 seconds


### PR DESCRIPTION
Fixes an intermittent test breakage due to extrapolation bringing us out-of-bounds

https://yamato-artifactviewer.prd.cds.internal.unity3d.com/e710f00f-6bc9-411a-8817-ffd5bb64b4b1%2FTest_Report_1%2FUtrTestReport1/TestReport.html
