### PR TITLE
fix: NetworkBehaviourReference throws type case exception when using TryGet [NCCBUG-167]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -20,6 +20,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Removed
 
 ### Fixed
+- Fixed issue where `NetworkBehaviourReference` would throw a type cast exception if using `NetworkBehaviourReference.TryGet` and the component type was not found.
 - Fixed issue where one or more clients disconnecting during a scene event would cause `LoadEventCompleted` or `UnloadEventCompleted` to wait until the `NetworkConfig.LoadSceneTimeOut` period before being triggered. (#1973)
 - Fixed issues when multiple `ConnectionApprovalCallback`s were registered (#1972)
 - `FixedString` types can now be used in NetworkVariables and RPCs again without requiring a `ForceNetworkSerializeByMemcpy<>` wrapper (#1961)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -20,7 +20,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Removed
 
 ### Fixed
-- Fixed issue where `NetworkBehaviourReference` would throw a type cast exception if using `NetworkBehaviourReference.TryGet` and the component type was not found.
+- Fixed issue where `NetworkBehaviourReference` would throw a type cast exception if using `NetworkBehaviourReference.TryGet` and the component type was not found. (#1984)
 - Fixed issue where one or more clients disconnecting during a scene event would cause `LoadEventCompleted` or `UnloadEventCompleted` to wait until the `NetworkConfig.LoadSceneTimeOut` period before being triggered. (#1973)
 - Fixed issues when multiple `ConnectionApprovalCallback`s were registered (#1972)
 - `FixedString` types can now be used in NetworkVariables and RPCs again without requiring a `ForceNetworkSerializeByMemcpy<>` wrapper (#1961)

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/NetworkBehaviourReference.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/NetworkBehaviourReference.cs
@@ -53,7 +53,7 @@ namespace Unity.Netcode
         /// <returns>True if the <see cref="NetworkBehaviour"/> was found; False if the <see cref="NetworkBehaviour"/> was not found. This can happen if the corresponding <see cref="NetworkObject"/> has not been spawned yet. you can try getting the reference at a later point in time.</returns>
         public bool TryGet<T>(out T networkBehaviour, NetworkManager networkManager = null) where T : NetworkBehaviour
         {
-            networkBehaviour = (T)GetInternal(this, null);
+            networkBehaviour = GetInternal(this, null) as T;
             return networkBehaviour != null;
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/NetworkBehaviourReferenceTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/NetworkBehaviourReferenceTests.cs
@@ -57,6 +57,9 @@ namespace Unity.Netcode.RuntimeTests
             Assert.AreEqual(testNetworkBehaviour, testNetworkBehaviour.RpcReceivedBehaviour);
         }
 
+
+
+
         [UnityTest]
         public IEnumerator TestRpcImplicitNetworkBehaviour()
         {
@@ -147,6 +150,46 @@ namespace Unity.Netcode.RuntimeTests
         {
             //Create, instantiate, and host
             NetworkManagerHelper.StartNetworkManager(out _);
+        }
+    }
+
+    /// <summary>
+    /// Integration tests for NetworkBehaviourReference
+    /// </summary>
+    public class NetworkBehaviourReferenceIntegrationTests : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 1;
+
+        internal class FakeMissingComponent : NetworkBehaviour
+        {
+
+        }
+
+        internal class TestAddedComponent : NetworkBehaviour
+        {
+
+        }
+
+        protected override void OnCreatePlayerPrefab()
+        {
+            m_PlayerPrefab.AddComponent<TestAddedComponent>();
+            base.OnCreatePlayerPrefab();
+        }
+
+        /// <summary>
+        /// This test validates that if a component does not exist the NetworkBehaviourReference will not throw an
+        /// invalid cast exception.
+        /// (It is a full integration test to assure the NetworkObjects are spawned)
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestTryGetWithAndWithOutExistingComponent()
+        {
+            var networkBehaviourReference = new NetworkBehaviourReference(m_ClientNetworkManagers[0].LocalClient.PlayerObject.GetComponent<TestAddedComponent>());
+            var missingComponent = (FakeMissingComponent)null;
+            var testBehaviour = (TestAddedComponent)null;
+            Assert.IsFalse(networkBehaviourReference.TryGet(out missingComponent));
+            Assert.IsTrue(networkBehaviourReference.TryGet(out testBehaviour));
+            yield return null;
         }
     }
 }


### PR DESCRIPTION
This PR fixes an issue where if a user calls `NetworkBehaviourReference.TryGet` it would throw a type cast exception if the component type was not found.

[NCCBUG-167](https://jira.unity3d.com/browse/NCCBUG-167)

## Changelog
- Fixed: issue where `NetworkBehaviourReference` would throw a type cast exception if using `NetworkBehaviourReference.TryGet` and the component type was not found.

## Testing and Documentation
- Includes integration test
