### PR TITLE
fix: NetworkSceneManager Data Pool Test failures on console - switch

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableUserSerializableTypesTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableUserSerializableTypesTests.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using UnityEngine.TestTools;
 using NUnit.Framework;
 using Unity.Netcode.TestHelpers.Runtime;
@@ -74,7 +72,15 @@ namespace Unity.Netcode.RuntimeTests
 
         private T GetComponentForClient<T>(ulong clientId) where T : NetworkBehaviour
         {
-            return s_GlobalNetworkObjects[clientId].Values.Where((c) => c.GetComponent<T>() != null).FirstOrDefault().GetComponent<T>();
+            foreach (var component in Object.FindObjectsOfType<T>())
+            {
+                if (component.IsSpawned && component.NetworkManager.LocalClientId == clientId)
+                {
+                    return component;
+                }
+            }
+
+            return null;
         }
 
         [UnityTest]
@@ -89,20 +95,19 @@ namespace Unity.Netcode.RuntimeTests
                 value = new MyTypeOne();
                 reader.ReadValueSafe(out value.Value);
             };
-
-            var serverObject = SpawnObject(m_WorkingPrefab, m_ServerNetworkManager);
+            var serverObject = Object.Instantiate(m_WorkingPrefab);
             var serverNetworkObject = serverObject.GetComponent<NetworkObject>();
+            serverNetworkObject.NetworkManagerOwner = m_ServerNetworkManager;
+            serverNetworkObject.Spawn();
 
-            yield return WaitForMessageOfType<CreateObjectMessage>(m_ClientNetworkManagers[0]);
+            yield return NetcodeIntegrationTestHelpers.WaitForMessageOfTypeReceived<CreateObjectMessage>(m_ClientNetworkManagers[0]);
 
-            var serverComponent = serverObject.GetComponent<WorkingUserNetworkVariableComponent>();
-            serverComponent.NetworkVariable.Value = new MyTypeOne { Value = 20 };
+            serverNetworkObject.GetComponent<WorkingUserNetworkVariableComponent>().NetworkVariable.Value = new MyTypeOne { Value = 20 };
+
+            yield return NetcodeIntegrationTestHelpers.WaitForMessageOfTypeReceived<NetworkVariableDeltaMessage>(m_ClientNetworkManagers[0]);
+            yield return NetcodeIntegrationTestHelpers.WaitForMessageOfTypeReceived<NetworkVariableDeltaMessage>(m_ClientNetworkManagers[0]);
+
             var clientObject = GetComponentForClient<WorkingUserNetworkVariableComponent>(m_ClientNetworkManagers[0].LocalClientId);
-
-            yield return WaitForMessageOfType<NetworkVariableDeltaMessage>(m_ClientNetworkManagers[0], 2);
-
-            yield return WaitForConditionOrTimeOut(() => serverComponent.NetworkVariable.Value.Value == clientObject.NetworkVariable.Value.Value);
-            AssertOnTimeout($"Timed out waiting for the client side value to match the server side!  Server Side ({serverComponent.NetworkVariable.Value.Value}) | Client Side ({clientObject.NetworkVariable.Value.Value})");
 
             Assert.AreEqual(serverNetworkObject.GetComponent<WorkingUserNetworkVariableComponent>().NetworkVariable.Value.Value, clientObject.NetworkVariable.Value.Value);
             Assert.AreEqual(20, clientObject.NetworkVariable.Value.Value);
@@ -114,38 +119,22 @@ namespace Unity.Netcode.RuntimeTests
             UserNetworkVariableSerialization<MyTypeTwo>.WriteValue = NetworkVariableUserSerializableTypesTestsExtensionMethods.WriteValueSafe;
             UserNetworkVariableSerialization<MyTypeTwo>.ReadValue = NetworkVariableUserSerializableTypesTestsExtensionMethods.ReadValueSafe;
 
-            var serverObject = SpawnObject(m_ExtensionMethodPrefab, m_ServerNetworkManager);
+            var serverObject = Object.Instantiate(m_ExtensionMethodPrefab);
             var serverNetworkObject = serverObject.GetComponent<NetworkObject>();
+            serverNetworkObject.NetworkManagerOwner = m_ServerNetworkManager;
+            serverNetworkObject.Spawn();
 
-            yield return WaitForMessageOfType<CreateObjectMessage>(m_ClientNetworkManagers[0]);
+            yield return NetcodeIntegrationTestHelpers.WaitForMessageOfTypeReceived<CreateObjectMessage>(m_ClientNetworkManagers[0]);
+
             serverNetworkObject.GetComponent<WorkingUserNetworkVariableComponentUsingExtensionMethod>().NetworkVariable.Value = new MyTypeTwo { Value = 20 };
 
-            yield return WaitForMessageOfType<NetworkVariableDeltaMessage>(m_ClientNetworkManagers[0], 2);
-            var serverComponent = serverNetworkObject.GetComponent<WorkingUserNetworkVariableComponentUsingExtensionMethod>();
+            yield return NetcodeIntegrationTestHelpers.WaitForMessageOfTypeReceived<NetworkVariableDeltaMessage>(m_ClientNetworkManagers[0]);
+            yield return NetcodeIntegrationTestHelpers.WaitForMessageOfTypeReceived<NetworkVariableDeltaMessage>(m_ClientNetworkManagers[0]);
+
             var clientObject = GetComponentForClient<WorkingUserNetworkVariableComponentUsingExtensionMethod>(m_ClientNetworkManagers[0].LocalClientId);
-            yield return WaitForConditionOrTimeOut(() => serverComponent.NetworkVariable.Value.Value == clientObject.NetworkVariable.Value.Value);
-            AssertOnTimeout($"Timed out waiting for the client side value to match the server side!  Server Side ({serverComponent.NetworkVariable.Value.Value}) | Client Side ({clientObject.NetworkVariable.Value.Value})");
 
             Assert.AreEqual(serverNetworkObject.GetComponent<WorkingUserNetworkVariableComponentUsingExtensionMethod>().NetworkVariable.Value.Value, clientObject.NetworkVariable.Value.Value);
             Assert.AreEqual(20, clientObject.NetworkVariable.Value.Value);
-        }
-
-        /// <summary>
-        /// Waits for (count) message(s) of type T to be received by the networkManager client
-        /// </summary>
-        private IEnumerator WaitForMessageOfType<T>(NetworkManager networkManager, int count = 1) where T : INetworkMessage
-        {
-            var messageHookEntries = new List<MessageHookEntry>();
-            for (int i = 0; i < count; i++)
-            {
-                var messageHookEntry = new MessageHookEntry(networkManager);
-                messageHookEntry.AssignMessageType<T>();
-                messageHookEntries.Add(messageHookEntry);
-            }
-            var messageHookConditional = new MessageHooksConditional(messageHookEntries);
-            yield return WaitForConditionOrTimeOut(messageHookConditional);
-            AssertOnTimeout($"Timed out waiting for message type {nameof(T)} to be received by client!\n Message Hooks Still Waiting:\n {messageHookConditional.GetHooksStillWaiting()}");
-            yield return s_DefaultWaitForTick;
         }
 
         [Test]

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableUserSerializableTypesTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableUserSerializableTypesTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using UnityEngine.TestTools;
 using NUnit.Framework;
 using Unity.Netcode.TestHelpers.Runtime;
@@ -72,15 +74,7 @@ namespace Unity.Netcode.RuntimeTests
 
         private T GetComponentForClient<T>(ulong clientId) where T : NetworkBehaviour
         {
-            foreach (var component in Object.FindObjectsOfType<T>())
-            {
-                if (component.IsSpawned && component.NetworkManager.LocalClientId == clientId)
-                {
-                    return component;
-                }
-            }
-
-            return null;
+            return s_GlobalNetworkObjects[clientId].Values.Where((c) => c.GetComponent<T>() != null).FirstOrDefault().GetComponent<T>();
         }
 
         [UnityTest]
@@ -95,19 +89,20 @@ namespace Unity.Netcode.RuntimeTests
                 value = new MyTypeOne();
                 reader.ReadValueSafe(out value.Value);
             };
-            var serverObject = Object.Instantiate(m_WorkingPrefab);
+
+            var serverObject = SpawnObject(m_WorkingPrefab, m_ServerNetworkManager);
             var serverNetworkObject = serverObject.GetComponent<NetworkObject>();
-            serverNetworkObject.NetworkManagerOwner = m_ServerNetworkManager;
-            serverNetworkObject.Spawn();
 
-            yield return NetcodeIntegrationTestHelpers.WaitForMessageOfTypeReceived<CreateObjectMessage>(m_ClientNetworkManagers[0]);
+            yield return WaitForMessageOfType<CreateObjectMessage>(m_ClientNetworkManagers[0]);
 
-            serverNetworkObject.GetComponent<WorkingUserNetworkVariableComponent>().NetworkVariable.Value = new MyTypeOne { Value = 20 };
-
-            yield return NetcodeIntegrationTestHelpers.WaitForMessageOfTypeReceived<NetworkVariableDeltaMessage>(m_ClientNetworkManagers[0]);
-            yield return NetcodeIntegrationTestHelpers.WaitForMessageOfTypeReceived<NetworkVariableDeltaMessage>(m_ClientNetworkManagers[0]);
-
+            var serverComponent = serverObject.GetComponent<WorkingUserNetworkVariableComponent>();
+            serverComponent.NetworkVariable.Value = new MyTypeOne { Value = 20 };
             var clientObject = GetComponentForClient<WorkingUserNetworkVariableComponent>(m_ClientNetworkManagers[0].LocalClientId);
+
+            yield return WaitForMessageOfType<NetworkVariableDeltaMessage>(m_ClientNetworkManagers[0], 2);
+
+            yield return WaitForConditionOrTimeOut(() => serverComponent.NetworkVariable.Value.Value == clientObject.NetworkVariable.Value.Value);
+            AssertOnTimeout($"Timed out waiting for the client side value to match the server side!  Server Side ({serverComponent.NetworkVariable.Value.Value}) | Client Side ({clientObject.NetworkVariable.Value.Value})");
 
             Assert.AreEqual(serverNetworkObject.GetComponent<WorkingUserNetworkVariableComponent>().NetworkVariable.Value.Value, clientObject.NetworkVariable.Value.Value);
             Assert.AreEqual(20, clientObject.NetworkVariable.Value.Value);
@@ -119,22 +114,38 @@ namespace Unity.Netcode.RuntimeTests
             UserNetworkVariableSerialization<MyTypeTwo>.WriteValue = NetworkVariableUserSerializableTypesTestsExtensionMethods.WriteValueSafe;
             UserNetworkVariableSerialization<MyTypeTwo>.ReadValue = NetworkVariableUserSerializableTypesTestsExtensionMethods.ReadValueSafe;
 
-            var serverObject = Object.Instantiate(m_ExtensionMethodPrefab);
+            var serverObject = SpawnObject(m_ExtensionMethodPrefab, m_ServerNetworkManager);
             var serverNetworkObject = serverObject.GetComponent<NetworkObject>();
-            serverNetworkObject.NetworkManagerOwner = m_ServerNetworkManager;
-            serverNetworkObject.Spawn();
 
-            yield return NetcodeIntegrationTestHelpers.WaitForMessageOfTypeReceived<CreateObjectMessage>(m_ClientNetworkManagers[0]);
-
+            yield return WaitForMessageOfType<CreateObjectMessage>(m_ClientNetworkManagers[0]);
             serverNetworkObject.GetComponent<WorkingUserNetworkVariableComponentUsingExtensionMethod>().NetworkVariable.Value = new MyTypeTwo { Value = 20 };
 
-            yield return NetcodeIntegrationTestHelpers.WaitForMessageOfTypeReceived<NetworkVariableDeltaMessage>(m_ClientNetworkManagers[0]);
-            yield return NetcodeIntegrationTestHelpers.WaitForMessageOfTypeReceived<NetworkVariableDeltaMessage>(m_ClientNetworkManagers[0]);
-
+            yield return WaitForMessageOfType<NetworkVariableDeltaMessage>(m_ClientNetworkManagers[0], 2);
+            var serverComponent = serverNetworkObject.GetComponent<WorkingUserNetworkVariableComponentUsingExtensionMethod>();
             var clientObject = GetComponentForClient<WorkingUserNetworkVariableComponentUsingExtensionMethod>(m_ClientNetworkManagers[0].LocalClientId);
+            yield return WaitForConditionOrTimeOut(() => serverComponent.NetworkVariable.Value.Value == clientObject.NetworkVariable.Value.Value);
+            AssertOnTimeout($"Timed out waiting for the client side value to match the server side!  Server Side ({serverComponent.NetworkVariable.Value.Value}) | Client Side ({clientObject.NetworkVariable.Value.Value})");
 
             Assert.AreEqual(serverNetworkObject.GetComponent<WorkingUserNetworkVariableComponentUsingExtensionMethod>().NetworkVariable.Value.Value, clientObject.NetworkVariable.Value.Value);
             Assert.AreEqual(20, clientObject.NetworkVariable.Value.Value);
+        }
+
+        /// <summary>
+        /// Waits for (count) message(s) of type T to be received by the networkManager client
+        /// </summary>
+        private IEnumerator WaitForMessageOfType<T>(NetworkManager networkManager, int count = 1) where T : INetworkMessage
+        {
+            var messageHookEntries = new List<MessageHookEntry>();
+            for (int i = 0; i < count; i++)
+            {
+                var messageHookEntry = new MessageHookEntry(networkManager);
+                messageHookEntry.AssignMessageType<T>();
+                messageHookEntries.Add(messageHookEntry);
+            }
+            var messageHookConditional = new MessageHooksConditional(messageHookEntries);
+            yield return WaitForConditionOrTimeOut(messageHookConditional);
+            AssertOnTimeout($"Timed out waiting for message type {nameof(T)} to be received by client!\n Message Hooks Still Waiting:\n {messageHookConditional.GetHooksStillWaiting()}");
+            yield return s_DefaultWaitForTick;
         }
 
         [Test]

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
@@ -246,9 +246,23 @@ namespace TestProject.RuntimeTests
 
             m_CurrentSceneName = scene.name;
 
-            var result = m_ServerNetworkManager.SceneManager.UnloadScene(scene);
-            Assert.True(result == SceneEventProgressStatus.Started, $"UnloadScene did not start and returned {result}!");
-
+            bool WaitForSceneUnload()
+            {
+                var result = m_ServerNetworkManager.SceneManager.UnloadScene(scene);
+                if (result == SceneEventProgressStatus.SceneEventInProgress)
+                {
+                    return false;
+                }
+                else if (result == SceneEventProgressStatus.Started || result == SceneEventProgressStatus.SceneNotLoaded)
+                {
+                    return true;
+                }
+                else
+                {
+                    throw new Exception($"Encountered the following unload scene status during scene unloading: {result}!");
+                }
+            }
+            yield return WaitForConditionOrTimeOut(WaitForSceneUnload);
             yield return WaitForConditionOrTimeOut(() => !scene.isLoaded);
             AssertOnTimeout($"Timed out waiting for server-side scene to unload scene {m_CurrentSceneName}!");
 
@@ -382,11 +396,6 @@ namespace TestProject.RuntimeTests
                 m_ScenesLoaded.Clear();
             }
             yield return null;
-        }
-
-        protected override IEnumerator OnTearDown()
-        {
-            yield return UnloadAllScenes();
         }
     }
 }

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventDataPoolTest.cs
@@ -246,6 +246,7 @@ namespace TestProject.RuntimeTests
 
             m_CurrentSceneName = scene.name;
 
+            // Waits for the m_ServerNetworkManager to be ready to unload the next scene
             bool WaitForSceneUnload()
             {
                 var result = m_ServerNetworkManager.SceneManager.UnloadScene(scene);


### PR DESCRIPTION
This adjustment should help to prevent the failures in NetworkSceneManagerEventDataPoolTest on the switch where a scene is not finished unloading before it tries to unload another scene.

NetworkVariableUserSerializableTypesTests was slightly modified to avoid timing issues with the initial NetworkVariable delta message upon spawning and the network variable delta message that is part of the test to avoid timing.

## Testing and Documentation
- Includes integration test modifications