### PR TITLE
fix: Fixed enum networkvariables throwing exceptions

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -8,12 +8,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ## [Unreleased]
 
-### Fixed
-
-- Fixed NetworkVariables wrapping enum types throwing runtime exceptions about not being supported. (#1999)
-
-## [1.0.0-pre.10]
-
 ### Added
 
 - Added test to ensure a warning occurs when nesting NetworkObjects in a NetworkPrefab (#1969)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -8,6 +8,12 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed NetworkVariables wrapping enum types throwing runtime exceptions about not being supported. (#1999)
+
+## [1.0.0-pre.10]
+
 ### Added
 
 - Added test to ensure a warning occurs when nesting NetworkObjects in a NetworkPrefab (#1969)

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableSerialization.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableSerialization.cs
@@ -207,9 +207,16 @@ namespace Unity.Netcode
             {
                 return new UnmanagedTypeSerializer<T>();
             }
+            if (typeof(Enum).IsAssignableFrom(typeof(T)))
+            {
+                return new UnmanagedTypeSerializer<T>();
+            }
 
             if (typeof(INetworkSerializable).IsAssignableFrom(typeof(T)))
             {
+                // Obtains "Open Instance Delegates" for the type's NetworkSerialize() methods -
+                // one for an instance of the generic method taking BufferSerializerWriter as T,
+                // one for an instance of the generic method taking BufferSerializerReader as T
                 var writeMethod = (NetworkSerializableSerializer<T>.WriteValueDelegate)Delegate.CreateDelegate(typeof(NetworkSerializableSerializer<T>.WriteValueDelegate), null, typeof(T).GetMethod(nameof(INetworkSerializable.NetworkSerialize)).MakeGenericMethod(typeof(BufferSerializerWriter)));
                 var readMethod = (NetworkSerializableSerializer<T>.ReadValueDelegate)Delegate.CreateDelegate(typeof(NetworkSerializableSerializer<T>.ReadValueDelegate), null, typeof(T).GetMethod(nameof(INetworkSerializable.NetworkSerialize)).MakeGenericMethod(typeof(BufferSerializerReader)));
                 return new NetworkSerializableSerializer<T> { WriteValue = writeMethod, ReadValue = readMethod };
@@ -217,6 +224,8 @@ namespace Unity.Netcode
 
             if (typeof(IUTF8Bytes).IsAssignableFrom(typeof(T)) && typeof(INativeList<byte>).IsAssignableFrom(typeof(T)))
             {
+                // Get "OpenInstanceDelegates" for the Length property (get and set, which are prefixed
+                // with "get_" and "set_" under the hood and emitted as methods) and GetUnsafePtr()
                 var getLength = (FixedStringSerializer<T>.GetLengthDelegate)Delegate.CreateDelegate(typeof(FixedStringSerializer<T>.GetLengthDelegate), null, typeof(T).GetMethod("get_" + nameof(INativeList<byte>.Length)));
                 var setLength = (FixedStringSerializer<T>.SetLengthDelegate)Delegate.CreateDelegate(typeof(FixedStringSerializer<T>.SetLengthDelegate), null, typeof(T).GetMethod("set_" + nameof(INativeList<byte>.Length)));
                 var getUnsafePtr = (FixedStringSerializer<T>.GetUnsafePtrDelegate)Delegate.CreateDelegate(typeof(FixedStringSerializer<T>.GetUnsafePtrDelegate), null, typeof(T).GetMethod(nameof(IUTF8Bytes.GetUnsafePtr)));

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -271,7 +271,14 @@ namespace Unity.Netcode.RuntimeTests
 
     public class NetworkVariableTest : NetworkBehaviour
     {
+        public enum SomeEnum
+        {
+            A,
+            B,
+            C
+        }
         public readonly NetworkVariable<int> TheScalar = new NetworkVariable<int>();
+        public readonly NetworkVariable<SomeEnum> TheEnum = new NetworkVariable<SomeEnum>();
         public readonly NetworkList<int> TheList = new NetworkList<int>();
         public readonly NetworkList<FixedString128Bytes> TheLargeList = new NetworkList<FixedString128Bytes>();
 
@@ -598,11 +605,28 @@ namespace Unity.Netcode.RuntimeTests
             bool VerifyStructure()
             {
                 return m_Player1OnClient1.TheStruct.Value.SomeBool == m_Player1OnServer.TheStruct.Value.SomeBool &&
-                    m_Player1OnClient1.TheStruct.Value.SomeInt == m_Player1OnServer.TheStruct.Value.SomeInt;
+                       m_Player1OnClient1.TheStruct.Value.SomeInt == m_Player1OnServer.TheStruct.Value.SomeInt;
             }
 
             m_Player1OnServer.TheStruct.Value = new TestStruct() { SomeInt = k_TestUInt, SomeBool = false };
             m_Player1OnServer.TheStruct.SetDirty(true);
+
+            // Wait for the client-side to notify it is finished initializing and spawning.
+            yield return WaitForConditionOrTimeOut(VerifyStructure);
+        }
+
+        [UnityTest]
+        public IEnumerator TestNetworkVariableEnum([Values(true, false)] bool useHost)
+        {
+            yield return InitializeServerAndClients(useHost);
+
+            bool VerifyStructure()
+            {
+                return m_Player1OnClient1.TheEnum.Value == NetworkVariableTest.SomeEnum.C;
+            }
+
+            m_Player1OnServer.TheEnum.Value = NetworkVariableTest.SomeEnum.C;
+            m_Player1OnServer.TheEnum.SetDirty(true);
 
             // Wait for the client-side to notify it is finished initializing and spawning.
             yield return WaitForConditionOrTimeOut(VerifyStructure);


### PR DESCRIPTION
Enums accidentally got left out in the recent NetworkVariable serialization refactor - this PR restores them.

## Changelog

- Fixed: Fixed NetworkVariables wrapping enum types throwing runtime exceptions about not being supported.
- 
## Testing and Documentation

- Includes integration tests.
- No documentation changes or additions were necessary.