### PR TITLE
fix: mono cecil compatibility and UNET removal fixes for 2022.2.0a13 and above

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -608,18 +608,20 @@ namespace Unity.Netcode.Editor.CodeGen
                             foreach (var constraint in method.GenericParameters[0].Constraints)
                             {
 #if CECIL_CONSTRAINTS_ARE_TYPE_REFERENCES
-                                var resolvedConstraint = constraint.Resolve();
+                                var resolvedConstraint = constraint.Resolve().DoSomething();
+                                var constraintTypeRef = constraint;
 #else
                                 var resolvedConstraint = constraint.ConstraintType.Resolve();
+                                var constraintTypeRef = constraint.ConstraintType;
 #endif
 
                                 var resolvedConstraintName = resolvedConstraint.FullNameWithGenericParameters(new[] { method.GenericParameters[0] }, new[] { checkType });
-                                if (constraint.IsGenericInstance)
+                                if (constraintTypeRef.IsGenericInstance)
                                 {
-                                    var genericConstraint = (GenericInstanceType)constraint;
+                                    var genericConstraint = (GenericInstanceType)constraintTypeRef;
                                     if (genericConstraint.HasGenericArguments && genericConstraint.GenericArguments[0].Resolve() != null)
                                     {
-                                        resolvedConstraintName = constraint.FullName;
+                                        resolvedConstraintName = constraintTypeRef.FullName;
                                     }
                                 }
                                 if ((resolvedConstraint.IsInterface && !checkType.HasInterface(resolvedConstraintName)) ||
@@ -751,18 +753,20 @@ namespace Unity.Netcode.Editor.CodeGen
                             {
 #if CECIL_CONSTRAINTS_ARE_TYPE_REFERENCES
                                 var resolvedConstraint = constraint.Resolve();
+                                var constraintTypeRef = constraint;
 #else
                                 var resolvedConstraint = constraint.ConstraintType.Resolve();
+                                var constraintTypeRef = constraint.ConstraintType;
 #endif
 
 
                                 var resolvedConstraintName = resolvedConstraint.FullNameWithGenericParameters(new[] { method.GenericParameters[0] }, new[] { checkType });
-                                if (constraint.IsGenericInstance)
+                                if (constraintTypeRef.IsGenericInstance)
                                 {
-                                    var genericConstraint = (GenericInstanceType)constraint;
+                                    var genericConstraint = (GenericInstanceType)constraintTypeRef;
                                     if (genericConstraint.HasGenericArguments && genericConstraint.GenericArguments[0].Resolve() != null)
                                     {
-                                        resolvedConstraintName = constraint.FullName;
+                                        resolvedConstraintName = constraintTypeRef.FullName;
                                     }
                                 }
 

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -608,7 +608,7 @@ namespace Unity.Netcode.Editor.CodeGen
                             foreach (var constraint in method.GenericParameters[0].Constraints)
                             {
 #if CECIL_CONSTRAINTS_ARE_TYPE_REFERENCES
-                                var resolvedConstraint = constraint.Resolve().DoSomething();
+                                var resolvedConstraint = constraint.Resolve();
                                 var constraintTypeRef = constraint;
 #else
                                 var resolvedConstraint = constraint.ConstraintType.Resolve();

--- a/testproject/Assets/Scenes/MultiprocessTestScene.unity
+++ b/testproject/Assets/Scenes/MultiprocessTestScene.unity
@@ -104,7 +104,7 @@ NavMeshSettings:
   serializedVersion: 2
   m_ObjectHideFlags: 0
   m_BuildSettings:
-    serializedVersion: 2
+    serializedVersion: 3
     agentTypeID: 0
     agentRadius: 0.5
     agentHeight: 2
@@ -117,7 +117,7 @@ NavMeshSettings:
     cellSize: 0.16666667
     manualTileSize: 0
     tileSize: 256
-    accuratePlacement: 0
+    buildHeightMesh: 0
     maxJobWorkers: 0
     preserveTilesOutsideBounds: 0
     debug:
@@ -212,6 +212,7 @@ Transform:
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
   m_LocalPosition: {x: 0, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
@@ -223,7 +224,7 @@ LightingSettings:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: 
-  serializedVersion: 3
+  serializedVersion: 5
   m_GIWorkflowMode: 1
   m_EnableBakedLightmaps: 1
   m_EnableRealtimeLightmaps: 0
@@ -236,7 +237,7 @@ LightingSettings:
   m_LightmapMaxSize: 1024
   m_BakeResolution: 40
   m_Padding: 2
-  m_TextureCompression: 1
+  m_LightmapCompression: 3
   m_AO: 0
   m_AOMaxDistance: 1
   m_CompAOExponent: 1
@@ -263,7 +264,7 @@ LightingSettings:
   m_LightProbeSampleCountMultiplier: 4
   m_PVRBounces: 2
   m_PVRMinBounces: 2
-  m_PVREnvironmentMIS: 1
+  m_PVREnvironmentImportanceSampling: 1
   m_PVRFilteringMode: 1
   m_PVRDenoiserTypeDirect: 1
   m_PVRDenoiserTypeIndirect: 1
@@ -277,6 +278,8 @@ LightingSettings:
   m_PVRFilteringAtrousPositionSigmaDirect: 0.5
   m_PVRFilteringAtrousPositionSigmaIndirect: 2
   m_PVRFilteringAtrousPositionSigmaAO: 1
+  m_PVRTiledBaking: 0
+  m_NumRaysToShootPerTexel: -1
 --- !u!1 &160940364
 GameObject:
   m_ObjectHideFlags: 0
@@ -369,6 +372,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -10, y: -10, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 5
@@ -480,6 +484,7 @@ Transform:
   m_LocalRotation: {x: 0.2164396, y: 0, z: 0, w: 0.97629607}
   m_LocalPosition: {x: -45, y: 10, z: 10}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 7
@@ -524,9 +529,17 @@ Camera:
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -563,6 +576,7 @@ Transform:
   m_LocalRotation: {x: 0.21736304, y: -0, z: -0, w: 0.97609085}
   m_LocalPosition: {x: 0, y: 9.15, z: -27.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -659,6 +673,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 4
@@ -755,6 +770,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 10, y: 10, z: 10}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 3
@@ -794,7 +810,7 @@ MonoBehaviour:
   LogLevel: 1
   NetworkConfig:
     ProtocolVersion: 0
-    NetworkTransport: {fileID: 1674777073}
+    NetworkTransport: {fileID: 2027640073}
     PlayerPrefab: {fileID: 4700706668509470175, guid: 7eeaaf9e50c0afc4dab93584a54fb0d6,
       type: 3}
     NetworkPrefabs:
@@ -829,6 +845,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1674777072}
   - {fileID: 2027640072}
@@ -905,6 +922,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 10, y: 10, z: 10}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 6
@@ -948,6 +966,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1211923376}
   m_RootOrder: 0
@@ -998,6 +1017,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1211923376}
   m_RootOrder: 1

--- a/testproject/Assets/Scenes/MultiprocessTestScene.unity
+++ b/testproject/Assets/Scenes/MultiprocessTestScene.unity
@@ -104,7 +104,7 @@ NavMeshSettings:
   serializedVersion: 2
   m_ObjectHideFlags: 0
   m_BuildSettings:
-    serializedVersion: 3
+    serializedVersion: 2
     agentTypeID: 0
     agentRadius: 0.5
     agentHeight: 2
@@ -117,7 +117,7 @@ NavMeshSettings:
     cellSize: 0.16666667
     manualTileSize: 0
     tileSize: 256
-    buildHeightMesh: 0
+    accuratePlacement: 0
     maxJobWorkers: 0
     preserveTilesOutsideBounds: 0
     debug:
@@ -212,7 +212,6 @@ Transform:
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
   m_LocalPosition: {x: 0, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
@@ -224,7 +223,7 @@ LightingSettings:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: 
-  serializedVersion: 5
+  serializedVersion: 3
   m_GIWorkflowMode: 1
   m_EnableBakedLightmaps: 1
   m_EnableRealtimeLightmaps: 0
@@ -237,7 +236,7 @@ LightingSettings:
   m_LightmapMaxSize: 1024
   m_BakeResolution: 40
   m_Padding: 2
-  m_LightmapCompression: 3
+  m_TextureCompression: 1
   m_AO: 0
   m_AOMaxDistance: 1
   m_CompAOExponent: 1
@@ -264,7 +263,7 @@ LightingSettings:
   m_LightProbeSampleCountMultiplier: 4
   m_PVRBounces: 2
   m_PVRMinBounces: 2
-  m_PVREnvironmentImportanceSampling: 1
+  m_PVREnvironmentMIS: 1
   m_PVRFilteringMode: 1
   m_PVRDenoiserTypeDirect: 1
   m_PVRDenoiserTypeIndirect: 1
@@ -278,8 +277,6 @@ LightingSettings:
   m_PVRFilteringAtrousPositionSigmaDirect: 0.5
   m_PVRFilteringAtrousPositionSigmaIndirect: 2
   m_PVRFilteringAtrousPositionSigmaAO: 1
-  m_PVRTiledBaking: 0
-  m_NumRaysToShootPerTexel: -1
 --- !u!1 &160940364
 GameObject:
   m_ObjectHideFlags: 0
@@ -372,7 +369,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -10, y: -10, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 5
@@ -484,7 +480,6 @@ Transform:
   m_LocalRotation: {x: 0.2164396, y: 0, z: 0, w: 0.97629607}
   m_LocalPosition: {x: -45, y: 10, z: 10}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 7
@@ -529,17 +524,9 @@ Camera:
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
-  m_Iso: 200
-  m_ShutterSpeed: 0.005
-  m_Aperture: 16
-  m_FocusDistance: 10
-  m_FocalLength: 50
-  m_BladeCount: 5
-  m_Curvature: {x: 2, y: 11}
-  m_BarrelClipping: 0.25
-  m_Anamorphism: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -576,7 +563,6 @@ Transform:
   m_LocalRotation: {x: 0.21736304, y: -0, z: -0, w: 0.97609085}
   m_LocalPosition: {x: 0, y: 9.15, z: -27.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -673,7 +659,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 4
@@ -770,7 +755,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 10, y: 10, z: 10}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 3
@@ -810,7 +794,7 @@ MonoBehaviour:
   LogLevel: 1
   NetworkConfig:
     ProtocolVersion: 0
-    NetworkTransport: {fileID: 2027640073}
+    NetworkTransport: {fileID: 1674777073}
     PlayerPrefab: {fileID: 4700706668509470175, guid: 7eeaaf9e50c0afc4dab93584a54fb0d6,
       type: 3}
     NetworkPrefabs:
@@ -845,7 +829,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1674777072}
   - {fileID: 2027640072}
@@ -922,7 +905,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 10, y: 10, z: 10}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 6
@@ -966,7 +948,6 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1211923376}
   m_RootOrder: 0
@@ -1017,7 +998,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1211923376}
   m_RootOrder: 1

--- a/testproject/Assets/Tests/Runtime/MultiprocessRuntime/BaseMultiprocessTests.cs
+++ b/testproject/Assets/Tests/Runtime/MultiprocessRuntime/BaseMultiprocessTests.cs
@@ -5,6 +5,9 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 using Object = UnityEngine.Object;
+#if UNITY_UNET_PRESENT
+using Unity.Netcode.Transports.UNET;
+#endif
 using Unity.Netcode.Transports.UTP;
 
 
@@ -83,10 +86,18 @@ namespace Unity.Netcode.MultiprocessRuntimeTests
             MultiprocessLogger.Log($"transport is {transport}");
             switch (transport)
             {
+#if UNITY_UNET_PRESENT
+                case UNetTransport unetTransport:
+                    unetTransport.ConnectPort = int.Parse(TestCoordinator.Port);
+                    unetTransport.ServerListenPort = int.Parse(TestCoordinator.Port);
+                    unetTransport.ConnectAddress = "127.0.0.1";
+                    MultiprocessLogger.Log($"Setting ConnectAddress to {unetTransport.ConnectAddress} port {unetTransport.ConnectPort}, {unetTransport.ServerListenPort}");
+
+                    break;
+#endif
                 case UnityTransport unityTransport:
                     unityTransport.ConnectionData.ServerListenAddress = "0.0.0.0";
-                    unityTransport.ConnectionData.Port = ushort.Parse(TestCoordinator.Port);
-                    MultiprocessLogger.Log($"Setting unityTransport.ConnectionData to {unityTransport.ConnectionData.ServerListenAddress} {unityTransport.ConnectionData.Port}");
+                    MultiprocessLogger.Log($"Setting unityTransport.ConnectionData.Port {unityTransport.ConnectionData.ServerListenAddress}");
                     break;
                 default:
                     MultiprocessLogger.LogError($"The transport {transport} has no case");

--- a/testproject/Assets/Tests/Runtime/MultiprocessRuntime/BaseMultiprocessTests.cs
+++ b/testproject/Assets/Tests/Runtime/MultiprocessRuntime/BaseMultiprocessTests.cs
@@ -85,7 +85,8 @@ namespace Unity.Netcode.MultiprocessRuntimeTests
             {
                 case UnityTransport unityTransport:
                     unityTransport.ConnectionData.ServerListenAddress = "0.0.0.0";
-                    MultiprocessLogger.Log($"Setting unityTransport.ConnectionData.Port {unityTransport.ConnectionData.ServerListenAddress}");
+                    unityTransport.ConnectionData.Port = ushort.Parse(TestCoordinator.Port);
+                    MultiprocessLogger.Log($"Setting unityTransport.ConnectionData to {unityTransport.ConnectionData.ServerListenAddress} {unityTransport.ConnectionData.Port}");
                     break;
                 default:
                     MultiprocessLogger.LogError($"The transport {transport} has no case");

--- a/testproject/Assets/Tests/Runtime/MultiprocessRuntime/BaseMultiprocessTests.cs
+++ b/testproject/Assets/Tests/Runtime/MultiprocessRuntime/BaseMultiprocessTests.cs
@@ -5,7 +5,6 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 using Object = UnityEngine.Object;
-using Unity.Netcode.Transports.UNET;
 using Unity.Netcode.Transports.UTP;
 
 
@@ -84,13 +83,6 @@ namespace Unity.Netcode.MultiprocessRuntimeTests
             MultiprocessLogger.Log($"transport is {transport}");
             switch (transport)
             {
-                case UNetTransport unetTransport:
-                    unetTransport.ConnectPort = int.Parse(TestCoordinator.Port);
-                    unetTransport.ServerListenPort = int.Parse(TestCoordinator.Port);
-                    unetTransport.ConnectAddress = "127.0.0.1";
-                    MultiprocessLogger.Log($"Setting ConnectAddress to {unetTransport.ConnectAddress} port {unetTransport.ConnectPort}, {unetTransport.ServerListenPort}");
-
-                    break;
                 case UnityTransport unityTransport:
                     unityTransport.ConnectionData.ServerListenAddress = "0.0.0.0";
                     MultiprocessLogger.Log($"Setting unityTransport.ConnectionData.Port {unityTransport.ConnectionData.ServerListenAddress}");

--- a/testproject/Assets/Tests/Runtime/MultiprocessRuntime/TestCoordinator.cs
+++ b/testproject/Assets/Tests/Runtime/MultiprocessRuntime/TestCoordinator.cs
@@ -7,7 +7,6 @@ using Unity.Netcode;
 using NUnit.Framework;
 using UnityEngine;
 using Unity.Netcode.MultiprocessRuntimeTests;
-using Unity.Netcode.Transports.UNET;
 using Unity.Netcode.Transports.UTP;
 
 /// <summary>
@@ -156,15 +155,6 @@ public class TestCoordinator : NetworkBehaviour
         MultiprocessLogger.Log($"transport is {transport}");
         switch (transport)
         {
-            case UNetTransport unetTransport:
-                unetTransport.ConnectPort = ushortport;
-                unetTransport.ServerListenPort = ushortport;
-                if (m_IsClient)
-                {
-                    MultiprocessLogger.Log($"Setting ConnectAddress to {m_ConnectAddress} port {ushortport} isClient: {m_IsClient}");
-                    unetTransport.ConnectAddress = m_ConnectAddress;
-                }
-                break;
             case UnityTransport unityTransport:
                 MultiprocessLogger.Log($"Setting unityTransport.ConnectionData.Port {ushortport}, isClient: {m_IsClient}, Address {m_ConnectAddress}");
                 unityTransport.ConnectionData.Port = ushortport;

--- a/testproject/Assets/Tests/Runtime/MultiprocessRuntime/TestCoordinator.cs
+++ b/testproject/Assets/Tests/Runtime/MultiprocessRuntime/TestCoordinator.cs
@@ -7,6 +7,9 @@ using Unity.Netcode;
 using NUnit.Framework;
 using UnityEngine;
 using Unity.Netcode.MultiprocessRuntimeTests;
+#if UNITY_UNET_PRESENT
+using Unity.Netcode.Transports.UNET;
+#endif
 using Unity.Netcode.Transports.UTP;
 
 /// <summary>
@@ -155,6 +158,17 @@ public class TestCoordinator : NetworkBehaviour
         MultiprocessLogger.Log($"transport is {transport}");
         switch (transport)
         {
+#if UNITY_UNET_PRESENT
+            case UNetTransport unetTransport:
+                unetTransport.ConnectPort = ushortport;
+                unetTransport.ServerListenPort = ushortport;
+                if (m_IsClient)
+                {
+                    MultiprocessLogger.Log($"Setting ConnectAddress to {m_ConnectAddress} port {ushortport} isClient: {m_IsClient}");
+                    unetTransport.ConnectAddress = m_ConnectAddress;
+                }
+                break;
+#endif
             case UnityTransport unityTransport:
                 MultiprocessLogger.Log($"Setting unityTransport.ConnectionData.Port {ushortport}, isClient: {m_IsClient}, Address {m_ConnectAddress}");
                 unityTransport.ConnectionData.Port = ushortport;


### PR DESCRIPTION
Fix compile errors in 2022.2.0a13 caused by Cecil and removal of UNET

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.
