### PR TITLE
fix: NetcodeIntegrationTest remove extra OnNewClientCreated call

### DIFF
--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -302,7 +302,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
             AssertOnTimeout($"{nameof(CreateAndStartNewClient)} timed out waiting for the new client to be connected!");
             ClientNetworkManagerPostStart(networkManager);
             VerboseDebug($"[{networkManager.name}] Created and connected!");
-            OnNewClientCreated(networkManager);
         }
 
         protected IEnumerator StopOneClient(NetworkManager networkManager, bool destroy = false)

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -288,6 +288,9 @@ namespace Unity.Netcode.TestHelpers.Runtime
         {
             var networkManager = NetcodeIntegrationTestHelpers.CreateNewClient(m_ClientNetworkManagers.Length);
             networkManager.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
+
+            // Notification that the new client (NetworkManager) has been created
+            // in the event any modifications need to be made before starting the client
             OnNewClientCreated(networkManager);
 
             NetcodeIntegrationTestHelpers.StartOneClient(networkManager);


### PR DESCRIPTION
This PR removes the extra call to OnNewClientCreated.

## Changelog
None

## Testing and Documentation
- No tests have been added (existing tests verify the fix)
