### PR TITLE
style: fixing spelling issue OnIsServerAuthoritatitive

### DIFF
--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -943,8 +943,7 @@ namespace Unity.Netcode.Components
         }
 
         /// <summary>
-        /// Override this and return false to follow the owner authoritative
-        /// Otherwise, it defaults to server authoritative
+        /// Override this method and return false to switch to owner authoritative mode
         /// </summary>
         protected virtual bool OnIsServerAuthoritative()
         {

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -946,7 +946,7 @@ namespace Unity.Netcode.Components
         /// Override this and return false to follow the owner authoritative
         /// Otherwise, it defaults to server authoritative
         /// </summary>
-        protected virtual bool OnIsServerAuthoritatitive()
+        protected virtual bool OnIsServerAuthoritative()
         {
             return true;
         }
@@ -956,7 +956,7 @@ namespace Unity.Netcode.Components
         /// </summary>
         internal bool IsServerAuthoritative()
         {
-            return OnIsServerAuthoritatitive();
+            return OnIsServerAuthoritative();
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
@@ -267,7 +267,7 @@ namespace Unity.Netcode.RuntimeTests
                 }
             }
 
-            protected override bool OnIsServerAuthoritatitive()
+            protected override bool OnIsServerAuthoritative()
             {
                 return false;
             }


### PR DESCRIPTION
This PR fixes spelling issue with NetworkTransform.OnIsServerAuthoritatitive that should be NetworkTransform.OnIsServerAuthoritative