### PR TITLE
fix: observers not being cleared on despawning NetworkObject

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -20,7 +20,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Removed
 
 ### Fixed
-- Fixed issue where `NetworkObject.Observers` was not being cleared when despawned.
+- Fixed issue where `NetworkObject.Observers` was not being cleared when despawned. (#2009)
 - Fixed `NetworkAnimator` could not run in the server authoritative mode. (#2003)
 - Fixed issue where late joining clients would get a soft synchronization error if any in-scene placed NetworkObjects were parented under another `NetworkObject`. (#1985)
 - Fixed issue where `NetworkBehaviourReference` would throw a type cast exception if using `NetworkBehaviourReference.TryGet` and the component type was not found. (#1984)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -20,7 +20,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Removed
 
 ### Fixed
-
+- Fixed issue where `NetworkObject.Observers` was not being cleared when despawned.
 - Fixed `NetworkAnimator` could not run in the server authoritative mode. (#2003)
 - Fixed issue where late joining clients would get a soft synchronization error if any in-scene placed NetworkObjects were parented under another `NetworkObject`. (#1985)
 - Fixed issue where `NetworkBehaviourReference` would throw a type cast exception if using `NetworkBehaviourReference.TryGet` and the component type was not found. (#1984)

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -811,6 +811,9 @@ namespace Unity.Netcode
                 SpawnedObjectsList.Remove(networkObject);
             }
 
+            // Always clear out the observers list when despawned
+            networkObject.Observers.Clear();
+
             var gobj = networkObject.gameObject;
             if (destroyGameObject && gobj != null)
             {

--- a/testproject/Assets/Tests/Runtime/RpcObserverTests.cs
+++ b/testproject/Assets/Tests/Runtime/RpcObserverTests.cs
@@ -163,7 +163,7 @@ namespace TestProject.RuntimeTests
 
             Assert.True(m_ServerRpcObserverObject.NetworkObject.Observers.Count == 0, $"Despawned {m_ServerRpcObserverObject.name} but it still has {m_ServerRpcObserverObject.NetworkObject.Observers.Count} observers!");
 
-            for(int i = 4; i < NumberOfClients; i++)
+            for (int i = 4; i < NumberOfClients; i++)
             {
                 nonObservers.Add(m_ClientNetworkManagers[i].LocalClientId);
                 m_ServerNetworkManager.DisconnectClient(m_ClientNetworkManagers[i].LocalClientId);


### PR DESCRIPTION
NetworkObjects were not getting their observers list cleared upon being despawned.
This PR resolves this issue.

[MTT-3476](https://jira.unity3d.com/browse/MTT-3476)
[MTT-3134](https://jira.unity3d.com/browse/MTT-3134)
Also pertaining to Github Issue #2007

## Changelog
- Fixed:  issue where `NetworkObject.Observers` was not being cleared when despawned

## Testing and Documentation
- Includes integration test.
