### PR TITLE
fix: Clear UnityTransport reliable receive queues on shutdown

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1126,6 +1126,8 @@ namespace Unity.Netcode.Transports.UTP
 
             DisposeInternals();
 
+            m_ReliableReceiveQueues.Clear();
+
             // We must reset this to zero because UTP actually re-uses clientIds if there is a clean disconnect
             m_ServerClientId = 0;
         }


### PR DESCRIPTION
If `UnityTransport` was shut down and then the same instance of the object was re-initialized, it was possible to reuse the previous reliable receive queues. This could have caused corruption of the data stream if an incomplete message was stored inside those queues.

This _might_ fix MTT-3685, but it's very much a stretch. In fact, I'm not sure this fix is actually addressing something that ever was a problem to begin with. I'm submitting the fix more for completeness's sake than anything.

## Changelog

N/A (Didn't think it was worthy of a changelog entry.)

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.