### PR TITLE
chore: Run tests on 2022.2

### DIFF
--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -43,6 +43,7 @@ projects:
     test_editors:
       - 2020.3
       - 2021.3
+      - 2022.2
       - trunk
   - name: minimalproject
     path: minimalproject


### PR DESCRIPTION
Trunk is now 2023.1 
Add 2022.2 to the list of test-editors.

## Changelog

n/a

## Testing and Documentation

CI must be green
