### PR TITLE
chore: Run validation tests on all supported editors and desktop platforms

### DIFF
--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -10,7 +10,9 @@ develop_nightly:
   dependencies:
     - .yamato/_run-all.yml#run_all_tests
 {% for project in projects -%}
+{% if project.has_tests == "true" -%}
     - .yamato/code-coverage.yml#code_coverage_win_{{ project.name }}_{{ validation_editor }}
+{% endif -%}
 {% endfor -%}
 
 develop_weekly_trunk:

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -43,7 +43,7 @@ pull_request_trigger:
 {% for project in projects -%}
 {% for package in project.packages -%}
 {% if project.validate == "true" -%}
-    - .yamato/project-tests.yml#validate_{{ package.name }}_{{ test_platforms.first.name }}_{{ validation_editor }}
+    - .yamato/project-publish.yml#validate_{{ package.name }}_{{ test_platforms.first.name }}_{{ validation_editor }}
 {% endif -%}
 {% endfor -%}
 {% for platform in test_platforms -%}
@@ -84,7 +84,7 @@ badges_test_trigger:
 {% for project in projects -%}
 {% for package in project.packages -%}
 {% if project.validate == "true" -%}
-    - .yamato/project-tests.yml#validate_{{ package.name }}_{{ test_platforms.first.name }}_{{ validation_editor }}
+    - .yamato/project-publish.yml#validate_{{ package.name }}_{{ test_platforms.first.name }}_{{ validation_editor }}
 {% endif -%}
 {% for editor in project.test_editors -%}
 {% if editor != "trunk" -%}

--- a/.yamato/package-tests.yml
+++ b/.yamato/package-tests.yml
@@ -17,7 +17,7 @@ test_{{project.name}}_{{  package.name }}_{{ editor }}_{{ platform.name }}:
     flavor: {{ platform.flavor}}
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - {% if platform.name == "centos" %}DISPLAY=:0 {% endif %}upm-ci project test -u {{ editor }} --type package-tests --project-path {{ project.name }} --package-filter {{ package.name }}
+    - {% if platform.name == "ubuntu" %}DISPLAY=:0 {% endif %}upm-ci project test -u {{ editor }} --type package-tests --project-path {{ project.name }} --package-filter {{ package.name }}
   artifacts:
     logs:
       paths:

--- a/.yamato/project-promotion.yml
+++ b/.yamato/project-promotion.yml
@@ -3,25 +3,27 @@
 {% for project in projects -%}
 {% if project.publish == "true" -%}
 {% for package in project.packages -%}
-# Validation job for package {{ package.name }}, only using the first entry in the
-# platform and editor meta data
-promotion_validate_{{ project.name }}_{{ package.name }}_{{ test_platforms.first.name }}_{{ validation_editor }}:
-  name : Validate Project {{ project.name }} - Package {{ package.name }} - {{ validation_editor }} on {{ test_platforms.first.name }}
+{% for editor in project.test_editors -%}
+{% for platform in test_platforms -%}
+promotion_validate_{{ project.name }}_{{ package.name }}_{{ platform.name }}_{{ editor }}:
+  name : Validate (Vetting Tests) Project {{ project.name }} - Package {{ package.name }} - {{ editor }} on {{ platform.name }}
   agent:
-    type: {{ test_platforms.first.type }}
-    image: {{ test_platforms.first.image }}
-    flavor: {{ test_platforms.first.flavor}}
+    type: {{ platform.type }}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor}}
   variables:
     UPMCI_PROMOTION: 1
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - upm-ci project test -u {{ validation_editor }} --project-path {{ project.path }} --type vetting-tests --project-path {{ project.path }} --package-filter {{ package.name }}
+    - {% if platform.name == "ubuntu" %}DISPLAY=:0 {% endif %}upm-ci project test -u {{ editor }} --project-path {{ project.path }} --type vetting-tests --project-path {{ project.path }} --package-filter {{ package.name }}
   artifacts:
     logs:
       paths:
         - "upm-ci~/test-results/**/*"
   dependencies:
     - .yamato/project-pack.yml#pack_{{ project.name }}
+{% endfor -%}
+{% endfor -%}
 
 promote_{{ project.name }}_{{ package.name }}:
   name: Promote Project {{ project.name }} - Package {{ package.name }} to Production

--- a/.yamato/project-publish.yml
+++ b/.yamato/project-publish.yml
@@ -3,6 +3,26 @@
 {% for project in projects -%}
 {% if project.publish == "true" -%}
 {% for package in project.packages -%}
+{% for editor in project.test_editors -%}
+{% for platform in test_platforms -%}
+validate_{{ package.name }}_{{ platform.name }}_{{ editor }}:
+  name : Validate (Isolation Tests) Package {{ package.name }} - {{ editor }} on {{ platform.name }}
+  agent:
+    type: {{ platform.type }}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor}}
+  commands:
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    - {% if platform.name == "ubuntu" %}DISPLAY=:0 {% endif %}upm-ci project test -u {{ editor }} --type isolation-tests --project-path {{ project.path }} --package-filter {{ package.name }} --platform editmode
+  artifacts:
+    logs:
+      paths:
+        - "upm-ci~/test-results/**/*"
+  dependencies:
+    - .yamato/project-pack.yml#pack_{{ project.name }}
+{% endfor -%}
+{% endfor -%}
+
 publish_{{ project.name }}_{{ package.name }}:
   name: Publish Project {{project.name }} - Package {{ package.name }} to Internal Registry
   agent:

--- a/.yamato/project-tests.yml
+++ b/.yamato/project-tests.yml
@@ -1,28 +1,30 @@
 {% metadata_file .yamato/project.metafile %}
 ---
 
-# Validation job for package {{ package.name }}, only using the first entry in the
-# platform and editor meta data
-# Validation only occurs in editmode.
+# Validation job for package {{ package.name }}. Validation only occurs in editmode.
 
 {% for project in projects -%}
 {% if project.validate == "true" %}
 {% for package in project.packages -%}
-validate_{{ package.name }}_{{ test_platforms.first.name }}_{{ validation_editor }}:
-  name : Validate Package {{ package.name }} - {{ validation_editor }} on {{ test_platforms.first.name }}
+{% for editor in project.test_editors -%}
+{% for platform in test_platforms -%}
+validate_{{ package.name }}_{{ platform.name }}_{{ editor }}:
+  name : Validate (Isolation Tests) Package {{ package.name }} - {{ editor }} on {{ platform.name }}
   agent:
-    type: {{ test_platforms.first.type }}
-    image: {{ test_platforms.first.image }}
-    flavor: {{ test_platforms.first.flavor}}
+    type: {{ platform.type }}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor}}
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - {% if platform.name == "centos" %}DISPLAY=:0 {% endif %}upm-ci project test -u {{ validation_editor }} --type vetting-tests --project-path {{ project.path }} --package-filter {{ package.name }} --platform editmode
+    - {% if platform.name == "ubuntu" %}DISPLAY=:0 {% endif %}upm-ci project test -u {{ editor }} --type isolation-tests --project-path {{ project.path }} --package-filter {{ package.name }} --platform editmode
   artifacts:
     logs:
       paths:
         - "upm-ci~/test-results/**/*"
   dependencies:
     - .yamato/project-pack.yml#pack_{{ project.name }}
+{% endfor -%}
+{% endfor -%}
 {% endfor -%}
 {% endif -%}
 {% endfor -%}

--- a/.yamato/project-tests.yml
+++ b/.yamato/project-tests.yml
@@ -1,34 +1,6 @@
 {% metadata_file .yamato/project.metafile %}
 ---
 
-# Validation job for package {{ package.name }}. Validation only occurs in editmode.
-
-{% for project in projects -%}
-{% if project.validate == "true" %}
-{% for package in project.packages -%}
-{% for editor in project.test_editors -%}
-{% for platform in test_platforms -%}
-validate_{{ package.name }}_{{ platform.name }}_{{ editor }}:
-  name : Validate (Isolation Tests) Package {{ package.name }} - {{ editor }} on {{ platform.name }}
-  agent:
-    type: {{ platform.type }}
-    image: {{ platform.image }}
-    flavor: {{ platform.flavor}}
-  commands:
-    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - {% if platform.name == "ubuntu" %}DISPLAY=:0 {% endif %}upm-ci project test -u {{ editor }} --type isolation-tests --project-path {{ project.path }} --package-filter {{ package.name }} --platform editmode
-  artifacts:
-    logs:
-      paths:
-        - "upm-ci~/test-results/**/*"
-  dependencies:
-    - .yamato/project-pack.yml#pack_{{ project.name }}
-{% endfor -%}
-{% endfor -%}
-{% endfor -%}
-{% endif -%}
-{% endfor -%}
-
 # For every platform and editor version, run its project tests without
 # running package tests too since they are handled on their respective
 # jobs

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -62,6 +62,7 @@ projects:
     has_tests: true
     test_editors:
       - 2021.3
+      - 2022.2
       - trunk
 
 # Scripting backends used by Standalone Playmode Tests


### PR DESCRIPTION
- Run Promotion/Publish Validation tests on all supported editors and desktop platforms. This will help catch any APV failures earlier on our CI.

- Run Isolation tests before publishing, and Vetting tests before promotion. Vetting tests are a subset of Isolation tests. 

- Move Publish Validation tests to `project-publish.yml` 

Isolation-tests: For each locally-developed package referenced in the tested project, this argument creates a new project and executes the complete suite of tests required for publishing a package. Additionally, it executes package validation suite, validates clean console and package has tests, and executes package tests.

Vetting-tests: For each locally-developed package referenced in the tested project, this argument creates a new project, executes package validation suite, and validates clean console and package has tests.
[UPM-CI docs](https://internaldocs.unity.com/upm-ci/commands/project-context/)

<img width="756" alt="image" src="https://user-images.githubusercontent.com/36935028/173463604-d8569eb7-2162-4ed7-aa69-2d6bc28d51d1.png">
<img width="674" alt="image" src="https://user-images.githubusercontent.com/36935028/173463679-d016306f-5b47-45ba-bf36-d505da3353e6.png">



This PR does not affect PR triggers. PR Project Tests are still only triggered on 2020.3

Other small changes:
- Add 2022.2 to test-project-tools-integration tests
- Change centos to ubuntu because we don't run on centos.

## Changelog

None

## Testing and Documentation

CI 