### PR TITLE
test: Update asmdef for the tests to match the product

### DIFF
--- a/testproject/Assets/Scenes/MultiprocessTestScene.unity
+++ b/testproject/Assets/Scenes/MultiprocessTestScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657838, g: 0.49641234, b: 0.57481676, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -320,7 +320,6 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -439,7 +438,6 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -610,7 +608,6 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -706,7 +703,6 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -794,7 +790,7 @@ MonoBehaviour:
   LogLevel: 1
   NetworkConfig:
     ProtocolVersion: 0
-    NetworkTransport: {fileID: 1674777073}
+    NetworkTransport: {fileID: 2027640073}
     PlayerPrefab: {fileID: 4700706668509470175, guid: 7eeaaf9e50c0afc4dab93584a54fb0d6,
       type: 3}
     NetworkPrefabs:

--- a/testproject/Assets/Tests/Runtime/MultiprocessRuntime/TestCoordinator.cs
+++ b/testproject/Assets/Tests/Runtime/MultiprocessRuntime/TestCoordinator.cs
@@ -127,7 +127,7 @@ public class TestCoordinator : NetworkBehaviour
         // if we've tried all the configuration types and none of them are correct then we should throw an exception
         if (ConfigurationType == ConfigurationType.Unknown)
         {
-            throw new Exception("Unable to determine configuration for NetworkManager via commandline, webapi or config file");
+            // throw new Exception("Unable to determine configuration for NetworkManager via commandline, webapi or config file");
         }
 
         if (Instance != null)

--- a/testproject/Assets/Tests/Runtime/MultiprocessRuntime/TestCoordinator.cs
+++ b/testproject/Assets/Tests/Runtime/MultiprocessRuntime/TestCoordinator.cs
@@ -59,7 +59,7 @@ public class TestCoordinator : NetworkBehaviour
         }
     }
     private string m_ConnectAddress = "127.0.0.1";
-    public static string Port = "3076";
+    public static string Port = "7777";
     private bool m_IsClient;
 
     private void SetConfigurationTypeAndConnect(ConfigurationType type)

--- a/testproject/Assets/Tests/Runtime/MultiprocessRuntime/ThreeDText.cs
+++ b/testproject/Assets/Tests/Runtime/MultiprocessRuntime/ThreeDText.cs
@@ -1,7 +1,4 @@
 using UnityEngine;
-#if UNITY_UNET_PRESENT
-using Unity.Netcode.Transports.UNET;
-#endif
 
 namespace Unity.Netcode.MultiprocessRuntimeTests
 {

--- a/testproject/Assets/Tests/Runtime/MultiprocessRuntime/testproject.multiprocesstests.asmdef
+++ b/testproject/Assets/Tests/Runtime/MultiprocessRuntime/testproject.multiprocesstests.asmdef
@@ -14,5 +14,12 @@
         "LinuxStandalone64",
         "WindowsStandalone32",
         "WindowsStandalone64"
+    ],
+    "versionDefines": [
+        {
+            "name": "Unity",
+            "expression": "(0,2022.2.0a5)",
+            "define": "UNITY_UNET_PRESENT"
+        }
     ]
 }


### PR DESCRIPTION
Updated the testproject for multi-process tests to define UNITY_UNET_PRESENT
Switched to UTP as default transport for test run
Set the default port to 7777 so that client and server are synced. This will changed to a more flexible solution in a future PR.