### PR TITLE
fix: Dynamically spawned NetworkObject throws exception due to no scene of origin handle [MTT-3852]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -20,6 +20,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Removed
 
 ### Fixed
+- Fixed issue where dynamically spawned `NetworkObject`s could throw an exception if the scene of origin handle was zero (0) and the `NetworkObject` was already spawned. (#2017)
 - Fixed issue where `NetworkObject.Observers` was not being cleared when despawned. (#2009)
 - Fixed `NetworkAnimator` could not run in the server authoritative mode. (#2003)
 - Fixed issue where late joining clients would get a soft synchronization error if any in-scene placed NetworkObjects were parented under another `NetworkObject`. (#1985)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -221,8 +221,7 @@ namespace Unity.Netcode
         /// </summary>
         internal int GetSceneOriginHandle()
         {
-            // Sanity check to make sure nothing
-            if (SceneOriginHandle == 0 && IsSpawned)
+            if (SceneOriginHandle == 0 && IsSpawned && IsSceneObject != false)
             {
                 throw new Exception($"{nameof(GetSceneOriginHandle)} called when {nameof(SceneOriginHandle)} is still zero but the {nameof(NetworkObject)} is already spawned!");
             }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOnSpawnTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOnSpawnTests.cs
@@ -168,6 +168,23 @@ namespace Unity.Netcode.RuntimeTests
             Assert.False(s_GlobalTimeoutHelper.TimedOut, "Timed out while waiting for client side despawns! (2nd pass)");
         }
 
+        [Test]
+        public void DynamicallySpawnedNoSceneOriginException()
+        {
+            var gameObject = new GameObject();
+            var networkObject = gameObject.AddComponent<NetworkObject>();
+            networkObject.IsSpawned = true;
+            networkObject.SceneOriginHandle = 0;
+            networkObject.IsSceneObject = false;
+            // This validates invoking GetSceneOriginHandle will not throw an exception for a dynamically spawned NetworkObject
+            // when the scene of origin handle is zero
+            var sceneOriginHandle = networkObject.GetSceneOriginHandle();
+
+            // This validates that GetSceneOriginHandle will return the GameObject's scene handle that should be the currently active scene
+            var activeSceneHandle = UnityEngine.SceneManagement.SceneManager.GetActiveScene().handle;
+            Assert.IsTrue(sceneOriginHandle == activeSceneHandle, $"{nameof(NetworkObject)} should have returned the active scene handle of {activeSceneHandle} but returned {sceneOriginHandle}");
+        }
+
         private class TrackOnSpawnFunctions : NetworkBehaviour
         {
             public int OnNetworkSpawnCalledCount { get; private set; }


### PR DESCRIPTION
This resolves the issue where if you spawn a NetworkObject during the awake method you could get an exception when a dynamically spawned NetworkObject has no scene of origin handle.  Since the scene of origin handle only applies to in-scene placed NetworkObjects, this PR adjusts the offending code to only throw an exception if the scene of origin handle is 0, the NetworkObject is spawned, and the NetworkObject is in-scene placed.

[MTT-3852](https://jira.unity3d.com/browse/MTT-3852)

## Changelog

-Fixed: issue where dynamically spawned `NetworkObject`s could throw an exception if the scene of origin handle was zero (0) and the `NetworkObject` was already spawned.

## Testing and Documentation

- Includes unit test to validate the fix.
