### PR TITLE
chore: Add ability to run mobile tests on all supported unity versions

### DIFF
--- a/.yamato/_run-all.yml
+++ b/.yamato/_run-all.yml
@@ -5,8 +5,8 @@ run_all_tests:
   dependencies:
     # Pull in package and validate jobs through the badges job
     - .yamato/_triggers.yml#badges_test_trigger
-    - .yamato/mobile-build-and-test.yml#2021.2_Run_iOS_Player_With_Tests
-    - .yamato/mobile-build-and-test.yml#2021.2_Run_Android_Player_With_Tests
+    - .yamato/mobile-build-and-test.yml#run_{{ projects.first.name }}_tests_{{ mobile_validation_editor }}_iOS
+    - .yamato/mobile-build-and-test.yml#run_{{ projects.first.name }}_tests_{{ mobile_validation_editor }}_android
     # - .yamato/_run-all.yml#all_project_tests_standalone
 {% for platform in test_platforms -%}
 {% for project in projects -%}
@@ -89,4 +89,16 @@ all_project_tests_standalone:
 {% endfor -%}
 {% endif -%}
 {% endfor -%}
+{% endfor -%}
+
+all_project_tests_mobile:
+  name: Run All Project Tests - Mobile
+  dependencies:
+{% for project in projects -%}
+{% if project.name == "testproject" -%}
+{% for editor in project.test_editors -%}
+    - .yamato/mobile-build-and-test.yml#run_{{ project.name }}_tests_{{ editor }}_android
+    - .yamato/mobile-build-and-test.yml#run_{{ project.name }}_tests_{{ editor }}_iOS
+{% endfor -%}
+{% endif -%}
 {% endfor -%}

--- a/.yamato/mobile-build-and-test.yml
+++ b/.yamato/mobile-build-and-test.yml
@@ -1,5 +1,11 @@
-2021.2_Build_Android_player:
-  name: 2021.2 Build Android player
+{% metadata_file .yamato/project.metafile %}
+---
+
+{% for project in projects -%}
+{% if project.name == "testproject" -%}
+{% for editor in project.test_editors -%}
+build_{{ project.name }}_tests_{{ editor }}_android:
+  name: Build {{ project.name }} Tests - {{ editor }} - Android
   agent:
       type: Unity::VM
       image: desktop/android-execution-r19:v0.1.1-860408
@@ -8,10 +14,10 @@
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
     - python .yamato/disable-burst-if-requested.py --project-path testproject --platform Android
-    - unity-downloader-cli -u 2021.2 -c editor -c Android -w --fast
+    - unity-downloader-cli -u {{ editor }} -c editor -c Android -w --fast
     - |
        set UTR_VERSION=0.12.0
-       utr.bat --artifacts_path=artifacts --timeout=1800 --testproject=testproject --editor-location=.Editor --suite=playmode --platform=android --build-only --player-save-path=build/players --extra-editor-arg=-batchmode --extra-editor-arg=-nographics --testfilter=Unity.Netcode.RuntimeTests
+       utr.bat --artifacts_path=artifacts --timeout=1800 --testproject={{ project.name }} --editor-location=.Editor --suite=playmode --platform=android --build-only --player-save-path=build/players --extra-editor-arg=-batchmode --extra-editor-arg=-nographics --testfilter=Unity.Netcode.RuntimeTests
   artifacts:
     logs:
       paths:
@@ -28,20 +34,27 @@
   variables:
     CI: true
     ENABLE_BURST_COMPILATION: False
+{% endfor -%}
+{% endif -%}
+{% endfor -%}
 
-2021.2_Build_iOS_player:
-  name: 2021.2 Build iOS player
+
+{% for project in projects -%}
+{% if project.name == "testproject" -%}
+{% for editor in project.test_editors -%}
+build_{{ project.name }}_tests_{{ editor }}_iOS:
+  name: Build {{ project.name }} Tests - {{ editor }} - iOS
   agent:
     type: Unity::VM::osx
-    image: mobile/macos-10.15-testing:stable
+    image: mobile/ios-macos-11:stable
     flavor: b1.large
   commands:
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
-    - unity-downloader-cli -u 2021.2 -c editor -c iOS -w --fast
+    - unity-downloader-cli -u {{ editor }} -c editor -c iOS -w --fast
     - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
     - chmod +x ./utr
     - export UTR_VERSION=0.12.0
-    - ./utr --artifacts_path=artifacts --timeout=1800 --testproject=testproject --editor-location=.Editor --suite=playmode --platform=iOS --build-only --player-save-path=build/players --extra-editor-arg=-batchmode --extra-editor-arg=-nographics --testfilter=Unity.Netcode.RuntimeTests
+    - ./utr --artifacts_path=artifacts --timeout=1800 --testproject={{ project.name }} --editor-location=.Editor --suite=playmode --platform=iOS --build-only --player-save-path=build/players --extra-editor-arg=-batchmode --extra-editor-arg=-nographics --testfilter=Unity.Netcode.RuntimeTests
   artifacts:
     logs:
       paths:
@@ -55,18 +68,24 @@
       - build/test-results/**
       - artifacts/**
       - build/players/**
+{% endfor -%}
+{% endif -%}
+{% endfor -%}
 
 
-2021.2_Run_iOS_Player_With_Tests:
-  name: 2021.2 Run iOS player with tests
+{% for project in projects -%}
+{% if project.name == "testproject" -%}
+{% for editor in project.test_editors -%}
+run_{{ project.name }}_tests_{{ editor }}_iOS:
+  name: Run {{ project.name }} Tests - {{ editor }} - iOS
   agent:
       type: Unity::mobile::iPhone
       model: SE
-      image: mobile/macos-10.15-testing:stable
+      image: mobile/ios-macos-11:stable
       flavor: b1.medium
   # Set a dependency on the build job
   dependencies:
-    - .yamato/mobile-build-and-test.yml#2021.2_Build_iOS_player
+    - .yamato/mobile-build-and-test.yml#build_{{ project.name }}_tests_{{ editor }}_iOS
   commands:
     # Download standalone UnityTestRunner
     - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
@@ -74,7 +93,7 @@
     - chmod +x ./utr
     # Run the test build on the device
     - export UTR_VERSION=0.12.0
-    - ./utr -artifacts_path=artifacts --testproject=testproject --editor-location=.Editor --reruncount=2 --suite=playmode --platform=iOS --player-load-path=build/players --testfilter=Unity.Netcode.RuntimeTests
+    - ./utr -artifacts_path=artifacts --testproject={{ project.name }} --editor-location=.Editor --reruncount=2 --suite=playmode --platform=iOS --player-load-path=build/players --testfilter=Unity.Netcode.RuntimeTests
   artifacts:
     logs:
       paths:
@@ -88,9 +107,16 @@
       - build/test-results/**
       - artifacts/**
       - build/players/**
+{% endfor -%}
+{% endif -%}
+{% endfor -%}
+
     
-2021.2_Run_Android_Player_With_Tests:
-  name: 2021.2 Run Android player with tests
+{% for project in projects -%}
+{% if project.name == "testproject" -%}
+{% for editor in project.test_editors -%}
+run_{{ project.name }}_tests_{{ editor }}_android:
+  name: Run {{ project.name }} Tests - {{ editor }} - Android
   agent:
       type: Unity::mobile::shield
       image: mobile/android-execution-r19:stable
@@ -99,7 +125,7 @@
   skip_checkout: true
   # Set a dependency on the build job
   dependencies:
-    - .yamato/mobile-build-and-test.yml#2021.2_Build_Android_player
+    - .yamato/mobile-build-and-test.yml#build_{{ project.name }}_tests_{{ editor }}_android
   commands:
     - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
     - |
@@ -107,7 +133,7 @@
        start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
        start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
        set UTR_VERSION=0.12.0
-       ./utr --artifacts_path=artifacts --testproject=testproject --editor-location=.Editor --reruncount=2 --suite=playmode --platform=android --player-connection-ip=%BOKKEN_HOST_IP% --player-load-path=build/players --testfilter=Unity.Netcode.RuntimeTests
+       ./utr --artifacts_path=artifacts --testproject={{ project.name }} --editor-location=.Editor --reruncount=2 --suite=playmode --platform=android --player-connection-ip=%BOKKEN_HOST_IP% --player-load-path=build/players --testfilter=Unity.Netcode.RuntimeTests
   # Set uploadable artifact paths
   artifacts:
     logs:
@@ -122,3 +148,6 @@
       - build/test-results/**
       - artifacts/**
       - build/players/**
+{% endfor -%}
+{% endif -%}
+{% endfor -%}

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -1,4 +1,5 @@
 validation_editor: 2020.3
+mobile_validation_editor: 2021.3
 
 # Platforms that will be tested. The first entry in this array will also
 # be used for validation


### PR DESCRIPTION
Run Android and iOS tests across all supported Unity versions. 
Last bit from https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/1807

Note: This does not increase nightly builds. They will still only run on 2021.3. This just adds the ability to kick off mobile tests on all versions if desired. 
We don't have Mobile tests running on PR triggers, so no change there.

Update iOS image to `mobile/ios-macos-11` because trunk now needs xcode13.

## Changelog

None

## Testing and Documentation

[CI](https://yamato.cds.internal.unity3d.com/jobs/1201-Unity%2520Netcode%2520for%2520GameObjects/tree/chore%252Fmobile-tests/.yamato%252F_run-all.yml%2523all_project_tests_mobile/14703944/job)
