### PR TITLE
fix: Updating NetworkManager.ConnectionApprovalCallback to make it a Func<> instead of an Action<>, as stated in the 1.0.0.pre-10 changelog, due to it still being an Action<>

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -404,7 +404,7 @@ namespace Unity.Netcode
         /// <summary>
         /// The callback to invoke during connection approval. Allows client code to decide whether or not to allow incoming client connection
         /// </summary>
-        public Action<ConnectionApprovalRequest, ConnectionApprovalResponse> ConnectionApprovalCallback
+        public Func<ConnectionApprovalRequest, ConnectionApprovalResponse> ConnectionApprovalCallback
         {
             get => m_ConnectionApprovalCallback;
             set
@@ -420,7 +420,7 @@ namespace Unity.Netcode
             }
         }
 
-        private Action<ConnectionApprovalRequest, ConnectionApprovalResponse> m_ConnectionApprovalCallback;
+        private Func<ConnectionApprovalRequest, ConnectionApprovalResponse> m_ConnectionApprovalCallback;
 
         /// <summary>
         /// The current NetworkConfig
@@ -1066,8 +1066,7 @@ namespace Unity.Netcode
 
             if (NetworkConfig.ConnectionApproval && ConnectionApprovalCallback != null)
             {
-                var response = new ConnectionApprovalResponse();
-                ConnectionApprovalCallback(new ConnectionApprovalRequest { Payload = NetworkConfig.ConnectionData, ClientNetworkId = ServerClientId }, response);
+                var response = ConnectionApprovalCallback(new ConnectionApprovalRequest { Payload = NetworkConfig.ConnectionData, ClientNetworkId = ServerClientId });
                 if (!response.Approved)
                 {
                     if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionRequestMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionRequestMessage.cs
@@ -101,15 +101,16 @@ namespace Unity.Netcode
             {
                 // Note: Delegate creation allocates.
                 // Note: ToArray() also allocates. :(
-                var response = new NetworkManager.ConnectionApprovalResponse();
-                networkManager.ClientsToApprove[senderId] = response;
+                //var response = new NetworkManager.ConnectionApprovalResponse();
+                //networkManager.ClientsToApprove[senderId] = response;
 
-                networkManager.ConnectionApprovalCallback(
+                networkManager.ClientsToApprove[senderId] = networkManager.ConnectionApprovalCallback(
                     new NetworkManager.ConnectionApprovalRequest
                     {
                         Payload = ConnectionData,
                         ClientNetworkId = senderId
-                    }, response);
+                    }
+                );
             }
             else
             {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApproval.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApproval.cs
@@ -47,19 +47,32 @@ namespace Unity.Netcode.RuntimeTests
             Assert.True(m_IsValidated);
         }
 
-        private void NetworkManagerObject_ConnectionApprovalCallback(NetworkManager.ConnectionApprovalRequest request, NetworkManager.ConnectionApprovalResponse response)
+        private NetworkManager.ConnectionApprovalResponse NetworkManagerObject_ConnectionApprovalCallback(NetworkManager.ConnectionApprovalRequest request)
         {
+
+            //NetworkManager.ConnectionApprovalResponse response = new  NetworkManager.ConnectionApprovalResponse();
             var stringGuid = Encoding.UTF8.GetString(request.Payload);
             if (m_ValidationToken.ToString() == stringGuid)
             {
                 m_IsValidated = true;
             }
 
-            response.Approved = m_IsValidated;
-            response.CreatePlayerObject = false;
-            response.Position = null;
-            response.Rotation = null;
-            response.PlayerPrefabHash = null;
+
+            return new NetworkManager.ConnectionApprovalResponse{
+                Approved = m_IsValidated,
+                CreatePlayerObject = false,
+                Position = null,
+                Rotation = null,
+                PlayerPrefabHash = null
+            };
+
+            //response.Approved = m_IsValidated;
+            //response.CreatePlayerObject = false;
+            //response.Position = null;
+            //response.Rotation = null;
+            //response.PlayerPrefabHash = null;
+
+            //return response;
         }
 
         [TearDown]

--- a/testproject/Assets/Tests/Manual/Scripts/ConnectionApprovalComponent.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/ConnectionApprovalComponent.cs
@@ -152,9 +152,12 @@ namespace TestProject.ManualTests
         /// Invoked only on the server, this will handle the various connection approval combinations
         /// </summary>
         /// <param name="request">The connection approval request</param>
-        /// <returns>ConnectionApprovalResult with the approval decision, with parameters</returns>
-        private void ConnectionApprovalCallback(NetworkManager.ConnectionApprovalRequest request, NetworkManager.ConnectionApprovalResponse response)
+        /// <returns>ConnectionApprovalResponse with the approval decision, with parameters</returns>
+        private NetworkManager.ConnectionApprovalResponse ConnectionApprovalCallback(NetworkManager.ConnectionApprovalRequest request)
         {
+
+            NetworkManager.ConnectionApprovalResponse response = new NetworkManager.ConnectionApprovalResponse();
+
             string approvalToken = Encoding.ASCII.GetString(request.Payload);
             var isTokenValid = approvalToken == m_ApprovalToken;
             if (m_SimulateFailure && m_SimulateFailure.isOn && IsServer && request.ClientNetworkId != NetworkManager.LocalClientId)
@@ -192,6 +195,7 @@ namespace TestProject.ManualTests
 
                 m_ConnectionMessageToDisplay.gameObject.SetActive(true);
             }
+            return response;
         }
 
         /// <summary>

--- a/testproject/Assets/Tests/Runtime/MultiClientConnectionApproval.cs
+++ b/testproject/Assets/Tests/Runtime/MultiClientConnectionApproval.cs
@@ -189,11 +189,11 @@ namespace TestProject.RuntimeTests
         /// <summary>
         /// Delegate handler for the connection approval callback
         /// </summary>
-        /// <param name="connectionData">the NetworkConfig.ConnectionData sent from the client being approved</param>
-        /// <param name="clientId">the client id being approved</param>
-        /// <param name="callback">the callback invoked to handle approval</param>
-        private void ConnectionApprovalCallback(NetworkManager.ConnectionApprovalRequest request, NetworkManager.ConnectionApprovalResponse response)
+        /// <param name="request">the NetworkManager.ConnectionApprovalRequest for the current client that is being approved/rejected</param>
+        /// <returns>the connenction approval response.</param>
+        private NetworkManager.ConnectionApprovalResponse ConnectionApprovalCallback(NetworkManager.ConnectionApprovalRequest request)
         {
+            NetworkManager.ConnectionApprovalResponse response = new NetworkManager.ConnectionApprovalResponse();
             string approvalToken = Encoding.ASCII.GetString(request.Payload);
             var isApproved = approvalToken == m_ConnectionToken;
 
@@ -228,6 +228,7 @@ namespace TestProject.RuntimeTests
                 response.Rotation = null;
                 response.PlayerPrefabHash = m_PrefabOverrideGlobalObjectIdHash;
             }
+            return response;
         }
 
 


### PR DESCRIPTION
<!-- Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

See #2035. The [1.0.0.pre-10 changelog](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/releases/tag/1.0.0-pre.10) says that `NetworkManager.ConnectionApprovalCallback` is meant to be a `Func<>` instead of an `Action<>`, but it's still an `Action<>`. This PR turns it into a `Func<>` for realsies this time.



## Changelog


- Fixed: `NetworkManager.ConnectionApprovalCallback` is now `Func<>` instead of an `Action<>`, as described by the changelog for 1.0.0.pre-10 (see #2035). 
- Changed: Updated tests which use `NetworkManager.ConnectionApprovalCallback` to use it as a `Func<>`, instead of as an `Action<>`.
- Changed: `ConnectionRequestMessage` also uses `NetworkManager.ConnectionApprovalCallback` as a `Func<>` instead of as an `Action<>`.

## Testing and Documentation

- No tests have been added.
  * Updated `com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApproval.cs`, `testproject/Assets/Tests/Manual/Scripts/ConnectionApprovalComponent.cs`, and `testproject/Assets/Tests/Runtime/MultiClientConnectionApproval.cs` to use the `Func<>` version of `NetworkManager.ConnectionApprovalCallback`
- No documentation changes or additions were necessary.


