### PR TITLE
fix: Actually documenting the change from 'OnIsServerAuthoritatitive' to 'OnIsServerAuthoritative' in NetworkTransform

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -19,6 +19,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 - Updated `UnityTransport` dependency on `com.unity.transport` to 1.1.0. (#2025)
 - (API Breaking) `ConnectionApprovalCallback` is no longer an `event` and will not allow more than 1 handler registered at a time. Also, `ConnectionApprovalCallback` is now a `Func<>` taking `ConnectionApprovalRequest` in and returning `ConnectionApprovalResponse` back out (#1972)
+- (API Breaking) `NetworkTransform.OnIsServerAuthoritatitive` is now obsolete. Use `NetworkTransform.OnIsServerAuthoritative` instead.
 
 ### Removed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -19,7 +19,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 - Updated `UnityTransport` dependency on `com.unity.transport` to 1.1.0. (#2025)
 - (API Breaking) `ConnectionApprovalCallback` is no longer an `event` and will not allow more than 1 handler registered at a time. Also, `ConnectionApprovalCallback` is now a `Func<>` taking `ConnectionApprovalRequest` in and returning `ConnectionApprovalResponse` back out (#1972)
-- (API Breaking) `NetworkTransform.OnIsServerAuthoritatitive` is now obsolete. Use `NetworkTransform.OnIsServerAuthoritative` instead.
+- (API Breaking) `NetworkTransform.OnIsServerAuthoritatitive` is now obsolete. Use `NetworkTransform.OnIsServerAuthoritative` instead. (typo in original method name)
 
 ### Removed
 

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -947,9 +947,10 @@ namespace Unity.Netcode.Components
         /// Please override <see cref="OnIsServerAuthoritative"/> instead (typo in this method's name).
         /// Do not use this method as of v1.0.0.pre-10
         /// </summary>
-        [Obsolete("Method OnIsServerAuthoritatitive has been deprecated. Use OnIsServerAuthoritative instead (UnityUpgradable)", true)]
-        protected virtual bool OnIsServerAuthoritatitive(){
-            return OnIsServerAuthoritative();
+        [System.Obsolete("Method OnIsServerAuthoritatitive has been deprecated. Use OnIsServerAuthoritative instead (UnityUpgradable)", true)]
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected bool OnIsServerAuthoritatitive(){
+            throw new NotSupportedException("OnIsServerAuthoritatitive method has been deprecated.");
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -947,7 +947,7 @@ namespace Unity.Netcode.Components
         /// Please override <see cref="OnIsServerAuthoritative"/> instead (typo in this method's name).
         /// Do not use this method as of v1.0.0.pre-10
         /// </summary>
-        [ObsoleteAttribute("This method has been deprecated. Please use OnIsServerAuthoritative instead.", true)]
+        [Obsolete("Method OnIsServerAuthoritatitive has been deprecated. Use OnIsServerAuthoritative instead (UnityUpgradable)", true)]
         protected virtual bool OnIsServerAuthoritatitive(){
             return OnIsServerAuthoritative();
         }

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -942,6 +942,15 @@ namespace Unity.Netcode.Components
             m_LocalAuthoritativeNetworkState.IsTeleportingNextFrame = false;
         }
 
+
+        /// <summary>
+        /// Please override <see cref="OnIsServerAuthoritative"/> instead.
+        /// </summary>
+        [ObsoleteAttribute("This method has been deprecated. Please use OnIsServerAuthoritative instead.", true)]
+        protected virtual bool OnIsServerAuthoritatitive(){
+            return true;
+        }
+
         /// <summary>
         /// Override this method and return false to switch to owner authoritative mode
         /// </summary>

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -944,7 +944,8 @@ namespace Unity.Netcode.Components
 
 
         /// <summary>
-        /// Please override <see cref="OnIsServerAuthoritative"/> instead.
+        /// Please override <see cref="OnIsServerAuthoritative"/> instead (typo in this method's name).
+        /// Do not use this method as of v1.0.0.pre-10
         /// </summary>
         [ObsoleteAttribute("This method has been deprecated. Please use OnIsServerAuthoritative instead.", true)]
         protected virtual bool OnIsServerAuthoritatitive(){

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -948,7 +948,7 @@ namespace Unity.Netcode.Components
         /// </summary>
         [ObsoleteAttribute("This method has been deprecated. Please use OnIsServerAuthoritative instead.", true)]
         protected virtual bool OnIsServerAuthoritatitive(){
-            return true;
+            return OnIsServerAuthoritative();
         }
 
         /// <summary>


### PR DESCRIPTION
Documenting #2006, and I've re-added `NetworkTransform.OnIsServerAuthoritatitive()` but with an 'Obsolete' tag on it, so people know to use `NetworkTransform.OnIsServerAuthoritative()` instead, and this time it's actually mentioned in the changelog.

It'll probably be safe to remove the obsolete `NetworkTransform.OnIsServerAuthoritatitive()` entirely in pre-11, but in the meantime this explicitly tells users to not use it, giving them an opportunity to fix their code to not use it.

This is to prevent further instances of #2037.


## Changelog

- Fixed: Re-added `NetworkTransform.OnIsServerAuthoritatitive()` so it can be marked as obsolete, to avoid unexpected cryptic compiler errors due to the sudden lack of that method (such as #2037).
  - The new method is still called within `NetworkTransform`. The old method is only still here so things that still override that method get given an error message.
- Fixed: Updated changelog to explicitly state that `NetworkTransform.OnIsServerAuthoritatitive()` has been replaced by `NetworkTransform.OnIsServerAuthoritative()`. 
- Deprecated: `NetworkTransform.OnIsServerAuthoritatitive()` is obsolete (due to a typo in method name). Please use `NetworkTransform.OnIsServerAuthoritative()` instead.

## Testing and Documentation


- Includes edits to existing public API documentation.


### Deprecated API
- [x] An `[Obsolete]` attribute was added ~~along with a `(RemovedAfter yyyy-mm-dd)` entry.~~
- [x] An [api updater] was added.
- [x] Deprecation of the API is explained in the CHANGELOG.
- [x] The users can understand why this API was removed and what they should use instead.

