### PR TITLE
chore: Add config for promotion audit

### DIFF
--- a/.yamato/project-promotion.yml
+++ b/.yamato/project-promotion.yml
@@ -69,6 +69,22 @@ promote_{{ project.name }}_{{ package.name }}_dry_run:
 {% endfor -%}
 {% endfor -%}
 
+promotion_audit_{{ project.name }}_{{ package.name }}_{{ test_platforms.first.name }}_{{ validation_editor }}:
+  name : Promotion Audit - XML Validation {{ project.name }} - Package {{ package.name }} - {{ validation_editor }} on {{ test_platforms.first.name }}
+  agent:
+    type: {{ test_platforms.first.type }}
+    image: {{ test_platforms.first.image }}
+    flavor: {{ test_platforms.first.flavor}}
+  commands:
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    - upm-ci package test -u {{ validation_editor }} --package-path {{ package.path }} --type promotion-audit --import-samples
+  artifacts:
+    logs:
+      paths:
+        - "upm-ci~/test-results/**/*"
+  dependencies:
+    - .yamato/project-pack.yml#pack_{{ project.name }}
+
 {% endfor -%}
 {% endif -%}
 {% endfor -%}


### PR DESCRIPTION
Add config to run Promotion Audit. This config will usually fail due to several reasons (for example if run after a package is promoted etc), but will generate a report for XML Validation.
It should purely be used to view the XML Validation results, and other failures be ignored.

## Changelog
none

## Testing and Documentation
[CI](https://yamato.cds.internal.unity3d.com/jobs/1201-Unity%2520Netcode%2520for%2520GameObjects/tree/chore%252Fpromotion-audit/.yamato%252Fproject-promotion.yml%2523promotion_audit_testproject_com.unity.netcode.gameobjects_win_2020.3/14787181/job/pipeline)