### PR TITLE
Save selected SimulatorConfiguration

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/Simulator/NetworkSimulatorEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/Simulator/NetworkSimulatorEditor.cs
@@ -20,7 +20,8 @@ namespace Unity.Netcode.Editor
             m_Inspector.Add(new NetworkEventsView(
                 new NetworkEventsApi(m_NetworkSimulator, m_NetworkSimulator.GetComponent<UnityTransport>())));
 
-            m_Inspector.Add(new NetworkTypeView(m_NetworkSimulator));
+            var simulatorConfigurationProperty = serializedObject.FindProperty(nameof(NetworkSimulator.m_SimulatorConfiguration));
+            m_Inspector.Add(new NetworkTypeView(simulatorConfigurationProperty, m_NetworkSimulator));
 
             return m_Inspector;
         }

--- a/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulator.cs
@@ -1,13 +1,13 @@
 ﻿using Unity.Netcode.Transports.UTP;
 using UnityEngine;
-using UnityEngine.Serialization;
 
 namespace Unity.Netcode
 {
     [RequireComponent(typeof(UnityTransport))]
     public class NetworkSimulator : MonoBehaviour
     {
-        private NetworkSimulatorConfiguration m_SimulatorConfiguration;
+        [SerializeField]
+        NetworkSimulatorConfiguration m_SimulatorConfiguration;
 
         public NetworkSimulatorConfiguration SimulatorConfiguration
         {

--- a/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulator.cs
@@ -7,7 +7,7 @@ namespace Unity.Netcode
     public class NetworkSimulator : MonoBehaviour
     {
         [SerializeField]
-        NetworkSimulatorConfiguration m_SimulatorConfiguration;
+        internal NetworkSimulatorConfiguration m_SimulatorConfiguration;
 
         public NetworkSimulatorConfiguration SimulatorConfiguration
         {


### PR DESCRIPTION
Currently, the `SimulatorConfiguration` isn't serialized, this PR adds this functionality.

There are some formatting updates and other QoL changes.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.
