### PR TITLE
Fix NetworkEventsView dangling listener 

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/Simulator/NetworkEventsView.cs
+++ b/com.unity.netcode.gameobjects/Editor/Simulator/NetworkEventsView.cs
@@ -19,6 +19,7 @@ namespace Unity.Netcode.Editor
             m_NetworkEventsApi = networkEventsApi;
             AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(UXML).CloneTree(this);
 
+            RegisterCallback<DetachFromPanelEvent>(OnDetachedFromPanel);
             DisconnectButton.RegisterCallback<MouseUpEvent>(OnDisconnectMouseUp);
             LagSpikeButton.RegisterCallback<MouseUpEvent>(OnLagSpikeMouseUp);
             LagSpikeDurationSlider.RegisterCallback<ChangeEvent<int>>(OnLagSpikeChange);
@@ -26,6 +27,12 @@ namespace Unity.Netcode.Editor
 
             EditorApplication.update += OnEditorUpdate;
         }
+
+        void OnDetachedFromPanel(DetachFromPanelEvent evt)
+        {
+            EditorApplication.update -= OnEditorUpdate;
+        }
+        
         void OnLagSpikeChange(ChangeEvent<int> evt)
         {
             LagSpikeButton.SetEnabled(evt.newValue != 0);

--- a/com.unity.netcode.gameobjects/Editor/Simulator/NetworkSimulatorEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/Simulator/NetworkSimulatorEditor.cs
@@ -20,7 +20,8 @@ namespace Unity.Netcode.Editor
             m_Inspector.Add(new NetworkEventsView(
                 new NetworkEventsApi(m_NetworkSimulator, m_NetworkSimulator.GetComponent<UnityTransport>())));
 
-            m_Inspector.Add(new NetworkTypeView(m_NetworkSimulator));
+            var simulatorConfigurationProperty = serializedObject.FindProperty(nameof(NetworkSimulator.m_SimulatorConfiguration));
+            m_Inspector.Add(new NetworkTypeView(simulatorConfigurationProperty, m_NetworkSimulator));
 
             return m_Inspector;
         }

--- a/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulator.cs
@@ -1,13 +1,13 @@
 ﻿using Unity.Netcode.Transports.UTP;
 using UnityEngine;
-using UnityEngine.Serialization;
 
 namespace Unity.Netcode
 {
     [RequireComponent(typeof(UnityTransport))]
     public class NetworkSimulator : MonoBehaviour
     {
-        private NetworkSimulatorConfiguration m_SimulatorConfiguration;
+        [SerializeField]
+        NetworkSimulatorConfiguration m_SimulatorConfiguration;
 
         public NetworkSimulatorConfiguration SimulatorConfiguration
         {

--- a/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulator.cs
@@ -7,7 +7,7 @@ namespace Unity.Netcode
     public class NetworkSimulator : MonoBehaviour
     {
         [SerializeField]
-        NetworkSimulatorConfiguration m_SimulatorConfiguration;
+        internal NetworkSimulatorConfiguration m_SimulatorConfiguration;
 
         public NetworkSimulatorConfiguration SimulatorConfiguration
         {


### PR DESCRIPTION
This PR fixes the following `NullReference` exception:

```
NullReferenceException: Object reference not set to an instance of an object
Unity.Netcode.Editor.NetworkEventsView.OnEditorUpdate () (at c:/com.unity.netcode.gameobjects-3/com.unity.netcode.gameobjects/Editor/Simulator/NetworkEventsView.cs:60)
UnityEditor.EditorApplication.Internal_CallUpdateFunctions () (at <acbba03e2d1741d08d11e7ae310b8d6e>:0)
```

The issue happens because we add the `OnEditorUpdate` event handler in the `NetworkEventsView` constructor, but we never remove the handler. Since `NetworkEventsView` is created from a `CreateInspectorGUI`, basically every time we selected the gameObject containing the `NetworkSimulator` component a new listener is added and leaked, preventing the VisualElement from ever getting disposed.

Making sure to remove the listener once we remove the VisualElement ensured to remove the leak.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.
