### PR TITLE
Experimental/mtt 3872 netsim scripting define

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Simulator/INetworkEventsApi.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Simulator/INetworkEventsApi.cs
@@ -1,4 +1,15 @@
-﻿using System;
+﻿// NetSim Implementation compilation boilerplate
+// All references to UNITY_MP_TOOLS_NETSIM_ENABLED should be defined in the same way,
+// as any discrepancies are likely to result in build failures
+// ---------------------------------------------------------------------------------------------------------------------
+#if UNITY_EDITOR || ((DEVELOPMENT_BUILD && !UNITY_MP_TOOLS_NETSIM_DISABLED_IN_DEVELOP) || (!DEVELOPMENT_BUILD && UNITY_MP_TOOLS_NETSIM_ENABLED_IN_RELEASE))
+    #define UNITY_MP_TOOLS_NETSIM_ENABLED
+#endif
+// ---------------------------------------------------------------------------------------------------------------------
+
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
+
+using System;
 using System.Threading.Tasks;
 using Unity.Netcode.Transports.UTP;
 using UnityEngine;
@@ -88,3 +99,5 @@ namespace Unity.Netcode
         }
     }
 }
+
+#endif

--- a/com.unity.netcode.gameobjects/Runtime/Simulator/INetworkEventsApi.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Simulator/INetworkEventsApi.cs
@@ -7,7 +7,6 @@
 #endif
 // ---------------------------------------------------------------------------------------------------------------------
 
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
 
 using System;
 using System.Threading.Tasks;
@@ -60,29 +59,43 @@ namespace Unity.Netcode
 
     public class NetworkEventsApi : INetworkEventsApi
     {
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
         readonly NetworkSimulator m_NetworkSimulator;
         readonly UnityTransport m_UnityTransport;
+#endif
 
         public NetworkEventsApi(NetworkSimulator networkSimulator, UnityTransport unityTransport)
         {
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
             m_NetworkSimulator = networkSimulator;
             m_UnityTransport = unityTransport;
+#endif
         }
 
-        public bool IsDisabledBySimulator => m_UnityTransport.IsDisabledBySimulator;
+        public bool IsDisabledBySimulator
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
+            => m_UnityTransport.IsDisabledBySimulator;
+#else
+            => false;
+#endif
 
         public void TriggerDisconnect()
         {
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
             m_UnityTransport.TriggerDisconnect();
+#endif
         }
 
         public void TriggerReconnect()
         {
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
             m_UnityTransport.TriggerReconnect();
+#endif
         }
 
         public void TriggerLagSpike(TimeSpan duration)
         {
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
             Task.Run(async () =>
             {
                 TriggerDisconnect();
@@ -91,13 +104,14 @@ namespace Unity.Netcode
 
                 TriggerReconnect();
             });
+#endif
         }
 
         public void ChangeNetworkType(NetworkSimulatorConfiguration newNetworkSimulatorConfiguration)
         {
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
             m_NetworkSimulator.SimulatorConfiguration = newNetworkSimulatorConfiguration;
+#endif
         }
     }
 }
-
-#endif

--- a/com.unity.netcode.gameobjects/Runtime/Simulator/INetworkSimulatorScenario.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Simulator/INetworkSimulatorScenario.cs
@@ -1,4 +1,15 @@
-﻿using System.Threading.Tasks;
+﻿// NetSim Implementation compilation boilerplate
+// All references to UNITY_MP_TOOLS_NETSIM_ENABLED should be defined in the same way,
+// as any discrepancies are likely to result in build failures
+// ---------------------------------------------------------------------------------------------------------------------
+#if UNITY_EDITOR || ((DEVELOPMENT_BUILD && !UNITY_MP_TOOLS_NETSIM_DISABLED_IN_DEVELOP) || (!DEVELOPMENT_BUILD && UNITY_MP_TOOLS_NETSIM_ENABLED_IN_RELEASE))
+#define UNITY_MP_TOOLS_NETSIM_ENABLED
+#endif
+// ---------------------------------------------------------------------------------------------------------------------
+
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
+
+using System.Threading.Tasks;
 
 namespace Unity.Netcode
 {
@@ -15,3 +26,5 @@ namespace Unity.Netcode
         }
     }
 }
+
+#endif

--- a/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkScenario.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkScenario.cs
@@ -1,3 +1,14 @@
+// NetSim Implementation compilation boilerplate
+// All references to UNITY_MP_TOOLS_NETSIM_ENABLED should be defined in the same way,
+// as any discrepancies are likely to result in build failures
+// ---------------------------------------------------------------------------------------------------------------------
+#if UNITY_EDITOR || ((DEVELOPMENT_BUILD && !UNITY_MP_TOOLS_NETSIM_DISABLED_IN_DEVELOP) || (!DEVELOPMENT_BUILD && UNITY_MP_TOOLS_NETSIM_ENABLED_IN_RELEASE))
+    #define UNITY_MP_TOOLS_NETSIM_ENABLED
+#endif
+// ---------------------------------------------------------------------------------------------------------------------
+
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
+
 using UnityEngine;
 
 namespace Unity.Netcode
@@ -9,3 +20,5 @@ namespace Unity.Netcode
         public INetworkSimulatorScenario NetworkSimulatorScenario { get; set; }
     }
 }
+
+#endif

--- a/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulationConfiguration.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulationConfiguration.cs
@@ -1,4 +1,15 @@
-﻿using UnityEngine;
+﻿// NetSim Implementation compilation boilerplate
+// All references to UNITY_MP_TOOLS_NETSIM_ENABLED should be defined in the same way,
+// as any discrepancies are likely to result in build failures
+// ---------------------------------------------------------------------------------------------------------------------
+#if UNITY_EDITOR || ((DEVELOPMENT_BUILD && !UNITY_MP_TOOLS_NETSIM_DISABLED_IN_DEVELOP) || (!DEVELOPMENT_BUILD && UNITY_MP_TOOLS_NETSIM_ENABLED_IN_RELEASE))
+    #define UNITY_MP_TOOLS_NETSIM_ENABLED
+#endif
+// ---------------------------------------------------------------------------------------------------------------------
+
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
+
+using UnityEngine;
 
 namespace Unity.Netcode
 {
@@ -103,3 +114,5 @@ namespace Unity.Netcode
         }
     }
 }
+
+#endif

--- a/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulator.cs
@@ -9,9 +9,9 @@
 
 #if UNITY_MP_TOOLS_NETSIM_ENABLED
 
+using System;
 using Unity.Netcode.Transports.UTP;
 using UnityEngine;
-using UnityEngine.Serialization;
 
 namespace Unity.Netcode
 {

--- a/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulator.cs
@@ -7,7 +7,6 @@
 #endif
 // ---------------------------------------------------------------------------------------------------------------------
 
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
 
 using System;
 using Unity.Netcode.Transports.UTP;
@@ -33,6 +32,7 @@ namespace Unity.Netcode
 
         public void UpdateLiveParameters()
         {
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
             if (!Application.isPlaying)
             {
                 return;
@@ -43,8 +43,7 @@ namespace Unity.Netcode
             {
                 transport.UpdateSimulationPipelineParameters(SimulatorConfiguration);
             }
+#endif
         }
     }
 }
-
-#endif

--- a/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulator.cs
@@ -1,4 +1,15 @@
-﻿using Unity.Netcode.Transports.UTP;
+﻿// NetSim Implementation compilation boilerplate
+// All references to UNITY_MP_TOOLS_NETSIM_ENABLED should be defined in the same way,
+// as any discrepancies are likely to result in build failures
+// ---------------------------------------------------------------------------------------------------------------------
+#if UNITY_EDITOR || ((DEVELOPMENT_BUILD && !UNITY_MP_TOOLS_NETSIM_DISABLED_IN_DEVELOP) || (!DEVELOPMENT_BUILD && UNITY_MP_TOOLS_NETSIM_ENABLED_IN_RELEASE))
+    #define UNITY_MP_TOOLS_NETSIM_ENABLED
+#endif
+// ---------------------------------------------------------------------------------------------------------------------
+
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
+
+using Unity.Netcode.Transports.UTP;
 using UnityEngine;
 
 namespace Unity.Netcode
@@ -29,3 +40,5 @@ namespace Unity.Netcode
         }
     }
 }
+
+#endif

--- a/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulatorConfiguration.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulatorConfiguration.cs
@@ -7,8 +7,6 @@
 #endif
 // ---------------------------------------------------------------------------------------------------------------------
 
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
-
 using UnityEngine;
 
 namespace Unity.Netcode
@@ -96,5 +94,3 @@ namespace Unity.Netcode
         }
     }
 }
-
-#endif

--- a/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkTypePresets.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkTypePresets.cs
@@ -1,4 +1,15 @@
-﻿namespace Unity.Netcode
+﻿// NetSim Implementation compilation boilerplate
+// All references to UNITY_MP_TOOLS_NETSIM_ENABLED should be defined in the same way,
+// as any discrepancies are likely to result in build failures
+// ---------------------------------------------------------------------------------------------------------------------
+#if UNITY_EDITOR || ((DEVELOPMENT_BUILD && !UNITY_MP_TOOLS_NETSIM_DISABLED_IN_DEVELOP) || (!DEVELOPMENT_BUILD && UNITY_MP_TOOLS_NETSIM_ENABLED_IN_RELEASE))
+    #define UNITY_MP_TOOLS_NETSIM_ENABLED
+#endif
+// ---------------------------------------------------------------------------------------------------------------------
+
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
+
+namespace Unity.Netcode
 {
     public class NetworkTypePresets
     {
@@ -36,3 +47,5 @@
         };
     }
 }
+
+#endif

--- a/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkTypePresets.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkTypePresets.cs
@@ -7,8 +7,6 @@
 #endif
 // ---------------------------------------------------------------------------------------------------------------------
 
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
-
 namespace Unity.Netcode
 {
     public class NetworkTypePresets
@@ -19,17 +17,72 @@ namespace Unity.Netcode
         const string k_DecentMobileDescription = "Suitable for synchronous multiplayer, except that ping (and overall connection quality and stability) may be quite poor.\n\nExpect to handle players dropping all packets in bursts of 1-60s. I.e. Ensure you handle reconnections.";
         const string k_GoodMobileDescription = "In many places, expect this to be 'as good as' or 'better than' home broadband.";
 
-        public static readonly NetworkSimulatorConfiguration None = NetworkSimulatorConfiguration.Create("None", string.Empty, 0, 0, 0, 0, 0);
-        public static readonly NetworkSimulatorConfiguration HomeBroadband = NetworkSimulatorConfiguration.Create("Home Broadband [WIFI, Cable, Console, PC]", k_BroadbandDescription, 2, 2, 1, 0, 0);
-        public static readonly NetworkSimulatorConfiguration Mobile2G = NetworkSimulatorConfiguration.Create("Mobile 2G [CDMA & GSM, '00]", k_PoorMobileDescription, 400, 200, 5, 0, 0);
-        public static readonly NetworkSimulatorConfiguration Mobile2_5G = NetworkSimulatorConfiguration.Create("Mobile 2.5G [GPRS, G, '00]", k_PoorMobileDescription, 200, 100, 5, 0, 0);
-        public static readonly NetworkSimulatorConfiguration Mobile2_75G = NetworkSimulatorConfiguration.Create("Mobile 2.75G [Edge, E, '06]", k_PoorMobileDescription, 200, 100, 5, 0, 0);
-        public static readonly NetworkSimulatorConfiguration Mobile3G = NetworkSimulatorConfiguration.Create("Mobile 3G [WCDMA & UMTS, '03]", k_PoorMobileDescription, 200, 100, 5, 0, 0);
-        public static readonly NetworkSimulatorConfiguration Mobile3_5G = NetworkSimulatorConfiguration.Create("Mobile 3.5G [HSDPA, H, '06]", k_MediumMobileDescription, 75, 50, 5, 0, 0);
-        public static readonly NetworkSimulatorConfiguration Mobile3_75G = NetworkSimulatorConfiguration.Create("Mobile 3.75G [HDSDPA+, H+, '11]", k_DecentMobileDescription, 75, 50, 5, 0, 0);
-        public static readonly NetworkSimulatorConfiguration Mobile4G = NetworkSimulatorConfiguration.Create("Mobile 4G [4G, LTE, '13]", k_DecentMobileDescription, 50, 25, 3, 0, 0);
-        public static readonly NetworkSimulatorConfiguration Mobile4_5G = NetworkSimulatorConfiguration.Create("Mobile 4.5G [4G+, LTE-A, '16]", k_DecentMobileDescription, 50, 25, 3, 0, 0);
-        public static readonly NetworkSimulatorConfiguration Mobile5G = NetworkSimulatorConfiguration.Create("Mobile 5G ['20]", k_GoodMobileDescription, 1, 10, 1, 0, 0);
+        public static readonly NetworkSimulatorConfiguration None
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
+            = NetworkSimulatorConfiguration.Create("None", string.Empty, 0, 0, 0, 0, 0);
+#else
+            = null;
+#endif
+        public static readonly NetworkSimulatorConfiguration HomeBroadband
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
+            = NetworkSimulatorConfiguration.Create("Home Broadband [WIFI, Cable, Console, PC]", k_BroadbandDescription, 2, 2, 1, 0, 0);
+#else
+            = null;
+#endif
+        public static readonly NetworkSimulatorConfiguration Mobile2G
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
+            = NetworkSimulatorConfiguration.Create("Mobile 2G [CDMA & GSM, '00]", k_PoorMobileDescription, 400, 200, 5, 0, 0);
+#else
+            = null;
+#endif
+        public static readonly NetworkSimulatorConfiguration Mobile2_5G
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
+            = NetworkSimulatorConfiguration.Create("Mobile 2.5G [GPRS, G, '00]", k_PoorMobileDescription, 200, 100, 5, 0, 0);
+#else
+            = null;
+#endif
+        public static readonly NetworkSimulatorConfiguration Mobile2_75G
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
+            = NetworkSimulatorConfiguration.Create("Mobile 2.75G [Edge, E, '06]", k_PoorMobileDescription, 200, 100, 5, 0, 0);
+#else
+            = null;
+#endif
+        public static readonly NetworkSimulatorConfiguration Mobile3G
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
+            = NetworkSimulatorConfiguration.Create("Mobile 3G [WCDMA & UMTS, '03]", k_PoorMobileDescription, 200, 100, 5, 0, 0);
+#else
+            = null;
+#endif
+        public static readonly NetworkSimulatorConfiguration Mobile3_5G
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
+            = NetworkSimulatorConfiguration.Create("Mobile 3.5G [HSDPA, H, '06]", k_MediumMobileDescription, 75, 50, 5, 0, 0);
+#else
+            = null;
+#endif
+        public static readonly NetworkSimulatorConfiguration Mobile3_75G
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
+            = NetworkSimulatorConfiguration.Create("Mobile 3.75G [HDSDPA+, H+, '11]", k_DecentMobileDescription, 75, 50, 5, 0, 0);
+#else
+            = null;
+#endif
+        public static readonly NetworkSimulatorConfiguration Mobile4G
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
+            = NetworkSimulatorConfiguration.Create("Mobile 4G [4G, LTE, '13]", k_DecentMobileDescription, 50, 25, 3, 0, 0);
+#else
+            = null;
+#endif
+        public static readonly NetworkSimulatorConfiguration Mobile4_5G
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
+            = NetworkSimulatorConfiguration.Create("Mobile 4.5G [4G+, LTE-A, '16]", k_DecentMobileDescription, 50, 25, 3, 0, 0);
+#else
+            = null;
+#endif
+        public static readonly NetworkSimulatorConfiguration Mobile5G
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
+            = NetworkSimulatorConfiguration.Create("Mobile 5G ['20]", k_GoodMobileDescription, 1, 10, 1, 0, 0);
+#else
+            = null;
+#endif
 
         public static NetworkSimulatorConfiguration[] Values = new[]
         {
@@ -47,5 +100,3 @@ namespace Unity.Netcode
         };
     }
 }
-
-#endif

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1,3 +1,12 @@
+// NetSim Implementation compilation boilerplate
+// All references to UNITY_MP_TOOLS_NETSIM_ENABLED should be defined in the same way,
+// as any discrepancies are likely to result in build failures
+// ---------------------------------------------------------------------------------------------------------------------
+#if UNITY_EDITOR || ((DEVELOPMENT_BUILD && !UNITY_MP_TOOLS_NETSIM_DISABLED_IN_DEVELOP) || (!DEVELOPMENT_BUILD && UNITY_MP_TOOLS_NETSIM_ENABLED_IN_RELEASE))
+    #define UNITY_MP_TOOLS_NETSIM_ENABLED
+#endif
+// ---------------------------------------------------------------------------------------------------------------------
+
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -1069,6 +1078,7 @@ namespace Unity.Netcode.Transports.UTP
         {
             NetworkPipelineStageCollection.RegisterPipelineStage(new NetworkMetricsPipelineStage());
 
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
             var configuration = GetComponent<NetworkSimulator>()?.SimulatorConfiguration;
             m_NetworkSettings.WithSimulatorStageParameters(
                 300,
@@ -1081,6 +1091,7 @@ namespace Unity.Netcode.Transports.UTP
                 packetDuplicationPercentage: configuration?.PacketDuplicationPercent ?? 0);
 
             m_SimulatorInitialized = true;
+#endif
 
             m_NetworkSettings.WithNetworkConfigParameters(
                 maxConnectAttempts: transport.m_MaxConnectAttempts,
@@ -1109,6 +1120,7 @@ namespace Unity.Netcode.Transports.UTP
             );
         }
 
+#if UNITY_MP_TOOLS_NETSIM_ENABLED
         public void UpdateSimulationPipelineParameters(NetworkSimulatorConfiguration configuration)
         {
             if (!m_SimulatorInitialized)
@@ -1137,6 +1149,8 @@ namespace Unity.Netcode.Transports.UTP
 
             m_NetworkSettings.AddRawParameterStruct(ref *parameter);
         }
+
+#endif
 
         public void TriggerDisconnect()
         {


### PR DESCRIPTION
Wrapping Network Simulation files into a scripting symbol.

Having it configurable through options, as well as not breaking code if using API will come in a future PR.

MTT-3872

- No tests have been added.
