### PR TITLE
test: Allow for the detection of whether to run Multiprocess tests with local clients or remote clients.

### DIFF
--- a/testproject/Assets/Tests/Runtime/MultiprocessRuntime/BaseMultiprocessTests.cs
+++ b/testproject/Assets/Tests/Runtime/MultiprocessRuntime/BaseMultiprocessTests.cs
@@ -173,7 +173,7 @@ namespace Unity.Netcode.MultiprocessRuntimeTests
                     }
                 }
             }
-            else if (m_LaunchRemotely)
+            else
             {
                 var launchProcessList = new List<Process>();
                 if (NetworkManager.Singleton.ConnectedClients.Count - 1 < GetWorkerCount())

--- a/testproject/Assets/Tests/Runtime/MultiprocessRuntime/BaseMultiprocessTests.cs
+++ b/testproject/Assets/Tests/Runtime/MultiprocessRuntime/BaseMultiprocessTests.cs
@@ -184,7 +184,12 @@ namespace Unity.Netcode.MultiprocessRuntimeTests
             {
                 if (NetworkManager.Singleton.ConnectedClients.Count - 1 < GetWorkerCount())
                 {
-
+                    var machines = MultiprocessOrchestration.GetRemoteMachineList();
+                    foreach (var machine in machines)
+                    {
+                        MultiprocessLogger.Log($"Would launch on {machine.Name} too get worker count to {GetWorkerCount()} from {NetworkManager.Singleton.ConnectedClients.Count - 1}");
+                        MultiprocessOrchestration.StartWorkersOnRemoteNodes(machine);
+                    }
                 }
             }
 

--- a/testproject/Assets/Tests/Runtime/MultiprocessRuntime/BaseMultiprocessTests.cs
+++ b/testproject/Assets/Tests/Runtime/MultiprocessRuntime/BaseMultiprocessTests.cs
@@ -29,15 +29,6 @@ namespace Unity.Netcode.MultiprocessRuntimeTests
         protected int GetWorkerCount()
         {
             platformList = MultiprocessOrchestration.GetRemotePlatformList();
-
-            if (platformList == null)
-            {
-                m_LaunchRemotely = false;
-            }
-            else
-            {
-                m_LaunchRemotely = true;
-            }
             return platformList == null ? WorkerCount : platformList.Length;
         }
         protected bool m_LaunchRemotely;
@@ -150,14 +141,11 @@ namespace Unity.Netcode.MultiprocessRuntimeTests
         public virtual IEnumerator Setup()
         {
             yield return new WaitUntil(() => NetworkManager.Singleton != null);
-            MultiprocessLogger.Log("NetworkManager.Singleton != null");
             yield return new WaitUntil(() => NetworkManager.Singleton.IsServer);
-            MultiprocessLogger.Log("NetworkManager.Singleton.IsServer");
             yield return new WaitUntil(() => NetworkManager.Singleton.IsListening);
-            MultiprocessLogger.Log("NetworkManager.Singleton.IsListening");
             yield return new WaitUntil(() => m_HasSceneLoaded == true);
-            MultiprocessLogger.Log("m_HasSceneLoaded");
             var startTime = Time.time;
+            m_LaunchRemotely = MultiprocessOrchestration.IsRemoteOperationEnabled();
 
             MultiprocessLogger.Log($"Active Worker Count is {MultiprocessOrchestration.ActiveWorkerCount()}" +
                 $" and connected client count is {NetworkManager.Singleton.ConnectedClients.Count} " +

--- a/testproject/Assets/Tests/Runtime/MultiprocessRuntime/BaseMultiprocessTests.cs
+++ b/testproject/Assets/Tests/Runtime/MultiprocessRuntime/BaseMultiprocessTests.cs
@@ -157,7 +157,10 @@ namespace Unity.Netcode.MultiprocessRuntimeTests
             MultiprocessLogger.Log("m_HasSceneLoaded");
             var startTime = Time.time;
 
-            MultiprocessLogger.Log($"Active Worker Count is {MultiprocessOrchestration.ActiveWorkerCount()} and connected client count is {NetworkManager.Singleton.ConnectedClients.Count}");
+            MultiprocessLogger.Log($"Active Worker Count is {MultiprocessOrchestration.ActiveWorkerCount()}" +
+                $" and connected client count is {NetworkManager.Singleton.ConnectedClients.Count} " +
+                $" and WorkerCount is {GetWorkerCount()} " +
+                $" and LaunchRemotely is {m_LaunchRemotely}");
             if (MultiprocessOrchestration.ActiveWorkerCount() + 1 < NetworkManager.Singleton.ConnectedClients.Count)
             {
                 MultiprocessLogger.Log("Is this a bad state?");

--- a/testproject/Assets/Tests/Runtime/MultiprocessRuntime/BaseMultiprocessTests.cs
+++ b/testproject/Assets/Tests/Runtime/MultiprocessRuntime/BaseMultiprocessTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -185,13 +187,14 @@ namespace Unity.Netcode.MultiprocessRuntimeTests
             }
             else if (m_LaunchRemotely)
             {
+                var launchProcessList = new List<Process>();
                 if (NetworkManager.Singleton.ConnectedClients.Count - 1 < GetWorkerCount())
                 {
                     var machines = MultiprocessOrchestration.GetRemoteMachineList();
                     foreach (var machine in machines)
                     {
                         MultiprocessLogger.Log($"Would launch on {machine.Name} too get worker count to {GetWorkerCount()} from {NetworkManager.Singleton.ConnectedClients.Count - 1}");
-                        MultiprocessOrchestration.StartWorkersOnRemoteNodes(machine);
+                        launchProcessList.Add(MultiprocessOrchestration.StartWorkersOnRemoteNodes(machine));
                     }
                 }
             }

--- a/testproject/Assets/Tests/Runtime/MultiprocessRuntime/Helpers/MultiprocessLogger.cs
+++ b/testproject/Assets/Tests/Runtime/MultiprocessRuntime/Helpers/MultiprocessLogger.cs
@@ -62,7 +62,7 @@ namespace Unity.Netcode.MultiprocessRuntimeTests
                 testName = "unknown";
             }
 
-            Debug.unityLogger.logHandler.LogFormat(logType, context, $"MPLOG({DateTime.Now:T}) : {testName} : {format}", args);
+            UnityEngine.Debug.LogFormat(logType, LogOption.NoStacktrace, context, $"MPLOG({DateTime.Now:T}) : {testName} : {format}", args);
         }
     }
 }

--- a/testproject/Assets/Tests/Runtime/MultiprocessRuntime/Helpers/MultiprocessLogger.cs
+++ b/testproject/Assets/Tests/Runtime/MultiprocessRuntime/Helpers/MultiprocessLogger.cs
@@ -62,7 +62,7 @@ namespace Unity.Netcode.MultiprocessRuntimeTests
                 testName = "unknown";
             }
 
-            UnityEngine.Debug.LogFormat(logType, LogOption.NoStacktrace, context, $"MPLOG({DateTime.Now:T}) : {testName} : {format}", args);
+            Debug.LogFormat(logType, LogOption.NoStacktrace, context, $"MPLOG({DateTime.Now:T}) : {testName} : {format}", args);
         }
     }
 }

--- a/testproject/Assets/Tests/Runtime/MultiprocessRuntime/Helpers/MultiprocessOrchestration.cs
+++ b/testproject/Assets/Tests/Runtime/MultiprocessRuntime/Helpers/MultiprocessOrchestration.cs
@@ -52,10 +52,16 @@ public class MultiprocessOrchestration
         initMultiprocessDirinfo();
         MultiprocessLogger.Log($" userprofile: {s_MultiprocessDirInfo.FullName} localipfile: {s_Localip_fileinfo}");
         var rootdir_FileInfo = new FileInfo(Path.Combine(MultiprocessDirInfo.FullName, "rootdir"));
+        MultiprocessLogger.Log($"Checking for the existence of {rootdir_FileInfo.FullName}");
         if (rootdir_FileInfo.Exists)
         {
             var rootDirText = (File.ReadAllText(rootdir_FileInfo.FullName)).Trim();
             PathToDll = Path.Combine(rootDirText, "multiplayer-multiprocess-test-tools/BokkenForNetcode/ProvisionBokkenMachines/bin/Debug/netcoreapp3.1/osx-x64", "ProvisionBokkenMachines.dll");
+        }
+        else
+        {
+            MultiprocessLogger.Log("PathToDll cannot be set as rootDir doesn't exist");
+            PathToDll = "unknown";
         }
     }
 
@@ -262,7 +268,7 @@ public class MultiprocessOrchestration
 
         ProcessList.Add(workerProcess);
 
-        MultiprocessLogger.Log($"Execute Command: {command} End");
+        MultiprocessLogger.Log($"Execute Command: {PathToDll} {command} End");
         return workerProcess;
     }
 }

--- a/testproject/Assets/Tests/Runtime/MultiprocessRuntime/Helpers/MultiprocessOrchestration.cs
+++ b/testproject/Assets/Tests/Runtime/MultiprocessRuntime/Helpers/MultiprocessOrchestration.cs
@@ -204,19 +204,24 @@ public class MultiprocessOrchestration
         s_Processes.Clear();
     }
 
+    public static bool IsRemoteOperationEnabled()
+    {
+        string encodedPlatformList = Environment.GetEnvironmentVariable("MP_PLATFORM_LIST");
+        if (encodedPlatformList != null && encodedPlatformList.Split(',').Length > 1)
+        {
+            return true;
+        }
+        return false;
+    }
+
     public static string[] GetRemotePlatformList()
     {
         // "default-win:test-win,default-mac:test-mac"
-        string encodedPlatformList = Environment.GetEnvironmentVariable("MP_PLATFORM_LIST");
-        if (encodedPlatformList == null)
+        if (!IsRemoteOperationEnabled())
         {
-            MultiprocessLogger.Log($"MP_PLATFORM_LIST is null!");
             return null;
         }
-        else
-        {
-            MultiprocessLogger.Log($"MP_PLATFORM_LIST is: {encodedPlatformList}");
-        }
+        string encodedPlatformList = Environment.GetEnvironmentVariable("MP_PLATFORM_LIST");
         string[] separated = encodedPlatformList.Split(',');
         return separated;
     }

--- a/testproject/Assets/Tests/Runtime/MultiprocessRuntime/Helpers/MultiprocessOrchestration.cs
+++ b/testproject/Assets/Tests/Runtime/MultiprocessRuntime/Helpers/MultiprocessOrchestration.cs
@@ -21,6 +21,9 @@ public class MultiprocessOrchestration
     }
     private static List<Process> s_Processes = new List<Process>();
     private static int s_TotalProcessCounter = 0;
+    public static string PathToDll { get; private set; }
+    public static List<Process> ProcessList = new List<Process>();
+    private static FileInfo s_Localip_fileinfo;
 
     private static DirectoryInfo initMultiprocessDirinfo()
     {
@@ -39,12 +42,21 @@ public class MultiprocessOrchestration
         {
             MultiprocessDirInfo.Create();
         }
+        s_Localip_fileinfo = new FileInfo(Path.Combine(s_MultiprocessDirInfo.FullName, "localip"));
+
         return s_MultiprocessDirInfo;
     }
 
     static MultiprocessOrchestration()
     {
         initMultiprocessDirinfo();
+        MultiprocessLogger.Log($" userprofile: {s_MultiprocessDirInfo.FullName} localipfile: {s_Localip_fileinfo}");
+        var rootdir_FileInfo = new FileInfo(Path.Combine(MultiprocessDirInfo.FullName, "rootdir"));
+        if (rootdir_FileInfo.Exists)
+        {
+            var rootDirText = (File.ReadAllText(rootdir_FileInfo.FullName)).Trim();
+            PathToDll = Path.Combine(rootDirText, "multiplayer-multiprocess-test-tools/BokkenForNetcode/ProvisionBokkenMachines/bin/Debug/netcoreapp3.1/osx-x64", "ProvisionBokkenMachines.dll");
+        }
     }
 
     /// <summary>
@@ -184,5 +196,73 @@ public class MultiprocessOrchestration
         }
 
         s_Processes.Clear();
+    }
+
+    public static string[] GetRemotePlatformList()
+    {
+        // "default-win:test-win,default-mac:test-mac"
+        string encodedPlatformList = Environment.GetEnvironmentVariable("MP_PLATFORM_LIST");
+        if (encodedPlatformList == null)
+        {
+            MultiprocessLogger.Log($"MP_PLATFORM_LIST is null!");
+            return null;
+        }
+        else
+        {
+            MultiprocessLogger.Log($"MP_PLATFORM_LIST is: {encodedPlatformList}");
+        }
+        string[] separated = encodedPlatformList.Split(',');
+        return separated;
+    }
+
+    public static List<FileInfo> GetRemoteMachineList()
+    {
+        var machineJson = new List<FileInfo>();
+        foreach (var f in MultiprocessDirInfo.GetFiles("*.json"))
+        {
+            if (f.Name.Equals("remoteConfig.json"))
+            {
+                continue;
+            }
+            else
+            {
+                machineJson.Add(f);
+            }
+        }
+        return machineJson;
+    }
+
+    public static Process StartWorkersOnRemoteNodes(FileInfo machine)
+    {
+        string command = $" --command launch " +
+                $"--input-path {machine.FullName} ";
+
+        var workerProcess = new Process();
+
+        workerProcess.StartInfo.FileName = Path.Combine("dotnet");
+        workerProcess.StartInfo.UseShellExecute = false;
+        workerProcess.StartInfo.RedirectStandardError = true;
+        workerProcess.StartInfo.RedirectStandardOutput = true;
+        workerProcess.StartInfo.Arguments = $"{PathToDll} {command} ";
+        try
+        {
+            var newProcessStarted = workerProcess.Start();
+
+            if (!newProcessStarted)
+            {
+                throw new Exception("Failed to start worker process!");
+            }
+        }
+        catch (Win32Exception e)
+        {
+            MultiprocessLogger.LogError($"Error starting bokken process, {e.Message} {e.Data} {e.ErrorCode}");
+            throw;
+        }
+
+
+        ProcessList.Add(workerProcess);
+
+        MultiprocessLogger.Log($"Execute Command: {command} End");
+        return workerProcess;
     }
 }


### PR DESCRIPTION
Added dependency on the environment variable `MP_PLATFORM_LIST`. Based on the existence of this variable  the Multiprocess tests will switch between running clients locally and running them on remote nodes.

Add parsing code for using the value of the variable to determine which types of hosts to run the clients on.

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->
No Jira associated with this whole project.
<!-- Add RFC link here if applicable. -->
No RFC associated with this whole project
## Changelog

No changes for the testlog

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

N/A for deprecated API