### PR TITLE
feat: Network Simulator can be included via build arguments

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/Simulator/Settings.meta
+++ b/com.unity.netcode.gameobjects/Editor/Simulator/Settings.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 36f578ea3d11480ba06e5192b8797565
+timeCreated: 1657552895

--- a/com.unity.netcode.gameobjects/Editor/Simulator/Settings/NetworkSimulatorBuildLogEntry.cs
+++ b/com.unity.netcode.gameobjects/Editor/Simulator/Settings/NetworkSimulatorBuildLogEntry.cs
@@ -1,0 +1,40 @@
+using System.Linq;
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using UnityEngine;
+
+namespace Unity.Netcode.Editor
+{
+    public class NetworkSimulatorBuildLogEntry : IPostprocessBuildWithReport
+    {
+        public int callbackOrder => 1;
+
+        public void OnPostprocessBuild(BuildReport report)
+        {
+            var target = report.summary.platform;
+
+            var targetGroup = BuildPipeline.GetBuildTargetGroup(target);
+            var namedTarget = NamedBuildTarget.FromBuildTargetGroup(targetGroup);
+            PlayerSettings.GetScriptingDefineSymbols(namedTarget, out var symbols);
+
+            var isDevelopBuild = (report.summary.options & BuildOptions.Development) != 0;
+            var isReleaseBuild = !isDevelopBuild;
+
+            var enabledInDevelop = !symbols.Contains(NetworkSimulatorBuildSymbolStrings.k_DisableInDevelop);
+            var enabledInRelease =  symbols.Contains(NetworkSimulatorBuildSymbolStrings.k_EnableInRelease);
+            var overrideEnabled  =  symbols.Contains(NetworkSimulatorBuildSymbolStrings.k_OverrideEnabled);
+
+            // This logic needs to match the preprocessor logic for the inclusion of the NetSim
+            // implementation in the NetSim implementation source files
+            var netSimImplementationEnabled = overrideEnabled ||
+                (isDevelopBuild && enabledInDevelop) ||
+                (isReleaseBuild && enabledInRelease);
+
+            var buildType = isDevelopBuild ? "development" : "release";
+            var enabled = netSimImplementationEnabled ? "enabled" : "disabled";
+
+            Debug.Log($"Network Simulator implementation {enabled} in {buildType} build targeting {target}");
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Editor/Simulator/Settings/NetworkSimulatorBuildLogEntry.cs.meta
+++ b/com.unity.netcode.gameobjects/Editor/Simulator/Settings/NetworkSimulatorBuildLogEntry.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: adfaefc729cf45b991891737e543048a
+timeCreated: 1657553309

--- a/com.unity.netcode.gameobjects/Editor/Simulator/Settings/NetworkSimulatorBuildSettings.cs
+++ b/com.unity.netcode.gameobjects/Editor/Simulator/Settings/NetworkSimulatorBuildSettings.cs
@@ -1,0 +1,169 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.Build;
+
+namespace Unity.Netcode.Editor
+{
+    /// <summary>
+    /// Methods to control whether the Network Simulator is included in the build.
+    /// When making automated builds of your project, you can use this to dynamically
+    /// control whether the simulator is included in release or development builds.
+    /// </summary>
+    public class NetworkSimulatorBuildSettings
+    {
+        internal static IReadOnlyList<NamedBuildTarget> k_AllBuildTargets => new List<NamedBuildTarget>
+        {
+            NamedBuildTarget.Android,
+            NamedBuildTarget.CloudRendering,
+            NamedBuildTarget.EmbeddedLinux,
+            NamedBuildTarget.iOS,
+            NamedBuildTarget.NintendoSwitch,
+            NamedBuildTarget.PS4,
+
+            // For some reason BuildTarget.PS5 is defined but NamedBuildTarget.PS5 isn't
+            // (as of 2021.2.3f1)
+            NamedBuildTarget.FromBuildTargetGroup(BuildTargetGroup.PS5),
+
+            NamedBuildTarget.Server,
+            NamedBuildTarget.Stadia,
+            NamedBuildTarget.Standalone,
+            NamedBuildTarget.tvOS,
+            NamedBuildTarget.WebGL,
+            NamedBuildTarget.WindowsStoreApps,
+            NamedBuildTarget.XboxOne,
+        };
+
+        // NOTE: These top four public, parameterless methods are needed because our CI can only call
+        // methods that are public and parameterless (not even optional parameters are allowed).
+
+        /// <summary>
+        /// Enables the Network Simulator in development builds for all build targets
+        /// </summary>
+        public static void EnableInDevelopForAllBuildTargets()
+        {
+            SetSymbolForAllBuildTargets(NetworkSimulatorBuildSymbol.DisableInDevelop, false);
+        }
+
+        /// <summary>
+        /// Disables the Network Simulator in development builds for all build targets
+        /// </summary>
+        public static void DisableInDevelopForAllBuildTargets()
+        {
+            SetSymbolForAllBuildTargets(NetworkSimulatorBuildSymbol.DisableInDevelop, true);
+        }
+
+        /// <summary>
+        /// Enables the Network Simulator in release builds for all build targets
+        /// </summary>
+        public static void EnableInReleaseForAllBuildTargets()
+        {
+            SetSymbolForAllBuildTargets(NetworkSimulatorBuildSymbol.EnableInRelease, true);
+        }
+
+        /// <summary>
+        /// Disables the Network Simulator in release builds for all build targets
+        /// </summary>
+        public static void DisableInReleaseForAllBuildTargets()
+        {
+            SetSymbolForAllBuildTargets(NetworkSimulatorBuildSymbol.EnableInRelease, false);
+        }
+
+        /// Adds the symbol to the build target
+        static void AddSymbolToBuildTarget(
+            NamedBuildTarget buildTarget,
+            NetworkSimulatorBuildSymbol symbol)
+        {
+            var symbolString = symbol.GetBuildSymbolString();
+            PlayerSettings.GetScriptingDefineSymbols(buildTarget, out string[] defines);
+            if (!defines.Contains(symbolString))
+            {
+                PlayerSettings.SetScriptingDefineSymbols(
+                    buildTarget,
+                    defines.Append(symbolString).ToArray());
+            }
+        }
+
+        /// Removes the symbol from the build target
+        static void RemoveSymbolFromBuildTarget(
+            NamedBuildTarget buildTarget,
+            NetworkSimulatorBuildSymbol symbol)
+        {
+            var symbolString = symbol.GetBuildSymbolString();
+            PlayerSettings.GetScriptingDefineSymbols(buildTarget, out string[] symbols);
+            if (symbols.Contains(symbolString))
+            {
+                var symbolsExcludingNetSimEnable = symbols
+                    .Where(scriptingSymbol => scriptingSymbol != symbolString)
+                    .ToArray();
+                PlayerSettings.SetScriptingDefineSymbols(buildTarget, symbolsExcludingNetSimEnable);
+            }
+        }
+
+        /// Enables or disables the symbol in the build target
+        static void SetSymbolForBuildTarget(
+            NamedBuildTarget buildTarget,
+            NetworkSimulatorBuildSymbol symbol,
+            bool enabled)
+        {
+            if (enabled)
+            {
+                AddSymbolToBuildTarget(buildTarget, symbol);
+            }
+            else
+            {
+                RemoveSymbolFromBuildTarget(buildTarget, symbol);
+            }
+        }
+
+        /// Returns true if the symbol is defined in the build targets
+        static bool GetSymbolInBuildTarget(
+            NamedBuildTarget buildTarget,
+            NetworkSimulatorBuildSymbol symbol)
+        {
+            PlayerSettings.GetScriptingDefineSymbols(buildTarget, out string[] defines);
+            return defines.Contains(symbol.GetBuildSymbolString());
+        }
+
+        /// Adds the symbol to all build targets
+        internal static void AddSymbolToAllBuildTargets(NetworkSimulatorBuildSymbol symbol)
+        {
+            foreach (var buildTarget in k_AllBuildTargets)
+            {
+                AddSymbolToBuildTarget(buildTarget, symbol);
+            }
+        }
+
+        /// Removes the symbol from all build targets
+        internal static void RemoveSymbolFromAllBuildTargets(NetworkSimulatorBuildSymbol symbol)
+        {
+            foreach (var buildTarget in k_AllBuildTargets)
+            {
+                RemoveSymbolFromBuildTarget(buildTarget, symbol);
+            }
+        }
+
+        /// Enables or disables the symbol in all build targets
+        internal static void SetSymbolForAllBuildTargets(
+            NetworkSimulatorBuildSymbol symbol,
+            bool enabled)
+        {
+            foreach (var buildTarget in k_AllBuildTargets)
+            {
+                SetSymbolForBuildTarget(buildTarget, symbol, enabled);
+            }
+        }
+
+        /// Returns true if the symbol is defined in all build targets
+        internal static bool GetSymbolInAllBuildTargets(NetworkSimulatorBuildSymbol symbol)
+        {
+            return k_AllBuildTargets.All(target => GetSymbolInBuildTarget(target, symbol));
+        }
+
+        /// Returns true if the symbol is defined in any build targets
+        internal static bool GetEnabledForAnyBuildTargets(NetworkSimulatorBuildSymbol symbol)
+        {
+            return k_AllBuildTargets.Any(target => GetSymbolInBuildTarget(target, symbol));
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Editor/Simulator/Settings/NetworkSimulatorBuildSettings.cs.meta
+++ b/com.unity.netcode.gameobjects/Editor/Simulator/Settings/NetworkSimulatorBuildSettings.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9f0f38f9f20b475390badd5237f146c1
+timeCreated: 1657554900

--- a/com.unity.netcode.gameobjects/Editor/Simulator/Settings/NetworkSimulatorBuildSymbol.cs
+++ b/com.unity.netcode.gameobjects/Editor/Simulator/Settings/NetworkSimulatorBuildSymbol.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace Unity.Netcode.Editor
+{
+    internal enum NetworkSimulatorBuildSymbol
+    {
+        None,
+
+        /// This is phrased as a negative so that the default state (not defined) matches the
+        /// desired default behaviour (inclusion in develop builds)
+        DisableInDevelop,
+
+        EnableInRelease,
+
+        /// By adding this scripting define symbol users can override our build logic and
+        /// forcibly enable the Network Simulator in both development and release. This option takes
+        /// precedence over DisableInDevelop
+        OverrideEnabled,
+    }
+
+    internal static class NetworkSimulatorBuildSymbolStrings
+    {
+        public const string k_DisableInDevelop = "UNITY_MP_TOOLS_NETSIM_DISABLED_IN_DEVELOP";
+        public const string k_EnableInRelease  = "UNITY_MP_TOOLS_NETSIM_ENABLED_IN_RELEASE";
+        public const string k_OverrideEnabled  = "UNITY_MP_TOOLS_NETSIM_ENABLED";
+    }
+
+    internal static class NetworkSimulatorBuildSymbolExtensions
+    {
+        public static string GetBuildSymbolString(this NetworkSimulatorBuildSymbol symbol)
+        {
+            switch (symbol)
+            {
+                case NetworkSimulatorBuildSymbol.None:
+                    return "";
+                case NetworkSimulatorBuildSymbol.DisableInDevelop:
+                    return NetworkSimulatorBuildSymbolStrings.k_DisableInDevelop;
+                case NetworkSimulatorBuildSymbol.EnableInRelease:
+                    return NetworkSimulatorBuildSymbolStrings.k_EnableInRelease;
+                case NetworkSimulatorBuildSymbol.OverrideEnabled:
+                    return NetworkSimulatorBuildSymbolStrings.k_OverrideEnabled;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(symbol), symbol, null);
+            }
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Editor/Simulator/Settings/NetworkSimulatorBuildSymbol.cs.meta
+++ b/com.unity.netcode.gameobjects/Editor/Simulator/Settings/NetworkSimulatorBuildSymbol.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7b06b7dda994478da3ce36b7090ce37b
+timeCreated: 1657554254

--- a/com.unity.netcode.gameobjects/Tests/Editor/Simulator.meta
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Simulator.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6cec65b79fd143d782837943cd3940c4
+timeCreated: 1657560931

--- a/com.unity.netcode.gameobjects/Tests/Editor/Simulator/NetworkSimulatorBuildSettingsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Simulator/NetworkSimulatorBuildSettingsTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Unity.Netcode.Editor;
+using UnityEditor;
+using UnityEditor.Build;
+
+namespace Unity.Netcode.EditorTests.Simulator
+{
+    [TestFixture]
+    [Explicit("Running these tests modifies compile flags and can trigger a recompile, " +
+        "so should only be run when needed. " +
+        "They are also pretty simple so don't need to be run at a all times.")]
+    public class NetworkSimulatorBuildSettingsTests
+    {
+        private readonly IReadOnlyList<NetworkSimulatorBuildSymbol> k_AllBuildSymbols = new List<NetworkSimulatorBuildSymbol>()
+        {
+            NetworkSimulatorBuildSymbol.DisableInDevelop,
+            NetworkSimulatorBuildSymbol.EnableInRelease
+        };
+
+        readonly Dictionary<NamedBuildTarget, string[]> m_BuildSettingsPerTarget
+            = new Dictionary<NamedBuildTarget, string[]>();
+
+        [OneTimeSetUp]
+        public void SaveScriptingDefineSymbols()
+        {
+            m_BuildSettingsPerTarget.Clear();
+            foreach (var target in NetworkSimulatorBuildSettings.k_AllBuildTargets)
+            {
+                PlayerSettings.GetScriptingDefineSymbols(target, out string[] symbols);
+                m_BuildSettingsPerTarget[target] = symbols;
+            }
+        }
+
+        [OneTimeTearDown]
+        public void RestoreScriptingDefineSymbols()
+        {
+            foreach (var (target, symbols) in m_BuildSettingsPerTarget)
+            {
+                PlayerSettings.SetScriptingDefineSymbols(target, symbols);
+            }
+        }
+
+        [Test]
+        public void When_NetworkSimulatorSymbolIsEnabled_ItIsEnabled()
+        {
+            foreach (var symbol in k_AllBuildSymbols)
+            {
+                NetworkSimulatorBuildSettings.AddSymbolToAllBuildTargets(symbol);
+                Assert.IsTrue(NetworkSimulatorBuildSettings.GetEnabledForAnyBuildTargets(symbol));
+                Assert.IsTrue(NetworkSimulatorBuildSettings.GetSymbolInAllBuildTargets(symbol));
+            }
+        }
+
+        [Test]
+        public void When_NetworkSimulatorSymbolIsDisabled_ItIsDisabled()
+        {
+            foreach (var symbol in k_AllBuildSymbols)
+            {
+                NetworkSimulatorBuildSettings.RemoveSymbolFromAllBuildTargets(symbol);
+                Assert.IsFalse(NetworkSimulatorBuildSettings.GetEnabledForAnyBuildTargets(symbol));
+                Assert.IsFalse(NetworkSimulatorBuildSettings.GetSymbolInAllBuildTargets(symbol));
+            }
+        }
+
+        [Test]
+        public void When_NetworkSimulatorIsEnabledThenDisabled_ItIsDisabled()
+        {
+            foreach (var symbol in k_AllBuildSymbols)
+            {
+                NetworkSimulatorBuildSettings.AddSymbolToAllBuildTargets(symbol);
+                NetworkSimulatorBuildSettings.RemoveSymbolFromAllBuildTargets(symbol);
+
+                Assert.IsFalse(NetworkSimulatorBuildSettings.GetEnabledForAnyBuildTargets(symbol));
+                Assert.IsFalse(NetworkSimulatorBuildSettings.GetSymbolInAllBuildTargets(symbol));
+            }
+        }
+
+        [Test]
+        public void When_NetworkSimulatorIsEnabledThenDisabledThenEnabled_ItIsEnabled()
+        {
+            foreach (var symbol in k_AllBuildSymbols)
+            {
+                NetworkSimulatorBuildSettings.AddSymbolToAllBuildTargets(symbol);
+                NetworkSimulatorBuildSettings.RemoveSymbolFromAllBuildTargets(symbol);
+                NetworkSimulatorBuildSettings.AddSymbolToAllBuildTargets(symbol);
+
+                Assert.IsTrue(NetworkSimulatorBuildSettings.GetEnabledForAnyBuildTargets(symbol));
+                Assert.IsTrue(NetworkSimulatorBuildSettings.GetSymbolInAllBuildTargets(symbol));
+            }
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Editor/Simulator/NetworkSimulatorBuildSettingsTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Simulator/NetworkSimulatorBuildSettingsTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 439e9a76e0454647b430b6d93a7056e7
+timeCreated: 1657560948


### PR DESCRIPTION
This adds build arguments and build symbols to include the network simulator when building through CI or command line builds.

MTT-3997

## Testing and Documentation

- Includes unit tests.
