### PR TITLE
fix: m_ListAtLastReset and dynamically spawned objects

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
-## [1.0.1] - 
+## [Unreleased]
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,6 +10,10 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+### Fixed
+
+- "NetworkLists not populating on client". NetworkList now uses the most recent list as opposed to the list at the end of previous frame, when sending full updates to dynamically spawned NetworkObject. The difference in behaviour is required as scene management spawns those objects at a different time in the frame, relative to updates. (#2062)
+
 - Changed version to 1.0.0. (#2046)
 
 ## [1.0.0-pre.10] - 2022-06-21

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,7 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- "NetworkLists not populating on client". NetworkList now uses the most recent list as opposed to the list at the end of previous frame, when sending full updates to dynamically spawned NetworkObject. The difference in behaviour is required as scene management spawns those objects at a different time in the frame, relative to updates. (#2062)
+- Fixed NetworkLists not populating on client. NetworkList now uses the most recent list as opposed to the list at the end of previous frame, when sending full updates to dynamically spawned NetworkObject. The difference in behaviour is required as scene management spawns those objects at a different time in the frame, relative to updates. (#2062)
 
 ## [1.0.0] - 2022-06-27
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,13 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
-## [1.0.0] - 2022-06-27
+## [1.0.1] - 
 
 ### Changed
 
 ### Fixed
 
 - "NetworkLists not populating on client". NetworkList now uses the most recent list as opposed to the list at the end of previous frame, when sending full updates to dynamically spawned NetworkObject. The difference in behaviour is required as scene management spawns those objects at a different time in the frame, relative to updates. (#2062)
+
+## [1.0.0] - 2022-06-27
+
+### Changed
 
 - Changed version to 1.0.0. (#2046)
 

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -122,10 +122,26 @@ namespace Unity.Netcode
         /// <inheritdoc />
         public override void WriteField(FastBufferWriter writer)
         {
-            writer.WriteValueSafe((ushort)m_ListAtLastReset.Length);
-            for (int i = 0; i < m_ListAtLastReset.Length; i++)
+            // The listAtLastReset mechanism was put in place to deal with duplicate adds
+            // upon initial spawn. However, it causes issues with in-scene placed objects
+            // due to difference in spawn order. In order to address this, we pick the right
+            // list based on the type of object.
+            bool isSceneObject = m_NetworkBehaviour.NetworkObject.IsSceneObject != false;
+            if (isSceneObject)
             {
-                NetworkVariableSerialization<T>.Write(writer, ref m_ListAtLastReset.ElementAt(i));
+                writer.WriteValueSafe((ushort)m_ListAtLastReset.Length);
+                for (int i = 0; i < m_ListAtLastReset.Length; i++)
+                {
+                    NetworkVariableSerialization<T>.Write(writer, ref m_ListAtLastReset.ElementAt(i));
+                }
+            }
+            else
+            {
+                writer.WriteValueSafe((ushort)m_List.Length);
+                for (int i = 0; i < m_List.Length; i++)
+                {
+                    NetworkVariableSerialization<T>.Write(writer, ref m_List.ElementAt(i));
+                }
             }
         }
 


### PR DESCRIPTION
Limiting the use of the m_ListAtLastReset to cases where we have an in-scene placed object. Addresses consistency issues in NetworkList for spawned objects. Addresses #2062 and https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/1983 Jira: [MTT-4085](https://jira.unity3d.com/browse/MTT-4085) and [MTT-4089](https://jira.unity3d.com/browse/MTT-4089)

Uses the `m_ListAtLastReset` of `NetworkList` only for in-scene placed object. Uses the normal `m_List` for spawned objects.

