### PR TITLE
fix: previous value was not set correctly when changing the element o…

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -436,13 +436,15 @@ namespace Unity.Netcode
             get => m_List[index];
             set
             {
+                var previousValue = m_List[index];
                 m_List[index] = value;
 
                 var listEvent = new NetworkListEvent<T>()
                 {
                     Type = NetworkListEvent<T>.EventType.Value,
                     Index = index,
-                    Value = value
+                    Value = value,
+                    PreviousValue = previousValue
                 };
 
                 HandleAddListEvent(listEvent);


### PR DESCRIPTION
…f a NetworkList.

This fixes an issue were the previous value of an item of a NetworkList was not properly set in the NetworkListEvent struct when using the indexer of the NetworkList. The problem only existed on the server as the replicated clients would correctly derive the previous value themselves.
<!-- Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

## Changelog

- Fixed: previous value was not set correctly when changing the element of a NetworkList

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.