### PR TITLE
fix: correctly setting PreviousValue when changing the element of NetworkList

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -14,6 +14,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 - Fixed NetworkLists not populating on client. NetworkList now uses the most recent list as opposed to the list at the end of previous frame, when sending full updates to dynamically spawned NetworkObject. The difference in behaviour is required as scene management spawns those objects at a different time in the frame, relative to updates. (#2062)
 
+- Fixed NetworkList Value event on the server. PreviousValue is now set correctly. (#2067)
+
 ## [1.0.0] - 2022-06-27
 
 ### Changed

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -14,7 +14,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 - Fixed NetworkLists not populating on client. NetworkList now uses the most recent list as opposed to the list at the end of previous frame, when sending full updates to dynamically spawned NetworkObject. The difference in behaviour is required as scene management spawns those objects at a different time in the frame, relative to updates. (#2062)
 
-- Fixed NetworkList Value event on the server. PreviousValue is now set correctly. (#2067)
+- Fixed NetworkList Value event on the server. PreviousValue is now set correctly when a new value is set through property setter. (#2067)
 
 ## [1.0.0] - 2022-06-27
 

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -436,13 +436,15 @@ namespace Unity.Netcode
             get => m_List[index];
             set
             {
+                var previousValue = m_List[index];
                 m_List[index] = value;
 
                 var listEvent = new NetworkListEvent<T>()
                 {
                     Type = NetworkListEvent<T>.EventType.Value,
                     Index = index,
-                    Value = value
+                    Value = value,
+                    PreviousValue = previousValue
                 };
 
                 HandleAddListEvent(listEvent);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ListChangedTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ListChangedTest.cs
@@ -30,8 +30,12 @@ namespace Unity.Netcode.RuntimeTests
             return null;
         }
 
+        public NetworkList<int> MyNetworkList = new NetworkList<int>();
+
         public override void OnNetworkSpawn()
         {
+            MyNetworkList.OnListChanged += Changed;
+
             if (NetworkManager.LocalClientId == ClientIdToTarget)
             {
                 ClientTargetedNetworkObjects.Add(this);
@@ -46,14 +50,6 @@ namespace Unity.Netcode.RuntimeTests
                 ClientTargetedNetworkObjects.Remove(this);
             }
             base.OnNetworkDespawn();
-        }
-
-        public NetworkList<int> MyNetworkList;
-
-        private void Start()
-        {
-            MyNetworkList = new NetworkList<int>();
-            MyNetworkList.OnListChanged += Changed;
         }
 
         public void Changed(NetworkListEvent<int> listEvent)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ListChangedTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ListChangedTest.cs
@@ -1,7 +1,4 @@
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 using Unity.Netcode.TestHelpers.Runtime;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ListChangedTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ListChangedTest.cs
@@ -1,0 +1,131 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Unity.Netcode.TestHelpers.Runtime;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    public class NetworkListChangedTestComponent : NetworkBehaviour
+    {
+
+    }
+
+    public class ListChangedObject : NetworkBehaviour
+    {
+        public static List<ListChangedObject> ClientTargetedNetworkObjects = new List<ListChangedObject>();
+        public static ulong ClientIdToTarget;
+
+        public static NetworkObject GetNetworkObjectById(ulong networkObjectId)
+        {
+            foreach (var entry in ClientTargetedNetworkObjects)
+            {
+                if (entry.NetworkObjectId == networkObjectId)
+                {
+                    return entry.NetworkObject;
+                }
+            }
+            return null;
+        }
+
+        public override void OnNetworkSpawn()
+        {
+            if (NetworkManager.LocalClientId == ClientIdToTarget)
+            {
+                ClientTargetedNetworkObjects.Add(this);
+            }
+            base.OnNetworkSpawn();
+        }
+
+        public override void OnNetworkDespawn()
+        {
+            if (ClientTargetedNetworkObjects.Contains(this))
+            {
+                ClientTargetedNetworkObjects.Remove(this);
+            }
+            base.OnNetworkDespawn();
+        }
+
+        public NetworkList<int> MyNetworkList;
+
+        private void Start()
+        {
+            MyNetworkList = new NetworkList<int>();
+            MyNetworkList.OnListChanged += Changed;
+        }
+
+        public void Changed(NetworkListEvent<int> listEvent)
+        {
+            Debug.Log($"listEvent.Type is {listEvent.Type}");
+        }
+    }
+
+    public class NetworkListChangedTests : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 2;
+
+        private ulong m_ClientId0;
+        private GameObject m_PrefabToSpawn;
+
+        private NetworkObject m_NetSpawnedObject1;
+        private NetworkObject m_NetSpawnedObject2;
+        private NetworkObject m_NetSpawnedObject3;
+        private NetworkObject m_Object1OnClient0;
+        private NetworkObject m_Object2OnClient0;
+        private NetworkObject m_Object3OnClient0;
+
+        protected override void OnCreatePlayerPrefab()
+        {
+            var networkTransform = m_PlayerPrefab.AddComponent<NetworkListChangedTestComponent>();
+        }
+
+        protected override void OnServerAndClientsCreated()
+        {
+            m_PrefabToSpawn = CreateNetworkObjectPrefab("ListChangedObject");
+            m_PrefabToSpawn.AddComponent<ListChangedObject>();
+        }
+
+        private bool RefreshNetworkObjects()
+        {
+            m_Object1OnClient0 = ListChangedObject.GetNetworkObjectById(m_NetSpawnedObject1.NetworkObjectId);
+            m_Object2OnClient0 = ListChangedObject.GetNetworkObjectById(m_NetSpawnedObject2.NetworkObjectId);
+            m_Object3OnClient0 = ListChangedObject.GetNetworkObjectById(m_NetSpawnedObject3.NetworkObjectId);
+            if (m_Object1OnClient0 == null || m_Object2OnClient0 == null || m_Object3OnClient0 == null)
+            {
+                return false;
+            }
+            Assert.True(m_Object1OnClient0.NetworkManagerOwner == m_ClientNetworkManagers[0]);
+            Assert.True(m_Object2OnClient0.NetworkManagerOwner == m_ClientNetworkManagers[0]);
+            Assert.True(m_Object3OnClient0.NetworkManagerOwner == m_ClientNetworkManagers[0]);
+            return true;
+        }
+
+
+        [UnityTest]
+        public IEnumerator NetworkListChangedTest()
+        {
+            m_ClientId0 = m_ClientNetworkManagers[0].LocalClientId;
+            ListChangedObject.ClientTargetedNetworkObjects.Clear();
+            ListChangedObject.ClientIdToTarget = m_ClientId0;
+
+            // create 3 objects
+            var spawnedObject1 = SpawnObject(m_PrefabToSpawn, m_ServerNetworkManager);
+            var spawnedObject2 = SpawnObject(m_PrefabToSpawn, m_ServerNetworkManager);
+            var spawnedObject3 = SpawnObject(m_PrefabToSpawn, m_ServerNetworkManager);
+            m_NetSpawnedObject1 = spawnedObject1.GetComponent<NetworkObject>();
+            m_NetSpawnedObject2 = spawnedObject2.GetComponent<NetworkObject>();
+            m_NetSpawnedObject3 = spawnedObject3.GetComponent<NetworkObject>();
+
+            // get the NetworkObject on a client instance
+            yield return WaitForConditionOrTimeOut(RefreshNetworkObjects);
+            AssertOnTimeout($"Could not refresh all NetworkObjects!");
+
+            m_NetSpawnedObject1.GetComponent<ListChangedObject>().MyNetworkList.Add(42);
+            m_NetSpawnedObject1.GetComponent<ListChangedObject>().MyNetworkList[0] = 44;
+
+            // todo
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ListChangedTest.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ListChangedTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b269e2a059f814075a737691bc02afa4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This change makes it so that the PreviousValue is correctly set when changing the element of NetworkList, on the server-side notification.

From user-submitted (#2067)

## Testing and Documentation

ListChangedTest.cs has been added
