### PR TITLE
fix: NetworkAnimator does not unsubscribe to OnClientConnectedCallback [MTT-4080]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,7 +11,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where NetworkAnimator was not removing its subscription from OnClientConnectedCallback when despawned during the shutdown sequence. As well, IsServer and IsClient will still be valid properties to check when any NetworkObject is despawned during the shutdown sequence. (#2074)
+- Fixed issue where NetworkAnimator was not removing its subscription from OnClientConnectedCallback when despawned during the shutdown sequence. (#2074)
+- Fixed IsServer and IsClient being set to false before object despawn during the shutdown sequence. (#2074)
 - Fixed NetworkLists not populating on client. NetworkList now uses the most recent list as opposed to the list at the end of previous frame, when sending full updates to dynamically spawned NetworkObject. The difference in behaviour is required as scene management spawns those objects at a different time in the frame, relative to updates. (#2062)
 - Fixed NetworkList Value event on the server. PreviousValue is now set correctly when a new value is set through property setter. (#2067)
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,7 +11,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where NetworkAnimator was not unsubscribing from OnClientConnectedCallback when despawned.
+- Fixed issue where NetworkAnimator was not removing its subscription from OnClientConnectedCallback when despawned during the shutdown sequence. As well, IsServer and IsClient will still be valid properties to check when any NetworkObject is despawned during the shutdown sequence. (#2074)
 - Fixed NetworkLists not populating on client. NetworkList now uses the most recent list as opposed to the list at the end of previous frame, when sending full updates to dynamically spawned NetworkObject. The difference in behaviour is required as scene management spawns those objects at a different time in the frame, relative to updates. (#2062)
 - Fixed NetworkList Value event on the server. PreviousValue is now set correctly when a new value is set through property setter. (#2067)
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -5,15 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
-
 ## [Unreleased]
 
 ### Changed
 
 ### Fixed
 
+- Fixed issue where NetworkAnimator was not unsubscribing from OnClientConnectedCallback when despawned.
 - Fixed NetworkLists not populating on client. NetworkList now uses the most recent list as opposed to the list at the end of previous frame, when sending full updates to dynamically spawned NetworkObject. The difference in behaviour is required as scene management spawns those objects at a different time in the frame, relative to updates. (#2062)
-
 - Fixed NetworkList Value event on the server. PreviousValue is now set correctly when a new value is set through property setter. (#2067)
 
 ## [1.0.0] - 2022-06-27

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1384,6 +1384,19 @@ namespace Unity.Netcode
             }
 
             IsConnectedClient = false;
+
+            // We need to clean up NetworkObjects before we reset the IsServer
+            // and IsClient properties. This provides consistency of these two
+            // property values for NetworkObjects that are still spawned when
+            // the shutdown cycle begins.
+            if (SpawnManager != null)
+            {
+                SpawnManager.DespawnAndDestroyNetworkObjects();
+                SpawnManager.ServerResetShudownStateForSceneObjects();
+
+                SpawnManager = null;
+            }
+
             IsServer = false;
             IsClient = false;
 
@@ -1404,14 +1417,6 @@ namespace Unity.Netcode
             if (NetworkConfig?.NetworkTransport != null)
             {
                 NetworkConfig.NetworkTransport.OnTransportEvent -= HandleRawTransportPoll;
-            }
-
-            if (SpawnManager != null)
-            {
-                SpawnManager.DespawnAndDestroyNetworkObjects();
-                SpawnManager.ServerResetShudownStateForSceneObjects();
-
-                SpawnManager = null;
             }
 
             if (DeferredMessageManager != null)

--- a/testproject/Assets/Tests/Runtime/Animation/AnimatorTestHelper.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/AnimatorTestHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using Unity.Netcode;
@@ -49,8 +50,14 @@ namespace TestProject.RuntimeTests
             base.OnNetworkSpawn();
         }
 
+        public Action<bool, bool> OnCheckIsServerIsClient;
+
         public override void OnNetworkDespawn()
         {
+            // This verifies the issue where IsServer and IsClient were
+            // being reset prior to NetworkObjects being despawned during
+            // the shutdown period.
+            OnCheckIsServerIsClient?.Invoke(IsServer, IsClient);
             if (ClientSideInstances.ContainsKey(NetworkManager.LocalClientId))
             {
                 ClientSideInstances.Remove(NetworkManager.LocalClientId);

--- a/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
@@ -456,17 +456,6 @@ namespace TestProject.RuntimeTests
             // Wait for the server and client to start and connect
             yield return WaitForClientsConnectedOrTimeOut();
 
-            // Spawn the same prefab again
-            objectInstance = SpawnPrefab(false, AuthoritativeMode.ServerAuth);
-            networkObjectInstance = objectInstance.GetComponent<NetworkObject>();
-
-            // Wait for it to spawn server-side
-            yield return WaitForConditionOrTimeOut(() => AnimatorTestHelper.ServerSideInstance != null);
-            AssertOnTimeout($"[Second Spawn] Timed out waiting for the  server-side instance of {GetNetworkAnimatorName(AuthoritativeMode.ServerAuth)} to be spawned!");
-
-            // Wait for it to spawn client-side
-            yield return WaitForConditionOrTimeOut(WaitForClientsToInitialize);
-            AssertOnTimeout($"[Second Spawn] Timed out waiting for the client-side instance of {GetNetworkAnimatorName(AuthoritativeMode.ServerAuth)} to be spawned!");
             VerboseDebug($" ++++++++++++++++++ Disconnect-Reconnect Server Test Stopping ++++++++++++++++++ ");
         }
 


### PR DESCRIPTION
This resolves the issue where a NetworkBehaviour component would not be able to determine if it was a client or server when its associated NetworkObject is despawned during the shutdown sequence.

[MTT-4080](https://jira.unity3d.com/browse/MTT-4080)
Fixes #2044 

## Changelog
- Fixed issue where NetworkAnimator was not removing its subscription from OnClientConnectedCallback when despawned during the shutdown sequence. As well, IsServer and IsClient will still be valid properties to check when any NetworkObject is despawned during the shutdown sequence.

## Testing and Documentation
- Includes integration validation test.

