### PR TITLE
fix: NetworkAnimator fails to synchronize end of animation loop for late joining clients [MTT-4060]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,7 +10,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Changed
 
 ### Fixed
-- Fixed issue where `NetworkAnimator` would not synchronize a looping animation for late joining clients if it was at the very end of its loop.
+- Fixed issue where `NetworkAnimator` would not synchronize a looping animation for late joining clients if it was at the very end of its loop. (#2076)
 - Fixed issue where `NetworkAnimator` was not removing its subscription from `OnClientConnectedCallback` when despawned during the shutdown sequence. (#2074)
 - Fixed IsServer and IsClient being set to false before object despawn during the shutdown sequence. (#2074)
 - Fixed NetworkLists not populating on client. NetworkList now uses the most recent list as opposed to the list at the end of previous frame, when sending full updates to dynamically spawned NetworkObject. The difference in behaviour is required as scene management spawns those objects at a different time in the frame, relative to updates. (#2062)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,8 +10,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Changed
 
 ### Fixed
-
-- Fixed issue where NetworkAnimator was not removing its subscription from OnClientConnectedCallback when despawned during the shutdown sequence. (#2074)
+- Fixed issue where `NetworkAnimator` would not synchronize a looping animation for late joining clients if it was at the very end of its loop.
+- Fixed issue where `NetworkAnimator` was not removing its subscription from `OnClientConnectedCallback` when despawned during the shutdown sequence. (#2074)
 - Fixed IsServer and IsClient being set to false before object despawn during the shutdown sequence. (#2074)
 - Fixed NetworkLists not populating on client. NetworkList now uses the most recent list as opposed to the list at the end of previous frame, when sending full updates to dynamically spawned NetworkObject. The difference in behaviour is required as scene management spawns those objects at a different time in the frame, relative to updates. (#2062)
 - Fixed NetworkList Value event on the server. PreviousValue is now set correctly when a new value is set through property setter. (#2067)

--- a/com.unity.netcode.gameobjects/Components/AssemblyInfo.cs
+++ b/com.unity.netcode.gameobjects/Components/AssemblyInfo.cs
@@ -5,6 +5,6 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Unity.Netcode.Editor.CodeGen")]
 [assembly: InternalsVisibleTo("Unity.Netcode.Editor")]
 [assembly: InternalsVisibleTo("TestProject.EditorTests")]
-[assembly: InternalsVisibleTo("TestProject.RuntimeTests")]
 #endif
+[assembly: InternalsVisibleTo("TestProject.RuntimeTests")]
 [assembly: InternalsVisibleTo("Unity.Netcode.RuntimeTests")]

--- a/com.unity.netcode.gameobjects/Components/AssemblyInfo.cs
+++ b/com.unity.netcode.gameobjects/Components/AssemblyInfo.cs
@@ -5,6 +5,6 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Unity.Netcode.Editor.CodeGen")]
 [assembly: InternalsVisibleTo("Unity.Netcode.Editor")]
 [assembly: InternalsVisibleTo("TestProject.EditorTests")]
-#endif
 [assembly: InternalsVisibleTo("TestProject.RuntimeTests")]
+#endif
 [assembly: InternalsVisibleTo("Unity.Netcode.RuntimeTests")]

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -424,11 +424,6 @@ namespace Unity.Netcode.Components
 
                     stateHash = nextState.fullPathHash;
                 }
-                else
-                if (st.normalizedTime >= adjustedNormalizedMaxTime)
-                {
-                    continue;
-                }
 
                 var animMsg = new AnimationMessage
                 {

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -378,11 +378,6 @@ namespace Unity.Netcode.Components
         }
 
         /// <summary>
-        /// Used for testing late join animation synchronization.
-        /// </summary>
-        internal Action<AnimationMessage> InternalNotifyAnimationMessage;
-
-        /// <summary>
         /// Synchronizes newly joined players
         /// </summary>
         internal void ServerSynchronizeNewPlayer(ulong playerId)
@@ -439,9 +434,6 @@ namespace Unity.Netcode.Components
                 };
                 // Server always send via client RPC
                 SendAnimStateClientRpc(animMsg, m_ClientRpcParams);
-
-                // For integration test tracking purposes
-                InternalNotifyAnimationMessage?.Invoke(animMsg);
             }
         }
 
@@ -841,8 +833,6 @@ namespace Unity.Netcode.Components
             var isServerAuthoritative = IsServerAuthoritative();
             if (!isServerAuthoritative && !IsOwner || isServerAuthoritative)
             {
-                // For integration test tracking purposes
-                InternalNotifyAnimationMessage?.Invoke(animSnapshot);
                 UpdateAnimationState(animSnapshot);
             }
         }

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -1,4 +1,5 @@
 #if COM_UNITY_MODULES_ANIMATION
+using System;
 using System.Collections.Generic;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
@@ -150,7 +151,6 @@ namespace Unity.Netcode.Components
             NetworkUpdateLoop.RegisterNetworkUpdate(this, NetworkUpdateStage.PreUpdate);
         }
     }
-
 
 
     /// <summary>
@@ -378,6 +378,11 @@ namespace Unity.Netcode.Components
         }
 
         /// <summary>
+        /// Used for testing late join animation synchronization.
+        /// </summary>
+        internal Action<AnimationMessage> InternalNotifyAnimationMessage;
+
+        /// <summary>
         /// Synchronizes newly joined players
         /// </summary>
         internal void ServerSynchronizeNewPlayer(ulong playerId)
@@ -434,6 +439,9 @@ namespace Unity.Netcode.Components
                 };
                 // Server always send via client RPC
                 SendAnimStateClientRpc(animMsg, m_ClientRpcParams);
+
+                // For integration test tracking purposes
+                InternalNotifyAnimationMessage?.Invoke(animMsg);
             }
         }
 
@@ -833,6 +841,8 @@ namespace Unity.Netcode.Components
             var isServerAuthoritative = IsServerAuthoritative();
             if (!isServerAuthoritative && !IsOwner || isServerAuthoritative)
             {
+                // For integration test tracking purposes
+                InternalNotifyAnimationMessage?.Invoke(animSnapshot);
                 UpdateAnimationState(animSnapshot);
             }
         }

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -1,5 +1,4 @@
 #if COM_UNITY_MODULES_ANIMATION
-using System;
 using System.Collections.Generic;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
@@ -151,6 +150,7 @@ namespace Unity.Netcode.Components
             NetworkUpdateLoop.RegisterNetworkUpdate(this, NetworkUpdateStage.PreUpdate);
         }
     }
+
 
 
     /// <summary>

--- a/testproject/Assets/Tests/Manual/NetworkAnimatorTests/CubeAnimatorController.controller
+++ b/testproject/Assets/Tests/Manual/NetworkAnimatorTests/CubeAnimatorController.controller
@@ -1,5 +1,82 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1101 &-9076771464115044414
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: LateJoinTest
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -8870587575130706737}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &-8870587575130706737
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: LateJoinSync
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 2097057606729455931}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 0dbf24ad942a3ef4e8045f46b378d431, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &-7881886588344925529
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: LateJoinTest
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 0}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &-6396453490711135124
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -244,21 +321,21 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: -1676030328622575462}
-    m_Position: {x: 290, y: 10, z: 0}
+    m_Position: {x: 290, y: 0, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 6353332194479835970}
-    m_Position: {x: 350, y: -150, z: 0}
+    m_Position: {x: 290, y: -150, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 2733578584814225138}
-    m_Position: {x: 180, y: 190, z: 0}
+    m_Position: {x: 290, y: 180, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
-  m_AnyStatePosition: {x: 50, y: 20, z: 0}
-  m_EntryPosition: {x: 420, y: 160, z: 0}
-  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_AnyStatePosition: {x: 540, y: 0, z: 0}
+  m_EntryPosition: {x: 20, y: 10, z: 0}
+  m_ExitPosition: {x: 540, y: 70, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: -1676030328622575462}
 --- !u!91 &9100000
@@ -306,6 +383,12 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 9100000}
+  - m_Name: LateJoinTest
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -328,6 +411,18 @@ AnimatorController:
     m_BlendingMode: 0
     m_SyncedLayerIndex: -1
     m_DefaultWeight: 0.5
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}
+  - serializedVersion: 5
+    m_Name: LateJoingSyncLayer
+    m_StateMachine: {fileID: 7987549579817906310}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 1
     m_IKPass: 0
     m_SyncedLayerAffectsTiming: 0
     m_Controller: {fileID: 9100000}
@@ -400,6 +495,31 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &2097057606729455931
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: LateJoinTest
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 5205197960406981613}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.5
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &2733578584814225138
 AnimatorState:
   serializedVersion: 6
@@ -467,6 +587,33 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1102 &5205197960406981613
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: New State
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -9076771464115044414}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: TestFloat
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!114 &5559889042091692034
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -531,3 +678,28 @@ AnimatorStateMachine:
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: -1607953088454488810}
+--- !u!1107 &7987549579817906310
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: LateJoingSyncLayer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: 5205197960406981613}
+    m_Position: {x: 450, y: 110, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -8870587575130706737}
+    m_Position: {x: 450, y: -20, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 50, y: 120, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: 5205197960406981613}

--- a/testproject/Assets/Tests/Manual/NetworkAnimatorTests/CubeAnimatorController.controller
+++ b/testproject/Assets/Tests/Manual/NetworkAnimatorTests/CubeAnimatorController.controller
@@ -37,7 +37,8 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 2097057606729455931}
-  m_StateMachineBehaviours: []
+  m_StateMachineBehaviours:
+  - {fileID: 4108346256824837128}
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
@@ -227,6 +228,18 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!114 &-1766406323300068053
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 768f2c827b02cc240a588a902e6bbdba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1102 &-1676030328622575462
 AnimatorState:
   serializedVersion: 6
@@ -240,7 +253,8 @@ AnimatorState:
   m_Transitions:
   - {fileID: -4282378417640754704}
   - {fileID: 1678733063235620591}
-  m_StateMachineBehaviours: []
+  m_StateMachineBehaviours:
+  - {fileID: 6706570197837314945}
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
@@ -267,7 +281,8 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -6396453490711135124}
-  m_StateMachineBehaviours: []
+  m_StateMachineBehaviours:
+  - {fileID: -1261272140589342921}
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
@@ -282,6 +297,18 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!114 &-1261272140589342921
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 768f2c827b02cc240a588a902e6bbdba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1102 &-338501773749300249
 AnimatorState:
   serializedVersion: 6
@@ -560,6 +587,30 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dec8cf4a19a8ef745ae0440ec04911ae, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &3735381422868909868
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 768f2c827b02cc240a588a902e6bbdba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4108346256824837128
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 768f2c827b02cc240a588a902e6bbdba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1102 &4311160535506449488
 AnimatorState:
   serializedVersion: 6
@@ -572,7 +623,8 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 1830534497079063084}
-  m_StateMachineBehaviours: []
+  m_StateMachineBehaviours:
+  - {fileID: 3735381422868909868}
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
   m_WriteDefaultValues: 0
@@ -599,7 +651,8 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -9076771464115044414}
-  m_StateMachineBehaviours: []
+  m_StateMachineBehaviours:
+  - {fileID: -1766406323300068053}
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
@@ -653,6 +706,18 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!114 &6706570197837314945
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 768f2c827b02cc240a588a902e6bbdba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1107 &7599406000257451018
 AnimatorStateMachine:
   serializedVersion: 6

--- a/testproject/Assets/Tests/Manual/NetworkAnimatorTests/Cube_Contolled_Rotation.anim
+++ b/testproject/Assets/Tests/Manual/NetworkAnimatorTests/Cube_Contolled_Rotation.anim
@@ -1,0 +1,199 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Cube_Contolled_Rotation
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.5
+        value: {x: 0, y: 180, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: 
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 4
+      script: {fileID: 0}
+      typeID: 4
+      customType: 4
+      isPPtrCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.5
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.5
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: localEulerAnglesRaw.x
+    path: 
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.5
+        value: 180
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: localEulerAnglesRaw.y
+    path: 
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.5
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: localEulerAnglesRaw.z
+    path: 
+    classID: 4
+    script: {fileID: 0}
+  m_EulerEditorCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve: []
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalEulerAngles.x
+    path: 
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve: []
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalEulerAngles.y
+    path: 
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve: []
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalEulerAngles.z
+    path: 
+    classID: 4
+    script: {fileID: 0}
+  m_HasGenericRootTransform: 1
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/testproject/Assets/Tests/Manual/NetworkAnimatorTests/Cube_Contolled_Rotation.anim.meta
+++ b/testproject/Assets/Tests/Manual/NetworkAnimatorTests/Cube_Contolled_Rotation.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0dbf24ad942a3ef4e8045f46b378d431
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/testproject/Assets/Tests/Runtime/Animation/AnimatorTestHelper.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/AnimatorTestHelper.cs
@@ -13,6 +13,7 @@ namespace TestProject.RuntimeTests
         public readonly static Dictionary<ulong, AnimatorTestHelper> ClientSideInstances = new Dictionary<ulong, AnimatorTestHelper>();
 
         public static bool IsTriggerTest;
+        public static bool IsLateJoinSyncTest;
 
         public static void Initialize()
         {
@@ -27,6 +28,13 @@ namespace TestProject.RuntimeTests
         {
             m_Animator = GetComponent<Animator>();
             m_NetworkAnimator = GetComponent<NetworkAnimator>();
+            m_NetworkAnimator.InternalNotifyAnimationMessage = NotifyAnimSync;
+        }
+
+        internal List<NetworkAnimator.AnimationMessage> AnimationMessages = new List<NetworkAnimator.AnimationMessage>();
+        private void NotifyAnimSync(NetworkAnimator.AnimationMessage animationMessage)
+        {
+            AnimationMessages.Add(animationMessage);
         }
 
         public override void OnNetworkSpawn()
@@ -35,6 +43,9 @@ namespace TestProject.RuntimeTests
             {
                 Debug.Log($"[AnimatorTestHelper][{IsServer}] {NetworkManager.name}");
             }
+
+            m_Animator = GetComponent<Animator>();
+            m_NetworkAnimator = GetComponent<NetworkAnimator>();
             if (IsServer)
             {
                 ServerSideInstance = this;
@@ -108,6 +119,16 @@ namespace TestProject.RuntimeTests
         public void SetTrigger(string name = "TestTrigger")
         {
             m_NetworkAnimator.SetTrigger(name);
+        }
+
+        public void SetLateJoinParam(bool isEnabled)
+        {
+            m_Animator.SetBool("LateJoinTest", isEnabled);
+        }
+
+        public Animator GetAnimator()
+        {
+            return m_Animator;
         }
     }
 }

--- a/testproject/Assets/Tests/Runtime/Animation/AnimatorTestHelper.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/AnimatorTestHelper.cs
@@ -13,7 +13,6 @@ namespace TestProject.RuntimeTests
         public readonly static Dictionary<ulong, AnimatorTestHelper> ClientSideInstances = new Dictionary<ulong, AnimatorTestHelper>();
 
         public static bool IsTriggerTest;
-        public static bool IsLateJoinSyncTest;
 
         public static void Initialize()
         {

--- a/testproject/Assets/Tests/Runtime/Animation/AnimatorTestHelper.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/AnimatorTestHelper.cs
@@ -28,13 +28,6 @@ namespace TestProject.RuntimeTests
         {
             m_Animator = GetComponent<Animator>();
             m_NetworkAnimator = GetComponent<NetworkAnimator>();
-            m_NetworkAnimator.InternalNotifyAnimationMessage = NotifyAnimSync;
-        }
-
-        internal List<NetworkAnimator.AnimationMessage> AnimationMessages = new List<NetworkAnimator.AnimationMessage>();
-        private void NotifyAnimSync(NetworkAnimator.AnimationMessage animationMessage)
-        {
-            AnimationMessages.Add(animationMessage);
         }
 
         public override void OnNetworkSpawn()

--- a/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
@@ -468,7 +468,7 @@ namespace TestProject.RuntimeTests
                 Assert.True(StateSyncTest.StatesEntered.ContainsKey(m_ServerNetworkManager.LocalClientId), $"Server does not have an entry for layer {i}!");
                 var animationStateInfo = serverAnimator.GetCurrentAnimatorStateInfo(i);
                 StateSyncTest.StatesEntered[m_ServerNetworkManager.LocalClientId][i] = animationStateInfo;
-                VerboseDebug($"[{i}][STATE-REFRESH][{m_ServerNetworkManager.name}] updated state normalized time when late joined client connected to {animationStateInfo.normalizedTime}!");
+                VerboseDebug($"[{i}][STATE-REFRESH][{m_ServerNetworkManager.name}] updated state normalized time ({animationStateInfo.normalizedTime}) to compare with late joined client.");
             }
         }
 

--- a/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
@@ -409,11 +409,11 @@ namespace TestProject.RuntimeTests
             yield return WaitForConditionOrTimeOut(WaitForClientsToInitialize);
             AssertOnTimeout($"Timed out waiting for the client-side instance of {GetNetworkAnimatorName(authoritativeMode)} to be spawned!");
 
-            // Set the trigger based on the type of test
+            // Set the late join parameter based on the type of test
             if (authoritativeMode == AuthoritativeMode.OwnerAuth)
             {
                 var objectToUpdate = ownerShipMode == OwnerShipMode.ClientOwner ? AnimatorTestHelper.ClientSideInstances[m_ClientNetworkManagers[0].LocalClientId] : AnimatorTestHelper.ServerSideInstance;
-                // Set the animation trigger via the owner
+                // Set the late join parameter via the owner
                 objectToUpdate.SetLateJoinParam(true);
             }
             else
@@ -446,6 +446,7 @@ namespace TestProject.RuntimeTests
             yield return WaitForConditionOrTimeOut(() => Mathf.Approximately(lateJoinObjectInstance.transform.rotation.eulerAngles.y, 180.0f));
             AssertOnTimeout($"[Late Join] Timed out waiting for cube to reach 180.0f!");
 
+            // Validate the fix by making sure the late joining client was synchronized to the server's Animator's states
             yield return WaitForConditionOrTimeOut(LateJoinClientSynchronized);
             AssertOnTimeout("[Late Join] Timed out waiting for newly joined client to have expected state synchronized!");
 

--- a/testproject/Assets/Tests/Runtime/Animation/StateSyncTest.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/StateSyncTest.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using UnityEngine;
+using Unity.Netcode;
+
+public class StateSyncTest : StateMachineBehaviour
+{
+    public static Dictionary<ulong, List<AnimatorStateInfo>> StatesEntered = new Dictionary<ulong, List<AnimatorStateInfo>>();
+    public static bool IsVerboseDebug;
+    public static void ResetTest()
+    {
+        StatesEntered.Clear();
+        IsVerboseDebug = false;
+    }
+
+    // OnStateEnter is called when a transition starts and the state machine starts to evaluate this state
+    // This provides us with the exact AnimatorStateInfo applied when a SendAnimStateClientRpc is received
+    // and applied.
+    override public void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    {
+        var networkObject = animator.GetComponent<NetworkObject>();
+        if (networkObject == null || networkObject.NetworkManager == null)
+        {
+            return;
+        }
+
+        var clientId = networkObject.NetworkManager.LocalClientId;
+        if (!StatesEntered.ContainsKey(clientId))
+        {
+            StatesEntered.Add(clientId, new List<AnimatorStateInfo>());
+        }
+
+        if (IsVerboseDebug)
+        {
+            Debug.Log($"[{layerIndex}][STATE-ENTER][{clientId}] {networkObject.NetworkManager.name} state entered!");
+        }
+    }
+}

--- a/testproject/Assets/Tests/Runtime/Animation/StateSyncTest.cs.meta
+++ b/testproject/Assets/Tests/Runtime/Animation/StateSyncTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 768f2c827b02cc240a588a902e6bbdba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/testproject/Assets/Tests/Runtime/Animation/TriggerTest.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/TriggerTest.cs
@@ -6,7 +6,7 @@ public class TriggerTest : StateMachineBehaviour
 {
     public static List<ulong> ClientsThatTriggered = new List<ulong>();
     public static bool IsVerboseDebug;
-    public static void Reset()
+    public static void ResetTest()
     {
         ClientsThatTriggered.Clear();
         ClientsThatResetTrigger.Clear();


### PR DESCRIPTION
This resolves the issue where NetworkAnimator didn't properly synchronize late joining clients when a looping animation state was at the end of its loop.

[MTT-4060](https://jira.unity3d.com/browse/MTT-4060)
Based on Github Issue #2056

## Changelog
- Fixed issue where `NetworkAnimator` would not synchronize a looping animation for late joining clients if it was at the very end of its loop.

## Testing and Documentation
- Includes integration validation test.

## Additional Notes:
The assets updated are required for the test.