### PR TITLE
fix: add exception for IsOwner/IsLocalPlayer at inappropriate times

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -15,6 +15,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed IsServer and IsClient being set to false before object despawn during the shutdown sequence. (#2074)
 - Fixed NetworkLists not populating on client. NetworkList now uses the most recent list as opposed to the list at the end of previous frame, when sending full updates to dynamically spawned NetworkObject. The difference in behaviour is required as scene management spawns those objects at a different time in the frame, relative to updates. (#2062)
 - Fixed NetworkList Value event on the server. PreviousValue is now set correctly when a new value is set through property setter. (#2067)
+- Added exception thrown when `NetworkBehaviour.IsOwner` or `.IsLocalPlayer`  is called at inappropriate times, such as before spawning an object. (#982)
 
 ## [1.0.0] - 2022-06-27
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -260,16 +260,40 @@ namespace Unity.Netcode
         /// </summary>
         public NetworkManager NetworkManager => NetworkObject.NetworkManager;
 
+        private bool m_IsLocalPlayer;
         /// <summary>
         /// If a NetworkObject is assigned, it will return whether or not this NetworkObject
         /// is the local player object.  If no NetworkObject is assigned it will always return false.
         /// </summary>
-        public bool IsLocalPlayer { get; private set; }
+        public bool IsLocalPlayer
+        {
+            get
+            {
+                if (!NetworkObject.IsSpawned)
+                {
+                    throw new Exception($"{nameof(IsLocalPlayer)} can only be used on spawned objects.");
+                }
+                return m_IsLocalPlayer;
+            }
+            private set { m_IsLocalPlayer = value; }
+        }
 
+        private bool m_IsOwner = false;
         /// <summary>
         /// Gets if the object is owned by the local player or if the object is the local player object
         /// </summary>
-        public bool IsOwner { get; internal set; }
+        public bool IsOwner
+        {
+            get
+            {
+                if (!NetworkObject.IsSpawned)
+                {
+                    throw new Exception($"{nameof(IsOwner)} can only be used on spawned objects.");
+                }
+                return m_IsOwner;
+            }
+            internal set { m_IsOwner = value; }
+        }
 
         /// <summary>
         /// Gets if we are executing as server
@@ -440,9 +464,9 @@ namespace Unity.Netcode
 
         internal void InternalOnNetworkDespawn()
         {
-            IsSpawned = false;
             UpdateNetworkProperties();
             OnNetworkDespawn();
+            IsSpawned = false;
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
@@ -256,10 +256,10 @@ namespace Unity.Netcode.RuntimeTests
 
             protected override void Update()
             {
-                CanCommitToTransform = IsOwner;
                 base.Update();
-                if (NetworkManager.Singleton != null && (NetworkManager.Singleton.IsConnectedClient || NetworkManager.Singleton.IsListening))
+                if (IsSpawned)
                 {
+                    CanCommitToTransform = IsOwner;
                     if (CanCommitToTransform)
                     {
                         TryCommitTransformToServer(transform, NetworkManager.LocalTime.Time);


### PR DESCRIPTION
Added exception thrown when `NetworkBehaviour.IsOwner` or `.IsLocalPlayer`  is called at inappropriate times, such as before spawning an object. (#982)

MTT-3460
