### PR TITLE
feat: Allow reliable sends to go over maximum payload size

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -9,6 +9,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+- When using `UnityTransport`, _reliable_ payloads are now allowed to exceed the configured 'Max Payload Size'. Unreliable payloads remain bounded by this limit.
+
 ### Fixed
 
 - Fixed issue where NetworkAnimator was not removing its subscription from OnClientConnectedCallback when despawned during the shutdown sequence. (#2074)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -9,7 +9,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
-- When using `UnityTransport`, _reliable_ payloads are now allowed to exceed the configured 'Max Payload Size'. Unreliable payloads remain bounded by this limit.
+- When using `UnityTransport`, _reliable_ payloads are now allowed to exceed the configured 'Max Payload Size'. Unreliable payloads remain bounded by this setting. (#2081)
 
 ### Fixed
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
@@ -457,5 +457,26 @@ namespace Unity.Netcode.RuntimeTests
 
             yield return null;
         }
+
+        [UnityTest]
+        public IEnumerator ReliablePayloadsCanBeLargerThanMaximum()
+        {
+            InitializeTransport(out m_Server, out m_ServerEvents);
+            InitializeTransport(out m_Client1, out m_Client1Events);
+
+            m_Server.StartServer();
+            m_Client1.StartClient();
+
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_Client1Events);
+
+            var payloadSize = UnityTransport.InitialMaxPayloadSize + 1;
+            var data = new ArraySegment<byte>(new byte[payloadSize]);
+
+            m_Server.Send(m_Client1.ServerClientId, data, NetworkDelivery.Reliable);
+
+            yield return WaitForNetworkEvent(NetworkEvent.Data, m_Client1Events);
+
+            yield return null;
+        }
     }
 }


### PR DESCRIPTION
The 'Max Payload Size' setting in `UnityTransport` determines the largest payload that can be sent in a single `Send` call. Internally, we use this value to configure the fragmentation limit in UTP's fragmentation pipeline stage. This pipeline stage is only used for unreliable traffic, though. Fragmentation of reliable traffic is done directly in the send/receive queues inside `UnityTransport`.

So technically, reliable payload size is not bound by that 'Max Payload Size' limit (it's bound by 'Max Send Queue Size' instead). Still, `UnityTransport.Send` would reject reliable sends larger than 'Max Payload Size' to remain consistent with the unreliable behavior. This PR changes this behavior and now allows reliable sends to go over the configured maximum payload size.

The reason for this change is that it's now apparent (from browsing Discord and the forums) that tweaking this maximum payload size limit is a source of friction for users. Since most traffic in NGO is reliable, this PR will make it look to most users as if the limit doesn't exist. (Remains the issue of having to tweak the 'Max Send Queue Size', but solving that is a bit more complicated.)

## Changelog

- Changed: When using `UnityTransport`, _reliable_ payloads are now allowed to exceed the configured 'Max Payload Size'. Unreliable payloads remain bounded by this setting.

## Testing and Documentation

- Includes unit/integration test.
- No documentation changes or additions were necessary.