### PR TITLE
Updating the network events api during runtime to make sure we have a valid API

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/Simulator/NetworkEventsView.cs
+++ b/com.unity.netcode.gameobjects/Editor/Simulator/NetworkEventsView.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using UnityEditor;
+using UnityEngine;
 using UnityEngine.UIElements;
 
 namespace Unity.Netcode.Editor
@@ -12,11 +13,12 @@ namespace Unity.Netcode.Editor
         Button LagSpikeButton => this.Q<Button>(nameof(LagSpikeButton));
         SliderInt LagSpikeDurationSlider => this.Q<SliderInt>(nameof(LagSpikeDurationSlider));
 
-        readonly INetworkEventsApi m_NetworkEventsApi;
+        INetworkEventsApi m_NetworkEventsApi;
+        readonly NetworkSimulator m_NetworkSimulator;
 
-        public NetworkEventsView(INetworkEventsApi networkEventsApi)
+        public NetworkEventsView(NetworkSimulator networkSimulator)
         {
-            m_NetworkEventsApi = networkEventsApi;
+            m_NetworkSimulator = networkSimulator;
 
             AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(UXML).CloneTree(this);
             LagSpikeButton.SetEnabled(LagSpikeDurationSlider.value != 0);
@@ -65,6 +67,7 @@ namespace Unity.Netcode.Editor
 
         void OnEditorUpdate()
         {
+            m_NetworkEventsApi = m_NetworkSimulator.NetworkEventsApi;
             DisconnectButton.text = m_NetworkEventsApi.IsDisabledBySimulator
                 ? "Re-enable Connection"
                 : "Disable Connection";

--- a/com.unity.netcode.gameobjects/Editor/Simulator/NetworkSimulatorEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/Simulator/NetworkSimulatorEditor.cs
@@ -13,11 +13,11 @@ namespace Unity.Netcode.Editor
         public override VisualElement CreateInspectorGUI()
         {
             m_NetworkSimulator = (NetworkSimulator)target;
-            
+
             m_Inspector = new VisualElement();
-            m_Inspector.Add(new NetworkEventsView(m_NetworkSimulator.NetworkEventsApi));
+            m_Inspector.Add(new NetworkEventsView(m_NetworkSimulator));
             m_Inspector.Add(new NetworkTypeView(serializedObject, m_NetworkSimulator));
-            
+
             return m_Inspector;
         }
     }


### PR DESCRIPTION
Depending on when the NetworkEventsView gets created, there's a change we have a NoOpNetworkEventsAPI instead of the correct one. Updating it during the runtime later on allows to make sure we have the proper API.

MTT-4123

- No tests have been added.
