### PR TITLE
fix: Nested NetworkBehaviours don't de-register or Invoke OnNetworkDespawn if destroyed while the parent NetworkObject remains spawned [NCCBUG-137]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -13,7 +13,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where destroying `GameObject`, with an attached NetworkBehaviour component, that was a child or any child generation of the assigned `NetworkObject` component's `GameObject` would not deregister with the NetworkObject nor would it have its OnNetworkSpawn method invoked.
+- Fixed issue where destroying `GameObject`, with an attached NetworkBehaviour component, that was a child or any child generation of the assigned `NetworkObject` component's `GameObject` would not deregister with the NetworkObject nor would it have its OnNetworkSpawn method invoked. (#2091)
 - Fixed issue where `NetworkObject.NetworkHide` was despawning and destroying, as opposed to only despawning, in-scene placed `NetworkObject`s. (#2086)
 - Fixed issue where `NetworkAnimator` would not synchronize a looping animation for late joining clients if it was at the very end of its loop. (#2076)
 - Fixed issue where `NetworkAnimator` was not removing its subscription from `OnClientConnectedCallback` when despawned during the shutdown sequence. (#2074)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -15,7 +15,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Fixed
 
 - Fixed issue when attempting to spawn a parent `GameObject`, with `NetworkObject` component attached, that has one or more child `GameObject`s, that are inactive in the hierarchy, with `NetworkBehaviour` components it will no longer attempt to spawn the associated NetworkBehaviour(s) or invoke ownership changed notifications but will log a warning message. (#2096)
-- Fixed issue where destroying `GameObject`, with an attached NetworkBehaviour component, that was a child or any child generation of the assigned `NetworkObject` component's `GameObject` would not deregister with the NetworkObject nor would it have its OnNetworkSpawn method invoked. (#2091)
+- Fixed an issue where destroying a NetworkBehaviour would not deregister it from the parent NetworkObject, leading to exceptions when the parent was later destroyed. (#2091)
 - Fixed issue where `NetworkObject.NetworkHide` was despawning and destroying, as opposed to only despawning, in-scene placed `NetworkObject`s. (#2086)
 - Fixed issue where `NetworkAnimator` would not synchronize a looping animation for late joining clients if it was at the very end of its loop. (#2076)
 - Fixed issue where `NetworkAnimator` was not removing its subscription from `OnClientConnectedCallback` when despawned during the shutdown sequence. (#2074)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - When using `UnityTransport`, _reliable_ payloads are now allowed to exceed the configured 'Max Payload Size'. Unreliable payloads remain bounded by this setting. (#2081)
 
 ### Fixed
+
+- Fixed issue where destroying `GameObject`, with an attached NetworkBehaviour component, that was a child or any child generation of the assigned `NetworkObject` component's `GameObject` would not deregister with the NetworkObject nor would it have its OnNetworkSpawn method invoked.
 - Fixed issue where `NetworkObject.NetworkHide` was despawning and destroying, as opposed to only despawning, in-scene placed `NetworkObject`s. (#2086)
 - Fixed issue where `NetworkAnimator` would not synchronize a looping animation for late joining clients if it was at the very end of its loop. (#2076)
 - Fixed issue where `NetworkAnimator` was not removing its subscription from `OnClientConnectedCallback` when despawned during the shutdown sequence. (#2074)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -331,7 +331,8 @@ namespace Unity.Netcode
                 // in Update and/or in FixedUpdate could still be checking NetworkBehaviour.NetworkObject directly (i.e. does it exist?)
                 // or NetworkBehaviour.IsSpawned (i.e. to early exit if not spawned) which, in turn, could generate several Warning messages
                 // per spawned NetworkObject.  Checking for ShutdownInProgress prevents these unnecessary LogWarning messages.
-                if (m_NetworkObject == null && (NetworkManager.Singleton == null || !NetworkManager.Singleton.ShutdownInProgress))
+                // We must check IsSpawned, otherwise a warning will be logged under certain valid conditions (see OnDestroy)
+                if (IsSpawned && m_NetworkObject == null && (NetworkManager.Singleton == null || !NetworkManager.Singleton.ShutdownInProgress))
                 {
                     if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
                     {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -760,12 +760,6 @@ namespace Unity.Netcode
         /// </summary>
         public virtual void OnDestroy()
         {
-            /// NCCBUG-135: This is a reminder to open a new ticket about
-            /// this OnDestroy method. Our current documentation already tells
-            /// users that they should always invoke the base class method if
-            /// they override this method, but in the event they forget then
-            /// this bug will still occur. Fixing that issue will potentially
-            /// require changes in how this OnDestroy method is handled.
             if (NetworkObject != null && NetworkObject.IsSpawned && IsSpawned)
             {
                 // Only under the condition that our assigned NetworkObject

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -762,15 +762,10 @@ namespace Unity.Netcode
         {
             if (NetworkObject != null && NetworkObject.IsSpawned && IsSpawned)
             {
-                // Only under the condition that our assigned NetworkObject
-                // does not share the same GameObject, then we want to notify
-                // the still spawned NetworkObject that this NetworkBehaviour
-                // is being destroyed so the NetworkObject can remove it from the
+                // If the associated NetworkObject is still spawned then this
+                // NetworkBehaviour will be removed from the NetworkObject's
                 // ChildNetworkBehaviours list.
-                if (NetworkObject.gameObject != gameObject)
-                {
-                    NetworkObject.OnNetworkBehaviourDestroyed(this);
-                }
+                NetworkObject.OnNetworkBehaviourDestroyed(this);
             }
 
             // this seems odd to do here, but in fact especially in tests we can find ourselves

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1221,27 +1221,18 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// This handles cleaning up any NetworkBehaviour attached
-        /// to a GameObject that is a child or any child generation of
-        /// the GameObject this NetworkObject component is attached to.
-        /// Note:
-        /// This will despawn the NetworkBehaviour and remove it
-        /// from the ChildNetworkBehaviours list only if:
-        /// 1.) The NetworkObject is still spawned
-        /// 2.) The NetworkBehaviour.IsSpawned property is still true
-        /// (i.e. it hasn't been despawned yet)
+        /// Removes a NetworkBehaviour from the ChildNetworkBehaviours list when destroyed
+        /// while the NetworkObject is still spawned.
         /// </summary>
         internal void OnNetworkBehaviourDestroyed(NetworkBehaviour networkBehaviour)
         {
             if (networkBehaviour.IsSpawned && IsSpawned)
             {
-                if (ChildNetworkBehaviours.Contains(networkBehaviour))
+                if (NetworkManager.LogLevel == LogLevel.Developer)
                 {
-                    // Assure the NetworkBehaviour runs through the despawn process
-                    // before removing it from the list.
-                    networkBehaviour.InternalOnNetworkDespawn();
-                    ChildNetworkBehaviours.Remove(networkBehaviour);
+                    NetworkLog.LogWarning($"{nameof(NetworkBehaviour)}-{networkBehaviour.name} is being destroyed while {nameof(NetworkObject)}-{name} is still spawned! (could break state synchronization)");
                 }
+                ChildNetworkBehaviours.Remove(networkBehaviour);
             }
         }
     }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1205,5 +1205,30 @@ namespace Unity.Netcode
 
             return GlobalObjectIdHash;
         }
+
+        /// <summary>
+        /// This handles cleaning up any NetworkBehaviour attached
+        /// to a GameObject that is a child or any child generation of
+        /// the GameObject this NetworkObject component is attached to.
+        /// Note:
+        /// This will despawn the NetworkBehaviour and remove it
+        /// from the ChildNetworkBehaviours list only if:
+        /// 1.) The NetworkObject is still spawned
+        /// 2.) The NetworkBehaviour.IsSpawned property is still true
+        /// (i.e. it hasn't been despawned yet)
+        /// </summary>
+        internal void OnNetworkBehaviourDestroyed(NetworkBehaviour networkBehaviour)
+        {
+            if (networkBehaviour.IsSpawned && IsSpawned)
+            {
+                if (ChildNetworkBehaviours.Contains(networkBehaviour))
+                {
+                    // Assure the NetworkBehaviour runs through the despawn process
+                    // before removing it from the list.
+                    networkBehaviour.InternalOnNetworkDespawn();
+                    ChildNetworkBehaviours.Remove(networkBehaviour);
+                }
+            }
+        }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
@@ -42,6 +42,9 @@ namespace Unity.Netcode.RuntimeTests
             // set the log level to developer
             m_ServerNetworkManager.LogLevel = LogLevel.Developer;
 
+            // The only valid condition for this would be if the NetworkBehaviour is spawned.
+            simpleNetworkBehaviour.IsSpawned = true;
+
             // Verify the warning gets logged under normal conditions
             var isNull = simpleNetworkBehaviour.NetworkObject == null;
             LogAssert.Expect(LogType.Warning, $"[Netcode] Could not get {nameof(NetworkObject)} for the {nameof(NetworkBehaviour)}. Are you missing a {nameof(NetworkObject)} component?");

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
@@ -38,12 +38,6 @@ namespace Unity.Netcode.RuntimeTests
             return base.OnSetup();
         }
 
-        protected override IEnumerator OnSetup()
-        {
-            m_AllowServerToStart = false;
-            return base.OnSetup();
-        }
-
         /// <summary>
         /// This validates the fix for when a child GameObject with a NetworkBehaviour
         /// is deleted while the parent GameObject with a NetworkObject is spawned and

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
@@ -131,10 +131,7 @@ namespace Unity.Netcode.RuntimeTests
             var childObject = new GameObject();
             childObject.transform.parent = parentObject.transform;
             var parentNetworkObject = parentObject.AddComponent<NetworkObject>();
-            var childNetworkBehaviour = childObject.AddComponent<SimpleNetworkBehaviour>();
-
-            // set the log level to developer
-            m_ServerNetworkManager.LogLevel = LogLevel.Developer;
+            childObject.AddComponent<SimpleNetworkBehaviour>();
 
             parentNetworkObject.Spawn();
             yield return s_DefaultWaitForTick;
@@ -143,7 +140,6 @@ namespace Unity.Netcode.RuntimeTests
             Object.Destroy(childObject);
 
             yield return s_DefaultWaitForTick;
-            Assert.IsTrue(childNetworkBehaviour.OnNetworkDespawnCalled, "Failed to invoke OnNetworkDespawn on child NetworkBehaviour!");
 
             // Assure no log messages are logged when they should not be logged
             LogAssert.NoUnexpectedReceived();

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using UnityEngine;
-using NUnit.Framework;
 using UnityEngine.TestTools;
 using Unity.Netcode.TestHelpers.Runtime;
 using Unity.Netcode.Components;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using UnityEngine;
+using NUnit.Framework;
 using UnityEngine.TestTools;
 using Unity.Netcode.TestHelpers.Runtime;
 
@@ -21,6 +22,13 @@ namespace Unity.Netcode.RuntimeTests
 
         public class SimpleNetworkBehaviour : NetworkBehaviour
         {
+            public bool OnNetworkDespawnCalled;
+
+            public override void OnNetworkDespawn()
+            {
+                OnNetworkDespawnCalled = true;
+                base.OnNetworkDespawn();
+            }
         }
 
         protected override IEnumerator OnSetup()
@@ -88,7 +96,7 @@ namespace Unity.Netcode.RuntimeTests
             var childObject = new GameObject();
             childObject.transform.parent = parentObject.transform;
             var parentNetworkObject = parentObject.AddComponent<NetworkObject>();
-            childObject.AddComponent<SimpleNetworkBehaviour>();
+            var childNetworkBehaviour = childObject.AddComponent<SimpleNetworkBehaviour>();
 
             // set the log level to developer
             m_ServerNetworkManager.LogLevel = LogLevel.Developer;
@@ -100,6 +108,8 @@ namespace Unity.Netcode.RuntimeTests
             Object.Destroy(childObject);
 
             yield return s_DefaultWaitForTick;
+            Assert.IsTrue(childNetworkBehaviour.OnNetworkDespawnCalled, "Failed to invoke OnNetworkDespawn on child NetworkBehaviour!");
+
             // Assure no log messages are logged when they should not be logged
             LogAssert.NoUnexpectedReceived();
 


### PR DESCRIPTION
This resolves the issue where destroying a GameObject with one or more NetworkBehaviour components that is a child or any child generation of the NetworkObject/GameObject that theNetworkBehaviour(s) are assigned to would still try to access the destroyed NetworkBehaviour since it was still an entry within the NetworkObject.ChildNetworkBehaviours list.  It also resolves the issue where under this scenario the NetworkBehaviours would not have their OnNetworkDespawn method invoked.

[NCCBUG-137](https://jira.unity3d.com/browse/NCCBUG-137)

## Changelog

- Fixed issue where destroying `GameObject`, with an attached NetworkBehaviour component, that was a child or any child generation of the assigned `NetworkObject` component's `GameObject` would not deregister with the NetworkObject nor would it have its OnNetworkSpawn method invoked.

## Testing and Documentation
- Includes integration tests. WIP
