### PR TITLE
fix: NetworkList "insert at end" bug

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -21,7 +21,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed IsServer and IsClient being set to false before object despawn during the shutdown sequence. (#2074)
 - Fixed NetworkLists not populating on client. NetworkList now uses the most recent list as opposed to the list at the end of previous frame, when sending full updates to dynamically spawned NetworkObject. The difference in behaviour is required as scene management spawns those objects at a different time in the frame, relative to updates. (#2062)
 - Fixed NetworkList Value event on the server. PreviousValue is now set correctly when a new value is set through property setter. (#2067)
-- Fixed NetworkList issue that showed when inserting at the very end of a NetworkList
+- Fixed NetworkList issue that showed when inserting at the very end of a NetworkList (#2099)
 
 ## [1.0.0] - 2022-06-27
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -21,6 +21,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed IsServer and IsClient being set to false before object despawn during the shutdown sequence. (#2074)
 - Fixed NetworkLists not populating on client. NetworkList now uses the most recent list as opposed to the list at the end of previous frame, when sending full updates to dynamically spawned NetworkObject. The difference in behaviour is required as scene management spawns those objects at a different time in the frame, relative to updates. (#2062)
 - Fixed NetworkList Value event on the server. PreviousValue is now set correctly when a new value is set through property setter. (#2067)
+- Fixed NetworkList issue that showed when inserting at the very end of a NetworkList
 
 ## [1.0.0] - 2022-06-27
 

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -196,8 +196,16 @@ namespace Unity.Netcode
                         {
                             reader.ReadValueSafe(out int index);
                             NetworkVariableSerialization<T>.Read(reader, out T value);
-                            m_List.InsertRangeWithBeginEnd(index, index + 1);
-                            m_List[index] = value;
+
+                            if (index < m_List.Length)
+                            {
+                                m_List.InsertRangeWithBeginEnd(index, index + 1);
+                                m_List[index] = value;
+                            }
+                            else
+                            {
+                                m_List.Add(value);
+                            }
 
                             if (OnListChanged != null)
                             {
@@ -419,8 +427,15 @@ namespace Unity.Netcode
         /// <inheritdoc />
         public void Insert(int index, T item)
         {
-            m_List.InsertRangeWithBeginEnd(index, index + 1);
-            m_List[index] = item;
+            if (index < m_List.Length)
+            {
+                m_List.InsertRangeWithBeginEnd(index, index + 1);
+                m_List[index] = item;
+            }
+            else
+            {
+                m_List.Add(item);
+            }
 
             var listEvent = new NetworkListEvent<T>()
             {


### PR DESCRIPTION
NetworkList using NativeList<T>.Add() instead of InsertRangeWithBeginEnd when inserting at end of container

Reported:
https://discord.com/channels/449263083769036810/994598309647888504/1002543855335374891

## Changelog

- Fixed NetworkList issue that showed when inserting at the very end of a NetworkList
