### PR TITLE
Using the standard scripting symbol generated by player settings

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Simulator/INetworkEventsApi.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Simulator/INetworkEventsApi.cs
@@ -1,9 +1,9 @@
 ﻿// NetSim Implementation compilation boilerplate
-// All references to UNITY_MP_TOOLS_NETSIM_ENABLED should be defined in the same way,
+// All references to UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED should be defined in the same way,
 // as any discrepancies are likely to result in build failures
 // ---------------------------------------------------------------------------------------------------------------------
 #if UNITY_EDITOR || ((DEVELOPMENT_BUILD && !UNITY_MP_TOOLS_NETSIM_DISABLED_IN_DEVELOP) || (!DEVELOPMENT_BUILD && UNITY_MP_TOOLS_NETSIM_ENABLED_IN_RELEASE))
-    #define UNITY_MP_TOOLS_NETSIM_ENABLED
+    #define UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
 #endif
 // ---------------------------------------------------------------------------------------------------------------------
 
@@ -59,21 +59,21 @@ namespace Unity.Netcode
 
     public class NetworkEventsApi : INetworkEventsApi
     {
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
         readonly NetworkSimulator m_NetworkSimulator;
         readonly UnityTransport m_UnityTransport;
 #endif
 
         public NetworkEventsApi(NetworkSimulator networkSimulator, UnityTransport unityTransport)
         {
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             m_NetworkSimulator = networkSimulator;
             m_UnityTransport = unityTransport;
 #endif
         }
 
         public bool IsDisabledBySimulator
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             => m_UnityTransport.IsDisabledBySimulator;
 #else
             => false;
@@ -81,21 +81,21 @@ namespace Unity.Netcode
 
         public void TriggerDisconnect()
         {
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             m_UnityTransport.TriggerDisconnect();
 #endif
         }
 
         public void TriggerReconnect()
         {
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             m_UnityTransport.TriggerReconnect();
 #endif
         }
 
         public void TriggerLagSpike(TimeSpan duration)
         {
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             Task.Run(async () =>
             {
                 TriggerDisconnect();
@@ -109,7 +109,7 @@ namespace Unity.Netcode
 
         public void ChangeNetworkType(INetworkSimulatorConfiguration newNetworkSimulatorConfiguration)
         {
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             m_NetworkSimulator.SimulatorConfiguration = newNetworkSimulatorConfiguration;
 #endif
         }

--- a/com.unity.netcode.gameobjects/Runtime/Simulator/INetworkSimulatorScenario.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Simulator/INetworkSimulatorScenario.cs
@@ -1,13 +1,13 @@
 // NetSim Implementation compilation boilerplate
-// All references to UNITY_MP_TOOLS_NETSIM_ENABLED should be defined in the same way,
+// All references to UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED should be defined in the same way,
 // as any discrepancies are likely to result in build failures
 // ---------------------------------------------------------------------------------------------------------------------
 #if UNITY_EDITOR || ((DEVELOPMENT_BUILD && !UNITY_MP_TOOLS_NETSIM_DISABLED_IN_DEVELOP) || (!DEVELOPMENT_BUILD && UNITY_MP_TOOLS_NETSIM_ENABLED_IN_RELEASE))
-#define UNITY_MP_TOOLS_NETSIM_ENABLED
+#define UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
 #endif
 // ---------------------------------------------------------------------------------------------------------------------
 
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
 
 using System;
 using System.Threading;

--- a/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkScenario.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkScenario.cs
@@ -1,13 +1,13 @@
 // NetSim Implementation compilation boilerplate
-// All references to UNITY_MP_TOOLS_NETSIM_ENABLED should be defined in the same way,
+// All references to UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED should be defined in the same way,
 // as any discrepancies are likely to result in build failures
 // ---------------------------------------------------------------------------------------------------------------------
 #if UNITY_EDITOR || ((DEVELOPMENT_BUILD && !UNITY_MP_TOOLS_NETSIM_DISABLED_IN_DEVELOP) || (!DEVELOPMENT_BUILD && UNITY_MP_TOOLS_NETSIM_ENABLED_IN_RELEASE))
-    #define UNITY_MP_TOOLS_NETSIM_ENABLED
+    #define UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
 #endif
 // ---------------------------------------------------------------------------------------------------------------------
 
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
 
 using System;
 using System.Collections;
@@ -50,15 +50,15 @@ namespace Unity.Netcode
             {
                 yield return null;
             }
-            
+
             NetworkSimulatorScenario.Start(NetworkSimulatorSimulator.NetworkEventsApi);
         }
-        
+
         void OnDestroy()
         {
             NetworkSimulatorScenario?.Dispose();
         }
-        
+
         void Update()
         {
             if (NetworkSimulatorScenario is INetworkSimulatorScenarioUpdateHandler updatableSimulator)

--- a/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulator.cs
@@ -1,9 +1,9 @@
 // NetSim Implementation compilation boilerplate
-// All references to UNITY_MP_TOOLS_NETSIM_ENABLED should be defined in the same way,
+// All references to UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED should be defined in the same way,
 // as any discrepancies are likely to result in build failures
 // ---------------------------------------------------------------------------------------------------------------------
 #if UNITY_EDITOR || ((DEVELOPMENT_BUILD && !UNITY_MP_TOOLS_NETSIM_DISABLED_IN_DEVELOP) || (!DEVELOPMENT_BUILD && UNITY_MP_TOOLS_NETSIM_ENABLED_IN_RELEASE))
-    #define UNITY_MP_TOOLS_NETSIM_ENABLED
+    #define UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
 #endif
 // ---------------------------------------------------------------------------------------------------------------------
 
@@ -26,11 +26,11 @@ namespace Unity.Netcode
 
         [SerializeReference, HideInInspector]
         internal INetworkSimulatorConfiguration m_ConfigurationReference = new NetworkSimulatorConfiguration();
-        
+
         INetworkEventsApi m_NetworkEventsApi;
 
         internal INetworkEventsApi NetworkEventsApi => m_NetworkEventsApi ??= new NoOpNetworkEventsApi();
-        
+
         internal bool IsInitialized { get; private set; }
 
         public INetworkSimulatorConfiguration SimulatorConfiguration
@@ -48,7 +48,7 @@ namespace Unity.Netcode
                 {
                     m_ConfigurationReference = value;
                 }
-                
+
                 UpdateLiveParameters();
                 OnPropertyChanged();
             }
@@ -56,7 +56,7 @@ namespace Unity.Netcode
 
         public void UpdateLiveParameters()
         {
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             if (!Application.isPlaying)
             {
                 return;

--- a/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulatorConfiguration.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulatorConfiguration.cs
@@ -1,9 +1,9 @@
 ﻿// NetSim Implementation compilation boilerplate
-// All references to UNITY_MP_TOOLS_NETSIM_ENABLED should be defined in the same way,
+// All references to UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED should be defined in the same way,
 // as any discrepancies are likely to result in build failures
 // ---------------------------------------------------------------------------------------------------------------------
 #if UNITY_EDITOR || ((DEVELOPMENT_BUILD && !UNITY_MP_TOOLS_NETSIM_DISABLED_IN_DEVELOP) || (!DEVELOPMENT_BUILD && UNITY_MP_TOOLS_NETSIM_ENABLED_IN_RELEASE))
-    #define UNITY_MP_TOOLS_NETSIM_ENABLED
+    #define UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
 #endif
 // ---------------------------------------------------------------------------------------------------------------------
 

--- a/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulatorConfigurationObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkSimulatorConfigurationObject.cs
@@ -1,9 +1,9 @@
 ﻿// NetSim Implementation compilation boilerplate
-// All references to UNITY_MP_TOOLS_NETSIM_ENABLED should be defined in the same way,
+// All references to UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED should be defined in the same way,
 // as any discrepancies are likely to result in build failures
 // ---------------------------------------------------------------------------------------------------------------------
 #if UNITY_EDITOR || ((DEVELOPMENT_BUILD && !UNITY_MP_TOOLS_NETSIM_DISABLED_IN_DEVELOP) || (!DEVELOPMENT_BUILD && UNITY_MP_TOOLS_NETSIM_ENABLED_IN_RELEASE))
-#define UNITY_MP_TOOLS_NETSIM_ENABLED
+#define UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
 #endif
 // ---------------------------------------------------------------------------------------------------------------------
 
@@ -89,7 +89,7 @@ namespace Unity.Netcode
             configuration.PacketLossInterval = packetLossInterval;
             configuration.PacketLossPercent = packetLossPercent;
             configuration.PacketDuplicationPercent = packetDuplicationPercent;
-            
+
             return configuration;
         }
     }

--- a/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkTypePresets.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Simulator/NetworkTypePresets.cs
@@ -1,9 +1,9 @@
 ﻿// NetSim Implementation compilation boilerplate
-// All references to UNITY_MP_TOOLS_NETSIM_ENABLED should be defined in the same way,
+// All references to UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED should be defined in the same way,
 // as any discrepancies are likely to result in build failures
 // ---------------------------------------------------------------------------------------------------------------------
 #if UNITY_EDITOR || ((DEVELOPMENT_BUILD && !UNITY_MP_TOOLS_NETSIM_DISABLED_IN_DEVELOP) || (!DEVELOPMENT_BUILD && UNITY_MP_TOOLS_NETSIM_ENABLED_IN_RELEASE))
-    #define UNITY_MP_TOOLS_NETSIM_ENABLED
+    #define UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
 #endif
 // ---------------------------------------------------------------------------------------------------------------------
 
@@ -19,67 +19,67 @@ namespace Unity.Netcode
         const string k_GoodMobileDescription = "In many places, expect this to be 'as good as' or 'better than' home broadband.";
 
         public static readonly NetworkSimulatorConfiguration None
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             = NetworkSimulatorConfiguration.Create("None", string.Empty, 0, 0, 0, 0, 0);
 #else
             = null;
 #endif
         public static readonly NetworkSimulatorConfiguration HomeBroadband
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             = NetworkSimulatorConfiguration.Create("Home Broadband [WIFI, Cable, Console, PC]", k_BroadbandDescription, 2, 2, 1, 0, 0);
 #else
             = null;
 #endif
         public static readonly NetworkSimulatorConfiguration Mobile2G
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             = NetworkSimulatorConfiguration.Create("Mobile 2G [CDMA & GSM, '00]", k_PoorMobileDescription, 400, 200, 5, 0, 0);
 #else
             = null;
 #endif
         public static readonly NetworkSimulatorConfiguration Mobile2_5G
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             = NetworkSimulatorConfiguration.Create("Mobile 2.5G [GPRS, G, '00]", k_PoorMobileDescription, 200, 100, 5, 0, 0);
 #else
             = null;
 #endif
         public static readonly NetworkSimulatorConfiguration Mobile2_75G
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             = NetworkSimulatorConfiguration.Create("Mobile 2.75G [Edge, E, '06]", k_PoorMobileDescription, 200, 100, 5, 0, 0);
 #else
             = null;
 #endif
         public static readonly NetworkSimulatorConfiguration Mobile3G
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             = NetworkSimulatorConfiguration.Create("Mobile 3G [WCDMA & UMTS, '03]", k_PoorMobileDescription, 200, 100, 5, 0, 0);
 #else
             = null;
 #endif
         public static readonly NetworkSimulatorConfiguration Mobile3_5G
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             = NetworkSimulatorConfiguration.Create("Mobile 3.5G [HSDPA, H, '06]", k_MediumMobileDescription, 75, 50, 5, 0, 0);
 #else
             = null;
 #endif
         public static readonly NetworkSimulatorConfiguration Mobile3_75G
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             = NetworkSimulatorConfiguration.Create("Mobile 3.75G [HDSDPA+, H+, '11]", k_DecentMobileDescription, 75, 50, 5, 0, 0);
 #else
             = null;
 #endif
         public static readonly NetworkSimulatorConfiguration Mobile4G
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             = NetworkSimulatorConfiguration.Create("Mobile 4G [4G, LTE, '13]", k_DecentMobileDescription, 50, 25, 3, 0, 0);
 #else
             = null;
 #endif
         public static readonly NetworkSimulatorConfiguration Mobile4_5G
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             = NetworkSimulatorConfiguration.Create("Mobile 4.5G [4G+, LTE-A, '16]", k_DecentMobileDescription, 50, 25, 3, 0, 0);
 #else
             = null;
 #endif
         public static readonly NetworkSimulatorConfiguration Mobile5G
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             = NetworkSimulatorConfiguration.Create("Mobile 5G ['20]", k_GoodMobileDescription, 1, 10, 1, 0, 0);
 #else
             = null;

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1,9 +1,9 @@
 // NetSim Implementation compilation boilerplate
-// All references to UNITY_MP_TOOLS_NETSIM_ENABLED should be defined in the same way,
+// All references to UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED should be defined in the same way,
 // as any discrepancies are likely to result in build failures
 // ---------------------------------------------------------------------------------------------------------------------
 #if UNITY_EDITOR || ((DEVELOPMENT_BUILD && !UNITY_MP_TOOLS_NETSIM_DISABLED_IN_DEVELOP) || (!DEVELOPMENT_BUILD && UNITY_MP_TOOLS_NETSIM_ENABLED_IN_RELEASE))
-    #define UNITY_MP_TOOLS_NETSIM_ENABLED
+    #define UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
 #endif
 // ---------------------------------------------------------------------------------------------------------------------
 
@@ -1142,7 +1142,7 @@ namespace Unity.Netcode.Transports.UTP
 #endif
             var maxFrameTimeMs = 0;
 
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             var configuration = GetComponent<NetworkSimulator>()?.SimulatorConfiguration;
             m_NetworkSettings.WithSimulatorStageParameters(
                 300,
@@ -1177,7 +1177,7 @@ namespace Unity.Netcode.Transports.UTP
 
             driver = NetworkDriver.Create(m_NetworkSettings);
 
-#if UNITY_EDITOR || DEVELOPMENT_BUILD || UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_EDITOR || DEVELOPMENT_BUILD || UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             if (DebugSimulator.PacketDelayMS > 0 || DebugSimulator.PacketDropRate > 0)
             {
                 unreliableFragmentedPipeline = driver.CreatePipeline(
@@ -1231,7 +1231,7 @@ namespace Unity.Netcode.Transports.UTP
             }
         }
 
-#if UNITY_MP_TOOLS_NETSIM_ENABLED
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
         public void UpdateSimulationPipelineParameters(INetworkSimulatorConfiguration configuration)
         {
             if (!m_SimulatorInitialized)


### PR DESCRIPTION
The Scripting symbol used did not match the one generated by our standard function inside tools package. Updated to match the format.

## Testing and Documentation

- No tests have been added.
