### PR TITLE
fix: NetworkTransform Bitset not being properly reset if there is no delta [MTT-4275]

### DIFF
--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -370,14 +370,17 @@ namespace Unity.Netcode.Components
         private readonly NetworkVariable<NetworkTransformState> m_ReplicatedNetworkStateOwner = new NetworkVariable<NetworkTransformState>(new NetworkTransformState(), NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
 
 
-        internal NetworkVariable<NetworkTransformState> GetReplicatedNetworkState()
+        internal NetworkVariable<NetworkTransformState> ReplicatedNetworkState
         {
-            if (!IsServerAuthoritative())
+            get
             {
-                return m_ReplicatedNetworkStateOwner;
-            }
+                if (!IsServerAuthoritative())
+                {
+                    return m_ReplicatedNetworkStateOwner;
+                }
 
-            return m_ReplicatedNetworkStateServer;
+                return m_ReplicatedNetworkStateServer;
+            }
         }
 
         private NetworkTransformState m_LocalAuthoritativeNetworkState;
@@ -484,7 +487,7 @@ namespace Unity.Netcode.Components
 
         private void CommitLocallyAndReplicate(NetworkTransformState networkState)
         {
-            GetReplicatedNetworkState().Value = networkState;
+            ReplicatedNetworkState.Value = networkState;
         }
 
         private void ResetInterpolatedStateToCurrentAuthoritativeState()
@@ -1024,7 +1027,7 @@ namespace Unity.Netcode.Components
         /// <inheritdoc/>
         public override void OnNetworkDespawn()
         {
-            GetReplicatedNetworkState().OnValueChanged -= OnNetworkStateChanged;
+            ReplicatedNetworkState.OnValueChanged -= OnNetworkStateChanged;
         }
 
         /// <inheritdoc/>
@@ -1052,7 +1055,7 @@ namespace Unity.Netcode.Components
             m_Transform = transform;
 
             CanCommitToTransform = IsServerAuthoritative() ? IsServer : IsOwner;
-            var replicatedState = GetReplicatedNetworkState();
+            var replicatedState = ReplicatedNetworkState;
             m_LocalAuthoritativeNetworkState = replicatedState.Value;
 
             if (CanCommitToTransform)
@@ -1180,7 +1183,7 @@ namespace Unity.Netcode.Components
                 ApplyTransformValues();
 
                 // Apply updated interpolated value
-                ApplyInterpolatedNetworkStateToTransform(GetReplicatedNetworkState().Value, m_Transform, serverTime.Time);
+                ApplyInterpolatedNetworkStateToTransform(ReplicatedNetworkState.Value, m_Transform, serverTime.Time);
 
                 // Always set the any new transform values to assure only the authoritative side is updating the transform
                 SetTransformValues();

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -912,13 +912,11 @@ namespace Unity.Netcode.Components
             m_CachedIsServer = IsServer;
             m_CachedNetworkManager = NetworkManager;
 
-
-            m_LocalAuthoritativeNetworkState = m_ReplicatedNetworkState.Value;
             if (CanCommitToTransform)
             {
                 TryCommitTransformToServer(m_Transform, m_CachedNetworkManager.LocalTime.Time);
             }
-
+            m_LocalAuthoritativeNetworkState = m_ReplicatedNetworkState.Value;
 
             // crucial we do this to reset the interpolators so that recycled objects when using a pool will
             //  not have leftover interpolator state from the previous object

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -406,23 +406,23 @@ namespace Unity.Netcode.Components
         }
 
         /// <summary>
-        /// Tries updating the server authoritative transform, only if allowed.
-        /// If this called server side, this will commit directly.
-        /// If no update is needed, nothing will be sent. This method should still be called every update, it'll self manage when it should and shouldn't send
+        /// Refer to <see cref="TryCommitTransform">, this is a legacy method.
         /// </summary>
-        /// <param name="transformToCommit"></param>
-        /// <param name="dirtyTime"></param>
         protected void TryCommitTransformToServer(Transform transformToCommit, double dirtyTime)
         {
             TryCommitTransform(transformToCommit, dirtyTime);
         }
 
-
+        /// <summary>
+        /// Tries updating the server authoritative transform, only if allowed.
+        /// </summary>
+        /// <param name="transformToCommit">the transform to be committed</param>
+        /// <param name="dirtyTime">time it was marked dirty</param>
         protected void TryCommitTransform(Transform transformToCommit, double dirtyTime)
         {
             if (!CanCommitToTransform)
             {
-                Debug.LogError($"[{name}] is trying to commit the transform without authority!");
+                NetworkLog.LogError($"[{name}] is trying to commit the transform without authority!");
                 return;
             }
             var isDirty = ApplyTransformToNetworkState(ref m_LocalAuthoritativeNetworkState, dirtyTime, transformToCommit);
@@ -690,9 +690,6 @@ namespace Unity.Netcode.Components
         /// from having too large of a delta time between the time it was last updated and the time any new update is
         /// sent.
         /// </remarks>
-        /// <param name="networkState">new state to apply</param>
-        /// <param name="transformToUpdate">transform to update</param>
-        /// <param name="serverTime">required to interpolate when axis is not updated in the state to apply</param>
         private void ApplyInterpolatedNetworkStateToTransform(NetworkTransformState networkState, Transform transformToUpdate, double serverTime)
         {
             var interpolatedPosition = InLocalSpace ? transformToUpdate.localPosition : transformToUpdate.position;
@@ -1060,7 +1057,7 @@ namespace Unity.Netcode.Components
 
             if (CanCommitToTransform)
             {
-                GetReplicatedNetworkState().OnValueChanged -= OnNetworkStateChanged;
+                replicatedState.OnValueChanged -= OnNetworkStateChanged;
                 TryCommitTransform(m_Transform, m_CachedNetworkManager.LocalTime.Time);
                 replicatedState.SetDirty(true);
             }
@@ -1212,7 +1209,7 @@ namespace Unity.Netcode.Components
             stateToSend.Position = newPosition;
             stateToSend.Rotation = newRotationEuler;
             stateToSend.Scale = newScale;
-            //ApplyInterpolatedNetworkStateToTransform(stateToSend, transform, m_CachedNetworkManager.ServerTime.Time);
+
             // set teleport flag in state to signal to ghosts not to interpolate
             m_LocalAuthoritativeNetworkState.IsTeleportingNextFrame = true;
 

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -681,7 +681,7 @@ namespace Unity.Netcode.Components
             // InLocalSpace Read
             InLocalSpace = networkState.InLocalSpace;
             // Position Read
-            if (networkState.HasPositionX )
+            if (networkState.HasPositionX)
             {
                 interpolatedPosition.x = networkState.IsTeleportingNextFrame || !Interpolate ? networkState.Position.x : m_PositionXInterpolator.GetInterpolatedValue();
             }

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -60,120 +60,120 @@ namespace Unity.Netcode.Components
             private const int k_ScaleYBit = 8;
             private const int k_ScaleZBit = 9;
             private const int k_TeleportingBit = 10;
-
             // 11-15: <unused>
-            internal ushort Bitset;
+
+            private ushort m_Bitset;
 
             internal bool InLocalSpace
             {
-                get => (Bitset & (1 << k_InLocalSpaceBit)) != 0;
+                get => (m_Bitset & (1 << k_InLocalSpaceBit)) != 0;
                 set
                 {
-                    if (value) { Bitset = (ushort)(Bitset | (1 << k_InLocalSpaceBit)); }
-                    else { Bitset = (ushort)(Bitset & ~(1 << k_InLocalSpaceBit)); }
+                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_InLocalSpaceBit)); }
+                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_InLocalSpaceBit)); }
                 }
             }
 
             // Position
             internal bool HasPositionX
             {
-                get => (Bitset & (1 << k_PositionXBit)) != 0;
+                get => (m_Bitset & (1 << k_PositionXBit)) != 0;
                 set
                 {
-                    if (value) { Bitset = (ushort)(Bitset | (1 << k_PositionXBit)); }
-                    else { Bitset = (ushort)(Bitset & ~(1 << k_PositionXBit)); }
+                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_PositionXBit)); }
+                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_PositionXBit)); }
                 }
             }
 
             internal bool HasPositionY
             {
-                get => (Bitset & (1 << k_PositionYBit)) != 0;
+                get => (m_Bitset & (1 << k_PositionYBit)) != 0;
                 set
                 {
-                    if (value) { Bitset = (ushort)(Bitset | (1 << k_PositionYBit)); }
-                    else { Bitset = (ushort)(Bitset & ~(1 << k_PositionYBit)); }
+                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_PositionYBit)); }
+                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_PositionYBit)); }
                 }
             }
 
             internal bool HasPositionZ
             {
-                get => (Bitset & (1 << k_PositionZBit)) != 0;
+                get => (m_Bitset & (1 << k_PositionZBit)) != 0;
                 set
                 {
-                    if (value) { Bitset = (ushort)(Bitset | (1 << k_PositionZBit)); }
-                    else { Bitset = (ushort)(Bitset & ~(1 << k_PositionZBit)); }
+                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_PositionZBit)); }
+                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_PositionZBit)); }
                 }
             }
 
             // RotAngles
             internal bool HasRotAngleX
             {
-                get => (Bitset & (1 << k_RotAngleXBit)) != 0;
+                get => (m_Bitset & (1 << k_RotAngleXBit)) != 0;
                 set
                 {
-                    if (value) { Bitset = (ushort)(Bitset | (1 << k_RotAngleXBit)); }
-                    else { Bitset = (ushort)(Bitset & ~(1 << k_RotAngleXBit)); }
+                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_RotAngleXBit)); }
+                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_RotAngleXBit)); }
                 }
             }
 
             internal bool HasRotAngleY
             {
-                get => (Bitset & (1 << k_RotAngleYBit)) != 0;
+                get => (m_Bitset & (1 << k_RotAngleYBit)) != 0;
                 set
                 {
-                    if (value) { Bitset = (ushort)(Bitset | (1 << k_RotAngleYBit)); }
-                    else { Bitset = (ushort)(Bitset & ~(1 << k_RotAngleYBit)); }
+                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_RotAngleYBit)); }
+                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_RotAngleYBit)); }
                 }
             }
 
             internal bool HasRotAngleZ
             {
-                get => (Bitset & (1 << k_RotAngleZBit)) != 0;
+                get => (m_Bitset & (1 << k_RotAngleZBit)) != 0;
                 set
                 {
-                    if (value) { Bitset = (ushort)(Bitset | (1 << k_RotAngleZBit)); }
-                    else { Bitset = (ushort)(Bitset & ~(1 << k_RotAngleZBit)); }
+                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_RotAngleZBit)); }
+                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_RotAngleZBit)); }
                 }
             }
 
             // Scale
             internal bool HasScaleX
             {
-                get => (Bitset & (1 << k_ScaleXBit)) != 0;
+                get => (m_Bitset & (1 << k_ScaleXBit)) != 0;
                 set
                 {
-                    if (value) { Bitset = (ushort)(Bitset | (1 << k_ScaleXBit)); }
-                    else { Bitset = (ushort)(Bitset & ~(1 << k_ScaleXBit)); }
+                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_ScaleXBit)); }
+                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_ScaleXBit)); }
                 }
             }
 
             internal bool HasScaleY
             {
-                get => (Bitset & (1 << k_ScaleYBit)) != 0;
+                get => (m_Bitset & (1 << k_ScaleYBit)) != 0;
                 set
                 {
-                    if (value) { Bitset = (ushort)(Bitset | (1 << k_ScaleYBit)); }
-                    else { Bitset = (ushort)(Bitset & ~(1 << k_ScaleYBit)); }
+                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_ScaleYBit)); }
+                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_ScaleYBit)); }
                 }
             }
 
             internal bool HasScaleZ
             {
-                get => (Bitset & (1 << k_ScaleZBit)) != 0;
+                get => (m_Bitset & (1 << k_ScaleZBit)) != 0;
                 set
                 {
-                    if (value) { Bitset = (ushort)(Bitset | (1 << k_ScaleZBit)); }
-                    else { Bitset = (ushort)(Bitset & ~(1 << k_ScaleZBit)); }
+                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_ScaleZBit)); }
+                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_ScaleZBit)); }
                 }
             }
 
             internal bool IsTeleportingNextFrame
             {
-                get => (Bitset & (1 << k_TeleportingBit)) != 0;
+                get => (m_Bitset & (1 << k_TeleportingBit)) != 0;
                 set
                 {
-                    if (value) { Bitset = (ushort)(Bitset | (1 << k_TeleportingBit)); }
-                    else { Bitset = (ushort)(Bitset & ~(1 << k_TeleportingBit)); }
+                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_TeleportingBit)); }
+                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_TeleportingBit)); }
                 }
             }
 
@@ -219,7 +219,7 @@ namespace Unity.Netcode.Components
             {
                 serializer.SerializeValue(ref SentTime);
                 // InLocalSpace + HasXXX Bits
-                serializer.SerializeValue(ref Bitset);
+                serializer.SerializeValue(ref m_Bitset);
                 // Position Values
                 if (HasPositionX)
                 {
@@ -414,11 +414,22 @@ namespace Unity.Netcode.Components
         /// <param name="dirtyTime"></param>
         protected void TryCommitTransformToServer(Transform transformToCommit, double dirtyTime)
         {
+            TryCommitTransform(transformToCommit, dirtyTime);
+        }
+
+
+        protected void TryCommitTransform(Transform transformToCommit, double dirtyTime)
+        {
+            if (!CanCommitToTransform)
+            {
+                Debug.LogError($"[{name}] is trying to commit the transform without authority!");
+                return;
+            }
             var isDirty = ApplyTransformToNetworkState(ref m_LocalAuthoritativeNetworkState, dirtyTime, transformToCommit);
             TryCommit(isDirty);
         }
 
-        private void TryCommitValuesToServer(Vector3 position, Vector3 rotation, Vector3 scale, double dirtyTime)
+        private void TryCommitValues(Vector3 position, Vector3 rotation, Vector3 scale, double dirtyTime)
         {
             var isDirty = ApplyTransformToNetworkStateWithInfo(ref m_LocalAuthoritativeNetworkState, dirtyTime, position, rotation, scale);
 
@@ -979,26 +990,6 @@ namespace Unity.Netcode.Components
             m_CachedIsServer = IsServer;
             m_CachedNetworkManager = NetworkManager;
 
-            CanCommitToTransform = IsServerAuthoritative() ? IsServer : IsOwner;
-
-            // must set up m_Transform in OnNetworkSpawn because it's possible an object spawns but is disabled
-            //  and thus awake won't be called.
-            // TODO: investigate further on not sending data for something that is not enabled
-            m_Transform = transform;
-
-            m_LocalAuthoritativeNetworkState = GetReplicatedNetworkState().Value;
-
-            if (CanCommitToTransform)
-            {
-                m_LastSentState = GetReplicatedNetworkState().Value;
-                TryCommitTransformToServer(m_Transform, m_CachedNetworkManager.LocalTime.Time);
-            }
-            else
-            {
-                GetReplicatedNetworkState().OnValueChanged += OnNetworkStateChanged;
-                // For the non-authoritative side, we need to capture these values
-                SetTransformValues();
-            }
 
             // crucial we do this to reset the interpolators so that recycled objects when using a pool will
             //  not have leftover interpolator state from the previous object
@@ -1025,14 +1016,35 @@ namespace Unity.Netcode.Components
 
         private void Initialize()
         {
+            if (!IsSpawned)
+            {
+                return;
+            }
+
+            // must set up m_Transform in OnNetworkSpawn because it's possible an object spawns but is disabled
+            //  and thus awake won't be called.
+            // TODO: investigate further on not sending data for something that is not enabled
+            m_Transform = transform;
+
+            CanCommitToTransform = IsServerAuthoritative() ? IsServer : IsOwner;
+            var replicatedState = GetReplicatedNetworkState();
+            m_LocalAuthoritativeNetworkState = replicatedState.Value;
+
             if (CanCommitToTransform)
             {
-                GetReplicatedNetworkState().SetDirty(true);
+                GetReplicatedNetworkState().OnValueChanged -= OnNetworkStateChanged;
+                TryCommitTransform(m_Transform, m_CachedNetworkManager.LocalTime.Time);
+                replicatedState.SetDirty(true);
             }
-            else if (m_Transform != null)
+            else
             {
+                replicatedState.OnValueChanged += OnNetworkStateChanged;
                 ResetInterpolatedStateToCurrentAuthoritativeState(); // useful for late joining
-                ApplyInterpolatedNetworkStateToTransform(GetReplicatedNetworkState().Value, m_Transform, NetworkManager.ServerTime.Time);
+
+                // For the non-authoritative side, we need to capture these values
+                SetTransformValues();
+
+                ApplyInterpolatedNetworkStateToTransform(replicatedState.Value, m_Transform, NetworkManager.ServerTime.Time);
             }
         }
 
@@ -1107,7 +1119,7 @@ namespace Unity.Netcode.Components
 
             if (CanCommitToTransform)
             {
-                TryCommitTransformToServer(m_Transform, m_CachedNetworkManager.LocalTime.Time);
+                TryCommitTransform(m_Transform, m_CachedNetworkManager.LocalTime.Time);
             }
             else
             {
@@ -1123,13 +1135,13 @@ namespace Unity.Netcode.Components
                 m_LastInterpolate = Interpolate;
 
                 // eventually, we could hoist this calculation so that it happens once for all objects, not once per object
-                var cachedDeltaTime = Time.deltaTime;
-                var serverTime = NetworkManager.ServerTime;
-                var cachedServerTime = serverTime.Time;
-                var cachedRenderTime = serverTime.TimeTicksAgo(1).Time;
 
+                var serverTime = NetworkManager.ServerTime;
                 if (Interpolate)
                 {
+                    var cachedDeltaTime = Time.deltaTime;
+                    var cachedServerTime = serverTime.Time;
+                    var cachedRenderTime = serverTime.TimeTicksAgo(1).Time;
                     foreach (var interpolator in m_AllFloatInterpolators)
                     {
                         interpolator.Update(cachedDeltaTime, cachedRenderTime, cachedServerTime);
@@ -1172,11 +1184,11 @@ namespace Unity.Netcode.Components
             stateToSend.Position = newPosition;
             stateToSend.Rotation = newRotationEuler;
             stateToSend.Scale = newScale;
-            //ApplyInterpolatedNetworkStateToTransform(stateToSend, transform, m_CachedNetworkManager.ServerTime.Time);
+            ApplyInterpolatedNetworkStateToTransform(stateToSend, transform, m_CachedNetworkManager.ServerTime.Time);
             // set teleport flag in state to signal to ghosts not to interpolate
             m_LocalAuthoritativeNetworkState.IsTeleportingNextFrame = true;
-            // check server side
-            TryCommitValuesToServer(newPosition, newRotationEuler, newScale, m_CachedNetworkManager.LocalTime.Time);
+
+            TryCommitValues(newPosition, newRotationEuler, newScale, m_CachedNetworkManager.LocalTime.Time);
             m_LocalAuthoritativeNetworkState.IsTeleportingNextFrame = false;
         }
 

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -62,118 +62,118 @@ namespace Unity.Netcode.Components
             private const int k_TeleportingBit = 10;
 
             // 11-15: <unused>
-            private ushort m_Bitset;
+            internal ushort Bitset;
 
             internal bool InLocalSpace
             {
-                get => (m_Bitset & (1 << k_InLocalSpaceBit)) != 0;
+                get => (Bitset & (1 << k_InLocalSpaceBit)) != 0;
                 set
                 {
-                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_InLocalSpaceBit)); }
-                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_InLocalSpaceBit)); }
+                    if (value) { Bitset = (ushort)(Bitset | (1 << k_InLocalSpaceBit)); }
+                    else { Bitset = (ushort)(Bitset & ~(1 << k_InLocalSpaceBit)); }
                 }
             }
 
             // Position
             internal bool HasPositionX
             {
-                get => (m_Bitset & (1 << k_PositionXBit)) != 0;
+                get => (Bitset & (1 << k_PositionXBit)) != 0;
                 set
                 {
-                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_PositionXBit)); }
-                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_PositionXBit)); }
+                    if (value) { Bitset = (ushort)(Bitset | (1 << k_PositionXBit)); }
+                    else { Bitset = (ushort)(Bitset & ~(1 << k_PositionXBit)); }
                 }
             }
 
             internal bool HasPositionY
             {
-                get => (m_Bitset & (1 << k_PositionYBit)) != 0;
+                get => (Bitset & (1 << k_PositionYBit)) != 0;
                 set
                 {
-                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_PositionYBit)); }
-                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_PositionYBit)); }
+                    if (value) { Bitset = (ushort)(Bitset | (1 << k_PositionYBit)); }
+                    else { Bitset = (ushort)(Bitset & ~(1 << k_PositionYBit)); }
                 }
             }
 
             internal bool HasPositionZ
             {
-                get => (m_Bitset & (1 << k_PositionZBit)) != 0;
+                get => (Bitset & (1 << k_PositionZBit)) != 0;
                 set
                 {
-                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_PositionZBit)); }
-                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_PositionZBit)); }
+                    if (value) { Bitset = (ushort)(Bitset | (1 << k_PositionZBit)); }
+                    else { Bitset = (ushort)(Bitset & ~(1 << k_PositionZBit)); }
                 }
             }
 
             // RotAngles
             internal bool HasRotAngleX
             {
-                get => (m_Bitset & (1 << k_RotAngleXBit)) != 0;
+                get => (Bitset & (1 << k_RotAngleXBit)) != 0;
                 set
                 {
-                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_RotAngleXBit)); }
-                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_RotAngleXBit)); }
+                    if (value) { Bitset = (ushort)(Bitset | (1 << k_RotAngleXBit)); }
+                    else { Bitset = (ushort)(Bitset & ~(1 << k_RotAngleXBit)); }
                 }
             }
 
             internal bool HasRotAngleY
             {
-                get => (m_Bitset & (1 << k_RotAngleYBit)) != 0;
+                get => (Bitset & (1 << k_RotAngleYBit)) != 0;
                 set
                 {
-                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_RotAngleYBit)); }
-                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_RotAngleYBit)); }
+                    if (value) { Bitset = (ushort)(Bitset | (1 << k_RotAngleYBit)); }
+                    else { Bitset = (ushort)(Bitset & ~(1 << k_RotAngleYBit)); }
                 }
             }
 
             internal bool HasRotAngleZ
             {
-                get => (m_Bitset & (1 << k_RotAngleZBit)) != 0;
+                get => (Bitset & (1 << k_RotAngleZBit)) != 0;
                 set
                 {
-                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_RotAngleZBit)); }
-                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_RotAngleZBit)); }
+                    if (value) { Bitset = (ushort)(Bitset | (1 << k_RotAngleZBit)); }
+                    else { Bitset = (ushort)(Bitset & ~(1 << k_RotAngleZBit)); }
                 }
             }
 
             // Scale
             internal bool HasScaleX
             {
-                get => (m_Bitset & (1 << k_ScaleXBit)) != 0;
+                get => (Bitset & (1 << k_ScaleXBit)) != 0;
                 set
                 {
-                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_ScaleXBit)); }
-                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_ScaleXBit)); }
+                    if (value) { Bitset = (ushort)(Bitset | (1 << k_ScaleXBit)); }
+                    else { Bitset = (ushort)(Bitset & ~(1 << k_ScaleXBit)); }
                 }
             }
 
             internal bool HasScaleY
             {
-                get => (m_Bitset & (1 << k_ScaleYBit)) != 0;
+                get => (Bitset & (1 << k_ScaleYBit)) != 0;
                 set
                 {
-                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_ScaleYBit)); }
-                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_ScaleYBit)); }
+                    if (value) { Bitset = (ushort)(Bitset | (1 << k_ScaleYBit)); }
+                    else { Bitset = (ushort)(Bitset & ~(1 << k_ScaleYBit)); }
                 }
             }
 
             internal bool HasScaleZ
             {
-                get => (m_Bitset & (1 << k_ScaleZBit)) != 0;
+                get => (Bitset & (1 << k_ScaleZBit)) != 0;
                 set
                 {
-                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_ScaleZBit)); }
-                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_ScaleZBit)); }
+                    if (value) { Bitset = (ushort)(Bitset | (1 << k_ScaleZBit)); }
+                    else { Bitset = (ushort)(Bitset & ~(1 << k_ScaleZBit)); }
                 }
             }
 
             internal bool IsTeleportingNextFrame
             {
-                get => (m_Bitset & (1 << k_TeleportingBit)) != 0;
+                get => (Bitset & (1 << k_TeleportingBit)) != 0;
                 set
                 {
-                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_TeleportingBit)); }
-                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_TeleportingBit)); }
+                    if (value) { Bitset = (ushort)(Bitset | (1 << k_TeleportingBit)); }
+                    else { Bitset = (ushort)(Bitset & ~(1 << k_TeleportingBit)); }
                 }
             }
 
@@ -219,7 +219,7 @@ namespace Unity.Netcode.Components
             {
                 serializer.SerializeValue(ref SentTime);
                 // InLocalSpace + HasXXX Bits
-                serializer.SerializeValue(ref m_Bitset);
+                serializer.SerializeValue(ref Bitset);
                 // Position Values
                 if (HasPositionX)
                 {
@@ -523,76 +523,130 @@ namespace Unity.Netcode.Components
             //  this still is overly costly and could use more improvements.
             //
             // (ditto for scale components)
-            if (SyncPositionX &&
-                Mathf.Abs(networkState.PositionX - position.x) > PositionThreshold)
+            if (SyncPositionX)
             {
-                networkState.PositionX = position.x;
-                networkState.HasPositionX = true;
-                isPositionDirty = true;
+                if (Mathf.Abs(networkState.PositionX - position.x) > PositionThreshold)
+                {
+                    networkState.PositionX = position.x;
+                    networkState.HasPositionX = true;
+                    isPositionDirty = true;
+                }
+                else
+                {
+                    networkState.HasPositionX = false;
+                }
             }
 
-            if (SyncPositionY &&
-                Mathf.Abs(networkState.PositionY - position.y) > PositionThreshold)
+            if (SyncPositionY)
             {
-                networkState.PositionY = position.y;
-                networkState.HasPositionY = true;
-                isPositionDirty = true;
+                if (Mathf.Abs(networkState.PositionY - position.y) > PositionThreshold)
+                {
+                    networkState.PositionY = position.y;
+                    networkState.HasPositionY = true;
+                    isPositionDirty = true;
+                }
+                else
+                {
+                    networkState.HasPositionY = false;
+                }
             }
 
-            if (SyncPositionZ &&
-                Mathf.Abs(networkState.PositionZ - position.z) > PositionThreshold)
+            if (SyncPositionZ)
             {
-                networkState.PositionZ = position.z;
-                networkState.HasPositionZ = true;
-                isPositionDirty = true;
+                if (Mathf.Abs(networkState.PositionZ - position.z) > PositionThreshold)
+                {
+                    networkState.PositionZ = position.z;
+                    networkState.HasPositionZ = true;
+                    isPositionDirty = true;
+                }
+                else
+                {
+                    networkState.HasPositionZ = false;
+                }
             }
 
-            if (SyncRotAngleX &&
-                Mathf.Abs(Mathf.DeltaAngle(networkState.RotAngleX, rotAngles.x)) > RotAngleThreshold)
+            if (SyncRotAngleX)
             {
-                networkState.RotAngleX = rotAngles.x;
-                networkState.HasRotAngleX = true;
-                isRotationDirty = true;
+                if (Mathf.Abs(Mathf.DeltaAngle(networkState.RotAngleX, rotAngles.x)) > RotAngleThreshold)
+                {
+                    networkState.RotAngleX = rotAngles.x;
+                    networkState.HasRotAngleX = true;
+                    isRotationDirty = true;
+                }
+                else
+                {
+                    networkState.HasRotAngleX = false;
+                }
             }
 
-            if (SyncRotAngleY &&
-                Mathf.Abs(Mathf.DeltaAngle(networkState.RotAngleY, rotAngles.y)) > RotAngleThreshold)
+            if (SyncRotAngleY)
             {
-                networkState.RotAngleY = rotAngles.y;
-                networkState.HasRotAngleY = true;
-                isRotationDirty = true;
+                if (Mathf.Abs(Mathf.DeltaAngle(networkState.RotAngleY, rotAngles.y)) > RotAngleThreshold)
+                {
+                    networkState.RotAngleY = rotAngles.y;
+                    networkState.HasRotAngleY = true;
+                    isRotationDirty = true;
+                }
+                else
+                {
+                    networkState.HasRotAngleY = false;
+                }
             }
 
-            if (SyncRotAngleZ &&
-                Mathf.Abs(Mathf.DeltaAngle(networkState.RotAngleZ, rotAngles.z)) > RotAngleThreshold)
+            if (SyncRotAngleZ)
             {
-                networkState.RotAngleZ = rotAngles.z;
-                networkState.HasRotAngleZ = true;
-                isRotationDirty = true;
+                if (Mathf.Abs(Mathf.DeltaAngle(networkState.RotAngleZ, rotAngles.z)) > RotAngleThreshold)
+                {
+                    networkState.RotAngleZ = rotAngles.z;
+                    networkState.HasRotAngleZ = true;
+                    isRotationDirty = true;
+                }
+                else
+                {
+                    networkState.HasRotAngleZ = false;
+                }
             }
 
-            if (SyncScaleX &&
-                Mathf.Abs(networkState.ScaleX - scale.x) > ScaleThreshold)
+            if (SyncScaleX)
             {
-                networkState.ScaleX = scale.x;
-                networkState.HasScaleX = true;
-                isScaleDirty = true;
+                if (Mathf.Abs(networkState.ScaleX - scale.x) > ScaleThreshold)
+                {
+                    networkState.ScaleX = scale.x;
+                    networkState.HasScaleX = true;
+                    isScaleDirty = true;
+                }
+                else
+                {
+                    networkState.HasScaleX = false;
+                }
             }
 
-            if (SyncScaleY &&
-                Mathf.Abs(networkState.ScaleY - scale.y) > ScaleThreshold)
+            if (SyncScaleY)
             {
-                networkState.ScaleY = scale.y;
-                networkState.HasScaleY = true;
-                isScaleDirty = true;
+                if (Mathf.Abs(networkState.ScaleY - scale.y) > ScaleThreshold)
+                {
+                    networkState.ScaleY = scale.y;
+                    networkState.HasScaleY = true;
+                    isScaleDirty = true;
+                }
+                else
+                {
+                    networkState.HasScaleY = false;
+                }
             }
 
-            if (SyncScaleZ &&
-                Mathf.Abs(networkState.ScaleZ - scale.z) > ScaleThreshold)
+            if (SyncScaleZ)
             {
-                networkState.ScaleZ = scale.z;
-                networkState.HasScaleZ = true;
-                isScaleDirty = true;
+                if (Mathf.Abs(networkState.ScaleZ - scale.z) > ScaleThreshold)
+                {
+                    networkState.ScaleZ = scale.z;
+                    networkState.HasScaleZ = true;
+                    isScaleDirty = true;
+                }
+                else
+                {
+                    networkState.HasScaleZ = false;
+                }
             }
 
             isDirty |= isPositionDirty || isRotationDirty || isScaleDirty;
@@ -858,11 +912,13 @@ namespace Unity.Netcode.Components
             m_CachedIsServer = IsServer;
             m_CachedNetworkManager = NetworkManager;
 
+
+            m_LocalAuthoritativeNetworkState = m_ReplicatedNetworkState.Value;
             if (CanCommitToTransform)
             {
                 TryCommitTransformToServer(m_Transform, m_CachedNetworkManager.LocalTime.Time);
             }
-            m_LocalAuthoritativeNetworkState = m_ReplicatedNetworkState.Value;
+
 
             // crucial we do this to reset the interpolators so that recycled objects when using a pool will
             //  not have leftover interpolator state from the previous object

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -368,6 +368,11 @@ namespace Unity.Netcode.Components
 
         private readonly NetworkVariable<NetworkTransformState> m_ReplicatedNetworkState = new NetworkVariable<NetworkTransformState>(new NetworkTransformState());
 
+        internal NetworkVariable<NetworkTransformState> GetReplicatedNetworkState()
+        {
+            return m_ReplicatedNetworkState;
+        }
+
         private NetworkTransformState m_LocalAuthoritativeNetworkState;
 
         private const int k_DebugDrawLineTime = 10;
@@ -387,6 +392,11 @@ namespace Unity.Netcode.Components
         private Transform m_Transform; // cache the transform component to reduce unnecessary bounce between managed and native
         private int m_LastSentTick;
         private NetworkTransformState m_LastSentState;
+
+        internal NetworkTransformState GetLastSentState()
+        {
+            return m_LastSentState;
+        }
 
         /// <summary>
         /// Tries updating the server authoritative transform, only if allowed.
@@ -850,7 +860,10 @@ namespace Unity.Netcode.Components
                 m_PositionZInterpolator.AddMeasurement(newState.PositionZ, sentTime);
             }
 
-            m_RotationInterpolator.AddMeasurement(Quaternion.Euler(newState.Rotation), sentTime);
+            if (newState.HasRotAngleX || newState.HasRotAngleY || newState.HasRotAngleZ)
+            {
+                m_RotationInterpolator.AddMeasurement(Quaternion.Euler(newState.Rotation), sentTime);
+            }
 
             if (newState.HasScaleX)
             {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -279,7 +279,7 @@ namespace Unity.Netcode.RuntimeTests
 
             authoritativeNetworkTransform.transform.rotation = Quaternion.Euler(1, 2, 3);
             var serverLastSentState = authoritativeNetworkTransform.GetLastSentState();
-            var clientReplicatedState = otherSideNetworkTransform.GetReplicatedNetworkState().Value;
+            var clientReplicatedState = otherSideNetworkTransform.ReplicatedNetworkState.Value;
             yield return WaitForConditionOrTimeOut(() => ValidateBitSetValues(serverLastSentState, clientReplicatedState));
             AssertOnTimeout($"Server-side sent Bitset state != Client-side replicated Bitset state!");
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -250,6 +250,17 @@ namespace Unity.Netcode.RuntimeTests
             Assert.IsTrue(results.isRotationDirty, $"Rotation was not dirty when rotated by {Mathf.DeltaAngle(0, serverEulerRotation.y)} degrees!");
         }
 
+        private bool ValidateBitSetValues(NetworkTransform.NetworkTransformState serverState, NetworkTransform.NetworkTransformState clientState)
+        {
+            if (serverState.HasPositionX == clientState.HasPositionX && serverState.HasPositionY == clientState.HasPositionY && serverState.HasPositionZ == clientState.HasPositionZ &&
+                serverState.HasRotAngleX == clientState.HasRotAngleX && serverState.HasRotAngleY == clientState.HasRotAngleY && serverState.HasRotAngleZ == clientState.HasRotAngleZ &&
+                serverState.HasScaleX == clientState.HasScaleX && serverState.HasScaleY == clientState.HasScaleY && serverState.HasScaleZ == clientState.HasScaleZ)
+            {
+                return true;
+            }
+            return false;
+        }
+
         /// <summary>
         /// </summary>
         [UnityTest]
@@ -269,8 +280,8 @@ namespace Unity.Netcode.RuntimeTests
             authoritativeNetworkTransform.transform.rotation = Quaternion.Euler(1, 2, 3);
             var serverLastSentState = authoritativeNetworkTransform.GetLastSentState();
             var clientReplicatedState = otherSideNetworkTransform.GetReplicatedNetworkState().Value;
-            yield return WaitForConditionOrTimeOut(() => clientReplicatedState.Bitset.Equals(serverLastSentState.Bitset));
-            AssertOnTimeout($"Server-side sent state Bitset {serverLastSentState.Bitset} != Client-side replicated state Bitset {clientReplicatedState.Bitset}");
+            yield return WaitForConditionOrTimeOut(() => ValidateBitSetValues(serverLastSentState, clientReplicatedState));
+            AssertOnTimeout($"Server-side sent Bitset state != Client-side replicated Bitset state!");
 
             yield return WaitForConditionOrTimeOut(ServerClientRotationMatches);
             AssertOnTimeout($"[Timed-Out] Server-side client rotation {m_ServerSideClientPlayer.transform.rotation.eulerAngles} != Client-side client rotation {m_ClientSideClientPlayer.transform.rotation.eulerAngles}");

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 #if NGO_TRANSFORM_DEBUG
 using System.Text.RegularExpressions;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -335,7 +335,7 @@ namespace Unity.Netcode.RuntimeTests
         protected override IEnumerator OnTearDown()
         {
             m_EnableVerboseDebug = false;
-            UnityEngine.Object.DestroyImmediate(m_PlayerPrefab);
+            Object.DestroyImmediate(m_PlayerPrefab);
             yield return base.OnTearDown();
         }
     }

--- a/testproject/Assets/Prefabs/ObjectToOverride-VariantBlueCylinder.prefab
+++ b/testproject/Assets/Prefabs/ObjectToOverride-VariantBlueCylinder.prefab
@@ -82,5 +82,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: 29cabf623d47bb345a9bb4140e4397d7,
+        type: 3}
+      propertyPath: PositionThreshold
+      value: 0.01
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 29cabf623d47bb345a9bb4140e4397d7, type: 3}

--- a/testproject/Assets/Prefabs/Player.prefab
+++ b/testproject/Assets/Prefabs/Player.prefab
@@ -36,6 +36,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 5, y: 0.625, z: 5}
   m_LocalScale: {x: 1.25, y: 1.25, z: 1.25}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3519470446676406143}
   m_Father: {fileID: 0}
@@ -62,12 +63,11 @@ MonoBehaviour:
   SyncScaleX: 1
   SyncScaleY: 1
   SyncScaleZ: 1
-  PositionThreshold: 0
-  RotAngleThreshold: 0
-  ScaleThreshold: 0
+  PositionThreshold: 0.01
+  RotAngleThreshold: 0.01
+  ScaleThreshold: 0.1
   InLocalSpace: 0
   Interpolate: 1
-  FixedSendsPerSecond: 15
 --- !u!114 &-3775814466963834669
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -103,6 +103,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -239,6 +240,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1.045, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4079352819444256611}
   m_RootOrder: 0
@@ -262,6 +264,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/AdditiveSceneMultiInstance.unity
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/AdditiveSceneMultiInstance.unity
@@ -195,6 +195,21 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: ScaleThreshold
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: PositionThreshold
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: RotAngleThreshold
+      value: 0.1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ea906834639fa3f4ba65c95db6181d6b, type: 3}
 --- !u!1001 &365996112
@@ -269,6 +284,21 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: ScaleThreshold
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: PositionThreshold
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: RotAngleThreshold
+      value: 0.1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ea906834639fa3f4ba65c95db6181d6b, type: 3}
 --- !u!850595691 &903034822
@@ -278,7 +308,7 @@ LightingSettings:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: 
-  serializedVersion: 3
+  serializedVersion: 4
   m_GIWorkflowMode: 1
   m_EnableBakedLightmaps: 1
   m_EnableRealtimeLightmaps: 0
@@ -291,7 +321,7 @@ LightingSettings:
   m_LightmapMaxSize: 1024
   m_BakeResolution: 40
   m_Padding: 2
-  m_TextureCompression: 1
+  m_LightmapCompression: 3
   m_AO: 0
   m_AOMaxDistance: 1
   m_CompAOExponent: 1
@@ -332,6 +362,7 @@ LightingSettings:
   m_PVRFilteringAtrousPositionSigmaDirect: 0.5
   m_PVRFilteringAtrousPositionSigmaIndirect: 2
   m_PVRFilteringAtrousPositionSigmaAO: 1
+  m_PVRTiledBaking: 0
 --- !u!1001 &1152084533
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -403,6 +434,21 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: ScaleThreshold
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: PositionThreshold
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: RotAngleThreshold
+      value: 0.1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ea906834639fa3f4ba65c95db6181d6b, type: 3}
@@ -477,6 +523,21 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: ScaleThreshold
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: PositionThreshold
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: RotAngleThreshold
+      value: 0.1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ea906834639fa3f4ba65c95db6181d6b, type: 3}

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/ClientNetworkTransform.cs
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/ClientNetworkTransform.cs
@@ -1,0 +1,12 @@
+using Unity.Netcode.Components;
+
+namespace TestProject.ManualTests
+{
+    public class ClientNetworkTransform : NetworkTransform
+    {
+        protected override bool OnIsServerAuthoritative()
+        {
+            return false;
+        }
+    }
+}

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/ClientNetworkTransform.cs.meta
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/ClientNetworkTransform.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf01cca54b77c0241ad6d9da5ef6a709
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/PlayerClientAuthoritative.prefab
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/PlayerClientAuthoritative.prefab
@@ -1,0 +1,297 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4079352819444256614
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4079352819444256611}
+  - component: {fileID: 972770265172480408}
+  - component: {fileID: -3775814466963834669}
+  - component: {fileID: 4079352819444256610}
+  - component: {fileID: 4079352819444256613}
+  - component: {fileID: 4079352819444256612}
+  - component: {fileID: 1750810845806302260}
+  - component: {fileID: 4053684789567975459}
+  - component: {fileID: 6442518961346739709}
+  - component: {fileID: 2756533617708860847}
+  - component: {fileID: 9187250582412873179}
+  m_Layer: 8
+  m_Name: PlayerClientAuthoritative
+  m_TagString: Player
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4079352819444256611
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4079352819444256614}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 5, y: 0.625, z: 5}
+  m_LocalScale: {x: 1.25, y: 1.25, z: 1.25}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3519470446676406143}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &972770265172480408
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4079352819444256614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf01cca54b77c0241ad6d9da5ef6a709, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  SyncPositionX: 1
+  SyncPositionY: 1
+  SyncPositionZ: 1
+  SyncRotAngleX: 1
+  SyncRotAngleY: 1
+  SyncRotAngleZ: 1
+  SyncScaleX: 1
+  SyncScaleY: 1
+  SyncScaleZ: 1
+  PositionThreshold: 0.01
+  RotAngleThreshold: 0.01
+  ScaleThreshold: 0.01
+  InLocalSpace: 0
+  Interpolate: 1
+--- !u!114 &-3775814466963834669
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4079352819444256614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 951099334
+  AlwaysReplicateAsRoot: 0
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1
+--- !u!33 &4079352819444256610
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4079352819444256614}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4079352819444256613
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4079352819444256614}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a7b755ad8e4fe4bdb8f5518c951abc70, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &4079352819444256612
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4079352819444256614}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &1750810845806302260
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4079352819444256614}
+  serializedVersion: 2
+  m_Mass: 100
+  m_Drag: 7
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 1
+  m_Constraints: 112
+  m_CollisionDetection: 1
+--- !u!114 &4053684789567975459
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4079352819444256614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 24a9235f10bc6456183432fdb3015157, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &6442518961346739709
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4079352819444256614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3e4ecffca0894dfa88af779c2a67b9e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2756533617708860847
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4079352819444256614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8e5aa2f75493a4fee8ec635d215f03c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MoveSpeed: 10
+--- !u!114 &9187250582412873179
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4079352819444256614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f6c0be61502bb534f922ebb746851216, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &6479012615216050269
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3519470446676406143}
+  - component: {fileID: 6858102498835906389}
+  - component: {fileID: 2780619303711114328}
+  m_Layer: 8
+  m_Name: PlayerSub
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3519470446676406143
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6479012615216050269}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.045, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4079352819444256611}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6858102498835906389
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6479012615216050269}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2780619303711114328
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6479012615216050269}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/PlayerClientAuthoritative.prefab.meta
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/PlayerClientAuthoritative.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3cc5d500f7b2e1245bfb8652adadb286
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/SceneTransitioningBase1.unity
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/SceneTransitioningBase1.unity
@@ -171,8 +171,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 475de064003ff104fb88b1fbccd0f417, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_ActivateOnLoad: 0
   m_SceneToLoad: AdditiveSceneMultiInstance
   m_SceneAsset: {fileID: 102900000, guid: 0ae94f636016d3b40bfbecad57d99553, type: 3}
@@ -224,12 +224,13 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 244f0414ea8419b41ac51adb305d64b0, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_SwitchSceneButtonObject: {fileID: 1347823141}
   m_SceneToSwitchTo: SceneTransitioningBase2
   m_EnableAutoSwitch: 0
   m_AutoSwitchTimeOut: 60
+  DisconnectClientUponLoadScene: 0
 --- !u!1 &37242881
 GameObject:
   m_ObjectHideFlags: 0
@@ -379,8 +380,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -455,8 +456,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -632,8 +633,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 475de064003ff104fb88b1fbccd0f417, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_ActivateOnLoad: 0
   m_SceneToLoad: AdditiveSceneMultiInstance
   m_SceneAsset: {fileID: 102900000, guid: 0ae94f636016d3b40bfbecad57d99553, type: 3}
@@ -686,8 +687,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -762,8 +763,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -823,8 +824,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -840,8 +841,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_UiScaleMode: 0
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -924,8 +925,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -941,8 +942,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -1055,8 +1056,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 475de064003ff104fb88b1fbccd0f417, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_ActivateOnLoad: 0
   m_SceneToLoad: AdditiveScene2
   m_SceneAsset: {fileID: 102900000, guid: c6a3d883c8253ee43bca4f2b03797d7b, type: 3}
@@ -1109,8 +1110,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -1156,7 +1157,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   m_IsOn: 0
@@ -1306,8 +1307,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -1353,7 +1354,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   m_IsOn: 0
@@ -1406,8 +1407,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1482,8 +1483,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1558,8 +1559,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.9811321, g: 0.9811321, b: 0.9811321, a: 1}
   m_RaycastTarget: 1
@@ -1722,8 +1723,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0.5058824, b: 0.003921569, a: 1}
   m_RaycastTarget: 1
@@ -1802,8 +1803,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1878,8 +1879,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1954,8 +1955,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -2030,8 +2031,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 475de064003ff104fb88b1fbccd0f417, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_ActivateOnLoad: 0
   m_SceneToLoad: AdditiveScene1
   m_SceneAsset: {fileID: 102900000, guid: 41a0239b0c49e2047b7063c822f0df8a, type: 3}
@@ -2041,8 +2042,8 @@ LightingSettings:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name:
-  serializedVersion: 3
+  m_Name: 
+  serializedVersion: 4
   m_GIWorkflowMode: 1
   m_EnableBakedLightmaps: 1
   m_EnableRealtimeLightmaps: 0
@@ -2145,8 +2146,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -2299,8 +2300,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 475de064003ff104fb88b1fbccd0f417, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_ActivateOnLoad: 0
   m_SceneToLoad: AdditiveSceneMultiInstance
   m_SceneAsset: {fileID: 102900000, guid: 0ae94f636016d3b40bfbecad57d99553, type: 3}
@@ -2313,10 +2314,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1024114720}
-  - component: {fileID: 1024114719}
   - component: {fileID: 1024114718}
   - component: {fileID: 1024114721}
   - component: {fileID: 1024114722}
+  - component: {fileID: 1024114723}
   m_Layer: 0
   m_Name: NetworkManager
   m_TagString: Untagged
@@ -2334,13 +2335,13 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 593a2fe42fa9d37498c96f9a383b6521, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   RunInBackground: 1
   LogLevel: 1
   NetworkConfig:
     ProtocolVersion: 0
-    NetworkTransport: {fileID: 1024114719}
+    NetworkTransport: {fileID: 1024114723}
     PlayerPrefab: {fileID: 4079352819444256614, guid: c16f03336b6104576a565ef79ad643c0,
       type: 3}
     NetworkPrefabs:
@@ -2397,7 +2398,7 @@ MonoBehaviour:
     TickRate: 30
     ClientConnectionBufferTimeout: 10
     ConnectionApproval: 0
-    ConnectionData:
+    ConnectionData: 
     EnableTimeResync: 0
     TimeResyncInterval: 30
     EnsureNetworkVariableLengthSafety: 0
@@ -2409,25 +2410,6 @@ MonoBehaviour:
     LoadSceneTimeOut: 120
     SpawnTimeout: 1
     EnableNetworkLogs: 1
---- !u!114 &1024114719
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1024114717}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b84c2d8dfe509a34fb59e2b81f8e1319, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
-  MessageBufferSize: 65535
-  MaxConnections: 100
-  MaxSentMessageQueueSize: 512
-  ConnectAddress: 127.0.0.1
-  ConnectPort: 7777
-  ServerListenPort: 7777
-  MessageSendMode: 0
 --- !u!4 &1024114720
 Transform:
   m_ObjectHideFlags: 0
@@ -2453,8 +2435,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0e6f8504d891fc44881b2d9703017d03, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &1024114722
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2465,10 +2447,38 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 71c52a32bd1c1c84691050b6d045ab4a, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   LogToConsole: 1
   TimeToLive: 10
+--- !u!114 &1024114723
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1024114717}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6960e84d07fb87f47956e7a81d71c4e6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ProtocolType: 0
+  m_MaxPacketQueueSize: 128
+  m_MaxPayloadSize: 512000
+  m_MaxSendQueueSize: 4096000
+  m_HeartbeatTimeoutMS: 500
+  m_ConnectTimeoutMS: 1000
+  m_MaxConnectAttempts: 60
+  m_DisconnectTimeoutMS: 30000
+  ConnectionData:
+    Address: 127.0.0.1
+    Port: 7777
+    ServerListenAddress: 
+  DebugSimulator:
+    PacketDelayMS: 0
+    PacketJitterMS: 0
+    PacketDropRate: 0
 --- !u!1 &1113539278
 GameObject:
   m_ObjectHideFlags: 0
@@ -2497,8 +2507,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8c48ea35c67e64f7fac22a3f6831ca88, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   AutoSpawnEnable: 1
   InitialSpawnDelay: 0.2
   SpawnsPerSecond: 1
@@ -2538,8 +2548,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   GlobalObjectIdHash: 1983031731
   AlwaysReplicateAsRoot: 0
   DontDestroyWithOwner: 0
@@ -2592,8 +2602,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 475de064003ff104fb88b1fbccd0f417, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_ActivateOnLoad: 0
   m_SceneToLoad: AdditiveSceneMultiInstance
   m_SceneAsset: {fileID: 102900000, guid: 0ae94f636016d3b40bfbecad57d99553, type: 3}
@@ -2645,8 +2655,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -2726,8 +2736,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -2935,8 +2945,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -3017,8 +3027,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -3060,7 +3070,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
 --- !u!114 &1347823144
@@ -3073,8 +3083,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.1981132, g: 0.1981132, b: 0.1981132, a: 1}
   m_RaycastTarget: 1
@@ -3150,8 +3160,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -3197,7 +3207,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   m_IsOn: 0
@@ -3249,8 +3259,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.990566, g: 0.990566, b: 0.990566, a: 1}
   m_RaycastTarget: 1
@@ -3367,8 +3377,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -3443,8 +3453,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -3519,8 +3529,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -3595,8 +3605,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -3673,8 +3683,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -3716,7 +3726,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
 --- !u!114 &1588117330
@@ -3729,8 +3739,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.1981132, g: 0.1981132, b: 0.1981132, a: 1}
   m_RaycastTarget: 1
@@ -3805,8 +3815,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -3886,8 +3896,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -3933,7 +3943,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   m_IsOn: 0
@@ -3986,8 +3996,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -4033,7 +4043,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   m_IsOn: 0
@@ -4086,8 +4096,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -4162,8 +4172,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -4218,8 +4228,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_HorizontalAxis: Horizontal
   m_VerticalAxis: Vertical
   m_SubmitButton: Submit
@@ -4237,8 +4247,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
@@ -4305,8 +4315,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0.5058824, b: 0.003921569, a: 1}
   m_RaycastTarget: 1
@@ -4645,8 +4655,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -4692,7 +4702,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   m_IsOn: 0
@@ -4744,8 +4754,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -4920,8 +4930,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -4970,7 +4980,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
 --- !u!1 &2107482020
@@ -5016,11 +5026,10 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: cb5f3e55f5dd247129d8a4979b80ebbb, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_ClientServerToggle: {fileID: 1588117327}
   m_TrackSceneEvents: 1
-  m_LogSceneEventsToConsole: 1
 --- !u!114 &2107482023
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5031,8 +5040,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   GlobalObjectIdHash: 3197939627
   AlwaysReplicateAsRoot: 0
   DontDestroyWithOwner: 0
@@ -5162,7 +5171,7 @@ PrefabInstance:
     - target: {fileID: 2848221157716786269, guid: 3200770c16e3b2b4ebe7f604154faac7,
         type: 3}
       propertyPath: m_FontData.m_Font
-      value:
+      value: 
       objectReference: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
     - target: {fileID: 2848221157716786269, guid: 3200770c16e3b2b4ebe7f604154faac7,
         type: 3}
@@ -5197,7 +5206,7 @@ PrefabInstance:
     - target: {fileID: 5266522511616468950, guid: 3200770c16e3b2b4ebe7f604154faac7,
         type: 3}
       propertyPath: m_SceneMenuToLoad
-      value:
+      value: 
       objectReference: {fileID: 11400000, guid: c10d995498e0c514a853c3506031d3fb,
         type: 2}
     m_RemovedComponents: []

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/SceneTransitioningBase1.unity
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/SceneTransitioningBase1.unity
@@ -2342,7 +2342,7 @@ MonoBehaviour:
   NetworkConfig:
     ProtocolVersion: 0
     NetworkTransport: {fileID: 1024114723}
-    PlayerPrefab: {fileID: 4079352819444256614, guid: c16f03336b6104576a565ef79ad643c0,
+    PlayerPrefab: {fileID: 4079352819444256614, guid: 3cc5d500f7b2e1245bfb8652adadb286,
       type: 3}
     NetworkPrefabs:
     - Override: 0

--- a/testproject/Assets/Tests/Manual/Scripts/PlayerMovementManager.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/PlayerMovementManager.cs
@@ -20,22 +20,20 @@ namespace TestProject.ManualTests
 
         private void Update()
         {
-            if (NetworkObject != null)
+            if (!IsSpawned)
             {
-                if (IsOwner && Input.GetKeyDown(KeyCode.Space))
-                {
-                    if (m_RandomMovement)
-                    {
-                        m_RandomMovement.enabled = !m_RandomMovement.enabled;
-                    }
-                }
+                return;
+            }
 
-                if (NetworkObject != null && NetworkObject.NetworkManager != null && NetworkObject.NetworkManager.IsListening)
+            if (IsOwner)
+            {
+                if (Input.GetKeyDown(KeyCode.Space))
                 {
-                    if (m_RandomMovement.enabled)
-                    {
-                        m_RandomMovement.Move(MoveSpeed);
-                    }
+                    m_RandomMovement.enabled = !m_RandomMovement.enabled;
+                }
+                if (m_RandomMovement.enabled)
+                {
+                    m_RandomMovement.Move(MoveSpeed);
                 }
             }
         }


### PR DESCRIPTION
**Bandwidth Consumption Fix:**
NetworkTransform's NetworkTransformState.Bitset was having bits set but never having bits "un-set" when there was no delta from the previous relative value or the delta had not crossed the threshold. This would result in any axis marked to synchronize previously being always marked to be synchronized which, in turn, would cause all marked axis to be sent anytime a delta in any of the marked axis crossed the threshold value.

On the non-authoritative side, NetworkTransform.ApplyInterpolatedNetworkStateToTransform was using the NetworkTransform.Sync<Position,RotAngle,Scale><axis> (i.e. NetworkTransform.SyncPositionX) as the determining factor as to whether it should apply all associated axis values as opposed to checking the updated NetworkTransformState.Has<Position,RotAngle,Scale><axis> to determine if it should be updated locally.

**Example of the Bitset Issue:**
- The authoritative transform detects changes to transform.position.x that exceeds the threshold
  - The transform.position.x bit flag is added to the authoritative state which is then synchronized with all non-authoritative remote instances
- Some time later, the authoritative transform detects changes to the transform.position.z and transform.localScale.y
  - The transform.position.z and transform.localScale.y bit flags are added to the authoritative state which is then synchronized with all non-authoritative remote instances
    - The state synchronizes the transform.position.x, transform.position.z, and transform.localScale.y values
- Some time later the authoritative transform only detects a change in transform.position.y that exceeds the threshold.
  - The transform.position.y bit flag is added to the authoritative state which is then synchronized with all non-authoritative remote instances
    - The state synchronizes the entire transform.position and the transform.localScale.y values.

**Authoritative Side Interpolation Fix**
This includes changes to fix the issue where the authoritative side was interpolating when it should not be.

**Client/Owner Authority Adjustments**
This includes adjustments to how we handle client-owner authority.  Instead of sending a ServerRpc which makes adjustments to a server write authority NetworkVariable, NetworkTransform now creates two versions of the NetworkVariable with one having server write permissions and the other having owner write permissions.

[<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->](https://jira.unity3d.com/browse/MTT-4275)



Pertains to #2022 and #2093, [BR-694](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/issues/694)

## Changelog
- Fixed: WIP

## Testing and Documentation
- Includes integration tests. (WIP)
