### PR TITLE
feat: host tells client which IDs it uses for INetworkMessages

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -2074,6 +2074,21 @@ namespace Unity.Netcode
                     {
                         SceneManager.SynchronizeNetworkObjects(ownerClientId);
                     }
+
+                    for (int index = 0; index < MessagingSystem.MessageHandlers.Length; index++)
+                    {
+                        if (MessagingSystem.ReverseTypeMap[index] != null)
+                        {
+                            var orderingMessage = new OrderingMessage
+                            {
+                                Order = index,
+                                Hash = MessagingSystem.ReverseTypeMap[index].FullName.GetHashCode()
+                            };
+
+                            SendMessage(ref orderingMessage, NetworkDelivery.ReliableFragmentedSequenced,
+                                ownerClientId);
+                        }
+                    }
                 }
                 else // Server just adds itself as an observer to all spawned NetworkObjects
                 {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -2065,16 +2065,6 @@ namespace Unity.Netcode
 
                     SendMessage(ref message, NetworkDelivery.ReliableFragmentedSequenced, ownerClientId);
 
-                    // If scene management is enabled, then let NetworkSceneManager handle the initial scene and NetworkObject synchronization
-                    if (!NetworkConfig.EnableSceneManagement)
-                    {
-                        InvokeOnClientConnectedCallback(ownerClientId);
-                    }
-                    else
-                    {
-                        SceneManager.SynchronizeNetworkObjects(ownerClientId);
-                    }
-
                     for (int index = 0; index < MessagingSystem.MessageHandlers.Length; index++)
                     {
                         if (MessagingSystem.ReverseTypeMap[index] != null)
@@ -2088,6 +2078,16 @@ namespace Unity.Netcode
                             SendMessage(ref orderingMessage, NetworkDelivery.ReliableFragmentedSequenced,
                                 ownerClientId);
                         }
+                    }
+
+                    // If scene management is enabled, then let NetworkSceneManager handle the initial scene and NetworkObject synchronization
+                    if (!NetworkConfig.EnableSceneManagement)
+                    {
+                        InvokeOnClientConnectedCallback(ownerClientId);
+                    }
+                    else
+                    {
+                        SceneManager.SynchronizeNetworkObjects(ownerClientId);
                     }
                 }
                 else // Server just adds itself as an observer to all spawned NetworkObjects

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -2072,7 +2072,7 @@ namespace Unity.Netcode
                             var orderingMessage = new OrderingMessage
                             {
                                 Order = index,
-                                Hash = MessagingSystem.ReverseTypeMap[index].FullName.GetHashCode()
+                                Hash = XXHash.Hash32(MessagingSystem.ReverseTypeMap[index].FullName)
                             };
 
                             SendMessage(ref orderingMessage, NetworkDelivery.ReliableFragmentedSequenced,

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -2075,8 +2075,7 @@ namespace Unity.Netcode
                                 Hash = MessagingSystem.ReverseTypeMap[index].FullName.GetHashCode()
                             };
 
-                            SendMessage(ref orderingMessage, NetworkDelivery.ReliableFragmentedSequenced,
-                                ownerClientId);
+                            SendMessage(ref orderingMessage, NetworkDelivery.ReliableFragmentedSequenced, ownerClientId);
                         }
                     }
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -2067,12 +2067,12 @@ namespace Unity.Netcode
 
                     for (int index = 0; index < MessagingSystem.MessageHandlers.Length; index++)
                     {
-                        if (MessagingSystem.ReverseTypeMap[index] != null)
+                        if (MessagingSystem.MessageTypes[index] != null)
                         {
                             var orderingMessage = new OrderingMessage
                             {
                                 Order = index,
-                                Hash = XXHash.Hash32(MessagingSystem.ReverseTypeMap[index].FullName)
+                                Hash = XXHash.Hash32(MessagingSystem.MessageTypes[index].FullName)
                             };
 
                             SendMessage(ref orderingMessage, NetworkDelivery.ReliableFragmentedSequenced, ownerClientId);

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/OrderingMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/OrderingMessage.cs
@@ -1,5 +1,4 @@
 using System;
-using UnityEngine;
 
 namespace Unity.Netcode
 {

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/OrderingMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/OrderingMessage.cs
@@ -3,10 +3,15 @@ using System;
 namespace Unity.Netcode
 {
     /// <summary>
-    /// This particular struct is a little weird because it doesn't actually contain the data
-    /// it's serializing. Instead, it contains references to the data it needs to do the
-    /// serialization. This is due to the generally amorphous nature of network variable
-    /// deltas, since they're all driven by custom virtual method overloads.
+    /// Upon connecting, the host sends a series of OrderingMessage to the client so that it can make sure both sides
+    /// have the same message types in the same positions in
+    /// - MessagingSystem.m_MessageHandlers
+    /// - MessagingSystem.m_ReverseTypeMap
+    /// even if one side has extra messages (compilation, version, patch, or platform differences, etc...)
+    ///
+    /// The ConnectionRequestedMessage, ConnectionApprovedMessage and OrderingMessage are prioritized at the beginning
+    /// of the mapping, to guarantee they can be exchanged before the two sides share their ordering
+    /// The sorting used in also stable so that even if MessageType names share hashes, it will work most of the time
     /// </summary>
     internal struct OrderingMessage : INetworkMessage
     {

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/OrderingMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/OrderingMessage.cs
@@ -1,0 +1,46 @@
+using System;
+using UnityEngine;
+
+namespace Unity.Netcode
+{
+    /// <summary>
+    /// This particular struct is a little weird because it doesn't actually contain the data
+    /// it's serializing. Instead, it contains references to the data it needs to do the
+    /// serialization. This is due to the generally amorphous nature of network variable
+    /// deltas, since they're all driven by custom virtual method overloads.
+    /// </summary>
+    internal struct OrderingMessage : INetworkMessage
+    {
+        public int Order;
+        public int Hash;
+
+        public void Serialize(FastBufferWriter writer)
+        {
+            if (!writer.TryBeginWrite(FastBufferWriter.GetWriteSize(Order) + FastBufferWriter.GetWriteSize(Hash)))
+            {
+                throw new OverflowException($"Not enough space in the buffer to write {nameof(OrderingMessage)}");
+            }
+
+            writer.WriteValue(Order);
+            writer.WriteValue(Hash);
+        }
+
+        public bool Deserialize(FastBufferReader reader, ref NetworkContext context)
+        {
+            if (!reader.TryBeginRead(FastBufferWriter.GetWriteSize(Order) + FastBufferWriter.GetWriteSize(Hash)))
+            {
+                throw new OverflowException($"Not enough data in the buffer to read {nameof(OrderingMessage)}");
+            }
+
+            reader.ReadValue(out Order);
+            reader.ReadValue(out Hash);
+
+            return true;
+        }
+
+        public void Handle(ref NetworkContext context)
+        {
+            NetworkManager.Singleton.MessagingSystem.ReorderMessage(Order, Hash);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/OrderingMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/OrderingMessage.cs
@@ -11,7 +11,7 @@ namespace Unity.Netcode
     internal struct OrderingMessage : INetworkMessage
     {
         public int Order;
-        public int Hash;
+        public uint Hash;
 
         public void Serialize(FastBufferWriter writer)
         {

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/OrderingMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/OrderingMessage.cs
@@ -39,7 +39,7 @@ namespace Unity.Netcode
 
         public void Handle(ref NetworkContext context)
         {
-            NetworkManager.Singleton.MessagingSystem.ReorderMessage(Order, Hash);
+            ((NetworkManager)context.SystemOwner).MessagingSystem.ReorderMessage(Order, Hash);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/OrderingMessage.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/OrderingMessage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3ada9e8fd5bf94b1f9a6a21531c8a3ee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
@@ -78,7 +78,7 @@ namespace Unity.Netcode
             public MessageHandler Handler;
         }
 
-        private List<MessageWithHandler> PrioritizeMessageOrder(List<MessageWithHandler> allowedTypes)
+        internal List<MessageWithHandler> PrioritizeMessageOrder(List<MessageWithHandler> allowedTypes)
         {
             var prioritizedTypes = new List<MessageWithHandler>();
 

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace Unity.Netcode
 {
-    internal class HandlerNotRegisteredException: SystemException
+    internal class HandlerNotRegisteredException : SystemException
     {
         public HandlerNotRegisteredException() { }
         public HandlerNotRegisteredException(string issue) : base(issue) { }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
@@ -275,10 +275,8 @@ namespace Unity.Netcode
                 return;
             }
 
-            Debug.Log($"Unexpected hash for {desiredOrder}");
-
-            // Insert placeholder
-
+            // Since the message at `desiredOrder` is not the expected one,
+            // insert an empty placeholder and move the messages down
             var typesAsList = m_ReverseTypeMap.ToList();
             typesAsList.Insert(desiredOrder, null);
             m_ReverseTypeMap = typesAsList.ToArray();
@@ -288,12 +286,11 @@ namespace Unity.Netcode
 
             int position = desiredOrder;
             bool found = false;
-            while(position < m_ReverseTypeMap.Length)
+            while (position < m_ReverseTypeMap.Length)
             {
                 if (m_ReverseTypeMap[position] != null &&
                     m_ReverseTypeMap[position].FullName.GetHashCode() == targetHash)
                 {
-                    Debug.Log($"Found {desiredOrder} at position {position}");
                     found = true;
                     break;
                 }
@@ -303,11 +300,11 @@ namespace Unity.Netcode
 
             if (found)
             {
-                // copy original and remove it
-
+                // Copy the handler and type to the right index
                 m_ReverseTypeMap[desiredOrder] = m_ReverseTypeMap[position];
                 m_MessageHandlers[desiredOrder] = m_MessageHandlers[position];
 
+                // Shift back the remaining messages
                 typesAsList = m_ReverseTypeMap.ToList();
                 typesAsList.RemoveAt(position);
                 m_ReverseTypeMap = typesAsList.ToArray();

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
@@ -259,7 +259,7 @@ namespace Unity.Netcode
             return true;
         }
 
-        internal void ReorderMessage(int desiredOrder, int targetHash)
+        internal void ReorderMessage(int desiredOrder, uint targetHash)
         {
             if (desiredOrder < 0)
             {
@@ -268,7 +268,7 @@ namespace Unity.Netcode
             }
 
             if (desiredOrder < m_ReverseTypeMap.Length &&
-                m_ReverseTypeMap[desiredOrder].FullName.GetHashCode() == targetHash)
+                XXHash.Hash32(m_ReverseTypeMap[desiredOrder].FullName) == targetHash)
             {
                 // matching positions and hashes. All good.
                 return;
@@ -291,7 +291,7 @@ namespace Unity.Netcode
             while (position < m_ReverseTypeMap.Length)
             {
                 if (m_ReverseTypeMap[position] != null &&
-                    m_ReverseTypeMap[position].FullName.GetHashCode() == targetHash)
+                    XXHash.Hash32(m_ReverseTypeMap[position].FullName) == targetHash)
                 {
                     found = true;
                     break;

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
@@ -81,25 +81,24 @@ namespace Unity.Netcode
         private List<MessageWithHandler> PrioritizeMessageOrder(List<MessageWithHandler> allowedTypes)
         {
             var prioritizedTypes = new List<MessageWithHandler>();
-            prioritizedTypes.Add(new MessageWithHandler()); // reserve space for Unity.Netcode.ConnectionRequestMessage
-            prioritizedTypes.Add(new MessageWithHandler()); // reserve space for Unity.Netcode.ConnectionApprovedMessage
-            prioritizedTypes.Add(new MessageWithHandler()); // reserve space for Unity.Netcode.OrderingMessage
+
+            // first pass puts the priority message in the first indices
+            // Those are the messages that must be delivered in order to allow re-ordering the others later
+            foreach (var t in allowedTypes)
+            {
+                if (t.MessageType.FullName == "Unity.Netcode.ConnectionRequestMessage" ||
+                    t.MessageType.FullName == "Unity.Netcode.ConnectionApprovedMessage" ||
+                    t.MessageType.FullName == "Unity.Netcode.OrderingMessage")
+                {
+                    prioritizedTypes.Add(t);
+                }
+            }
 
             foreach (var t in allowedTypes)
             {
-                if (t.MessageType.FullName == "Unity.Netcode.ConnectionRequestMessage")
-                {
-                    prioritizedTypes[0] = t;
-                }
-                else if (t.MessageType.FullName == "Unity.Netcode.ConnectionApprovedMessage")
-                {
-                    prioritizedTypes[1] = t;
-                }
-                else if (t.MessageType.FullName == "Unity.Netcode.OrderingMessage")
-                {
-                    prioritizedTypes[2] = t;
-                }
-                else
+                if (t.MessageType.FullName != "Unity.Netcode.ConnectionRequestMessage" &&
+                    t.MessageType.FullName != "Unity.Netcode.ConnectionApprovedMessage" &&
+                    t.MessageType.FullName != "Unity.Netcode.OrderingMessage")
                 {
                     prioritizedTypes.Add(t);
                 }
@@ -284,6 +283,9 @@ namespace Unity.Netcode
             handlersAsList.Insert(desiredOrder, null);
             m_MessageHandlers = handlersAsList.ToArray();
 
+            // we added a dummy message, bump the end up
+            m_HighMessageType++;
+
             int position = desiredOrder;
             bool found = false;
             while (position < m_ReverseTypeMap.Length)
@@ -311,6 +313,9 @@ namespace Unity.Netcode
                 handlersAsList = m_MessageHandlers.ToList();
                 handlersAsList.RemoveAt(position);
                 m_MessageHandlers = handlersAsList.ToArray();
+
+                // we removed a copy after moving a message, reduce the high message index
+                m_HighMessageType--;
             }
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
@@ -367,19 +367,16 @@ namespace Unity.Netcode
             var handler = m_MessageHandlers[header.MessageType];
             using (reader)
             {
-                // This will trigger an exception is if the server knows about a message type the client doesn't know
-                // about. In this case the handler will be null. It is still an issue the user must deal with: If the
-                // two connecting builds know about different messages, the server should not send a message to a client
-                // that doesn't know about it
-                if (handler == null)
-                {
-                    throw new HandlerNotRegisteredException("Received a NetworkMessage we don't know how to deal with. Make sure client and server have the same INetworkMessage");
-                }
                 // No user-land message handler exceptions should escape the receive loop.
                 // If an exception is throw, the message is ignored.
                 // Example use case: A bad message is received that can't be deserialized and throws
                 // an OverflowException because it specifies a length greater than the number of bytes in it
                 // for some dynamic-length value.
+
+                // This will also log an exception is if the server knows about a message type the client doesn't know
+                // about. In this case the handler will be null. It is still an issue the user must deal with: If the
+                // two connecting builds know about different messages, the server should not send a message to a client
+                // that doesn't know about it
                 try
                 {
                     handler.Invoke(reader, ref context, this);

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
@@ -60,7 +60,6 @@ namespace Unity.Netcode
 
         internal Type[] MessageTypes => m_ReverseTypeMap;
         internal MessageHandler[] MessageHandlers => m_MessageHandlers;
-        internal Type[] ReverseTypeMap => m_ReverseTypeMap;
 
         internal uint MessageHandlerCount => m_HighMessageType;
 
@@ -259,12 +258,14 @@ namespace Unity.Netcode
             return true;
         }
 
+        // Moves the handler for the type having hash `targetHash` to the `desiredOrder` position, in the handler list
+        // This allows the server to tell the client which id it is using for which message and make sure the right
+        // message is used when deserializing.
         internal void ReorderMessage(int desiredOrder, uint targetHash)
         {
             if (desiredOrder < 0)
             {
-                // invalid message re-ordering request. Ignore.
-                return;
+                throw new ArgumentException("ReorderMessage desiredOrder must be positive");
             }
 
             if (desiredOrder < m_ReverseTypeMap.Length &&

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageRegistrationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageRegistrationTests.cs
@@ -283,6 +283,19 @@ namespace Unity.Netcode.EditorTests
 
             // there should still not be any extras
             Assert.AreEqual(messagingSystem.MessageHandlerCount, 5);
+
+            // 4242 is a random hash that should not match anything
+            messagingSystem.ReorderMessage(3, 4242);
+
+            // that should result in an extra entry
+            Assert.AreEqual(messagingSystem.MessageHandlerCount, 6);
+
+            // with a null handler
+            Assert.AreEqual(messagingSystem.MessageHandlers[3], null);
+
+            // and it should have bumped the previous messages down
+            Assert.AreEqual(messagingSystem.MessageTypes[4], typeof(zzzLateLexicographicNetworkMessage));
+            Assert.AreEqual(messagingSystem.MessageTypes[5], typeof(AAAEarlyLexicographicNetworkMessage));
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageRegistrationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageRegistrationTests.cs
@@ -270,7 +270,7 @@ namespace Unity.Netcode.EditorTests
                 messagingSystem.ReorderMessage(-1, XXHash.Hash32(typeof(zzzLateLexicographicNetworkMessage).FullName));
                 Assert.Fail();
             }
-            catch(ArgumentException)
+            catch (ArgumentException)
             {
             }
 

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageRegistrationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageRegistrationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 
@@ -247,7 +248,6 @@ namespace Unity.Netcode.EditorTests
 
             // there should not be any extras
             Assert.AreEqual(messagingSystem.MessageHandlerCount, 5);
-            Assert.AreEqual(messagingSystem.MessageHandlerCount, 5);
 
             // reorder the zzz one to position 3
             messagingSystem.ReorderMessage(3, XXHash.Hash32(typeof(zzzLateLexicographicNetworkMessage).FullName));
@@ -263,8 +263,26 @@ namespace Unity.Netcode.EditorTests
 
             // there should still not be any extras
             Assert.AreEqual(messagingSystem.MessageHandlerCount, 5);
-            Assert.AreEqual(messagingSystem.MessageHandlerCount, 5);
 
+            // verify we get an exception when asking for an invalid position
+            try
+            {
+                messagingSystem.ReorderMessage(-1, XXHash.Hash32(typeof(zzzLateLexicographicNetworkMessage).FullName));
+                Assert.Fail();
+            }
+            catch(ArgumentException)
+            {
+            }
+
+            // reorder the zzz one to position 3, again, to check nothing bad happens
+            messagingSystem.ReorderMessage(3, XXHash.Hash32(typeof(zzzLateLexicographicNetworkMessage).FullName));
+
+            // the two non-priority should not have moved
+            Assert.AreEqual(messagingSystem.MessageTypes[3], typeof(zzzLateLexicographicNetworkMessage));
+            Assert.AreEqual(messagingSystem.MessageTypes[4], typeof(AAAEarlyLexicographicNetworkMessage));
+
+            // there should still not be any extras
+            Assert.AreEqual(messagingSystem.MessageHandlerCount, 5);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageSendingTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageSendingTests.cs
@@ -265,7 +265,7 @@ namespace Unity.Netcode.EditorTests
                 using (reader)
                 {
                     m_MessagingSystem.HandleMessage(messageHeader, reader, 0, 0, 0);
-                    LogAssert.Expect(LogType.Exception, new Regex(".*NullReferenceException.*"));
+                    LogAssert.Expect(LogType.Exception, new Regex(".*HandlerNotRegisteredException.*"));
                 }
             }
         }

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageSendingTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageSendingTests.cs
@@ -1,8 +1,11 @@
-using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Random = System.Random;
 
 namespace Unity.Netcode.EditorTests
 {
@@ -241,7 +244,7 @@ namespace Unity.Netcode.EditorTests
         }
 
         [Test]
-        public void WhenReceivingAMessageWithoutAHandler_ExceptionIsThrown()
+        public void WhenReceivingAMessageWithoutAHandler_ExceptionIsLogged()
         {
             m_MessagingSystem = new MessagingSystem(new NopMessageSender(), this, new TestNoHandlerMessageProvider());
 
@@ -261,16 +264,8 @@ namespace Unity.Netcode.EditorTests
                 var reader = new FastBufferReader(writer, Allocator.Temp);
                 using (reader)
                 {
-                    try
-                    {
-                        m_MessagingSystem.HandleMessage(messageHeader, reader, 0, 0, 0);
-                    }
-                    catch (HandlerNotRegisteredException)
-                    {
-                        return;
-                    }
-
-                    Assert.Fail();
+                    m_MessagingSystem.HandleMessage(messageHeader, reader, 0, 0, 0);
+                    LogAssert.Expect(LogType.Exception, new Regex(".*NullReferenceException.*"));
                 }
             }
         }


### PR DESCRIPTION
Adds a synchronization mechanism so that host tells client which IDs it uses for INetworkMessages. When there's discrepancies, allows the client to adjust its mapping.

Makes our SDK generally more robust.

Also necessary for https://jira.unity3d.com/browse/MTT-4166 since `2022.2` has different classes visible in some scenario.

