### PR TITLE
fix: initializing the LastSentState when spawning the NetworkTransform [MTT-3044]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -22,6 +22,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed NetworkLists not populating on client. NetworkList now uses the most recent list as opposed to the list at the end of previous frame, when sending full updates to dynamically spawned NetworkObject. The difference in behaviour is required as scene management spawns those objects at a different time in the frame, relative to updates. (#2062)
 - Fixed NetworkList Value event on the server. PreviousValue is now set correctly when a new value is set through property setter. (#2067)
 - Fixed NetworkList issue that showed when inserting at the very end of a NetworkList (#2099)
+- Fixed NetworkTransform LastSentState not initialized at time of spawning. (#2106)
 
 ## [1.0.0] - 2022-06-27
 

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -862,7 +862,7 @@ namespace Unity.Netcode.Components
             {
                 TryCommitTransformToServer(m_Transform, m_CachedNetworkManager.LocalTime.Time);
             }
-            m_LocalAuthoritativeNetworkState = m_ReplicatedNetworkState.Value;
+            m_LastSentState = m_LocalAuthoritativeNetworkState = m_ReplicatedNetworkState.Value;
 
             // crucial we do this to reset the interpolators so that recycled objects when using a pool will
             //  not have leftover interpolator state from the previous object


### PR DESCRIPTION
This simply makes sure that m_LastSentState is initialized when the NetworkTransform is spawned. Not initializing it caused [an issue](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/issues/694) with the ClientNetworkTransform where spawning it with client ownership would have the client send the uninitialized m_LastSentState to the server during the first Update, which could lead to the client and server versions having different rotations.

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->

<!-- Add RFC link here if applicable. -->

## Changelog

- Fixed the NetworkTransform's m_LastSentState being uninitialized at spawn

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
