### PR TITLE
fix: NetworkTransform teleport interpolating from last position on non-authoritative side [NCCBUG-166]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -14,6 +14,9 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue with the internal `NetworkTransformState.m_Bitset` flag not getting cleared upon the next tick advancement. (#2110)
+- Fixed interpolation issue with `NetworkTransform.Teleport`. (#2110)
+- Fixed issue where the authoritative side was interpolating its transform. (#2110)
 - Fixed issue where a client owner of a `NetworkVariable` with both owner read and write permissions would not update the server side when changed. (#2097)
 - Fixed issue when attempting to spawn a parent `GameObject`, with `NetworkObject` component attached, that has one or more child `GameObject`s, that are inactive in the hierarchy, with `NetworkBehaviour` components it will no longer attempt to spawn the associated `NetworkBehaviour`(s) or invoke ownership changed notifications but will log a warning message. (#2096)
 - Fixed an issue where destroying a NetworkBehaviour would not deregister it from the parent NetworkObject, leading to exceptions when the parent was later destroyed. (#2091)

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -683,7 +683,7 @@ namespace Unity.Netcode.Components
             var interpolatedRotAngles = networkState.InLocalSpace ? transformToUpdate.localEulerAngles : transformToUpdate.eulerAngles;
             var interpolatedScale = transformToUpdate.localScale;
 
-            // InLocalSpace Read: !! Must set the private Property !!
+            // InLocalSpace Read:
             InLocalSpace = networkState.InLocalSpace;
 
             // Update the position values that were changed in this state update

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -1176,10 +1176,6 @@ namespace Unity.Netcode.Components
                 m_Transform.rotation = rot;
             }
             m_Transform.localScale = scale;
-
-            m_Transform.position = pos;
-            m_Transform.rotation = rot;
-            m_Transform.localScale = scale;
             m_LocalAuthoritativeNetworkState.IsTeleportingNextFrame = shouldTeleport;
         }
 

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -370,14 +370,17 @@ namespace Unity.Netcode.Components
         private readonly NetworkVariable<NetworkTransformState> m_ReplicatedNetworkStateOwner = new NetworkVariable<NetworkTransformState>(new NetworkTransformState(), NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
 
 
-        internal NetworkVariable<NetworkTransformState> GetReplicatedNetworkState()
+        internal NetworkVariable<NetworkTransformState> ReplicatedNetworkState
         {
-            if (!IsServerAuthoritative())
+            get
             {
-                return m_ReplicatedNetworkStateOwner;
-            }
+                if (!IsServerAuthoritative())
+                {
+                    return m_ReplicatedNetworkStateOwner;
+                }
 
-            return m_ReplicatedNetworkStateServer;
+                return m_ReplicatedNetworkStateServer;
+            }
         }
 
         private NetworkTransformState m_LocalAuthoritativeNetworkState;
@@ -484,7 +487,7 @@ namespace Unity.Netcode.Components
 
         private void CommitLocallyAndReplicate(NetworkTransformState networkState)
         {
-            GetReplicatedNetworkState().Value = networkState;
+            ReplicatedNetworkState.Value = networkState;
         }
 
         private void ResetInterpolatedStateToCurrentAuthoritativeState()
@@ -1024,7 +1027,7 @@ namespace Unity.Netcode.Components
         /// <inheritdoc/>
         public override void OnNetworkDespawn()
         {
-            GetReplicatedNetworkState().OnValueChanged -= OnNetworkStateChanged;
+            ReplicatedNetworkState.OnValueChanged -= OnNetworkStateChanged;
         }
 
         /// <inheritdoc/>
@@ -1052,7 +1055,7 @@ namespace Unity.Netcode.Components
             m_Transform = transform;
 
             CanCommitToTransform = IsServerAuthoritative() ? IsServer : IsOwner;
-            var replicatedState = GetReplicatedNetworkState();
+            var replicatedState = ReplicatedNetworkState;
             m_LocalAuthoritativeNetworkState = replicatedState.Value;
 
             if (CanCommitToTransform)
@@ -1180,7 +1183,7 @@ namespace Unity.Netcode.Components
                 ApplyTransformValues();
 
                 // Apply updated interpolated value
-                ApplyInterpolatedNetworkStateToTransform(GetReplicatedNetworkState().Value, m_Transform, serverTime.Time);
+                ApplyInterpolatedNetworkStateToTransform(ReplicatedNetworkState.Value, m_Transform, serverTime.Time);
 
                 // Always set the any new transform values to assure only the authoritative side is updating the transform
                 SetTransformValues();

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -628,15 +628,16 @@ namespace Unity.Netcode.Components
         }
 
         /// <summary>
-        /// Applies the authoritative state to the local transform
+        /// Applies the authoritative state to the transform
         /// </summary>
-        private void ApplyAuthoritativeState(NetworkTransformState networkState, Transform transformToUpdate)
+        private void ApplyAuthoritativeState()
         {
-            var interpolatedPosition = networkState.InLocalSpace ? transformToUpdate.localPosition : transformToUpdate.position;
+            var networkState = ReplicatedNetworkState.Value;
+            var interpolatedPosition = networkState.InLocalSpace ? m_Transform.localPosition : m_Transform.position;
 
             // todo: we should store network state w/ quats vs. euler angles
-            var interpolatedRotAngles = networkState.InLocalSpace ? transformToUpdate.localEulerAngles : transformToUpdate.eulerAngles;
-            var interpolatedScale = transformToUpdate.localScale;
+            var interpolatedRotAngles = networkState.InLocalSpace ? m_Transform.localEulerAngles : m_Transform.eulerAngles;
+            var interpolatedScale = m_Transform.localScale;
 
             // InLocalSpace Read:
             InLocalSpace = networkState.InLocalSpace;
@@ -704,11 +705,11 @@ namespace Unity.Netcode.Components
                 if (InLocalSpace)
                 {
 
-                    transformToUpdate.localPosition = interpolatedPosition;
+                    m_Transform.localPosition = interpolatedPosition;
                 }
                 else
                 {
-                    transformToUpdate.position = interpolatedPosition;
+                    m_Transform.position = interpolatedPosition;
                 }
             }
 
@@ -717,18 +718,18 @@ namespace Unity.Netcode.Components
             {
                 if (InLocalSpace)
                 {
-                    transformToUpdate.localRotation = Quaternion.Euler(interpolatedRotAngles);
+                    m_Transform.localRotation = Quaternion.Euler(interpolatedRotAngles);
                 }
                 else
                 {
-                    transformToUpdate.rotation = Quaternion.Euler(interpolatedRotAngles);
+                    m_Transform.rotation = Quaternion.Euler(interpolatedRotAngles);
                 }
             }
 
             // Apply the new scale
             if (networkState.HasScaleX || networkState.HasScaleY || networkState.HasScaleZ)
             {
-                transformToUpdate.localScale = interpolatedScale;
+                m_Transform.localScale = interpolatedScale;
             }
         }
 
@@ -964,7 +965,7 @@ namespace Unity.Netcode.Components
             // that can be invoked when ownership changes.
             if (CanCommitToTransform)
             {
-                Teleport(m_Transform.position, m_Transform.rotation, m_Transform.localScale);
+                SetStateInternal(m_Transform.position, m_Transform.rotation, m_Transform.localScale, true);
                 TryCommitTransform(transform, m_CachedNetworkManager.LocalTime.Time);
             }
         }
@@ -1113,7 +1114,7 @@ namespace Unity.Netcode.Components
                 }
 
                 // Now apply the current authoritative state
-                ApplyAuthoritativeState(ReplicatedNetworkState.Value, m_Transform);
+                ApplyAuthoritativeState();
             }
         }
 

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -433,22 +433,16 @@ namespace Unity.Netcode.Components
         /// This will try to send/commit the current transform delta states (if any)
         /// </summary>
         /// <remarks>
-        /// Only client owners or the server should invoked this method
+        /// Only client owners or the server should invoke this method
         /// </remarks>
         /// <param name="transformToCommit">the transform to be committed</param>
         /// <param name="dirtyTime">time it was marked dirty</param>
         protected void TryCommitTransformToServer(Transform transformToCommit, double dirtyTime)
         {
-            //
+            // Only client owners or the server should invoke this method
             if (!IsOwner && !m_CachedIsServer)
             {
                 NetworkLog.LogError($"Non-owner instance, {name}, is trying to commit a transform!");
-                return;
-            }
-
-            if (m_CachedIsServer && !OnIsServerAuthoritative() && !IsOwner)
-            {
-                NetworkLog.LogError($"Server is trying to commit {name}'s transform to itself! Use {nameof(SetState)} instead!");
                 return;
             }
 

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -627,9 +627,9 @@ namespace Unity.Netcode.Components
                 networkState.SentTime = dirtyTime;
             }
 
-            // We need to set this in order to know when we can re-apply our local authority state
-            /// <see cref="Update"/>
-            networkState.IsDirty = !networkState.IsDirty && isDirty;
+            /// We need to set this in order to know when we can re-apply our local authority state <see cref="Update"/>
+            /// If our state is already dirty or we just found deltas (i.e. isDirty == true)
+            networkState.IsDirty |= isDirty;
             return isDirty;
         }
 

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -995,8 +995,6 @@ namespace Unity.Netcode.Components
             m_CachedIsServer = IsServer;
             m_CachedNetworkManager = NetworkManager;
 
-            // crucial we do this to reset the interpolators so that recycled objects when using a pool will
-            // not have leftover interpolator state from the previous object
             Initialize();
 
             // This assures the initial spawning of the object synchronizes all connected clients
@@ -1050,6 +1048,7 @@ namespace Unity.Netcode.Components
 
             // must set up m_Transform in OnNetworkSpawn because it's possible an object spawns but is disabled
             //  and thus awake won't be called.
+            // TODO: We might consider removing this and just using transform directly;
             m_Transform = transform;
 
             CanCommitToTransform = IsServerAuthoritative() ? IsServer : IsOwner;

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -502,7 +502,9 @@ namespace Unity.Netcode.Components
             }
             else if (!m_HasSentLastValue && m_CachedNetworkManager.LocalTime.Tick >= m_LastSentTick + 1) // check for state.IsDirty since update can happen more than once per tick. No need for client, RPCs will just queue up
             {
-                m_LastSentState.IsTeleportingNextFrame = false; // This is required here
+                // Since the last m_LocalAuthoritativeNetworkState could have included a IsTeleportingNextFrame
+                // we need to reset this here so only the deltas are applied and interpolation is not reset again.
+                m_LastSentState.IsTeleportingNextFrame = false;
                 m_LastSentState.SentTime = m_CachedNetworkManager.LocalTime.Time; // time 1+ tick later
                 // Commit the state
                 ReplicatedNetworkState.Value = m_LastSentState;

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -912,13 +912,11 @@ namespace Unity.Netcode.Components
             m_CachedIsServer = IsServer;
             m_CachedNetworkManager = NetworkManager;
 
-
-            m_LocalAuthoritativeNetworkState = m_ReplicatedNetworkState.Value;
             if (CanCommitToTransform)
             {
                 TryCommitTransformToServer(m_Transform, m_CachedNetworkManager.LocalTime.Time);
             }
-
+            m_LocalAuthoritativeNetworkState = m_ReplicatedNetworkState.Value;
 
             // crucial we do this to reset the interpolators so that recycled objects when using a pool will
             //  not have leftover interpolator state from the previous object

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -406,23 +406,23 @@ namespace Unity.Netcode.Components
         }
 
         /// <summary>
-        /// Tries updating the server authoritative transform, only if allowed.
-        /// If this called server side, this will commit directly.
-        /// If no update is needed, nothing will be sent. This method should still be called every update, it'll self manage when it should and shouldn't send
+        /// Refer to <see cref="TryCommitTransform">, this is a legacy method.
         /// </summary>
-        /// <param name="transformToCommit"></param>
-        /// <param name="dirtyTime"></param>
         protected void TryCommitTransformToServer(Transform transformToCommit, double dirtyTime)
         {
             TryCommitTransform(transformToCommit, dirtyTime);
         }
 
-
+        /// <summary>
+        /// Tries updating the server authoritative transform, only if allowed.
+        /// </summary>
+        /// <param name="transformToCommit">the transform to be committed</param>
+        /// <param name="dirtyTime">time it was marked dirty</param>
         protected void TryCommitTransform(Transform transformToCommit, double dirtyTime)
         {
             if (!CanCommitToTransform)
             {
-                Debug.LogError($"[{name}] is trying to commit the transform without authority!");
+                NetworkLog.LogError($"[{name}] is trying to commit the transform without authority!");
                 return;
             }
             var isDirty = ApplyTransformToNetworkState(ref m_LocalAuthoritativeNetworkState, dirtyTime, transformToCommit);
@@ -690,9 +690,6 @@ namespace Unity.Netcode.Components
         /// from having too large of a delta time between the time it was last updated and the time any new update is
         /// sent.
         /// </remarks>
-        /// <param name="networkState">new state to apply</param>
-        /// <param name="transformToUpdate">transform to update</param>
-        /// <param name="serverTime">required to interpolate when axis is not updated in the state to apply</param>
         private void ApplyInterpolatedNetworkStateToTransform(NetworkTransformState networkState, Transform transformToUpdate, double serverTime)
         {
             var interpolatedPosition = InLocalSpace ? transformToUpdate.localPosition : transformToUpdate.position;
@@ -1060,7 +1057,7 @@ namespace Unity.Netcode.Components
 
             if (CanCommitToTransform)
             {
-                GetReplicatedNetworkState().OnValueChanged -= OnNetworkStateChanged;
+                replicatedState.OnValueChanged -= OnNetworkStateChanged;
                 TryCommitTransform(m_Transform, m_CachedNetworkManager.LocalTime.Time);
                 replicatedState.SetDirty(true);
             }
@@ -1212,7 +1209,7 @@ namespace Unity.Netcode.Components
             stateToSend.Position = newPosition;
             stateToSend.Rotation = newRotationEuler;
             stateToSend.Scale = newScale;
-            //ApplyInterpolatedNetworkStateToTransform(stateToSend, transform, m_CachedNetworkManager.ServerTime.Time);
+
             // set teleport flag in state to signal to ghosts not to interpolate
             m_LocalAuthoritativeNetworkState.IsTeleportingNextFrame = true;
 

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -189,6 +189,7 @@ namespace Unity.Netcode.Components
             /// </summary>
             internal void ClearBitSetForNextTick()
             {
+                // since we store the actual value (and not a dirty bit) here, we need to preserve it
                 m_Bitset &= (ushort)(m_Bitset & (1 << k_InLocalSpaceBit));
                 IsDirty = false;
             }

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -630,7 +630,7 @@ namespace Unity.Netcode.Components
         /// <summary>
         /// Applies the authoritative state to the local transform
         /// </summary>
-        private void ApplyInterpolatedNetworkStateToTransform(NetworkTransformState networkState, Transform transformToUpdate)
+        private void ApplyAuthoritativeState(NetworkTransformState networkState, Transform transformToUpdate)
         {
             var interpolatedPosition = networkState.InLocalSpace ? transformToUpdate.localPosition : transformToUpdate.position;
 
@@ -1112,8 +1112,8 @@ namespace Unity.Netcode.Components
                     m_RotationInterpolator.Update(cachedDeltaTime, cachedRenderTime, cachedServerTime);
                 }
 
-                // Apply updated interpolated value
-                ApplyInterpolatedNetworkStateToTransform(ReplicatedNetworkState.Value, m_Transform);
+                // Now apply the current authoritative state
+                ApplyAuthoritativeState(ReplicatedNetworkState.Value, m_Transform);
             }
         }
 

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -276,6 +276,7 @@ namespace Unity.Netcode.Components
                 if (serializer.IsReader)
                 {
                     // Go ahead and mark the local state dirty or not dirty as well
+                    /// <see cref="TryCommitTransformToServer"/>
                     if (HasPositionChange || HasRotAngleChange || HasScaleChange)
                     {
                         IsDirty = true;
@@ -407,6 +408,8 @@ namespace Unity.Netcode.Components
 
         private bool m_HasSentLastValue = false; // used to send one last value, so clients can make the difference between lost replication data (clients extrapolate) and no more data to send.
 
+        private ClientRpcParams m_ClientRpcParams = new ClientRpcParams() { Send = new ClientRpcSendParams() };
+        private List<ulong> m_ClientIds = new List<ulong>() { 0 };
 
         private BufferedLinearInterpolator<float> m_PositionXInterpolator;
         private BufferedLinearInterpolator<float> m_PositionYInterpolator;
@@ -1066,8 +1069,6 @@ namespace Unity.Netcode.Components
             }
         }
 
-        private ClientRpcParams m_ClientRpcParams = new ClientRpcParams() { Send = new ClientRpcSendParams() };
-        private List<ulong> m_ClientIds = new List<ulong>() { 0 };
         /// <summary>
         /// Directly sets a state on the authoritative transform.
         /// Owner clients can directly set the state on a server authoritative transform

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -832,36 +832,19 @@ namespace Unity.Netcode.Components
 
             var currentPosition = InLocalSpace ? m_Transform.localPosition : m_Transform.position;
 
-            // Note: Any values we don't have an update for need their interpolator deltas reset.
-            // Bandwidth optimizations mean that an update without the value set indicates "this hasn't changed",
-            // and so we need to tell the interpolators that it's the last currently known axis value(s) at this
-            // time delta.
-
             if (newState.HasPositionX)
             {
                 m_PositionXInterpolator.AddMeasurement(newState.PositionX, sentTime);
-            }
-            else
-            {
-                m_PositionXInterpolator.AddMeasurement(m_LastStatePosition.x, sentTime);
             }
 
             if (newState.HasPositionY)
             {
                 m_PositionYInterpolator.AddMeasurement(newState.PositionY, sentTime);
             }
-            else
-            {
-                m_PositionYInterpolator.AddMeasurement(m_LastStatePosition.y, sentTime);
-            }
 
             if (newState.HasPositionZ)
             {
                 m_PositionZInterpolator.AddMeasurement(newState.PositionZ, sentTime);
-            }
-            else
-            {
-                m_PositionZInterpolator.AddMeasurement(m_LastStatePosition.z, sentTime);
             }
 
             // Here we take the new state Euler angles and apply any local
@@ -888,27 +871,15 @@ namespace Unity.Netcode.Components
             {
                 m_ScaleXInterpolator.AddMeasurement(newState.ScaleX, sentTime);
             }
-            else
-            {
-                m_ScaleXInterpolator.AddMeasurement(m_LocalScale.x, sentTime);
-            }
 
             if (newState.HasScaleY)
             {
                 m_ScaleYInterpolator.AddMeasurement(newState.ScaleY, sentTime);
             }
-            else
-            {
-                m_ScaleYInterpolator.AddMeasurement(m_LocalScale.y, sentTime);
-            }
 
             if (newState.HasScaleZ)
             {
                 m_ScaleZInterpolator.AddMeasurement(newState.ScaleZ, sentTime);
-            }
-            else
-            {
-                m_ScaleZInterpolator.AddMeasurement(m_LocalScale.z, sentTime);
             }
         }
 

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -189,7 +189,7 @@ namespace Unity.Netcode.Components
             /// </summary>
             internal void ClearBitSetForNextTick()
             {
-                // since we store the actual value (and not a dirty bit) here, we need to preserve it
+                // We need to preserve the local space settings for the current state
                 m_Bitset &= (ushort)(m_Bitset & (1 << k_InLocalSpaceBit));
                 IsDirty = false;
             }

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -681,7 +681,7 @@ namespace Unity.Netcode.Components
             // InLocalSpace Read
             InLocalSpace = networkState.InLocalSpace;
             // Position Read
-            if (networkState.HasPositionX )
+            if (networkState.HasPositionX)
             {
                 interpolatedPosition.x = networkState.IsTeleportingNextFrame || !Interpolate ? networkState.Position.x : m_PositionXInterpolator.GetInterpolatedValue();
             }

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -1017,6 +1017,13 @@ namespace Unity.Netcode.Components
             ReplicatedNetworkState.OnValueChanged -= OnNetworkStateChanged;
         }
 
+        public override void OnDestroy()
+        {
+            base.OnDestroy();
+            m_ReplicatedNetworkStateServer.Dispose();
+            m_ReplicatedNetworkStateOwner.Dispose();
+        }
+
         /// <inheritdoc/>
         public override void OnGainedOwnership()
         {

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -60,120 +60,120 @@ namespace Unity.Netcode.Components
             private const int k_ScaleYBit = 8;
             private const int k_ScaleZBit = 9;
             private const int k_TeleportingBit = 10;
-
             // 11-15: <unused>
-            internal ushort Bitset;
+
+            private ushort m_Bitset;
 
             internal bool InLocalSpace
             {
-                get => (Bitset & (1 << k_InLocalSpaceBit)) != 0;
+                get => (m_Bitset & (1 << k_InLocalSpaceBit)) != 0;
                 set
                 {
-                    if (value) { Bitset = (ushort)(Bitset | (1 << k_InLocalSpaceBit)); }
-                    else { Bitset = (ushort)(Bitset & ~(1 << k_InLocalSpaceBit)); }
+                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_InLocalSpaceBit)); }
+                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_InLocalSpaceBit)); }
                 }
             }
 
             // Position
             internal bool HasPositionX
             {
-                get => (Bitset & (1 << k_PositionXBit)) != 0;
+                get => (m_Bitset & (1 << k_PositionXBit)) != 0;
                 set
                 {
-                    if (value) { Bitset = (ushort)(Bitset | (1 << k_PositionXBit)); }
-                    else { Bitset = (ushort)(Bitset & ~(1 << k_PositionXBit)); }
+                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_PositionXBit)); }
+                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_PositionXBit)); }
                 }
             }
 
             internal bool HasPositionY
             {
-                get => (Bitset & (1 << k_PositionYBit)) != 0;
+                get => (m_Bitset & (1 << k_PositionYBit)) != 0;
                 set
                 {
-                    if (value) { Bitset = (ushort)(Bitset | (1 << k_PositionYBit)); }
-                    else { Bitset = (ushort)(Bitset & ~(1 << k_PositionYBit)); }
+                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_PositionYBit)); }
+                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_PositionYBit)); }
                 }
             }
 
             internal bool HasPositionZ
             {
-                get => (Bitset & (1 << k_PositionZBit)) != 0;
+                get => (m_Bitset & (1 << k_PositionZBit)) != 0;
                 set
                 {
-                    if (value) { Bitset = (ushort)(Bitset | (1 << k_PositionZBit)); }
-                    else { Bitset = (ushort)(Bitset & ~(1 << k_PositionZBit)); }
+                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_PositionZBit)); }
+                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_PositionZBit)); }
                 }
             }
 
             // RotAngles
             internal bool HasRotAngleX
             {
-                get => (Bitset & (1 << k_RotAngleXBit)) != 0;
+                get => (m_Bitset & (1 << k_RotAngleXBit)) != 0;
                 set
                 {
-                    if (value) { Bitset = (ushort)(Bitset | (1 << k_RotAngleXBit)); }
-                    else { Bitset = (ushort)(Bitset & ~(1 << k_RotAngleXBit)); }
+                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_RotAngleXBit)); }
+                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_RotAngleXBit)); }
                 }
             }
 
             internal bool HasRotAngleY
             {
-                get => (Bitset & (1 << k_RotAngleYBit)) != 0;
+                get => (m_Bitset & (1 << k_RotAngleYBit)) != 0;
                 set
                 {
-                    if (value) { Bitset = (ushort)(Bitset | (1 << k_RotAngleYBit)); }
-                    else { Bitset = (ushort)(Bitset & ~(1 << k_RotAngleYBit)); }
+                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_RotAngleYBit)); }
+                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_RotAngleYBit)); }
                 }
             }
 
             internal bool HasRotAngleZ
             {
-                get => (Bitset & (1 << k_RotAngleZBit)) != 0;
+                get => (m_Bitset & (1 << k_RotAngleZBit)) != 0;
                 set
                 {
-                    if (value) { Bitset = (ushort)(Bitset | (1 << k_RotAngleZBit)); }
-                    else { Bitset = (ushort)(Bitset & ~(1 << k_RotAngleZBit)); }
+                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_RotAngleZBit)); }
+                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_RotAngleZBit)); }
                 }
             }
 
             // Scale
             internal bool HasScaleX
             {
-                get => (Bitset & (1 << k_ScaleXBit)) != 0;
+                get => (m_Bitset & (1 << k_ScaleXBit)) != 0;
                 set
                 {
-                    if (value) { Bitset = (ushort)(Bitset | (1 << k_ScaleXBit)); }
-                    else { Bitset = (ushort)(Bitset & ~(1 << k_ScaleXBit)); }
+                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_ScaleXBit)); }
+                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_ScaleXBit)); }
                 }
             }
 
             internal bool HasScaleY
             {
-                get => (Bitset & (1 << k_ScaleYBit)) != 0;
+                get => (m_Bitset & (1 << k_ScaleYBit)) != 0;
                 set
                 {
-                    if (value) { Bitset = (ushort)(Bitset | (1 << k_ScaleYBit)); }
-                    else { Bitset = (ushort)(Bitset & ~(1 << k_ScaleYBit)); }
+                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_ScaleYBit)); }
+                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_ScaleYBit)); }
                 }
             }
 
             internal bool HasScaleZ
             {
-                get => (Bitset & (1 << k_ScaleZBit)) != 0;
+                get => (m_Bitset & (1 << k_ScaleZBit)) != 0;
                 set
                 {
-                    if (value) { Bitset = (ushort)(Bitset | (1 << k_ScaleZBit)); }
-                    else { Bitset = (ushort)(Bitset & ~(1 << k_ScaleZBit)); }
+                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_ScaleZBit)); }
+                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_ScaleZBit)); }
                 }
             }
 
             internal bool IsTeleportingNextFrame
             {
-                get => (Bitset & (1 << k_TeleportingBit)) != 0;
+                get => (m_Bitset & (1 << k_TeleportingBit)) != 0;
                 set
                 {
-                    if (value) { Bitset = (ushort)(Bitset | (1 << k_TeleportingBit)); }
-                    else { Bitset = (ushort)(Bitset & ~(1 << k_TeleportingBit)); }
+                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_TeleportingBit)); }
+                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_TeleportingBit)); }
                 }
             }
 
@@ -219,7 +219,7 @@ namespace Unity.Netcode.Components
             {
                 serializer.SerializeValue(ref SentTime);
                 // InLocalSpace + HasXXX Bits
-                serializer.SerializeValue(ref Bitset);
+                serializer.SerializeValue(ref m_Bitset);
                 // Position Values
                 if (HasPositionX)
                 {
@@ -414,11 +414,22 @@ namespace Unity.Netcode.Components
         /// <param name="dirtyTime"></param>
         protected void TryCommitTransformToServer(Transform transformToCommit, double dirtyTime)
         {
+            TryCommitTransform(transformToCommit, dirtyTime);
+        }
+
+
+        protected void TryCommitTransform(Transform transformToCommit, double dirtyTime)
+        {
+            if (!CanCommitToTransform)
+            {
+                Debug.LogError($"[{name}] is trying to commit the transform without authority!");
+                return;
+            }
             var isDirty = ApplyTransformToNetworkState(ref m_LocalAuthoritativeNetworkState, dirtyTime, transformToCommit);
             TryCommit(isDirty);
         }
 
-        private void TryCommitValuesToServer(Vector3 position, Vector3 rotation, Vector3 scale, double dirtyTime)
+        private void TryCommitValues(Vector3 position, Vector3 rotation, Vector3 scale, double dirtyTime)
         {
             var isDirty = ApplyTransformToNetworkStateWithInfo(ref m_LocalAuthoritativeNetworkState, dirtyTime, position, rotation, scale);
 
@@ -979,26 +990,6 @@ namespace Unity.Netcode.Components
             m_CachedIsServer = IsServer;
             m_CachedNetworkManager = NetworkManager;
 
-            CanCommitToTransform = IsServerAuthoritative() ? IsServer : IsOwner;
-
-            // must set up m_Transform in OnNetworkSpawn because it's possible an object spawns but is disabled
-            //  and thus awake won't be called.
-            // TODO: investigate further on not sending data for something that is not enabled
-            m_Transform = transform;
-
-            m_LocalAuthoritativeNetworkState = GetReplicatedNetworkState().Value;
-
-            if (CanCommitToTransform)
-            {
-                m_LastSentState = GetReplicatedNetworkState().Value;
-                TryCommitTransformToServer(m_Transform, m_CachedNetworkManager.LocalTime.Time);
-            }
-            else
-            {
-                GetReplicatedNetworkState().OnValueChanged += OnNetworkStateChanged;
-                // For the non-authoritative side, we need to capture these values
-                SetTransformValues();
-            }
 
             // crucial we do this to reset the interpolators so that recycled objects when using a pool will
             //  not have leftover interpolator state from the previous object
@@ -1025,14 +1016,35 @@ namespace Unity.Netcode.Components
 
         private void Initialize()
         {
+            if (!IsSpawned)
+            {
+                return;
+            }
+
+            // must set up m_Transform in OnNetworkSpawn because it's possible an object spawns but is disabled
+            //  and thus awake won't be called.
+            // TODO: investigate further on not sending data for something that is not enabled
+            m_Transform = transform;
+
+            CanCommitToTransform = IsServerAuthoritative() ? IsServer : IsOwner;
+            var replicatedState = GetReplicatedNetworkState();
+            m_LocalAuthoritativeNetworkState = replicatedState.Value;
+
             if (CanCommitToTransform)
             {
-                GetReplicatedNetworkState().SetDirty(true);
+                GetReplicatedNetworkState().OnValueChanged -= OnNetworkStateChanged;
+                TryCommitTransform(m_Transform, m_CachedNetworkManager.LocalTime.Time);
+                replicatedState.SetDirty(true);
             }
-            else if (m_Transform != null)
+            else
             {
+                replicatedState.OnValueChanged += OnNetworkStateChanged;
                 ResetInterpolatedStateToCurrentAuthoritativeState(); // useful for late joining
-                ApplyInterpolatedNetworkStateToTransform(GetReplicatedNetworkState().Value, m_Transform, NetworkManager.ServerTime.Time);
+
+                // For the non-authoritative side, we need to capture these values
+                SetTransformValues();
+
+                ApplyInterpolatedNetworkStateToTransform(replicatedState.Value, m_Transform, NetworkManager.ServerTime.Time);
             }
         }
 
@@ -1107,7 +1119,7 @@ namespace Unity.Netcode.Components
 
             if (CanCommitToTransform)
             {
-                TryCommitTransformToServer(m_Transform, m_CachedNetworkManager.LocalTime.Time);
+                TryCommitTransform(m_Transform, m_CachedNetworkManager.LocalTime.Time);
             }
             else
             {
@@ -1123,13 +1135,13 @@ namespace Unity.Netcode.Components
                 m_LastInterpolate = Interpolate;
 
                 // eventually, we could hoist this calculation so that it happens once for all objects, not once per object
-                var cachedDeltaTime = Time.deltaTime;
-                var serverTime = NetworkManager.ServerTime;
-                var cachedServerTime = serverTime.Time;
-                var cachedRenderTime = serverTime.TimeTicksAgo(1).Time;
 
+                var serverTime = NetworkManager.ServerTime;
                 if (Interpolate)
                 {
+                    var cachedDeltaTime = Time.deltaTime;
+                    var cachedServerTime = serverTime.Time;
+                    var cachedRenderTime = serverTime.TimeTicksAgo(1).Time;
                     foreach (var interpolator in m_AllFloatInterpolators)
                     {
                         interpolator.Update(cachedDeltaTime, cachedRenderTime, cachedServerTime);
@@ -1172,11 +1184,11 @@ namespace Unity.Netcode.Components
             stateToSend.Position = newPosition;
             stateToSend.Rotation = newRotationEuler;
             stateToSend.Scale = newScale;
-            //ApplyInterpolatedNetworkStateToTransform(stateToSend, transform, m_CachedNetworkManager.ServerTime.Time);
+            ApplyInterpolatedNetworkStateToTransform(stateToSend, transform, m_CachedNetworkManager.ServerTime.Time);
             // set teleport flag in state to signal to ghosts not to interpolate
             m_LocalAuthoritativeNetworkState.IsTeleportingNextFrame = true;
-            // check server side
-            TryCommitValuesToServer(newPosition, newRotationEuler, newScale, m_CachedNetworkManager.LocalTime.Time);
+
+            TryCommitValues(newPosition, newRotationEuler, newScale, m_CachedNetworkManager.LocalTime.Time);
             m_LocalAuthoritativeNetworkState.IsTeleportingNextFrame = false;
         }
 

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -62,118 +62,118 @@ namespace Unity.Netcode.Components
             private const int k_TeleportingBit = 10;
 
             // 11-15: <unused>
-            private ushort m_Bitset;
+            internal ushort Bitset;
 
             internal bool InLocalSpace
             {
-                get => (m_Bitset & (1 << k_InLocalSpaceBit)) != 0;
+                get => (Bitset & (1 << k_InLocalSpaceBit)) != 0;
                 set
                 {
-                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_InLocalSpaceBit)); }
-                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_InLocalSpaceBit)); }
+                    if (value) { Bitset = (ushort)(Bitset | (1 << k_InLocalSpaceBit)); }
+                    else { Bitset = (ushort)(Bitset & ~(1 << k_InLocalSpaceBit)); }
                 }
             }
 
             // Position
             internal bool HasPositionX
             {
-                get => (m_Bitset & (1 << k_PositionXBit)) != 0;
+                get => (Bitset & (1 << k_PositionXBit)) != 0;
                 set
                 {
-                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_PositionXBit)); }
-                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_PositionXBit)); }
+                    if (value) { Bitset = (ushort)(Bitset | (1 << k_PositionXBit)); }
+                    else { Bitset = (ushort)(Bitset & ~(1 << k_PositionXBit)); }
                 }
             }
 
             internal bool HasPositionY
             {
-                get => (m_Bitset & (1 << k_PositionYBit)) != 0;
+                get => (Bitset & (1 << k_PositionYBit)) != 0;
                 set
                 {
-                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_PositionYBit)); }
-                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_PositionYBit)); }
+                    if (value) { Bitset = (ushort)(Bitset | (1 << k_PositionYBit)); }
+                    else { Bitset = (ushort)(Bitset & ~(1 << k_PositionYBit)); }
                 }
             }
 
             internal bool HasPositionZ
             {
-                get => (m_Bitset & (1 << k_PositionZBit)) != 0;
+                get => (Bitset & (1 << k_PositionZBit)) != 0;
                 set
                 {
-                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_PositionZBit)); }
-                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_PositionZBit)); }
+                    if (value) { Bitset = (ushort)(Bitset | (1 << k_PositionZBit)); }
+                    else { Bitset = (ushort)(Bitset & ~(1 << k_PositionZBit)); }
                 }
             }
 
             // RotAngles
             internal bool HasRotAngleX
             {
-                get => (m_Bitset & (1 << k_RotAngleXBit)) != 0;
+                get => (Bitset & (1 << k_RotAngleXBit)) != 0;
                 set
                 {
-                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_RotAngleXBit)); }
-                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_RotAngleXBit)); }
+                    if (value) { Bitset = (ushort)(Bitset | (1 << k_RotAngleXBit)); }
+                    else { Bitset = (ushort)(Bitset & ~(1 << k_RotAngleXBit)); }
                 }
             }
 
             internal bool HasRotAngleY
             {
-                get => (m_Bitset & (1 << k_RotAngleYBit)) != 0;
+                get => (Bitset & (1 << k_RotAngleYBit)) != 0;
                 set
                 {
-                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_RotAngleYBit)); }
-                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_RotAngleYBit)); }
+                    if (value) { Bitset = (ushort)(Bitset | (1 << k_RotAngleYBit)); }
+                    else { Bitset = (ushort)(Bitset & ~(1 << k_RotAngleYBit)); }
                 }
             }
 
             internal bool HasRotAngleZ
             {
-                get => (m_Bitset & (1 << k_RotAngleZBit)) != 0;
+                get => (Bitset & (1 << k_RotAngleZBit)) != 0;
                 set
                 {
-                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_RotAngleZBit)); }
-                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_RotAngleZBit)); }
+                    if (value) { Bitset = (ushort)(Bitset | (1 << k_RotAngleZBit)); }
+                    else { Bitset = (ushort)(Bitset & ~(1 << k_RotAngleZBit)); }
                 }
             }
 
             // Scale
             internal bool HasScaleX
             {
-                get => (m_Bitset & (1 << k_ScaleXBit)) != 0;
+                get => (Bitset & (1 << k_ScaleXBit)) != 0;
                 set
                 {
-                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_ScaleXBit)); }
-                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_ScaleXBit)); }
+                    if (value) { Bitset = (ushort)(Bitset | (1 << k_ScaleXBit)); }
+                    else { Bitset = (ushort)(Bitset & ~(1 << k_ScaleXBit)); }
                 }
             }
 
             internal bool HasScaleY
             {
-                get => (m_Bitset & (1 << k_ScaleYBit)) != 0;
+                get => (Bitset & (1 << k_ScaleYBit)) != 0;
                 set
                 {
-                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_ScaleYBit)); }
-                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_ScaleYBit)); }
+                    if (value) { Bitset = (ushort)(Bitset | (1 << k_ScaleYBit)); }
+                    else { Bitset = (ushort)(Bitset & ~(1 << k_ScaleYBit)); }
                 }
             }
 
             internal bool HasScaleZ
             {
-                get => (m_Bitset & (1 << k_ScaleZBit)) != 0;
+                get => (Bitset & (1 << k_ScaleZBit)) != 0;
                 set
                 {
-                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_ScaleZBit)); }
-                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_ScaleZBit)); }
+                    if (value) { Bitset = (ushort)(Bitset | (1 << k_ScaleZBit)); }
+                    else { Bitset = (ushort)(Bitset & ~(1 << k_ScaleZBit)); }
                 }
             }
 
             internal bool IsTeleportingNextFrame
             {
-                get => (m_Bitset & (1 << k_TeleportingBit)) != 0;
+                get => (Bitset & (1 << k_TeleportingBit)) != 0;
                 set
                 {
-                    if (value) { m_Bitset = (ushort)(m_Bitset | (1 << k_TeleportingBit)); }
-                    else { m_Bitset = (ushort)(m_Bitset & ~(1 << k_TeleportingBit)); }
+                    if (value) { Bitset = (ushort)(Bitset | (1 << k_TeleportingBit)); }
+                    else { Bitset = (ushort)(Bitset & ~(1 << k_TeleportingBit)); }
                 }
             }
 
@@ -219,7 +219,7 @@ namespace Unity.Netcode.Components
             {
                 serializer.SerializeValue(ref SentTime);
                 // InLocalSpace + HasXXX Bits
-                serializer.SerializeValue(ref m_Bitset);
+                serializer.SerializeValue(ref Bitset);
                 // Position Values
                 if (HasPositionX)
                 {
@@ -523,76 +523,130 @@ namespace Unity.Netcode.Components
             //  this still is overly costly and could use more improvements.
             //
             // (ditto for scale components)
-            if (SyncPositionX &&
-                Mathf.Abs(networkState.PositionX - position.x) > PositionThreshold)
+            if (SyncPositionX)
             {
-                networkState.PositionX = position.x;
-                networkState.HasPositionX = true;
-                isPositionDirty = true;
+                if (Mathf.Abs(networkState.PositionX - position.x) > PositionThreshold)
+                {
+                    networkState.PositionX = position.x;
+                    networkState.HasPositionX = true;
+                    isPositionDirty = true;
+                }
+                else
+                {
+                    networkState.HasPositionX = false;
+                }
             }
 
-            if (SyncPositionY &&
-                Mathf.Abs(networkState.PositionY - position.y) > PositionThreshold)
+            if (SyncPositionY)
             {
-                networkState.PositionY = position.y;
-                networkState.HasPositionY = true;
-                isPositionDirty = true;
+                if (Mathf.Abs(networkState.PositionY - position.y) > PositionThreshold)
+                {
+                    networkState.PositionY = position.y;
+                    networkState.HasPositionY = true;
+                    isPositionDirty = true;
+                }
+                else
+                {
+                    networkState.HasPositionY = false;
+                }
             }
 
-            if (SyncPositionZ &&
-                Mathf.Abs(networkState.PositionZ - position.z) > PositionThreshold)
+            if (SyncPositionZ)
             {
-                networkState.PositionZ = position.z;
-                networkState.HasPositionZ = true;
-                isPositionDirty = true;
+                if (Mathf.Abs(networkState.PositionZ - position.z) > PositionThreshold)
+                {
+                    networkState.PositionZ = position.z;
+                    networkState.HasPositionZ = true;
+                    isPositionDirty = true;
+                }
+                else
+                {
+                    networkState.HasPositionZ = false;
+                }
             }
 
-            if (SyncRotAngleX &&
-                Mathf.Abs(Mathf.DeltaAngle(networkState.RotAngleX, rotAngles.x)) > RotAngleThreshold)
+            if (SyncRotAngleX)
             {
-                networkState.RotAngleX = rotAngles.x;
-                networkState.HasRotAngleX = true;
-                isRotationDirty = true;
+                if (Mathf.Abs(Mathf.DeltaAngle(networkState.RotAngleX, rotAngles.x)) > RotAngleThreshold)
+                {
+                    networkState.RotAngleX = rotAngles.x;
+                    networkState.HasRotAngleX = true;
+                    isRotationDirty = true;
+                }
+                else
+                {
+                    networkState.HasRotAngleX = false;
+                }
             }
 
-            if (SyncRotAngleY &&
-                Mathf.Abs(Mathf.DeltaAngle(networkState.RotAngleY, rotAngles.y)) > RotAngleThreshold)
+            if (SyncRotAngleY)
             {
-                networkState.RotAngleY = rotAngles.y;
-                networkState.HasRotAngleY = true;
-                isRotationDirty = true;
+                if (Mathf.Abs(Mathf.DeltaAngle(networkState.RotAngleY, rotAngles.y)) > RotAngleThreshold)
+                {
+                    networkState.RotAngleY = rotAngles.y;
+                    networkState.HasRotAngleY = true;
+                    isRotationDirty = true;
+                }
+                else
+                {
+                    networkState.HasRotAngleY = false;
+                }
             }
 
-            if (SyncRotAngleZ &&
-                Mathf.Abs(Mathf.DeltaAngle(networkState.RotAngleZ, rotAngles.z)) > RotAngleThreshold)
+            if (SyncRotAngleZ)
             {
-                networkState.RotAngleZ = rotAngles.z;
-                networkState.HasRotAngleZ = true;
-                isRotationDirty = true;
+                if (Mathf.Abs(Mathf.DeltaAngle(networkState.RotAngleZ, rotAngles.z)) > RotAngleThreshold)
+                {
+                    networkState.RotAngleZ = rotAngles.z;
+                    networkState.HasRotAngleZ = true;
+                    isRotationDirty = true;
+                }
+                else
+                {
+                    networkState.HasRotAngleZ = false;
+                }
             }
 
-            if (SyncScaleX &&
-                Mathf.Abs(networkState.ScaleX - scale.x) > ScaleThreshold)
+            if (SyncScaleX)
             {
-                networkState.ScaleX = scale.x;
-                networkState.HasScaleX = true;
-                isScaleDirty = true;
+                if (Mathf.Abs(networkState.ScaleX - scale.x) > ScaleThreshold)
+                {
+                    networkState.ScaleX = scale.x;
+                    networkState.HasScaleX = true;
+                    isScaleDirty = true;
+                }
+                else
+                {
+                    networkState.HasScaleX = false;
+                }
             }
 
-            if (SyncScaleY &&
-                Mathf.Abs(networkState.ScaleY - scale.y) > ScaleThreshold)
+            if (SyncScaleY)
             {
-                networkState.ScaleY = scale.y;
-                networkState.HasScaleY = true;
-                isScaleDirty = true;
+                if (Mathf.Abs(networkState.ScaleY - scale.y) > ScaleThreshold)
+                {
+                    networkState.ScaleY = scale.y;
+                    networkState.HasScaleY = true;
+                    isScaleDirty = true;
+                }
+                else
+                {
+                    networkState.HasScaleY = false;
+                }
             }
 
-            if (SyncScaleZ &&
-                Mathf.Abs(networkState.ScaleZ - scale.z) > ScaleThreshold)
+            if (SyncScaleZ)
             {
-                networkState.ScaleZ = scale.z;
-                networkState.HasScaleZ = true;
-                isScaleDirty = true;
+                if (Mathf.Abs(networkState.ScaleZ - scale.z) > ScaleThreshold)
+                {
+                    networkState.ScaleZ = scale.z;
+                    networkState.HasScaleZ = true;
+                    isScaleDirty = true;
+                }
+                else
+                {
+                    networkState.HasScaleZ = false;
+                }
             }
 
             isDirty |= isPositionDirty || isRotationDirty || isScaleDirty;
@@ -858,11 +912,13 @@ namespace Unity.Netcode.Components
             m_CachedIsServer = IsServer;
             m_CachedNetworkManager = NetworkManager;
 
+
+            m_LocalAuthoritativeNetworkState = m_ReplicatedNetworkState.Value;
             if (CanCommitToTransform)
             {
                 TryCommitTransformToServer(m_Transform, m_CachedNetworkManager.LocalTime.Time);
             }
-            m_LocalAuthoritativeNetworkState = m_ReplicatedNetworkState.Value;
+
 
             // crucial we do this to reset the interpolators so that recycled objects when using a pool will
             //  not have leftover interpolator state from the previous object

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -630,12 +630,7 @@ namespace Unity.Netcode.Components
         /// <summary>
         /// Applies the authoritative state to the local transform
         /// </summary>
-        /// <remarks>
-        /// The serverTime is required for position and scale in order to prevent a single element of each 3 elements
-        /// from having too large of a delta time between the time it was last updated and the time any new update is
-        /// sent.
-        /// </remarks>
-        private void ApplyInterpolatedNetworkStateToTransform(NetworkTransformState networkState, Transform transformToUpdate, double serverTime)
+        private void ApplyInterpolatedNetworkStateToTransform(NetworkTransformState networkState, Transform transformToUpdate)
         {
             var interpolatedPosition = networkState.InLocalSpace ? transformToUpdate.localPosition : transformToUpdate.position;
 
@@ -1102,10 +1097,10 @@ namespace Unity.Netcode.Components
             }
             else
             {
-                // eventually, we could hoist this calculation so that it happens once for all objects, not once per object
-                var serverTime = NetworkManager.ServerTime;
                 if (Interpolate)
                 {
+                    // eventually, we could hoist this calculation so that it happens once for all objects, not once per object
+                    var serverTime = NetworkManager.ServerTime;
                     var cachedDeltaTime = Time.deltaTime;
                     var cachedServerTime = serverTime.Time;
                     var cachedRenderTime = serverTime.TimeTicksAgo(1).Time;
@@ -1118,7 +1113,7 @@ namespace Unity.Netcode.Components
                 }
 
                 // Apply updated interpolated value
-                ApplyInterpolatedNetworkStateToTransform(ReplicatedNetworkState.Value, m_Transform, serverTime.Time);
+                ApplyInterpolatedNetworkStateToTransform(ReplicatedNetworkState.Value, m_Transform);
             }
         }
 

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -505,7 +505,8 @@ namespace Unity.Netcode.Components
             // making it immobile.
             if (isDirty)
             {
-                CommitLocallyAndReplicate(m_LocalAuthoritativeNetworkState);
+                // Commit the state
+                ReplicatedNetworkState.Value = m_LocalAuthoritativeNetworkState;
                 m_HasSentLastValue = false;
                 m_LastSentTick = m_CachedNetworkManager.LocalTime.Tick;
                 m_LastSentState = m_LocalAuthoritativeNetworkState;
@@ -514,14 +515,10 @@ namespace Unity.Netcode.Components
             {
                 m_LastSentState.IsTeleportingNextFrame = false; // This is required here
                 m_LastSentState.SentTime = m_CachedNetworkManager.LocalTime.Time; // time 1+ tick later
-                CommitLocallyAndReplicate(m_LastSentState);
+                // Commit the state
+                ReplicatedNetworkState.Value = m_LastSentState;
                 m_HasSentLastValue = true;
             }
-        }
-
-        private void CommitLocallyAndReplicate(NetworkTransformState networkState)
-        {
-            ReplicatedNetworkState.Value = networkState;
         }
 
         private void ResetInterpolatedStateToCurrentAuthoritativeState()

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -368,6 +368,11 @@ namespace Unity.Netcode.Components
 
         private readonly NetworkVariable<NetworkTransformState> m_ReplicatedNetworkState = new NetworkVariable<NetworkTransformState>(new NetworkTransformState());
 
+        internal NetworkVariable<NetworkTransformState> GetReplicatedNetworkState()
+        {
+            return m_ReplicatedNetworkState;
+        }
+
         private NetworkTransformState m_LocalAuthoritativeNetworkState;
 
         private const int k_DebugDrawLineTime = 10;
@@ -387,6 +392,11 @@ namespace Unity.Netcode.Components
         private Transform m_Transform; // cache the transform component to reduce unnecessary bounce between managed and native
         private int m_LastSentTick;
         private NetworkTransformState m_LastSentState;
+
+        internal NetworkTransformState GetLastSentState()
+        {
+            return m_LastSentState;
+        }
 
         /// <summary>
         /// Tries updating the server authoritative transform, only if allowed.
@@ -850,7 +860,10 @@ namespace Unity.Netcode.Components
                 m_PositionZInterpolator.AddMeasurement(newState.PositionZ, sentTime);
             }
 
-            m_RotationInterpolator.AddMeasurement(Quaternion.Euler(newState.Rotation), sentTime);
+            if (newState.HasRotAngleX || newState.HasRotAngleY || newState.HasRotAngleZ)
+            {
+                m_RotationInterpolator.AddMeasurement(Quaternion.Euler(newState.Rotation), sentTime);
+            }
 
             if (newState.HasScaleX)
             {

--- a/com.unity.netcode.gameobjects/Tests/Editor/Timing/NetworkTimeTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Timing/NetworkTimeTests.cs
@@ -147,75 +147,53 @@ namespace Unity.Netcode.EditorTests
             var random = new Random(42);
             var randomSteps = Enumerable.Repeat(0f, 1000).Select(t => Mathf.Lerp(1 / 25f, 1.80f, (float)random.NextDouble())).ToList();
 
-            void CheckResults((bool, string) value)
-            {
-                if (!value.Item1)
-                {
-                    Assert.Fail(value.Item2);
-                }
-            }
+            NetworkTimeAdvanceTestInternal(randomSteps, 60, 0f);
+            NetworkTimeAdvanceTestInternal(randomSteps, 1, 0f);
+            NetworkTimeAdvanceTestInternal(randomSteps, 10, 0f);
+            NetworkTimeAdvanceTestInternal(randomSteps, 20, 0f);
+            NetworkTimeAdvanceTestInternal(randomSteps, 30, 0f);
+            NetworkTimeAdvanceTestInternal(randomSteps, 144, 0f);
 
-            CheckResults(NetworkTimeAdvanceTestInternal(randomSteps, 60, 0f));
-
-            CheckResults(NetworkTimeAdvanceTestInternal(randomSteps, 1, 0f));
-            CheckResults(NetworkTimeAdvanceTestInternal(randomSteps, 10, 0f));
-            CheckResults(NetworkTimeAdvanceTestInternal(randomSteps, 20, 0f));
-            CheckResults(NetworkTimeAdvanceTestInternal(randomSteps, 30, 0f));
-            CheckResults(NetworkTimeAdvanceTestInternal(randomSteps, 144, 0f));
-
-            CheckResults(NetworkTimeAdvanceTestInternal(randomSteps, 60, 23132.231f));
-            CheckResults(NetworkTimeAdvanceTestInternal(randomSteps, 1, 23132.231f));
-            CheckResults(NetworkTimeAdvanceTestInternal(randomSteps, 10, 23132.231f));
-            CheckResults(NetworkTimeAdvanceTestInternal(randomSteps, 20, 23132.231f));
-            CheckResults(NetworkTimeAdvanceTestInternal(randomSteps, 30, 23132.231f));
-            CheckResults(NetworkTimeAdvanceTestInternal(randomSteps, 30, 23132.231f));
-            CheckResults(NetworkTimeAdvanceTestInternal(randomSteps, 144, 23132.231f));
-            randomSteps.Clear();
-            randomSteps = null;
+            NetworkTimeAdvanceTestInternal(randomSteps, 60, 23132.231f);
+            NetworkTimeAdvanceTestInternal(randomSteps, 1, 23132.231f);
+            NetworkTimeAdvanceTestInternal(randomSteps, 10, 23132.231f);
+            NetworkTimeAdvanceTestInternal(randomSteps, 20, 23132.231f);
+            NetworkTimeAdvanceTestInternal(randomSteps, 30, 23132.231f);
+            NetworkTimeAdvanceTestInternal(randomSteps, 30, 23132.231f);
+            NetworkTimeAdvanceTestInternal(randomSteps, 144, 23132.231f);
 
             var shortSteps = Enumerable.Repeat(1 / 30f, 1000);
+            NetworkTimeAdvanceTestInternal(shortSteps, 60, 0f);
+            NetworkTimeAdvanceTestInternal(shortSteps, 1, 0f);
+            NetworkTimeAdvanceTestInternal(shortSteps, 10, 0f);
+            NetworkTimeAdvanceTestInternal(shortSteps, 20, 0f);
+            NetworkTimeAdvanceTestInternal(shortSteps, 30, 0f);
+            NetworkTimeAdvanceTestInternal(shortSteps, 144, 0f);
 
-            CheckResults(NetworkTimeAdvanceTestInternal(shortSteps, 60, 0f));
-            CheckResults(NetworkTimeAdvanceTestInternal(shortSteps, 1, 0f));
-            CheckResults(NetworkTimeAdvanceTestInternal(shortSteps, 10, 0f));
-            CheckResults(NetworkTimeAdvanceTestInternal(shortSteps, 20, 0f));
-            CheckResults(NetworkTimeAdvanceTestInternal(shortSteps, 30, 0f));
-            CheckResults(NetworkTimeAdvanceTestInternal(shortSteps, 144, 0f));
-
-            CheckResults(NetworkTimeAdvanceTestInternal(shortSteps, 60, 1000000f));
-            CheckResults(NetworkTimeAdvanceTestInternal(shortSteps, 60, 1000000f));
-            CheckResults(NetworkTimeAdvanceTestInternal(shortSteps, 1, 1000000f));
-            CheckResults(NetworkTimeAdvanceTestInternal(shortSteps, 10, 1000000f));
-            CheckResults(NetworkTimeAdvanceTestInternal(shortSteps, 20, 1000000f));
-            CheckResults(NetworkTimeAdvanceTestInternal(shortSteps, 30, 1000000f));
-            CheckResults(NetworkTimeAdvanceTestInternal(shortSteps, 144, 1000000f));
-            shortSteps = null;
-
+            NetworkTimeAdvanceTestInternal(shortSteps, 60, 1000000f);
+            NetworkTimeAdvanceTestInternal(shortSteps, 60, 1000000f);
+            NetworkTimeAdvanceTestInternal(shortSteps, 1, 1000000f);
+            NetworkTimeAdvanceTestInternal(shortSteps, 10, 1000000f);
+            NetworkTimeAdvanceTestInternal(shortSteps, 20, 1000000f);
+            NetworkTimeAdvanceTestInternal(shortSteps, 30, 1000000f);
+            NetworkTimeAdvanceTestInternal(shortSteps, 144, 1000000f);
         }
 
-        private (bool, string) NetworkTimeAdvanceTestInternal(IEnumerable<float> steps, uint tickRate, float start, float start2 = 0f)
+        private void NetworkTimeAdvanceTestInternal(IEnumerable<float> steps, uint tickRate, float start, float start2 = 0f)
         {
             float maxAcceptableTotalOffset = 0.005f;
 
             var startTime = new NetworkTime(tickRate, start);
             var startTime2 = new NetworkTime(tickRate, start2);
             NetworkTime dif = startTime2 - startTime;
-
             foreach (var step in steps)
             {
                 startTime += step;
                 startTime2 += step;
-                var isExpectedValue = Approximately(startTime.Time, (startTime2 - dif).Time);
-                if (!isExpectedValue)
-                {
-                    return (false, $"[NetworkTimeAdvanceTest-Failure] startTime: {startTime.Time} | Step Time Diff: {(startTime2 - dif).Time}");
-                }
+                Assert.IsTrue(Approximately(startTime.Time, (startTime2 - dif).Time));
             }
-            if (!Approximately(startTime.Time, (startTime2 - dif).Time, maxAcceptableTotalOffset))
-            {
-                return (false, $"[NetworkTimeAdvanceTest-Failure-End] startTime: {startTime.Time} | Step Time Diff: {(startTime2 - dif).Time} | Max Accepted Total Offset: {maxAcceptableTotalOffset}");
-            }
-            return (true, string.Empty);
+
+            Assert.IsTrue(Approximately(startTime.Time, (startTime2 - dif).Time, maxAcceptableTotalOffset));
         }
 
         [Test]

--- a/com.unity.netcode.gameobjects/Tests/Editor/Timing/NetworkTimeTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Timing/NetworkTimeTests.cs
@@ -163,6 +163,7 @@ namespace Unity.Netcode.EditorTests
             NetworkTimeAdvanceTestInternal(randomSteps, 144, 23132.231f);
 
             var shortSteps = Enumerable.Repeat(1 / 30f, 1000);
+
             NetworkTimeAdvanceTestInternal(shortSteps, 60, 0f);
             NetworkTimeAdvanceTestInternal(shortSteps, 1, 0f);
             NetworkTimeAdvanceTestInternal(shortSteps, 10, 0f);
@@ -186,6 +187,7 @@ namespace Unity.Netcode.EditorTests
             var startTime = new NetworkTime(tickRate, start);
             var startTime2 = new NetworkTime(tickRate, start2);
             NetworkTime dif = startTime2 - startTime;
+
             foreach (var step in steps)
             {
                 startTime += step;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -1,10 +1,6 @@
 using System.Collections;
-#if NGO_TRANSFORM_DEBUG
-using System.Text.RegularExpressions;
-#endif
 using Unity.Netcode.Components;
 using NUnit.Framework;
-// using Unity.Netcode.Samples;
 using UnityEngine;
 using UnityEngine.TestTools;
 using Unity.Netcode.TestHelpers.Runtime;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -279,7 +279,7 @@ namespace Unity.Netcode.RuntimeTests
 
             authoritativeNetworkTransform.transform.rotation = Quaternion.Euler(1, 2, 3);
             var serverLastSentState = authoritativeNetworkTransform.GetLastSentState();
-            var clientReplicatedState = otherSideNetworkTransform.GetReplicatedNetworkState().Value;
+            var clientReplicatedState = otherSideNetworkTransform.ReplicatedNetworkState.Value;
             yield return WaitForConditionOrTimeOut(() => ValidateBitSetValues(serverLastSentState, clientReplicatedState));
             AssertOnTimeout($"Server-side sent Bitset state != Client-side replicated Bitset state!");
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -60,6 +60,12 @@ namespace Unity.Netcode.RuntimeTests
             Owner
         }
 
+        public enum Interpolation
+        {
+            DisableInterpolate,
+            EnableInterpolate
+        }
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -126,8 +132,11 @@ namespace Unity.Netcode.RuntimeTests
         /// to non-authoritative transforms.
         /// </summary>
         [UnityTest]
-        public IEnumerator TestAuthoritativeTransformChangeOneAtATime([Values] TransformSpace testLocalTransform)
+        public IEnumerator TestAuthoritativeTransformChangeOneAtATime([Values] TransformSpace testLocalTransform, [Values] Interpolation interpolation)
         {
+            m_AuthoritativeTransform.Interpolate = interpolation == Interpolation.EnableInterpolate;
+            m_NonAuthoritativeTransform.Interpolate = interpolation == Interpolation.EnableInterpolate;
+
             m_AuthoritativeTransform.InLocalSpace = testLocalTransform == TransformSpace.Local;
 
             // test position
@@ -159,8 +168,10 @@ namespace Unity.Netcode.RuntimeTests
         /// <param name="testClientAuthority"></param>
         /// <returns></returns>
         [UnityTest]
-        public IEnumerator VerifyNonAuthorityCantChangeTransform()
+        public IEnumerator VerifyNonAuthorityCantChangeTransform([Values] Interpolation interpolation)
         {
+            m_AuthoritativeTransform.Interpolate = interpolation == Interpolation.EnableInterpolate;
+            m_NonAuthoritativeTransform.Interpolate = interpolation == Interpolation.EnableInterpolate;
             Assert.AreEqual(Vector3.zero, m_NonAuthoritativeTransform.transform.position, "other side pos should be zero at first"); // sanity check
 
             m_NonAuthoritativeTransform.transform.position = new Vector3(4, 5, 6);
@@ -194,8 +205,11 @@ namespace Unity.Netcode.RuntimeTests
         /// results when rolling over between 0 and 360 degrees
         /// </summary>
         [UnityTest]
-        public IEnumerator TestRotationThresholdDeltaCheck()
+        public IEnumerator TestRotationThresholdDeltaCheck([Values] Interpolation interpolation)
         {
+            m_AuthoritativeTransform.Interpolate = interpolation == Interpolation.EnableInterpolate;
+            m_NonAuthoritativeTransform.Interpolate = interpolation == Interpolation.EnableInterpolate;
+
             m_NonAuthoritativeTransform.RotAngleThreshold = m_AuthoritativeTransform.RotAngleThreshold = 5.0f;
 
             var halfThreshold = m_AuthoritativeTransform.RotAngleThreshold * 0.5001f;
@@ -274,8 +288,10 @@ namespace Unity.Netcode.RuntimeTests
         /// Test to make sure that the bitset value is updated properly
         /// </summary>
         [UnityTest]
-        public IEnumerator TestBitsetValue()
+        public IEnumerator TestBitsetValue([Values] Interpolation interpolation)
         {
+            m_AuthoritativeTransform.Interpolate = interpolation == Interpolation.EnableInterpolate;
+            m_NonAuthoritativeTransform.Interpolate = interpolation == Interpolation.EnableInterpolate;
             m_NonAuthoritativeTransform.RotAngleThreshold = m_AuthoritativeTransform.RotAngleThreshold = 0.1f;
             yield return s_DefaultWaitForTick;
 
@@ -295,8 +311,10 @@ namespace Unity.Netcode.RuntimeTests
         /// Test Teleporting
         /// </summary>
         [UnityTest]
-        public IEnumerator TeleportTest()
+        public IEnumerator TeleportTest([Values] Interpolation interpolation)
         {
+            m_AuthoritativeTransform.Interpolate = interpolation == Interpolation.EnableInterpolate;
+            m_NonAuthoritativeTransform.Interpolate = interpolation == Interpolation.EnableInterpolate;
             var authTransform = m_AuthoritativeTransform.transform;
             var nonAuthPosition = m_NonAuthoritativeTransform.transform.position;
             var currentTick = m_AuthoritativeTransform.NetworkManager.ServerTime.Tick;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -132,7 +132,7 @@ namespace Unity.Netcode.RuntimeTests
             Local
         }
 
-        public enum OverideState
+        public enum OverrideState
         {
             Update,
             CommitToTransform
@@ -148,9 +148,9 @@ namespace Unity.Netcode.RuntimeTests
         /// to non-authoritative transforms.
         /// </summary>
         [UnityTest]
-        public IEnumerator TestAuthoritativeTransformChangeOneAtATime([Values] TransformSpace testLocalTransform, [Values] Interpolation interpolation, [Values] OverideState overideState)
+        public IEnumerator TestAuthoritativeTransformChangeOneAtATime([Values] TransformSpace testLocalTransform, [Values] Interpolation interpolation, [Values] OverrideState overideState)
         {
-            var overrideUpdate = overideState == OverideState.CommitToTransform;
+            var overrideUpdate = overideState == OverrideState.CommitToTransform;
             m_AuthoritativeTransform.Interpolate = interpolation == Interpolation.EnableInterpolate;
             m_NonAuthoritativeTransform.Interpolate = interpolation == Interpolation.EnableInterpolate;
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -250,6 +250,17 @@ namespace Unity.Netcode.RuntimeTests
             Assert.IsTrue(results.isRotationDirty, $"Rotation was not dirty when rotated by {Mathf.DeltaAngle(0, serverEulerRotation.y)} degrees!");
         }
 
+        private bool ValidateBitSetValues(NetworkTransform.NetworkTransformState serverState, NetworkTransform.NetworkTransformState clientState)
+        {
+            if (serverState.HasPositionX == clientState.HasPositionX && serverState.HasPositionY == clientState.HasPositionY && serverState.HasPositionZ == clientState.HasPositionZ &&
+                serverState.HasRotAngleX == clientState.HasRotAngleX && serverState.HasRotAngleY == clientState.HasRotAngleY && serverState.HasRotAngleZ == clientState.HasRotAngleZ &&
+                serverState.HasScaleX == clientState.HasScaleX && serverState.HasScaleY == clientState.HasScaleY && serverState.HasScaleZ == clientState.HasScaleZ)
+            {
+                return true;
+            }
+            return false;
+        }
+
         /// <summary>
         /// </summary>
         [UnityTest]
@@ -269,8 +280,8 @@ namespace Unity.Netcode.RuntimeTests
             authoritativeNetworkTransform.transform.rotation = Quaternion.Euler(1, 2, 3);
             var serverLastSentState = authoritativeNetworkTransform.GetLastSentState();
             var clientReplicatedState = otherSideNetworkTransform.GetReplicatedNetworkState().Value;
-            yield return WaitForConditionOrTimeOut(() => clientReplicatedState.Bitset.Equals(serverLastSentState.Bitset));
-            AssertOnTimeout($"Server-side sent state Bitset {serverLastSentState.Bitset} != Client-side replicated state Bitset {clientReplicatedState.Bitset}");
+            yield return WaitForConditionOrTimeOut(() => ValidateBitSetValues(serverLastSentState, clientReplicatedState));
+            AssertOnTimeout($"Server-side sent Bitset state != Client-side replicated Bitset state!");
 
             yield return WaitForConditionOrTimeOut(ServerClientRotationMatches);
             AssertOnTimeout($"[Timed-Out] Server-side client rotation {m_ServerSideClientPlayer.transform.rotation.eulerAngles} != Client-side client rotation {m_ClientSideClientPlayer.transform.rotation.eulerAngles}");

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 #if NGO_TRANSFORM_DEBUG
 using System.Text.RegularExpressions;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -335,7 +335,7 @@ namespace Unity.Netcode.RuntimeTests
         protected override IEnumerator OnTearDown()
         {
             m_EnableVerboseDebug = false;
-            UnityEngine.Object.DestroyImmediate(m_PlayerPrefab);
+            Object.DestroyImmediate(m_PlayerPrefab);
             yield return base.OnTearDown();
         }
     }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -142,10 +142,9 @@ namespace Unity.Netcode.RuntimeTests
         /// Tests changing all axial values one at a time.
         /// These tests are performed:
         /// - While in local space and world space
-        /// - While interpolation is enabled and disable
+        /// - While interpolation is enabled and disabled
         /// - Using the TryCommitTransformToServer "override" that can be used
         /// from a child derived or external class.
-        /// to non-authoritative transforms.
         /// </summary>
         [UnityTest]
         public IEnumerator TestAuthoritativeTransformChangeOneAtATime([Values] TransformSpace testLocalTransform, [Values] Interpolation interpolation, [Values] OverrideState overideState)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -32,7 +32,8 @@ namespace Unity.Netcode.RuntimeTests
 
         public (bool isDirty, bool isPositionDirty, bool isRotationDirty, bool isScaleDirty) ApplyState()
         {
-            return ApplyLocalNetworkState(transform);
+            var transformState = ApplyLocalNetworkState(transform);
+            return (transformState.IsDirty, transformState.HasPositionChange, transformState.HasRotAngleChange, transformState.HasScaleChange);
         }
     }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TransformInterpolationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TransformInterpolationTests.cs
@@ -10,21 +10,19 @@ namespace Unity.Netcode.RuntimeTests
 {
     public class TransformInterpolationObject : NetworkBehaviour
     {
+        // Set the minimum threshold which we will use as our margin of error
+        public const float MinThreshold = 0.001f;
+
         public bool CheckPosition;
         public bool IsMoving;
         public bool IsFixed;
 
         private void Update()
         {
-            // Since the local position is transformed from local to global and vice-versa on the server and client
-            // it may accumulate some error. We allow an error of 0.01 over the range of 1000 used in this test.
-            // This requires precision to 5 digits, so it doesn't weaken the test, while preventing spurious failures
-            const float maxRoundingError = 0.01f;
-
             // Check the position of the nested object on the client
             if (CheckPosition)
             {
-                if (transform.position.y < -maxRoundingError || transform.position.y > 100.0f + maxRoundingError)
+                if (transform.position.y < -MinThreshold || transform.position.y > 100.0f + MinThreshold)
                 {
                     Debug.LogError($"Interpolation failure. transform.position.y is {transform.position.y}. Should be between 0.0 and 100.0");
                 }
@@ -65,7 +63,8 @@ namespace Unity.Netcode.RuntimeTests
         protected override void OnServerAndClientsCreated()
         {
             m_PrefabToSpawn = CreateNetworkObjectPrefab("InterpTestObject");
-            m_PrefabToSpawn.AddComponent<NetworkTransform>();
+            var networkTransform = m_PrefabToSpawn.AddComponent<NetworkTransform>();
+            networkTransform.PositionThreshold = TransformInterpolationObject.MinThreshold;
             m_PrefabToSpawn.AddComponent<TransformInterpolationObject>();
         }
 
@@ -85,8 +84,6 @@ namespace Unity.Netcode.RuntimeTests
             m_SpawnedObjectOnClient = s_GlobalNetworkObjects[clientId][m_SpawnedAsNetworkObject.NetworkObjectId];
             // make sure the objects are set with the right network manager
             m_SpawnedObjectOnClient.NetworkManagerOwner = m_ClientNetworkManagers[0];
-
-
         }
 
         [UnityTest]

--- a/testproject/Assets/Prefabs/ObjectToOverride-VariantBlueCylinder.prefab
+++ b/testproject/Assets/Prefabs/ObjectToOverride-VariantBlueCylinder.prefab
@@ -82,5 +82,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: 29cabf623d47bb345a9bb4140e4397d7,
+        type: 3}
+      propertyPath: PositionThreshold
+      value: 0.01
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 29cabf623d47bb345a9bb4140e4397d7, type: 3}

--- a/testproject/Assets/Prefabs/Player.prefab
+++ b/testproject/Assets/Prefabs/Player.prefab
@@ -36,6 +36,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 5, y: 0.625, z: 5}
   m_LocalScale: {x: 1.25, y: 1.25, z: 1.25}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3519470446676406143}
   m_Father: {fileID: 0}
@@ -62,12 +63,11 @@ MonoBehaviour:
   SyncScaleX: 1
   SyncScaleY: 1
   SyncScaleZ: 1
-  PositionThreshold: 0
-  RotAngleThreshold: 0
-  ScaleThreshold: 0
+  PositionThreshold: 0.01
+  RotAngleThreshold: 0.01
+  ScaleThreshold: 0.1
   InLocalSpace: 0
   Interpolate: 1
-  FixedSendsPerSecond: 15
 --- !u!114 &-3775814466963834669
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -103,6 +103,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -239,6 +240,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1.045, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4079352819444256611}
   m_RootOrder: 0
@@ -262,6 +264,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1

--- a/testproject/Assets/Prefabs/Player.prefab
+++ b/testproject/Assets/Prefabs/Player.prefab
@@ -199,7 +199,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8e5aa2f75493a4fee8ec635d215f03c2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  MoveSpeed: 10
+  MoveSpeed: 5
 --- !u!114 &5257990644900685376
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/testproject/Assets/Prefabs/Player.prefab
+++ b/testproject/Assets/Prefabs/Player.prefab
@@ -34,7 +34,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4079352819444256614}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0.55, z: 0}
   m_LocalScale: {x: 1.25, y: 1.25, z: 1.25}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -65,7 +65,7 @@ MonoBehaviour:
   SyncScaleZ: 1
   PositionThreshold: 0.01
   RotAngleThreshold: 0.01
-  ScaleThreshold: 0.1
+  ScaleThreshold: 0.01
   InLocalSpace: 0
   Interpolate: 1
 --- !u!114 &-3775814466963834669
@@ -199,7 +199,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8e5aa2f75493a4fee8ec635d215f03c2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  MoveSpeed: 5
+  MoveSpeed: 10
 --- !u!114 &5257990644900685376
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/testproject/Assets/Prefabs/Player.prefab
+++ b/testproject/Assets/Prefabs/Player.prefab
@@ -34,7 +34,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4079352819444256614}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 5, y: 0.625, z: 5}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1.25, y: 1.25, z: 1.25}
   m_ConstrainProportionsScale: 0
   m_Children:

--- a/testproject/Assets/Prefabs/PlayerCube.prefab
+++ b/testproject/Assets/Prefabs/PlayerCube.prefab
@@ -274,7 +274,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3e34656ebae784afca7d1f7f6dc18580, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Range: 5
+  Range: 3
 --- !u!114 &2744080254494315543
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -308,8 +308,8 @@ MonoBehaviour:
   SyncScaleX: 1
   SyncScaleY: 1
   SyncScaleZ: 1
-  PositionThreshold: 0.01
-  RotAngleThreshold: 0.01
+  PositionThreshold: 0.005
+  RotAngleThreshold: 0.005
   ScaleThreshold: 0.1
   InLocalSpace: 0
   Interpolate: 1

--- a/testproject/Assets/Prefabs/PlayerCube.prefab
+++ b/testproject/Assets/Prefabs/PlayerCube.prefab
@@ -19,7 +19,6 @@ GameObject:
   - component: {fileID: 3809075828520557319}
   - component: {fileID: 7138389085065872747}
   - component: {fileID: 2744080254494315543}
-  - component: {fileID: 8494617645530090570}
   m_Layer: 0
   m_Name: PlayerCube
   m_TagString: Target
@@ -50,9 +49,9 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8685790303553767886}
   serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0
+  m_Mass: 2
+  m_Drag: 0.05
+  m_AngularDrag: 0.02
   m_UseGravity: 1
   m_IsKinematic: 1
   m_Interpolate: 1
@@ -248,8 +247,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 82b41b172a31546ffba450f1418f4e69, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Speed: 8
-  m_RotSpeed: 180
+  SyncPositionX: 1
+  SyncPositionY: 1
+  SyncPositionZ: 1
+  SyncRotAngleX: 0
+  SyncRotAngleY: 1
+  SyncRotAngleZ: 0
+  SyncScaleX: 0
+  SyncScaleY: 0
+  SyncScaleZ: 0
+  PositionThreshold: 0.001
+  RotAngleThreshold: 0.01
+  ScaleThreshold: 0.01
+  InLocalSpace: 0
+  Interpolate: 1
+  Speed: 7
+  RotSpeed: 2
 --- !u!114 &3809075828520557319
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -287,29 +300,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f6c0be61502bb534f922ebb746851216, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &8494617645530090570
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8685790303553767886}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e96cb6065543e43c4a752faaa1468eb1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  SyncPositionX: 1
-  SyncPositionY: 1
-  SyncPositionZ: 1
-  SyncRotAngleX: 0
-  SyncRotAngleY: 1
-  SyncRotAngleZ: 0
-  SyncScaleX: 1
-  SyncScaleY: 1
-  SyncScaleZ: 1
-  PositionThreshold: 0.001
-  RotAngleThreshold: 0.001
-  ScaleThreshold: 0.01
-  InLocalSpace: 0
-  Interpolate: 1

--- a/testproject/Assets/Prefabs/PlayerCube.prefab
+++ b/testproject/Assets/Prefabs/PlayerCube.prefab
@@ -50,12 +50,12 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8685790303553767886}
   serializedVersion: 2
-  m_Mass: 2
+  m_Mass: 1
   m_Drag: 0
-  m_AngularDrag: 0.02
+  m_AngularDrag: 0
   m_UseGravity: 1
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 80
   m_CollisionDetection: 2
 --- !u!65 &8685790303553767873
@@ -129,8 +129,8 @@ LineRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8685790303553767886}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
   m_DynamicOccludee: 1
   m_StaticShadowCaster: 0
   m_MotionVectors: 0
@@ -141,7 +141,7 @@ LineRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 16358fcb4e0c94cc8b980fbb17259843, type: 2}
+  - {fileID: 2100000, guid: 712559e4bd05f1942a8fd4bfa4e10c56, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -185,16 +185,16 @@ LineRenderer:
       m_RotationOrder: 4
     colorGradient:
       serializedVersion: 2
-      key0: {r: 0.73333335, g: 0.7137255, b: 0.6666667, a: 1}
-      key1: {r: 1, g: 1, b: 1, a: 1}
-      key2: {r: 1, g: 1, b: 1, a: 0}
+      key0: {r: 0.30566037, g: 0.90742147, b: 1, a: 1}
+      key1: {r: 0.28166604, g: 0.8183648, b: 0.8679245, a: 1}
+      key2: {r: 0.0391598, g: 0.9433962, b: 0.89236206, a: 0}
       key3: {r: 0, g: 0, b: 0, a: 0}
       key4: {r: 0, g: 0, b: 0, a: 0}
       key5: {r: 0, g: 0, b: 0, a: 0}
       key6: {r: 0, g: 0, b: 0, a: 0}
       key7: {r: 0, g: 0, b: 0, a: 0}
       ctime0: 0
-      ctime1: 25443
+      ctime1: 26021
       ctime2: 65535
       ctime3: 0
       ctime4: 0
@@ -209,15 +209,15 @@ LineRenderer:
       atime5: 0
       atime6: 0
       atime7: 0
-      m_Mode: 0
+      m_Mode: 1
       m_NumColorKeys: 3
       m_NumAlphaKeys: 2
     numCornerVertices: 0
     numCapVertices: 0
     alignment: 0
     textureMode: 0
-    shadowBias: 0.5
-    generateLightingData: 0
+    shadowBias: 1
+    generateLightingData: 1
   m_UseWorldSpace: 1
   m_Loop: 0
 --- !u!114 &947981134
@@ -248,8 +248,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 82b41b172a31546ffba450f1418f4e69, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Speed: 8
-  m_RotSpeed: 1.5
+  m_Speed: 6
+  m_RotSpeed: 2
 --- !u!114 &3809075828520557319
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -302,14 +302,14 @@ MonoBehaviour:
   SyncPositionX: 1
   SyncPositionY: 1
   SyncPositionZ: 1
-  SyncRotAngleX: 1
+  SyncRotAngleX: 0
   SyncRotAngleY: 1
-  SyncRotAngleZ: 1
+  SyncRotAngleZ: 0
   SyncScaleX: 1
   SyncScaleY: 1
   SyncScaleZ: 1
-  PositionThreshold: 0.005
-  RotAngleThreshold: 0.005
-  ScaleThreshold: 0.1
+  PositionThreshold: 0.001
+  RotAngleThreshold: 0.001
+  ScaleThreshold: 0.01
   InLocalSpace: 0
   Interpolate: 1

--- a/testproject/Assets/Prefabs/PlayerCube.prefab
+++ b/testproject/Assets/Prefabs/PlayerCube.prefab
@@ -248,8 +248,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 82b41b172a31546ffba450f1418f4e69, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Speed: 6
-  m_RotSpeed: 2
+  m_Speed: 8
+  m_RotSpeed: 180
 --- !u!114 &3809075828520557319
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/testproject/Assets/Prefabs/PlayerCube.prefab
+++ b/testproject/Assets/Prefabs/PlayerCube.prefab
@@ -50,14 +50,14 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8685790303553767886}
   serializedVersion: 2
-  m_Mass: 3
+  m_Mass: 2
   m_Drag: 0
-  m_AngularDrag: 0.05
+  m_AngularDrag: 0.02
   m_UseGravity: 1
   m_IsKinematic: 1
   m_Interpolate: 0
   m_Constraints: 80
-  m_CollisionDetection: 0
+  m_CollisionDetection: 2
 --- !u!65 &8685790303553767873
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -141,7 +141,7 @@ LineRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 0}
+  - {fileID: 2100000, guid: 16358fcb4e0c94cc8b980fbb17259843, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -248,8 +248,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 82b41b172a31546ffba450f1418f4e69, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Speed: 10
-  m_RotSpeed: 1
+  m_Speed: 8
+  m_RotSpeed: 1.5
 --- !u!114 &3809075828520557319
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -274,7 +274,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3e34656ebae784afca7d1f7f6dc18580, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Range: 10
+  Range: 5
 --- !u!114 &2744080254494315543
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/testproject/Assets/Prefabs/PlayerCube.prefab
+++ b/testproject/Assets/Prefabs/PlayerCube.prefab
@@ -18,8 +18,8 @@ GameObject:
   - component: {fileID: 8685790303553767876}
   - component: {fileID: 3809075828520557319}
   - component: {fileID: 7138389085065872747}
-  - component: {fileID: 8585540885791567915}
   - component: {fileID: 2744080254494315543}
+  - component: {fileID: 8494617645530090570}
   m_Layer: 0
   m_Name: PlayerCube
   m_TagString: Target
@@ -37,6 +37,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0.5, z: 0}
   m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -49,7 +50,7 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8685790303553767886}
   serializedVersion: 2
-  m_Mass: 1
+  m_Mass: 3
   m_Drag: 0
   m_AngularDrag: 0.05
   m_UseGravity: 1
@@ -89,6 +90,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -130,6 +132,7 @@ LineRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 0
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
@@ -246,7 +249,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Speed: 10
-  m_RotSpeed: 2
+  m_RotSpeed: 1
 --- !u!114 &3809075828520557319
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -272,33 +275,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Range: 10
---- !u!114 &8585540885791567915
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8685790303553767886}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 54c9647dc784a46bca664910f182491e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  SyncPositionX: 1
-  SyncPositionY: 1
-  SyncPositionZ: 1
-  SyncRotAngleX: 1
-  SyncRotAngleY: 1
-  SyncRotAngleZ: 1
-  SyncScaleX: 1
-  SyncScaleY: 1
-  SyncScaleZ: 1
-  PositionThreshold: 0
-  RotAngleThreshold: 0
-  ScaleThreshold: 0
-  InLocalSpace: 0
-  Interpolate: 1
-  FixedSendsPerSecond: 30
 --- !u!114 &2744080254494315543
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -311,3 +287,29 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f6c0be61502bb534f922ebb746851216, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &8494617645530090570
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8685790303553767886}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e96cb6065543e43c4a752faaa1468eb1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  SyncPositionX: 1
+  SyncPositionY: 1
+  SyncPositionZ: 1
+  SyncRotAngleX: 1
+  SyncRotAngleY: 1
+  SyncRotAngleZ: 1
+  SyncScaleX: 1
+  SyncScaleY: 1
+  SyncScaleZ: 1
+  PositionThreshold: 0.01
+  RotAngleThreshold: 0.01
+  ScaleThreshold: 0.1
+  InLocalSpace: 0
+  Interpolate: 1

--- a/testproject/Assets/References/Scene/Teleporting.asset
+++ b/testproject/Assets/References/Scene/Teleporting.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 39a16938ffb5cd846a9f6df7a686a9c4, type: 3}
+  m_Name: Teleporting
+  m_EditorClassIdentifier: 
+  SceneToReference: {fileID: 102900000, guid: efa247d1f78ca694f8d2dcb5672e8f8b, type: 3}
+  m_IncludedScenes: []
+  m_DisplayName: Teleporting
+  m_ReferencedScenes:
+  - TeleportSample

--- a/testproject/Assets/References/Scene/Teleporting.asset.meta
+++ b/testproject/Assets/References/Scene/Teleporting.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0509eb053ce4ef749afd8495f13128f1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/testproject/Assets/Samples/SamplesMenu.unity
+++ b/testproject/Assets/Samples/SamplesMenu.unity
@@ -2523,8 +2523,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_SceneMenus:
-  - {fileID: 11400000, guid: 7fdc32fee173cca45a4601ba234954d0, type: 2}
+  - {fileID: 11400000, guid: 0509eb053ce4ef749afd8495f13128f1, type: 2}
   - {fileID: 11400000, guid: 9a8d9296fb33f794f95514bf38de3cf9, type: 2}
+  - {fileID: 11400000, guid: 7fdc32fee173cca45a4601ba234954d0, type: 2}
   - {fileID: 11400000, guid: 21aae92071ad50448a45b013d8346639, type: 2}
   - {fileID: 11400000, guid: 660535b6e155b5b4bbede52313fcb32e, type: 2}
   - {fileID: 11400000, guid: d2e34ed37c087154dbd7f89fd463801b, type: 2}

--- a/testproject/Assets/Samples/Teleport.meta
+++ b/testproject/Assets/Samples/Teleport.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cce8b52742a026348a34cae6ea568558
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/testproject/Assets/Samples/Teleport/CollideTeleporter.cs
+++ b/testproject/Assets/Samples/Teleport/CollideTeleporter.cs
@@ -4,9 +4,13 @@ using Unity.Netcode;
 
 public class CollideTeleporter : MonoBehaviour
 {
+    [Tooltip("The destination GameObject transform. All rotation and scale will be applied, but position values can be ignored by setting the Preserve properties.")]
     public GameObject Destination;
+    [Tooltip("When checked, the x-axis position value will remain the same during teleporting.")]
     public bool Preserve_XAxis;
+    [Tooltip("When checked, the y-axis position value will remain the same during teleporting.")]
     public bool Preserve_YAxis;
+    [Tooltip("When checked, the z-axis position value will remain the same during teleporting.")]
     public bool Preserve_ZAxis;
 
     private void OnCollisionEnter(Collision collision)
@@ -48,7 +52,6 @@ public class CollideTeleporter : MonoBehaviour
             position.z = objectTransform.position.z;
         }
 
-        networkTransform.Teleport(position, networkTransform.transform.rotation, networkTransform.transform.localScale);
-        playerMover.Telporting();
+        playerMover.Telporting(position);
     }
 }

--- a/testproject/Assets/Samples/Teleport/CollideTeleporter.cs
+++ b/testproject/Assets/Samples/Teleport/CollideTeleporter.cs
@@ -1,22 +1,54 @@
 using UnityEngine;
 using Unity.Netcode.Components;
+using Unity.Netcode;
 
 public class CollideTeleporter : MonoBehaviour
 {
     public GameObject Destination;
+    public bool Preserve_XAxis;
+    public bool Preserve_YAxis;
+    public bool Preserve_ZAxis;
+
     private void OnCollisionEnter(Collision collision)
     {
-        var networkTransform = collision.gameObject.GetComponent<NetworkTransform>();
-        if (networkTransform != null && Destination != null)
+        if (NetworkManager.Singleton == null || !NetworkManager.Singleton.IsListening || !NetworkManager.Singleton.IsServer)
         {
-            if (networkTransform.NetworkManager.IsServer)
-            {
-                var playerMover = collision.gameObject.GetComponent<PlayerMovement>();
-                var position = Destination.transform.position;
-                position.y = transform.position.y + 0.1f;
-                networkTransform.Teleport(position, networkTransform.transform.rotation, networkTransform.transform.localScale);
-                playerMover.Telporting();
-            }
+            return;
         }
+        var playerMover = collision.gameObject.GetComponent<PlayerMovement>();
+        if (playerMover == null || playerMover.IsTeleporting)
+        {
+            return;
+        }
+
+        var networkTransform = collision.gameObject.GetComponent<NetworkTransform>();
+        if (networkTransform == null || Destination == null)
+        {
+            return;
+        }
+        var objectTransform = networkTransform.transform;
+        var position = Destination.transform.position;
+
+        if (Preserve_XAxis)
+        {
+            position.x = objectTransform.position.x;
+        }
+
+        if (Preserve_YAxis)
+        {
+            position.y = objectTransform.position.y;
+        }
+        else
+        {
+            position.y = transform.position.y + 0.1f;
+        }
+
+        if (Preserve_ZAxis)
+        {
+            position.z = objectTransform.position.z;
+        }
+
+        networkTransform.Teleport(position, networkTransform.transform.rotation, networkTransform.transform.localScale);
+        playerMover.Telporting();
     }
 }

--- a/testproject/Assets/Samples/Teleport/CollideTeleporter.cs
+++ b/testproject/Assets/Samples/Teleport/CollideTeleporter.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+using Unity.Netcode.Components;
+
+public class CollideTeleporter : MonoBehaviour
+{
+    public GameObject Destination;
+    private void OnCollisionEnter(Collision collision)
+    {
+        var networkTransform = collision.gameObject.GetComponent<NetworkTransform>();
+        if (networkTransform != null && Destination != null)
+        {
+            if (networkTransform.NetworkManager.IsServer)
+            {
+                var playerMover = collision.gameObject.GetComponent<PlayerMovement>();
+                var position = Destination.transform.position;
+                position.y = transform.position.y + 0.1f;
+                networkTransform.Teleport(position, networkTransform.transform.rotation, networkTransform.transform.localScale);
+                playerMover.Telporting();
+            }
+        }
+    }
+}

--- a/testproject/Assets/Samples/Teleport/CollideTeleporter.cs
+++ b/testproject/Assets/Samples/Teleport/CollideTeleporter.cs
@@ -15,7 +15,7 @@ public class CollideTeleporter : MonoBehaviour
 
     private void OnCollisionEnter(Collision collision)
     {
-        if (NetworkManager.Singleton == null || !NetworkManager.Singleton.IsListening || !NetworkManager.Singleton.IsServer)
+        if (NetworkManager.Singleton == null || !NetworkManager.Singleton.IsListening)
         {
             return;
         }

--- a/testproject/Assets/Samples/Teleport/CollideTeleporter.cs.meta
+++ b/testproject/Assets/Samples/Teleport/CollideTeleporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1de461850fd18574584d884cc31ed103
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/testproject/Assets/Samples/Teleport/TeleportSample.unity
+++ b/testproject/Assets/Samples/Teleport/TeleportSample.unity
@@ -279,6 +279,69 @@ Transform:
   m_Father: {fileID: 465045809}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &133022763
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 133022766}
+  - component: {fileID: 133022765}
+  - component: {fileID: 133022764}
+  m_Layer: 0
+  m_Name: Stats
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &133022764
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 133022763}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 4260285143
+  AlwaysReplicateAsRoot: 0
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1
+--- !u!114 &133022765
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 133022763}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb5f3e55f5dd247129d8a4979b80ebbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ClientServerToggle: {fileID: 0}
+  m_TrackSceneEvents: 1
+--- !u!4 &133022766
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 133022763}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 318.45444, y: 110.697815, z: 216.79077}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &277959947
 GameObject:
   m_ObjectHideFlags: 0
@@ -506,7 +569,7 @@ MonoBehaviour:
     PlayerPrefab: {fileID: 8685790303553767886, guid: 96e0a72e30d0c46c8a5c9a750e8f5807,
       type: 3}
     NetworkPrefabs: []
-    TickRate: 30
+    TickRate: 60
     ClientConnectionBufferTimeout: 10
     ConnectionApproval: 0
     ConnectionData: 

--- a/testproject/Assets/Samples/Teleport/TeleportSample.unity
+++ b/testproject/Assets/Samples/Teleport/TeleportSample.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.45081997, g: 0.50073934, b: 0.5746953, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657755, g: 0.4964127, b: 0.57481825, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -346,7 +346,7 @@ Light:
   m_CookieSize: 10
   m_Shadows:
     m_Type: 2
-    m_Resolution: -1
+    m_Resolution: 2
     m_CustomResolution: -1
     m_Strength: 1
     m_Bias: 0.05
@@ -396,14 +396,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 422011491}
-  m_LocalRotation: {x: 0.30070576, y: 0, z: 0, w: 0.953717}
+  m_LocalRotation: {x: 0.42261827, y: 0, z: 0, w: 0.9063079}
   m_LocalPosition: {x: 0, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 35, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 50, y: 0, z: 0}
 --- !u!1 &465045808
 GameObject:
   m_ObjectHideFlags: 0

--- a/testproject/Assets/Samples/Teleport/TeleportSample.unity
+++ b/testproject/Assets/Samples/Teleport/TeleportSample.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.45081997, g: 0.50073934, b: 0.5746953, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -143,7 +143,7 @@ PrefabInstance:
     - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
         type: 3}
       propertyPath: m_RootOrder
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
         type: 3}
@@ -248,6 +248,68 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 9495347}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &53041272
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 53041273}
+  m_Layer: 0
+  m_Name: DestinationBBottomZ
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &53041273
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 53041272}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.96, y: 0, z: -6.95}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 465045809}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &277959947
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 277959948}
+  m_Layer: 0
+  m_Name: DestinationBFarX
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &277959948
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 277959947}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -6.88, y: 0, z: -0.66}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 465045809}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &422011491
 GameObject:
   m_ObjectHideFlags: 0
@@ -276,7 +338,7 @@ Light:
   serializedVersion: 10
   m_Type: 1
   m_Shape: 0
-  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Color: {r: 0.990566, g: 0.98932636, b: 0.98589355, a: 1}
   m_Intensity: 1
   m_Range: 10
   m_SpotAngle: 30
@@ -334,14 +396,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 422011491}
-  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalRotation: {x: 0.30070576, y: 0, z: 0, w: 0.953717}
   m_LocalPosition: {x: 0, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+  m_LocalEulerAnglesHint: {x: 35, y: 0, z: 0}
 --- !u!1 &465045808
 GameObject:
   m_ObjectHideFlags: 0
@@ -366,12 +428,17 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 465045808}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.04, y: 0.5, z: 0}
+  m_LocalPosition: {x: -23.5, y: 0.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 277959948}
+  - {fileID: 2071037935}
+  - {fileID: 878389898}
+  - {fileID: 53041273}
+  - {fileID: 4012615692010092074}
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &539459709
 GameObject:
@@ -462,7 +529,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 539459709}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 9.879457, y: -10.436741, z: 1.1385593}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -505,7 +572,7 @@ Camera:
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 1
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_BackGroundColor: {r: 0.06755074, g: 0.28341934, b: 0.6226415, a: 0}
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
@@ -545,14 +612,76 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 567879417}
-  m_LocalRotation: {x: 0.2588191, y: 0, z: 0, w: 0.9659258}
-  m_LocalPosition: {x: 8.1, y: 10.9, z: -19.2}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: -11.75, y: 20, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 30, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!1 &778998217
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 778998218}
+  m_Layer: 0
+  m_Name: DestinationANearX
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &778998218
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 778998217}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -6.88, y: 0, z: -0.66}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1111851143}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &878389897
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 878389898}
+  m_Layer: 0
+  m_Name: DestinationBTopZ
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &878389898
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 878389897}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.75, y: 0, z: 6.89}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 465045809}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1031177247
 GameObject:
   m_ObjectHideFlags: 0
@@ -645,16 +774,163 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 1068532237}
   - {fileID: 9495348}
   - {fileID: 1632447478}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1001 &1068532236
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1031177251}
+    m_Modifications:
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.9806
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.9806
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.9806
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -22.946533
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -23.338623
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2848221156307247795, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_Name
+      value: ExitButton
+      objectReference: {fileID: 0}
+    - target: {fileID: 5266522511616468950, guid: 3200770c16e3b2b4ebe7f604154faac7,
+        type: 3}
+      propertyPath: m_SceneMenuToLoad
+      value: 
+      objectReference: {fileID: 11400000, guid: c10d995498e0c514a853c3506031d3fb,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3200770c16e3b2b4ebe7f604154faac7, type: 3}
+--- !u!224 &1068532237 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
+    type: 3}
+  m_PrefabInstance: {fileID: 1068532236}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1111851142
 GameObject:
   m_ObjectHideFlags: 0
@@ -679,12 +955,79 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1111851142}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 17.22, y: 0.5, z: 0}
+  m_LocalPosition: {x: -0, y: 0.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1346219376}
+  - {fileID: 778998218}
+  - {fileID: 1480985473}
+  - {fileID: 1774593016}
+  - {fileID: 4012615690793490293}
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1346219375
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1346219376}
+  m_Layer: 0
+  m_Name: DestinationAFarX
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1346219376
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1346219375}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 6.55, y: 0, z: -0.66}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_Father: {fileID: 1111851143}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1480985472
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1480985473}
+  m_Layer: 0
+  m_Name: DestinationATopZ
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1480985473
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1480985472}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.34, y: 0, z: 6.89}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1111851143}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1632447477
 GameObject:
@@ -717,7 +1060,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1031177251}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1632447479
 MonoBehaviour:
@@ -753,6 +1096,68 @@ MonoBehaviour:
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
+--- !u!1 &1774593015
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1774593016}
+  m_Layer: 0
+  m_Name: DestinationABottomZ
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1774593016
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1774593015}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.19, y: 0, z: -6.95}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1111851143}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2071037934
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2071037935}
+  m_Layer: 0
+  m_Name: DestinationBNearX
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2071037935
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2071037934}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 6.61, y: 0, z: -0.66}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 465045809}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &910007655381311276
 GameObject:
   m_ObjectHideFlags: 0
@@ -1043,7 +1448,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1de461850fd18574584d884cc31ed103, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Destination: {fileID: 465045808}
+  Destination: {fileID: 1346219375}
+  Preserve_XAxis: 0
+  Preserve_YAxis: 0
+  Preserve_ZAxis: 1
 --- !u!1 &4012615690780670402
 GameObject:
   m_ObjectHideFlags: 0
@@ -1154,7 +1562,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1de461850fd18574584d884cc31ed103, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Destination: {fileID: 1111851142}
+  Destination: {fileID: 277959947}
+  Preserve_XAxis: 0
+  Preserve_YAxis: 0
+  Preserve_ZAxis: 1
 --- !u!1 &4012615690793490290
 GameObject:
   m_ObjectHideFlags: 0
@@ -1178,8 +1589,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4012615690793490290}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.5, z: 0}
   m_LocalScale: {x: 0.25, y: 0.25, z: 0.25}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1192,8 +1603,8 @@ Transform:
   - {fileID: 6283120762361012840}
   - {fileID: 2290144462274530172}
   - {fileID: 6959258899469919941}
-  m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_Father: {fileID: 1111851143}
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &4012615691046896310
 MeshFilter:
@@ -1382,6 +1793,7 @@ GameObject:
   - component: {fileID: 4012615691302274499}
   - component: {fileID: 4012615691302274496}
   - component: {fileID: 4012615691302274497}
+  - component: {fileID: 4012615691302274559}
   m_Layer: 0
   m_Name: Side
   m_TagString: Boundary
@@ -1389,6 +1801,22 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!114 &4012615691302274559
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615691302274558}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1de461850fd18574584d884cc31ed103, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Destination: {fileID: 1480985472}
+  Preserve_XAxis: 1
+  Preserve_YAxis: 0
+  Preserve_ZAxis: 0
 --- !u!65 &4012615691539789092
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -1414,6 +1842,7 @@ GameObject:
   - component: {fileID: 4012615691539789094}
   - component: {fileID: 4012615691539789095}
   - component: {fileID: 4012615691539789092}
+  - component: {fileID: 4012615691539789098}
   m_Layer: 0
   m_Name: Side
   m_TagString: Boundary
@@ -1486,6 +1915,22 @@ Transform:
   m_Father: {fileID: 4012615690793490293}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4012615691539789098
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615691539789093}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1de461850fd18574584d884cc31ed103, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Destination: {fileID: 1774593015}
+  Preserve_XAxis: 1
+  Preserve_YAxis: 0
+  Preserve_ZAxis: 0
 --- !u!65 &4012615691934547958
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -1511,6 +1956,7 @@ GameObject:
   - component: {fileID: 4012615691934547960}
   - component: {fileID: 4012615691934547961}
   - component: {fileID: 4012615691934547958}
+  - component: {fileID: 4012615691934547964}
   m_Layer: 0
   m_Name: Side
   m_TagString: Boundary
@@ -1583,6 +2029,22 @@ Transform:
   m_Father: {fileID: 4012615690793490293}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4012615691934547964
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615691934547959}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1de461850fd18574584d884cc31ed103, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Destination: {fileID: 2071037934}
+  Preserve_XAxis: 0
+  Preserve_YAxis: 0
+  Preserve_ZAxis: 1
 --- !u!4 &4012615692010092074
 Transform:
   m_ObjectHideFlags: 0
@@ -1590,8 +2052,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4012615692010092077}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 17.2, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.5, z: 0}
   m_LocalScale: {x: 0.25, y: 0.25, z: 0.25}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1604,8 +2066,8 @@ Transform:
   - {fileID: 6283120761446335287}
   - {fileID: 2290144463474879011}
   - {fileID: 6959258898237589402}
-  m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_Father: {fileID: 465045809}
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4012615692010092077
 GameObject:
@@ -1713,6 +2175,7 @@ GameObject:
   - component: {fileID: 4012615692014524568}
   - component: {fileID: 4012615692014524571}
   - component: {fileID: 4012615692014524570}
+  - component: {fileID: 4012615692014524574}
   m_Layer: 0
   m_Name: Side
   m_TagString: Boundary
@@ -1720,6 +2183,22 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!114 &4012615692014524574
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615692014524573}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1de461850fd18574584d884cc31ed103, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Destination: {fileID: 778998217}
+  Preserve_XAxis: 0
+  Preserve_YAxis: 0
+  Preserve_ZAxis: 1
 --- !u!1 &4012615692280832996
 GameObject:
   m_ObjectHideFlags: 0
@@ -1759,7 +2238,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 00cf8ac777c8c42e8967157f70fbfcbf, type: 2}
+  - {fileID: 2100000, guid: d2f6bf650dfcc483794cdacf53f9fe2b, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -1907,6 +2386,7 @@ GameObject:
   - component: {fileID: 4012615692568749212}
   - component: {fileID: 4012615692568749215}
   - component: {fileID: 4012615692568749214}
+  - component: {fileID: 4012615692568749218}
   m_Layer: 0
   m_Name: Side
   m_TagString: Boundary
@@ -1914,6 +2394,22 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!114 &4012615692568749218
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615692568749217}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1de461850fd18574584d884cc31ed103, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Destination: {fileID: 878389897}
+  Preserve_XAxis: 1
+  Preserve_YAxis: 0
+  Preserve_ZAxis: 0
 --- !u!4 &4012615692740187254
 Transform:
   m_ObjectHideFlags: 0
@@ -1991,6 +2487,7 @@ GameObject:
   - component: {fileID: 4012615692740187257}
   - component: {fileID: 4012615692740187256}
   - component: {fileID: 4012615692740187259}
+  - component: {fileID: 4012615692740187260}
   m_Layer: 0
   m_Name: Side
   m_TagString: Boundary
@@ -2011,6 +2508,22 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 2}
   m_Center: {x: 0, y: 0, z: 0.5}
+--- !u!114 &4012615692740187260
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615692740187258}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1de461850fd18574584d884cc31ed103, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Destination: {fileID: 53041272}
+  Preserve_XAxis: 1
+  Preserve_YAxis: 0
+  Preserve_ZAxis: 0
 --- !u!65 &4559046434087525967
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/testproject/Assets/Samples/Teleport/TeleportSample.unity
+++ b/testproject/Assets/Samples/Teleport/TeleportSample.unity
@@ -143,7 +143,7 @@ PrefabInstance:
     - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
         type: 3}
@@ -774,6 +774,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 1485784454}
   - {fileID: 1068532237}
   - {fileID: 9495348}
   - {fileID: 1632447478}
@@ -805,7 +806,7 @@ PrefabInstance:
     - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
         type: 3}
       propertyPath: m_RootOrder
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2848221156307247792, guid: 3200770c16e3b2b4ebe7f604154faac7,
         type: 3}
@@ -1029,6 +1030,117 @@ Transform:
   m_Father: {fileID: 1111851143}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1485784453
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1485784454}
+  - component: {fileID: 1485784458}
+  - component: {fileID: 1485784457}
+  - component: {fileID: 1485784456}
+  - component: {fileID: 1485784455}
+  m_Layer: 5
+  m_Name: ServerHostClientDisplay
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1485784454
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1485784453}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1031177251}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 31}
+  m_SizeDelta: {x: 200, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1485784455
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1485784453}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 1332868523
+  AlwaysReplicateAsRoot: 0
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1
+--- !u!114 &1485784456
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1485784453}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7ea6e834b18e2c840a76ce574eb4b144, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_DisplayText: {fileID: 1485784457}
+--- !u!114 &1485784457
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1485784453}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.5058824, b: 0.003921569, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 0
+  m_Text: Server
+--- !u!222 &1485784458
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1485784453}
+  m_CullTransparentMesh: 1
 --- !u!1 &1632447477
 GameObject:
   m_ObjectHideFlags: 0
@@ -1060,7 +1172,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1031177251}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1632447479
 MonoBehaviour:

--- a/testproject/Assets/Samples/Teleport/TeleportSample.unity
+++ b/testproject/Assets/Samples/Teleport/TeleportSample.unity
@@ -1,0 +1,2193 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1001 &9495347
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1031177251}
+    m_Modifications:
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -952
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: -344
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6963777608485144162, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_Name
+      value: ConnectionModeButtons
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d725b5588e1b956458798319e6541d84, type: 3}
+--- !u!224 &9495348 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
+    type: 3}
+  m_PrefabInstance: {fileID: 9495347}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &422011491
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 422011493}
+  - component: {fileID: 422011492}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &422011492
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 422011491}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &422011493
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 422011491}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &465045808
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 465045809}
+  m_Layer: 0
+  m_Name: TeleportDestinationB
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &465045809
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 465045808}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.04, y: 0.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &539459709
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 539459712}
+  - component: {fileID: 539459711}
+  - component: {fileID: 539459710}
+  m_Layer: 0
+  m_Name: NetworkManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &539459710
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 539459709}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6960e84d07fb87f47956e7a81d71c4e6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ProtocolType: 0
+  m_MaxPacketQueueSize: 128
+  m_MaxPayloadSize: 128000
+  m_MaxSendQueueSize: 1000000
+  m_HeartbeatTimeoutMS: 500
+  m_ConnectTimeoutMS: 1000
+  m_MaxConnectAttempts: 60
+  m_DisconnectTimeoutMS: 30000
+  ConnectionData:
+    Address: 127.0.0.1
+    Port: 7777
+    ServerListenAddress: 
+  DebugSimulator:
+    PacketDelayMS: 0
+    PacketJitterMS: 0
+    PacketDropRate: 0
+--- !u!114 &539459711
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 539459709}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 593a2fe42fa9d37498c96f9a383b6521, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  RunInBackground: 1
+  LogLevel: 1
+  NetworkConfig:
+    ProtocolVersion: 0
+    NetworkTransport: {fileID: 539459710}
+    PlayerPrefab: {fileID: 8685790303553767886, guid: 96e0a72e30d0c46c8a5c9a750e8f5807,
+      type: 3}
+    NetworkPrefabs: []
+    TickRate: 30
+    ClientConnectionBufferTimeout: 10
+    ConnectionApproval: 0
+    ConnectionData: 
+    EnableTimeResync: 0
+    TimeResyncInterval: 30
+    EnsureNetworkVariableLengthSafety: 0
+    EnableSceneManagement: 1
+    ForceSamePrefabs: 1
+    RecycleNetworkIds: 1
+    NetworkIdRecycleDelay: 120
+    RpcHashSize: 0
+    LoadSceneTimeOut: 120
+    SpawnTimeout: 1
+    EnableNetworkLogs: 1
+--- !u!4 &539459712
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 539459709}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 9.879457, y: -10.436741, z: 1.1385593}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &567879417
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 567879420}
+  - component: {fileID: 567879419}
+  - component: {fileID: 567879418}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &567879418
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 567879417}
+  m_Enabled: 1
+--- !u!20 &567879419
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 567879417}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &567879420
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 567879417}
+  m_LocalRotation: {x: 0.2588191, y: 0, z: 0, w: 0.9659258}
+  m_LocalPosition: {x: 8.1, y: 10.9, z: -19.2}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 30, y: 0, z: 0}
+--- !u!1 &1031177247
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1031177251}
+  - component: {fileID: 1031177250}
+  - component: {fileID: 1031177249}
+  - component: {fileID: 1031177248}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1031177248
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1031177247}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1031177249
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1031177247}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &1031177250
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1031177247}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &1031177251
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1031177247}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9495348}
+  - {fileID: 1632447478}
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!1 &1111851142
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1111851143}
+  m_Layer: 0
+  m_Name: TeleportDestinationA
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1111851143
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1111851142}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 17.22, y: 0.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1632447477
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1632447478}
+  - component: {fileID: 1632447480}
+  - component: {fileID: 1632447479}
+  m_Layer: 5
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1632447478
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1632447477}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1031177251}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1632447479
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1632447477}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &1632447480
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1632447477}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!1 &910007655381311276
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6283120761446335287}
+  - component: {fileID: 3739510624132112197}
+  m_Layer: 0
+  m_Name: CornerBumper (1)
+  m_TagString: Boundary
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &910007656598437491
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6283120762361012840}
+  - component: {fileID: 3739510625366015514}
+  m_Layer: 0
+  m_Name: CornerBumper (1)
+  m_TagString: Boundary
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1854705290707056910
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2290144463474879011}
+  - component: {fileID: 4559046434087525967}
+  m_Layer: 0
+  m_Name: CornerBumper (2)
+  m_TagString: Boundary
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1854705291588622417
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2290144462274530172}
+  - component: {fileID: 4559046435286335248}
+  m_Layer: 0
+  m_Name: CornerBumper (2)
+  m_TagString: Boundary
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2290144462274530172
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1854705291588622417}
+  m_LocalRotation: {x: -0, y: -0.3771283, z: -0, w: -0.92616105}
+  m_LocalPosition: {x: -29.53, y: 0.98, z: -29.71}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4012615690793490293}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: -315.688, z: 0}
+--- !u!4 &2290144463474879011
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1854705290707056910}
+  m_LocalRotation: {x: -0, y: -0.3771283, z: -0, w: -0.92616105}
+  m_LocalPosition: {x: -29.53, y: 0.98, z: -29.71}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4012615692010092074}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: -315.688, z: 0}
+--- !u!65 &3136259738196406079
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4674276235128641327}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 4, y: 2, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!65 &3136259739378421344
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4674276234231314032}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 4, y: 2, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!65 &3739510624132112197
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910007655381311276}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 4, y: 2, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!65 &3739510625366015514
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910007656598437491}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 4, y: 2, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!4 &3910294715920693371
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4674276234231314032}
+  m_LocalRotation: {x: 0, y: -0.38268343, z: 0, w: 0.92387956}
+  m_LocalPosition: {x: 29.7, y: 0.98, z: -29.61}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4012615690793490293}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: -45, z: 0}
+--- !u!4 &3910294717136820516
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4674276235128641327}
+  m_LocalRotation: {x: 0, y: -0.38268343, z: 0, w: 0.92387956}
+  m_LocalPosition: {x: 29.7, y: 0.98, z: -29.61}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4012615692010092074}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: -45, z: 0}
+--- !u!4 &4012615690734689956
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615690734689960}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -30.5, y: 0.49999994, z: 0}
+  m_LocalScale: {x: 1, y: 3, z: 62}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4012615692010092074}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &4012615690734689958
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615690734689960}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00cf8ac777c8c42e8967157f70fbfcbf, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &4012615690734689959
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615690734689960}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &4012615690734689960
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4012615690734689956}
+  - component: {fileID: 4012615690734689959}
+  - component: {fileID: 4012615690734689958}
+  - component: {fileID: 4012615690734689961}
+  - component: {fileID: 4012615690734689962}
+  m_Layer: 0
+  m_Name: Side
+  m_TagString: Boundary
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &4012615690734689961
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615690734689960}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 2, y: 1, z: 1}
+  m_Center: {x: -0.5, y: 0, z: 0}
+--- !u!114 &4012615690734689962
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615690734689960}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1de461850fd18574584d884cc31ed103, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Destination: {fileID: 465045808}
+--- !u!1 &4012615690780670402
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4012615690780670406}
+  - component: {fileID: 4012615690780670407}
+  - component: {fileID: 4012615690780670404}
+  - component: {fileID: 4012615690780670405}
+  - component: {fileID: 4012615690780670408}
+  m_Layer: 0
+  m_Name: Side
+  m_TagString: Boundary
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &4012615690780670404
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615690780670402}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00cf8ac777c8c42e8967157f70fbfcbf, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &4012615690780670405
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615690780670402}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 2, y: 1, z: 1}
+  m_Center: {x: 0.5, y: 0, z: 0}
+--- !u!4 &4012615690780670406
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615690780670402}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 30.5, y: 0.49999994, z: 0}
+  m_LocalScale: {x: 1, y: 3, z: 62}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4012615690793490293}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &4012615690780670407
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615690780670402}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &4012615690780670408
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615690780670402}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1de461850fd18574584d884cc31ed103, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Destination: {fileID: 1111851142}
+--- !u!1 &4012615690793490290
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4012615690793490293}
+  m_Layer: 0
+  m_Name: SceneLevelGeometryStart
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4012615690793490293
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615690793490290}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.25, y: 0.25, z: 0.25}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4012615692280833000}
+  - {fileID: 4012615691539789097}
+  - {fileID: 4012615691302274498}
+  - {fileID: 4012615691934547963}
+  - {fileID: 4012615690780670406}
+  - {fileID: 3910294715920693371}
+  - {fileID: 6283120762361012840}
+  - {fileID: 2290144462274530172}
+  - {fileID: 6959258899469919941}
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &4012615691046896310
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615691046896315}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &4012615691046896311
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615691046896315}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.50000006, z: 0}
+  m_LocalScale: {x: 60, y: 1, z: 60}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4012615692010092074}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &4012615691046896312
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615691046896315}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &4012615691046896313
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615691046896315}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00cf8ac777c8c42e8967157f70fbfcbf, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &4012615691046896315
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4012615691046896311}
+  - component: {fileID: 4012615691046896310}
+  - component: {fileID: 4012615691046896313}
+  - component: {fileID: 4012615691046896312}
+  m_Layer: 0
+  m_Name: Floor
+  m_TagString: Floor
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &4012615691302274496
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615691302274558}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00cf8ac777c8c42e8967157f70fbfcbf, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &4012615691302274497
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615691302274558}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 2}
+  m_Center: {x: 0, y: 0, z: -0.5}
+--- !u!4 &4012615691302274498
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615691302274558}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.49999994, z: -30.5}
+  m_LocalScale: {x: 60, y: 3, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4012615690793490293}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &4012615691302274499
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615691302274558}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &4012615691302274558
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4012615691302274498}
+  - component: {fileID: 4012615691302274499}
+  - component: {fileID: 4012615691302274496}
+  - component: {fileID: 4012615691302274497}
+  m_Layer: 0
+  m_Name: Side
+  m_TagString: Boundary
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &4012615691539789092
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615691539789093}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 2}
+  m_Center: {x: 0, y: 0, z: 0.5}
+--- !u!1 &4012615691539789093
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4012615691539789097}
+  - component: {fileID: 4012615691539789094}
+  - component: {fileID: 4012615691539789095}
+  - component: {fileID: 4012615691539789092}
+  m_Layer: 0
+  m_Name: Side
+  m_TagString: Boundary
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!33 &4012615691539789094
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615691539789093}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4012615691539789095
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615691539789093}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00cf8ac777c8c42e8967157f70fbfcbf, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!4 &4012615691539789097
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615691539789093}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.49999994, z: 30.5}
+  m_LocalScale: {x: 60, y: 3, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4012615690793490293}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &4012615691934547958
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615691934547959}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 2, y: 1, z: 1}
+  m_Center: {x: -0.5, y: 0, z: 0}
+--- !u!1 &4012615691934547959
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4012615691934547963}
+  - component: {fileID: 4012615691934547960}
+  - component: {fileID: 4012615691934547961}
+  - component: {fileID: 4012615691934547958}
+  m_Layer: 0
+  m_Name: Side
+  m_TagString: Boundary
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!33 &4012615691934547960
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615691934547959}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4012615691934547961
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615691934547959}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00cf8ac777c8c42e8967157f70fbfcbf, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!4 &4012615691934547963
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615691934547959}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -30.5, y: 0.49999994, z: 0}
+  m_LocalScale: {x: 1, y: 3, z: 62}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4012615690793490293}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4012615692010092074
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615692010092077}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 17.2, y: 0, z: 0}
+  m_LocalScale: {x: 0.25, y: 0.25, z: 0.25}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4012615691046896311}
+  - {fileID: 4012615692740187254}
+  - {fileID: 4012615692568749213}
+  - {fileID: 4012615690734689956}
+  - {fileID: 4012615692014524569}
+  - {fileID: 3910294717136820516}
+  - {fileID: 6283120761446335287}
+  - {fileID: 2290144463474879011}
+  - {fileID: 6959258898237589402}
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4012615692010092077
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4012615692010092074}
+  m_Layer: 0
+  m_Name: SceneLevelGeometryTeleport
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!33 &4012615692014524568
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615692014524573}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &4012615692014524569
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615692014524573}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 30.5, y: 0.49999994, z: 0}
+  m_LocalScale: {x: 1, y: 3, z: 62}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4012615692010092074}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &4012615692014524570
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615692014524573}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 2, y: 1, z: 1}
+  m_Center: {x: 0.5, y: 0, z: 0}
+--- !u!23 &4012615692014524571
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615692014524573}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00cf8ac777c8c42e8967157f70fbfcbf, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &4012615692014524573
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4012615692014524569}
+  - component: {fileID: 4012615692014524568}
+  - component: {fileID: 4012615692014524571}
+  - component: {fileID: 4012615692014524570}
+  m_Layer: 0
+  m_Name: Side
+  m_TagString: Boundary
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &4012615692280832996
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4012615692280833000}
+  - component: {fileID: 4012615692280833001}
+  - component: {fileID: 4012615692280832998}
+  - component: {fileID: 4012615692280832999}
+  m_Layer: 0
+  m_Name: Floor
+  m_TagString: Floor
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &4012615692280832998
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615692280832996}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00cf8ac777c8c42e8967157f70fbfcbf, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &4012615692280832999
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615692280832996}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!4 &4012615692280833000
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615692280832996}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.50000006, z: 0}
+  m_LocalScale: {x: 60, y: 1, z: 60}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4012615690793490293}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &4012615692280833001
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615692280832996}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!33 &4012615692568749212
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615692568749217}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &4012615692568749213
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615692568749217}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.49999994, z: -30.5}
+  m_LocalScale: {x: 60, y: 3, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4012615692010092074}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &4012615692568749214
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615692568749217}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 2}
+  m_Center: {x: 0, y: 0, z: -0.5}
+--- !u!23 &4012615692568749215
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615692568749217}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00cf8ac777c8c42e8967157f70fbfcbf, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &4012615692568749217
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4012615692568749213}
+  - component: {fileID: 4012615692568749212}
+  - component: {fileID: 4012615692568749215}
+  - component: {fileID: 4012615692568749214}
+  m_Layer: 0
+  m_Name: Side
+  m_TagString: Boundary
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4012615692740187254
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615692740187258}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.49999994, z: 30.5}
+  m_LocalScale: {x: 60, y: 3, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4012615692010092074}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &4012615692740187256
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615692740187258}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00cf8ac777c8c42e8967157f70fbfcbf, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &4012615692740187257
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615692740187258}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &4012615692740187258
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4012615692740187254}
+  - component: {fileID: 4012615692740187257}
+  - component: {fileID: 4012615692740187256}
+  - component: {fileID: 4012615692740187259}
+  m_Layer: 0
+  m_Name: Side
+  m_TagString: Boundary
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &4012615692740187259
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012615692740187258}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 2}
+  m_Center: {x: 0, y: 0, z: 0.5}
+--- !u!65 &4559046434087525967
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1854705290707056910}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 4, y: 2, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!65 &4559046435286335248
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1854705291588622417}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 4, y: 2, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &4674276234231314032
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3910294715920693371}
+  - component: {fileID: 3136259739378421344}
+  m_Layer: 0
+  m_Name: CornerBumper
+  m_TagString: Boundary
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &4674276235128641327
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3910294717136820516}
+  - component: {fileID: 3136259738196406079}
+  m_Layer: 0
+  m_Name: CornerBumper
+  m_TagString: Boundary
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6283120761446335287
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910007655381311276}
+  m_LocalRotation: {x: -0, y: -0.9244967, z: -0, w: -0.38119}
+  m_LocalPosition: {x: -29.72, y: 0.98, z: 29.82}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4012615692010092074}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: -224.815, z: 0}
+--- !u!4 &6283120762361012840
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910007656598437491}
+  m_LocalRotation: {x: -0, y: -0.9244967, z: -0, w: -0.38119}
+  m_LocalPosition: {x: -29.72, y: 0.98, z: 29.82}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4012615690793490293}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: -224.815, z: 0}
+--- !u!4 &6959258898237589402
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7080625901594168492}
+  m_LocalRotation: {x: -0, y: 0.93588465, z: -0, w: -0.35230666}
+  m_LocalPosition: {x: 29.26, y: 0.98, z: 29.45}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4012615692010092074}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: -498.74298, z: 0}
+--- !u!4 &6959258899469919941
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7080625902744219123}
+  m_LocalRotation: {x: -0, y: 0.93588465, z: -0, w: -0.35230666}
+  m_LocalPosition: {x: 29.26, y: 0.98, z: 29.45}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4012615690793490293}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: -498.74298, z: 0}
+--- !u!1 &7080625901594168492
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6959258898237589402}
+  - component: {fileID: 7672408767872724259}
+  m_Layer: 0
+  m_Name: CornerBumper (3)
+  m_TagString: Boundary
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &7080625902744219123
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6959258899469919941}
+  - component: {fileID: 7672408766706977916}
+  m_Layer: 0
+  m_Name: CornerBumper (3)
+  m_TagString: Boundary
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &7672408766706977916
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7080625902744219123}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 4, y: 2, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!65 &7672408767872724259
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7080625901594168492}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 4, y: 2, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/testproject/Assets/Samples/Teleport/TeleportSample.unity.meta
+++ b/testproject/Assets/Samples/Teleport/TeleportSample.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: efa247d1f78ca694f8d2dcb5672e8f8b
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/testproject/Assets/Scripts/PlayerMovement.cs
+++ b/testproject/Assets/Scripts/PlayerMovement.cs
@@ -80,7 +80,6 @@ public class PlayerMovement : NetworkBehaviour
     private void MovePlayerServerRpc(MovePlayerData movePlayerData)
     {
         var serverTimeDelta = (float)(NetworkManager.ServerTime.Time - movePlayerData.ServerTime);
-        //Debug.Log($"ServerTimeDelta: {serverTimeDelta} | Calculated Time Delta: {m_TickFrequency * serverTimeDelta + Time.deltaTime}");
         MovePlayer(movePlayerData.VerticalAxis, movePlayerData.HorizontalAxis, m_TickFrequency * serverTimeDelta - Time.deltaTime);
     }
 

--- a/testproject/Assets/Scripts/PlayerMovement.cs
+++ b/testproject/Assets/Scripts/PlayerMovement.cs
@@ -9,30 +9,106 @@ public class PlayerMovement : NetworkBehaviour
     [SerializeField]
     private float m_RotSpeed = 5.0f;
 
+    private Rigidbody m_Rigidbody;
+
     public static Dictionary<ulong, PlayerMovement> Players = new Dictionary<ulong, PlayerMovement>();
 
     private void Start()
     {
-        if (IsLocalPlayer)
+
+    }
+
+    private float m_TickFrequency;
+    private float m_DelayInputForTeleport;
+
+    private bool m_IsTeleporting;
+
+    public void Telporting()
+    {
+        if (IsSpawned && IsServer)
         {
-            var temp = transform.position;
-            temp.y = 0.5f;
-            transform.position = temp;
+            m_IsTeleporting = true;
+            m_DelayInputForTeleport = Time.realtimeSinceStartup + (3 * m_TickFrequency);
+            m_Rigidbody.angularVelocity = Vector3.zero;
+            m_Rigidbody.velocity = Vector3.zero;
+            m_Rigidbody.isKinematic = true;
         }
     }
 
     public override void OnNetworkSpawn()
     {
+        m_Rigidbody = GetComponent<Rigidbody>();
+        if (IsServer)
+        {
+            m_TickFrequency = 1.0f / NetworkManager.NetworkTickSystem.TickRate;
+            var temp = transform.position;
+            temp.y = 0.5f;
+            transform.position = temp;
+        }
         base.OnNetworkSpawn();
         Players[OwnerClientId] = this; // todo should really have a NetworkStop for unregistering this...
     }
 
+    private void MovePlayer(float veritcal, float horizontal, float timeDelta)
+    {
+        if (m_IsTeleporting)
+        {
+            return;
+        }
+        var clampedTimeDelta = Mathf.Clamp(timeDelta, m_TickFrequency * 0.5f, 2 * m_TickFrequency);
+
+        var position = transform.position;
+
+        position += veritcal * m_Speed * clampedTimeDelta * transform.forward;
+
+        var rotation = Quaternion.Euler(0, horizontal * 90 * m_RotSpeed * clampedTimeDelta, 0) * transform.rotation;
+
+        m_Rigidbody.MovePosition(position);
+        m_Rigidbody.MoveRotation(rotation);
+    }
+
+    [ServerRpc]
+    private void MovePlayerServerRpc(float vertical, float horizontal)
+    {
+        MovePlayer(vertical, horizontal, m_TickFrequency + Time.deltaTime);
+    }
+
+    private void LateUpdate()
+    {
+        if (IsSpawned && IsOwner)
+        {
+            if (Input.GetKey(KeyCode.UpArrow) || Input.GetKey(KeyCode.DownArrow) || Input.GetKey(KeyCode.LeftArrow) || Input.GetKey(KeyCode.RightArrow))
+            {
+                if (IsServer)
+                {
+                    MovePlayer(Input.GetAxis("Vertical"), Input.GetAxis("Horizontal"), Time.deltaTime);
+                }
+                else
+                {
+                    MovePlayerServerRpc(Input.GetAxis("Vertical"), Input.GetAxis("Horizontal"));
+                }
+            }
+        }
+
+        if (IsServer)
+        {
+            if (m_IsTeleporting)
+            {
+                if (Time.realtimeSinceStartup >= m_DelayInputForTeleport)
+                {
+                    m_IsTeleporting = false;
+                    m_Rigidbody.isKinematic = false;
+                }
+                else
+                {
+                    return;
+                }
+            }
+        }
+    }
+
     private void FixedUpdate()
     {
-        if (IsLocalPlayer)
-        {
-            transform.position += Input.GetAxis("Vertical") * m_Speed * Time.fixedDeltaTime * transform.forward;
-            transform.rotation = Quaternion.Euler(0, Input.GetAxis("Horizontal") * 90 * m_RotSpeed * Time.fixedDeltaTime, 0) * transform.rotation;
-        }
+
     }
 }

--- a/testproject/Assets/Scripts/PlayerMovement.cs
+++ b/testproject/Assets/Scripts/PlayerMovement.cs
@@ -1,22 +1,18 @@
 using System.Collections.Generic;
-using Unity.Netcode;
 using UnityEngine;
+using Unity.Netcode;
+using Unity.Netcode.Components;
 
 public class PlayerMovement : NetworkBehaviour
 {
     [SerializeField]
-    private float m_Speed = 20.0f;
+    private float m_Speed = 4.0f;
     [SerializeField]
-    private float m_RotSpeed = 5.0f;
+    private float m_RotSpeed = 1.0f;
 
     private Rigidbody m_Rigidbody;
 
     public static Dictionary<ulong, PlayerMovement> Players = new Dictionary<ulong, PlayerMovement>();
-
-    private void Start()
-    {
-
-    }
 
     private float m_TickFrequency;
     private float m_DelayInputForTeleport;
@@ -30,17 +26,26 @@ public class PlayerMovement : NetworkBehaviour
         }
     }
 
+    private Quaternion m_PreviousRotation;
+    private RigidbodyInterpolation m_OrginalRigidbodyInterpolation;
 
-
-    public void Telporting()
+    public void Telporting(Vector3 destination)
     {
-        if (IsSpawned && IsServer)
+        if (IsSpawned && IsServer && !m_IsTeleporting)
         {
             m_IsTeleporting = true;
             m_DelayInputForTeleport = Time.realtimeSinceStartup + (2 * m_TickFrequency);
-            m_Rigidbody.angularVelocity = Vector3.zero;
-            m_Rigidbody.velocity = Vector3.zero;
             m_Rigidbody.isKinematic = true;
+            m_OrginalRigidbodyInterpolation = m_Rigidbody.interpolation;
+            m_Rigidbody.interpolation = RigidbodyInterpolation.None;
+            // Since the player-cube is a cube, when colliding with something it could
+            // cause the cube to rotate based on the surface being collided against
+            // and the facing of the cube. This prevents rotation from being changed
+            // due to colliding with a side wall (and then teleported)
+            transform.rotation = m_PreviousRotation;
+
+            // Now teleport
+            GetComponent<NetworkTransform>().Teleport(destination, transform.rotation, transform.localScale);
         }
     }
 
@@ -58,90 +63,243 @@ public class PlayerMovement : NetworkBehaviour
         Players[OwnerClientId] = this; // todo should really have a NetworkStop for unregistering this...
     }
 
-    private void MovePlayer(float veritcal, float horizontal, float timeDelta)
+    private void MovePlayer(float vertical, float horizontal, float timeDelta)
     {
         if (m_IsTeleporting)
         {
             return;
         }
-        var clampedTimeDelta = Mathf.Clamp(timeDelta, m_TickFrequency * 0.40f, m_TickFrequency);
 
-        var position = transform.position;
+        if (Mathf.Abs(vertical) > 0.001f)
+        {
+            var position = transform.position;
+            position += vertical * transform.forward * m_Speed * timeDelta;
+            m_Rigidbody.MovePosition(position);
+        }
 
-        position += veritcal * m_Speed * clampedTimeDelta * transform.forward;
-
-        var rotation = Quaternion.Euler(0, horizontal * 90 * m_RotSpeed * clampedTimeDelta, 0) * transform.rotation;
-
-        m_Rigidbody.MovePosition(position);
-        m_Rigidbody.MoveRotation(rotation);
+        if (Mathf.Abs(horizontal) > 0.001f)
+        {
+            var rotation = Quaternion.Euler(0, horizontal * 90 * m_RotSpeed * timeDelta, 0) * transform.rotation;
+            m_Rigidbody.rotation = rotation;
+        }
     }
 
     [ServerRpc]
     private void MovePlayerServerRpc(MovePlayerData movePlayerData)
     {
-        var serverTimeDelta = (float)(NetworkManager.ServerTime.Time - movePlayerData.ServerTime);
-        MovePlayer(movePlayerData.VerticalAxis, movePlayerData.HorizontalAxis, m_TickFrequency * serverTimeDelta - Time.deltaTime);
+        m_CurrentMoveState = m_MovePlayerState.UpdateFromData(movePlayerData);
     }
-
 
     private MovePlayerData m_MovePlayerData = new MovePlayerData();
+    private MovePlayerState m_MovePlayerState = new MovePlayerState();
+    private Vector2 m_CurrentMoveState;
+
     private void LateUpdate()
     {
-        if (IsSpawned && IsOwner)
+        if (!IsSpawned || m_IsTeleporting)
         {
-            if (Input.GetKey(KeyCode.UpArrow) || Input.GetKey(KeyCode.DownArrow) || Input.GetKey(KeyCode.LeftArrow) || Input.GetKey(KeyCode.RightArrow))
-            {
-                if (IsServer)
-                {
-                    MovePlayer(Input.GetAxis("Vertical"), Input.GetAxis("Horizontal"), m_TickFrequency * 0.40f);
-                }
-                else
-                {
-                    m_MovePlayerData.VerticalAxis = Input.GetAxis("Vertical");
-                    m_MovePlayerData.HorizontalAxis = Input.GetAxis("Horizontal");
-                    m_MovePlayerData.ServerTime = NetworkManager.ServerTime.Time;
-                    MovePlayerServerRpc(m_MovePlayerData);
-                }
-            }
+            return;
         }
-
-        if (IsServer)
+        if (IsOwner)
         {
-            if (m_IsTeleporting)
+            m_MovePlayerData.SetInputState();
+
+            if (IsServer)
             {
-                if (Time.realtimeSinceStartup >= m_DelayInputForTeleport)
+                m_CurrentMoveState = m_MovePlayerState.UpdateFromData(m_MovePlayerData);
+            }
+            else
+            {
+                if (m_MovePlayerData.HasKeyStates)
                 {
-                    m_IsTeleporting = false;
-                    m_Rigidbody.isKinematic = false;
+                    MovePlayerServerRpc(m_MovePlayerData);
+                    m_MovePlayerState.HadKeyStates = true;
                 }
-                else
+                else if (m_MovePlayerState.HadKeyStates)
                 {
-                    return;
+                    MovePlayerServerRpc(m_MovePlayerData);
+                    m_MovePlayerState.ResetKeyStates(m_MovePlayerData);
                 }
             }
         }
     }
 
+
+    private void FixedUpdate()
+    {
+        if (!IsSpawned || !IsServer)
+        {
+            return;
+        }
+
+        if (m_IsTeleporting)
+        {
+            if (Time.realtimeSinceStartup >= m_DelayInputForTeleport)
+            {
+                m_MovePlayerState.ResetKeyStates(m_MovePlayerData);
+                m_IsTeleporting = false;
+                m_Rigidbody.isKinematic = false;
+                m_Rigidbody.interpolation = m_OrginalRigidbodyInterpolation;
+            }
+            else
+            {
+                return;
+            }
+        }
+
+        MovePlayer(m_CurrentMoveState.y, m_CurrentMoveState.x, Time.deltaTime);
+        // This allows us to rollback to the previous rotation for the teleport
+        // sample. If we don't do this the box will collide with the wall and
+        // will slightly rotate the box to align with the wall
+        m_PreviousRotation = transform.rotation;
+    }
+
+    /// <summary>
+    /// An INetworkSerializable implementation to handle server authoritative motion
+    /// Uses the indices the key codes are registered as bit positions to send a single uint packed
+    /// </summary>
     public class MovePlayerData : INetworkSerializable
     {
-        public float HorizontalAxis;
-        public float VerticalAxis;
-        public double ServerTime;
+        private List<KeyCode> m_KeyCodes = new List<KeyCode>() { KeyCode.UpArrow, KeyCode.DownArrow, KeyCode.LeftArrow, KeyCode.RightArrow };
+
+        private uint m_KeyStates;
+
+        public bool HasKeyStates
+        {
+            get
+            {
+                return m_KeyStates > 0;
+            }
+        }
+
+        public void ResetKeyStates()
+        {
+            m_KeyStates = 0;
+        }
+
+        public List<KeyCode> KeyCodesPressed = new List<KeyCode>();
+
+        private const int k_MaxKeys = sizeof(uint) * 8;
+
+        public void SetInputState()
+        {
+            if (m_KeyCodes.Count >= k_MaxKeys)
+            {
+                throw new System.Exception($"Number of registered keys to track ({m_KeyCodes.Count}) exceeded maximum ({k_MaxKeys})");
+            }
+
+            m_KeyStates = 0;
+            for (int i = 0; i < m_KeyCodes.Count; i++)
+            {
+                if (Input.GetKey(m_KeyCodes[i]))
+                {
+                    m_KeyStates |= (uint)(1 << i);
+                }
+            }
+        }
+
+        public void GetInputState()
+        {
+            KeyCodesPressed.Clear();
+            for (int i = 0; i < m_KeyCodes.Count; i++)
+            {
+                if ((m_KeyStates & (uint)(1 << i)) > 0)
+                {
+                    KeyCodesPressed.Add(m_KeyCodes[i]);
+                }
+            }
+        }
+
         public void NetworkSerialize<T>(BufferSerializer<T> serializer) where T : IReaderWriter
         {
             if (serializer.IsWriter)
             {
                 var writer = serializer.GetFastBufferWriter();
-                BytePacker.WriteValuePacked(writer, HorizontalAxis);
-                BytePacker.WriteValuePacked(writer, VerticalAxis);
-                BytePacker.WriteValuePacked(writer, ServerTime);
+                BytePacker.WriteValuePacked(writer, m_KeyStates);
             }
             else
             {
                 var reader = serializer.GetFastBufferReader();
-                ByteUnpacker.ReadValuePacked(reader, out HorizontalAxis);
-                ByteUnpacker.ReadValuePacked(reader, out VerticalAxis);
-                ByteUnpacker.ReadValuePacked(reader, out ServerTime);
+                ByteUnpacker.ReadValuePacked(reader, out m_KeyStates);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Used to maintain the stats of the player's motion
+    /// </summary>
+    public class MovePlayerState
+    {
+        private float m_HorizontalAccel;
+        private float m_VerticalAccel;
+        private Vector2 m_XYInput;
+        public List<KeyCode> KeyCodesPressed = new List<KeyCode>();
+
+        public bool HadKeyStates;
+
+        public void ResetKeyStates(MovePlayerData movePlayerData)
+        {
+            movePlayerData.ResetKeyStates();
+            KeyCodesPressed.Clear();
+            m_HorizontalAccel = 0;
+            m_VerticalAccel = 0;
+            m_XYInput = Vector2.zero;
+            HadKeyStates = false;
+        }
+        public Vector2 UpdateAxis(bool decay = false, float lerpDecay = 0.15f)
+        {
+            m_XYInput.x = m_HorizontalAccel;
+            m_XYInput.y = m_VerticalAccel;
+            return m_XYInput;
+        }
+
+        public Vector2 UpdateFromData(MovePlayerData movePlayerData)
+        {
+            movePlayerData.GetInputState();
+
+            if (HadKeyStates && movePlayerData.KeyCodesPressed.Count == 0)
+            {
+                ResetKeyStates(movePlayerData);
+            }
+            else
+            {
+                UpdateAxialAcceleration(movePlayerData.KeyCodesPressed);
+            }
+
+            return UpdateAxis();
+        }
+
+        private void UpdateAxialAcceleration(List<KeyCode> keyCodesPressed)
+        {
+            KeyCodesPressed = keyCodesPressed;
+            m_VerticalAccel = Mathf.Lerp(m_VerticalAccel, 0.0f, 0.25f);
+            m_HorizontalAccel = Mathf.Lerp(m_HorizontalAccel, 0.0f, 0.25f);
+            HadKeyStates = keyCodesPressed.Count > 0;
+            foreach (var keyPressed in KeyCodesPressed)
+            {
+                switch (keyPressed)
+                {
+                    case KeyCode.UpArrow:
+                        {
+                            m_VerticalAccel = 1.0f;
+                            break;
+                        }
+                    case KeyCode.DownArrow:
+                        {
+                            m_VerticalAccel = -1.0f;
+                            break;
+                        }
+                    case KeyCode.RightArrow:
+                        {
+                            m_HorizontalAccel = 1.0f;
+                            break;
+                        }
+                    case KeyCode.LeftArrow:
+                        {
+                            m_HorizontalAccel = -1.0f;
+                            break;
+                        }
+                }
             }
         }
     }

--- a/testproject/Assets/Scripts/PlayerMovement.cs
+++ b/testproject/Assets/Scripts/PlayerMovement.cs
@@ -22,13 +22,22 @@ public class PlayerMovement : NetworkBehaviour
     private float m_DelayInputForTeleport;
 
     private bool m_IsTeleporting;
+    public bool IsTeleporting
+    {
+        get
+        {
+            return m_IsTeleporting;
+        }
+    }
+
+
 
     public void Telporting()
     {
         if (IsSpawned && IsServer)
         {
             m_IsTeleporting = true;
-            m_DelayInputForTeleport = Time.realtimeSinceStartup + (3 * m_TickFrequency);
+            m_DelayInputForTeleport = Time.realtimeSinceStartup + (2 * m_TickFrequency);
             m_Rigidbody.angularVelocity = Vector3.zero;
             m_Rigidbody.velocity = Vector3.zero;
             m_Rigidbody.isKinematic = true;
@@ -70,7 +79,7 @@ public class PlayerMovement : NetworkBehaviour
     [ServerRpc]
     private void MovePlayerServerRpc(float vertical, float horizontal)
     {
-        MovePlayer(vertical, horizontal, m_TickFrequency + Time.deltaTime);
+        MovePlayer(vertical, horizontal, (0.5f * m_TickFrequency));
     }
 
     private void LateUpdate()

--- a/testproject/Assets/Scripts/PlayerMovement.cs
+++ b/testproject/Assets/Scripts/PlayerMovement.cs
@@ -10,7 +10,7 @@ public class PlayerMovement : NetworkBehaviour
     [SerializeField]
     private float m_RotSpeed = 1.0f;
 
-    [Range(0.01f,1.0f)]
+    [Range(0.01f, 1.0f)]
     [Tooltip("The input response (1.0 is very responsive)")]
     [SerializeField]
     private float m_InputResponse = 0.5f;
@@ -58,7 +58,7 @@ public class PlayerMovement : NetworkBehaviour
         m_Rigidbody = GetComponent<Rigidbody>();
         if (IsServer)
         {
-            m_TickFrequency = 1.0f/NetworkManager.NetworkTickSystem.TickRate;
+            m_TickFrequency = 1.0f / NetworkManager.NetworkTickSystem.TickRate;
             var temp = transform.position;
             temp.y = 0.5f;
             transform.position = temp;

--- a/testproject/Assets/Scripts/PlayerMovement.cs
+++ b/testproject/Assets/Scripts/PlayerMovement.cs
@@ -3,21 +3,22 @@ using UnityEngine;
 using Unity.Netcode;
 using Unity.Netcode.Components;
 
-public class PlayerMovement : NetworkBehaviour
-{
-    [SerializeField]
-    private float m_Speed = 4.0f;
-    [SerializeField]
-    private float m_RotSpeed = 1.0f;
 
-    [Range(0.01f, 1.0f)]
-    [Tooltip("The input response (1.0 is very responsive)")]
-    [SerializeField]
-    private float m_InputResponse = 0.5f;
+public class PlayerMovement : NetworkTransform
+{
+
+    public float Speed = 4.0f;
+
+    public float RotSpeed = 1.0f;
 
     private Rigidbody m_Rigidbody;
-
     public static Dictionary<ulong, PlayerMovement> Players = new Dictionary<ulong, PlayerMovement>();
+
+    protected override bool OnIsServerAuthoritative()
+    {
+        return false;
+    }
+
     private float m_DelayInputForTeleport;
 
     private bool m_IsTeleporting;
@@ -32,13 +33,14 @@ public class PlayerMovement : NetworkBehaviour
     private float m_TickFrequency;
     private Quaternion m_PreviousRotation;
     private RigidbodyInterpolation m_OrginalRigidbodyInterpolation;
+    private Vector3 m_TeleportDestination;
 
     public void Telporting(Vector3 destination)
     {
-        if (IsSpawned && IsServer && !m_IsTeleporting)
+        if (IsSpawned && IsOwner && !m_IsTeleporting)
         {
             m_IsTeleporting = true;
-            m_DelayInputForTeleport = Time.realtimeSinceStartup + (1.5f * m_TickFrequency);
+            m_TeleportDestination = destination;
             m_Rigidbody.isKinematic = true;
             m_OrginalRigidbodyInterpolation = m_Rigidbody.interpolation;
             m_Rigidbody.interpolation = RigidbodyInterpolation.None;
@@ -47,275 +49,59 @@ public class PlayerMovement : NetworkBehaviour
             // and the facing of the cube. This prevents rotation from being changed
             // due to colliding with a side wall (and then teleported)
             transform.rotation = m_PreviousRotation;
-
+            m_DelayInputForTeleport = Time.realtimeSinceStartup + (3f * m_TickFrequency);
             // Now teleport
-            GetComponent<NetworkTransform>().Teleport(destination, transform.rotation, transform.localScale);
+            Teleport(m_TeleportDestination, transform.rotation, transform.localScale);
         }
     }
 
     public override void OnNetworkSpawn()
     {
-        m_Rigidbody = GetComponent<Rigidbody>();
-        if (IsServer)
+        if (IsOwner)
         {
-            m_TickFrequency = 1.0f / NetworkManager.NetworkTickSystem.TickRate;
             var temp = transform.position;
             temp.y = 0.5f;
             transform.position = temp;
         }
-        base.OnNetworkSpawn();
+        m_Rigidbody = GetComponent<Rigidbody>();
+        m_TickFrequency = 1.0f / NetworkManager.NetworkTickSystem.TickRate;
         Players[OwnerClientId] = this; // todo should really have a NetworkStop for unregistering this...
+
+        base.OnNetworkSpawn();
     }
-
-    private void MovePlayer(float vertical, float horizontal)
-    {
-        if (m_IsTeleporting)
-        {
-            return;
-        }
-        if (Mathf.Abs(vertical) > 0.001f)
-        {
-            var position = transform.position;
-            var yAxis = position.y;
-            position += vertical * transform.forward * m_Speed;
-            position.y = yAxis;
-            m_Rigidbody.position = Vector3.Lerp(transform.position, position, Time.fixedDeltaTime);
-        }
-
-        if (Mathf.Abs(horizontal) > 0.001f)
-        {
-            var currentRotation = m_Rigidbody.rotation;
-            var currentEuler = m_Rigidbody.rotation.eulerAngles;
-
-            currentEuler.y = Mathf.Lerp(currentEuler.y, currentEuler.y + horizontal * m_RotSpeed, Time.fixedDeltaTime);
-            currentRotation.eulerAngles = currentEuler;
-            m_Rigidbody.rotation = currentRotation;
-        }
-    }
-
-    private MovePlayerData m_CurrentClientData;
-
-    [ServerRpc]
-    private void MovePlayerServerRpc(MovePlayerData movePlayerData)
-    {
-        m_CurrentClientData = movePlayerData;
-    }
-
-    private MovePlayerData m_MovePlayerData = new MovePlayerData();
-    private MovePlayerState m_MovePlayerState = new MovePlayerState();
-    private Vector2 m_CurrentMoveState;
 
     private void LateUpdate()
     {
-        if (!IsSpawned || m_IsTeleporting)
+        if (!IsSpawned || !IsOwner || !m_IsTeleporting)
         {
             return;
         }
-        if (IsOwner)
+        if (Time.realtimeSinceStartup >= m_DelayInputForTeleport)
         {
-            m_MovePlayerData.SetInputState();
-
-            if (IsServer)
-            {
-                m_CurrentMoveState = m_MovePlayerState.UpdateFromData(m_MovePlayerData, m_InputResponse);
-            }
-            else
-            {
-                if (m_MovePlayerData.HasKeyStates)
-                {
-                    MovePlayerServerRpc(m_MovePlayerData);
-                    m_MovePlayerState.HadKeyStates = true;
-                }
-                else if (m_MovePlayerState.HadKeyStates)
-                {
-                    MovePlayerServerRpc(m_MovePlayerData);
-                    m_MovePlayerState.ResetKeyStates(m_MovePlayerData);
-                }
-            }
-        }
-        else if (IsServer && !IsOwner)
-        {
-            m_CurrentMoveState = m_MovePlayerState.UpdateFromData(m_CurrentClientData, m_InputResponse);
+            m_IsTeleporting = false;
+            m_Rigidbody.isKinematic = false;
+            m_Rigidbody.interpolation = m_OrginalRigidbodyInterpolation;
         }
     }
-
 
     private void FixedUpdate()
     {
-        if (!IsSpawned || !IsServer)
+        if (!IsSpawned || !IsOwner)
         {
             return;
         }
-
-        if (m_IsTeleporting)
+        else
         {
-            if (Time.realtimeSinceStartup >= m_DelayInputForTeleport)
-            {
-                m_MovePlayerState.ResetKeyStates(m_MovePlayerData);
-                m_IsTeleporting = false;
-                m_Rigidbody.isKinematic = false;
-                m_Rigidbody.interpolation = m_OrginalRigidbodyInterpolation;
-            }
-            else
-            {
-                return;
-            }
-        }
-
-        MovePlayer(m_CurrentMoveState.y, m_CurrentMoveState.x);
-        // This allows us to rollback to the previous rotation for the teleport
-        // sample. If we don't do this the box will collide with the wall and
-        // will slightly rotate the box to align with the wall
-        m_PreviousRotation = transform.rotation;
-    }
-
-    /// <summary>
-    /// An INetworkSerializable implementation to handle server authoritative motion
-    /// Uses the indices the key codes are registered as bit positions to send a single uint packed
-    /// </summary>
-    public class MovePlayerData : INetworkSerializable
-    {
-        private List<KeyCode> m_KeyCodes = new List<KeyCode>() { KeyCode.UpArrow, KeyCode.DownArrow, KeyCode.LeftArrow, KeyCode.RightArrow };
-
-        private uint m_KeyStates;
-
-        public bool HasKeyStates
-        {
-            get
-            {
-                return m_KeyStates > 0;
-            }
-        }
-
-        public void ResetKeyStates()
-        {
-            m_KeyStates = 0;
-        }
-
-        public List<KeyCode> KeyCodesPressed = new List<KeyCode>();
-
-        private const int k_MaxKeys = sizeof(uint) * 8;
-
-        public void SetInputState()
-        {
-            if (m_KeyCodes.Count >= k_MaxKeys)
-            {
-                throw new System.Exception($"Number of registered keys to track ({m_KeyCodes.Count}) exceeded maximum ({k_MaxKeys})");
-            }
-
-            m_KeyStates = 0;
-            for (int i = 0; i < m_KeyCodes.Count; i++)
-            {
-                if (Input.GetKey(m_KeyCodes[i]))
-                {
-                    m_KeyStates |= (uint)(1 << i);
-                }
-            }
-        }
-
-        public void GetInputState()
-        {
-            KeyCodesPressed.Clear();
-            for (int i = 0; i < m_KeyCodes.Count; i++)
-            {
-                if ((m_KeyStates & (uint)(1 << i)) > 0)
-                {
-                    KeyCodesPressed.Add(m_KeyCodes[i]);
-                }
-            }
-        }
-
-        public void NetworkSerialize<T>(BufferSerializer<T> serializer) where T : IReaderWriter
-        {
-            if (serializer.IsWriter)
-            {
-                var writer = serializer.GetFastBufferWriter();
-                BytePacker.WriteValuePacked(writer, m_KeyStates);
-            }
-            else
-            {
-                var reader = serializer.GetFastBufferReader();
-                ByteUnpacker.ReadValuePacked(reader, out m_KeyStates);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Used to maintain the stats of the player's motion
-    /// </summary>
-    public class MovePlayerState
-    {
-        private float m_HorizontalAccel;
-        private float m_VerticalAccel;
-        private Vector2 m_XYInput;
-        public List<KeyCode> KeyCodesPressed = new List<KeyCode>();
-
-        public bool HadKeyStates;
-
-        public void ResetKeyStates(MovePlayerData movePlayerData)
-        {
-            movePlayerData.ResetKeyStates();
-            KeyCodesPressed.Clear();
-            m_HorizontalAccel = 0;
-            m_VerticalAccel = 0;
-            m_XYInput = Vector2.zero;
-            HadKeyStates = false;
-        }
-        public Vector2 UpdateAxis(bool decay = false, float lerpDecay = 0.15f)
-        {
-            m_XYInput.x = m_HorizontalAccel;
-            m_XYInput.y = m_VerticalAccel;
-            return m_XYInput;
-        }
-
-        public Vector2 UpdateFromData(MovePlayerData movePlayerData, float inputResponse)
-        {
-            movePlayerData.GetInputState();
-
-            if (HadKeyStates && movePlayerData.KeyCodesPressed.Count == 0)
-            {
-                ResetKeyStates(movePlayerData);
-            }
-
-            UpdateAxialAcceleration(movePlayerData.KeyCodesPressed, inputResponse);
-
-            return UpdateAxis();
-        }
-
-        private void UpdateAxialAcceleration(List<KeyCode> keyCodesPressed, float inputResponse)
-        {
-            KeyCodesPressed = keyCodesPressed;
-            HadKeyStates = keyCodesPressed.Count > 0;
-            var targetVertical = 0.0f;
-            var targetHorizontal = 0.0f;
-            foreach (var keyPressed in KeyCodesPressed)
-            {
-                switch (keyPressed)
-                {
-                    case KeyCode.UpArrow:
-                        {
-                            targetVertical = 1.0f;
-                            break;
-                        }
-                    case KeyCode.DownArrow:
-                        {
-                            targetVertical = -1.0f;
-                            break;
-                        }
-                    case KeyCode.RightArrow:
-                        {
-                            targetHorizontal = 1.0f;
-                            break;
-                        }
-                    case KeyCode.LeftArrow:
-                        {
-                            targetHorizontal = -1.0f;
-                            break;
-                        }
-                }
-            }
-            m_VerticalAccel = Mathf.Lerp(m_VerticalAccel, targetVertical, inputResponse);
-            m_HorizontalAccel = Mathf.Lerp(m_HorizontalAccel, targetHorizontal, inputResponse);
+            transform.position = Vector3.Lerp(transform.position, transform.position + Input.GetAxis("Vertical") * Speed * transform.forward, Time.fixedDeltaTime);
+            var rotation = transform.rotation;
+            var euler = rotation.eulerAngles;
+            euler.y += Input.GetAxis("Horizontal") * 90 * RotSpeed * Time.fixedDeltaTime;
+            rotation.eulerAngles = euler;
+            transform.rotation = rotation;
+            // This allows us to rollback to the previous rotation for the teleport
+            // sample. If we don't do this the box will collide with the wall and
+            // will slightly rotate the box to align with the wall
+            m_PreviousRotation = transform.rotation;
         }
     }
 }

--- a/testproject/Assets/Scripts/ServerHostClientText.cs
+++ b/testproject/Assets/Scripts/ServerHostClientText.cs
@@ -6,12 +6,14 @@ public class ServerHostClientText : NetworkBehaviour
 {
     [SerializeField]
     private Text m_DisplayText;
+    private Color m_Color;
 
     private void Start()
     {
         if (m_DisplayText != null)
         {
             m_DisplayText.text = string.Empty;
+            m_Color = m_DisplayText.color;
         }
     }
 
@@ -19,7 +21,7 @@ public class ServerHostClientText : NetworkBehaviour
     {
         if (m_DisplayText != null)
         {
-            if (NetworkManager.IsServer )
+            if (NetworkManager.IsServer)
             {
                 m_DisplayText.text = NetworkManager.IsHost ? "Host" : "Server";
             }
@@ -27,6 +29,18 @@ public class ServerHostClientText : NetworkBehaviour
             {
                 m_DisplayText.text = "Client";
             }
+        }
+    }
+
+    private void OnGUI()
+    {
+        if (Application.isFocused)
+        {
+            m_DisplayText.color = m_Color;
+        }
+        else
+        {
+            m_DisplayText.color = Color.grey;
         }
     }
 }

--- a/testproject/Assets/Scripts/ServerHostClientText.cs
+++ b/testproject/Assets/Scripts/ServerHostClientText.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+using UnityEngine.UI;
+using Unity.Netcode;
+
+public class ServerHostClientText : NetworkBehaviour
+{
+    [SerializeField]
+    private Text m_DisplayText;
+
+    private void Start()
+    {
+        if (m_DisplayText != null)
+        {
+            m_DisplayText.text = string.Empty;
+        }
+    }
+
+    public override void OnNetworkSpawn()
+    {
+        if (m_DisplayText != null)
+        {
+            if (NetworkManager.IsServer )
+            {
+                m_DisplayText.text = NetworkManager.IsHost ? "Host" : "Server";
+            }
+            else if (NetworkManager.IsClient)
+            {
+                m_DisplayText.text = "Client";
+            }
+        }
+    }
+}

--- a/testproject/Assets/Scripts/ServerHostClientText.cs.meta
+++ b/testproject/Assets/Scripts/ServerHostClientText.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7ea6e834b18e2c840a76ce574eb4b144
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/AdditiveSceneMultiInstance.unity
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/AdditiveSceneMultiInstance.unity
@@ -195,6 +195,21 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: ScaleThreshold
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: PositionThreshold
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: RotAngleThreshold
+      value: 0.1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ea906834639fa3f4ba65c95db6181d6b, type: 3}
 --- !u!1001 &365996112
@@ -269,6 +284,21 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: ScaleThreshold
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: PositionThreshold
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: RotAngleThreshold
+      value: 0.1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ea906834639fa3f4ba65c95db6181d6b, type: 3}
 --- !u!850595691 &903034822
@@ -278,7 +308,7 @@ LightingSettings:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: 
-  serializedVersion: 3
+  serializedVersion: 4
   m_GIWorkflowMode: 1
   m_EnableBakedLightmaps: 1
   m_EnableRealtimeLightmaps: 0
@@ -291,7 +321,7 @@ LightingSettings:
   m_LightmapMaxSize: 1024
   m_BakeResolution: 40
   m_Padding: 2
-  m_TextureCompression: 1
+  m_LightmapCompression: 3
   m_AO: 0
   m_AOMaxDistance: 1
   m_CompAOExponent: 1
@@ -332,6 +362,7 @@ LightingSettings:
   m_PVRFilteringAtrousPositionSigmaDirect: 0.5
   m_PVRFilteringAtrousPositionSigmaIndirect: 2
   m_PVRFilteringAtrousPositionSigmaAO: 1
+  m_PVRTiledBaking: 0
 --- !u!1001 &1152084533
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -403,6 +434,21 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: ScaleThreshold
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: PositionThreshold
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: RotAngleThreshold
+      value: 0.1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ea906834639fa3f4ba65c95db6181d6b, type: 3}
@@ -477,6 +523,21 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: ScaleThreshold
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: PositionThreshold
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 4600632750638426092, guid: ea906834639fa3f4ba65c95db6181d6b,
+        type: 3}
+      propertyPath: RotAngleThreshold
+      value: 0.1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ea906834639fa3f4ba65c95db6181d6b, type: 3}

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/ClientNetworkTransform.cs
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/ClientNetworkTransform.cs
@@ -1,0 +1,12 @@
+using Unity.Netcode.Components;
+
+namespace TestProject.ManualTests
+{
+    public class ClientNetworkTransform : NetworkTransform
+    {
+        protected override bool OnIsServerAuthoritative()
+        {
+            return false;
+        }
+    }
+}

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/ClientNetworkTransform.cs.meta
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/ClientNetworkTransform.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf01cca54b77c0241ad6d9da5ef6a709
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/PlayerClientAuthoritative.prefab
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/PlayerClientAuthoritative.prefab
@@ -1,0 +1,297 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4079352819444256614
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4079352819444256611}
+  - component: {fileID: 972770265172480408}
+  - component: {fileID: -3775814466963834669}
+  - component: {fileID: 4079352819444256610}
+  - component: {fileID: 4079352819444256613}
+  - component: {fileID: 4079352819444256612}
+  - component: {fileID: 1750810845806302260}
+  - component: {fileID: 4053684789567975459}
+  - component: {fileID: 6442518961346739709}
+  - component: {fileID: 2756533617708860847}
+  - component: {fileID: 9187250582412873179}
+  m_Layer: 8
+  m_Name: PlayerClientAuthoritative
+  m_TagString: Player
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4079352819444256611
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4079352819444256614}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 5, y: 0.625, z: 5}
+  m_LocalScale: {x: 1.25, y: 1.25, z: 1.25}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3519470446676406143}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &972770265172480408
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4079352819444256614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf01cca54b77c0241ad6d9da5ef6a709, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  SyncPositionX: 1
+  SyncPositionY: 1
+  SyncPositionZ: 1
+  SyncRotAngleX: 1
+  SyncRotAngleY: 1
+  SyncRotAngleZ: 1
+  SyncScaleX: 1
+  SyncScaleY: 1
+  SyncScaleZ: 1
+  PositionThreshold: 0.01
+  RotAngleThreshold: 0.01
+  ScaleThreshold: 0.01
+  InLocalSpace: 0
+  Interpolate: 1
+--- !u!114 &-3775814466963834669
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4079352819444256614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 951099334
+  AlwaysReplicateAsRoot: 0
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1
+--- !u!33 &4079352819444256610
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4079352819444256614}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4079352819444256613
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4079352819444256614}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a7b755ad8e4fe4bdb8f5518c951abc70, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &4079352819444256612
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4079352819444256614}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &1750810845806302260
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4079352819444256614}
+  serializedVersion: 2
+  m_Mass: 100
+  m_Drag: 7
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 1
+  m_Constraints: 112
+  m_CollisionDetection: 1
+--- !u!114 &4053684789567975459
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4079352819444256614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 24a9235f10bc6456183432fdb3015157, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &6442518961346739709
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4079352819444256614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3e4ecffca0894dfa88af779c2a67b9e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2756533617708860847
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4079352819444256614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8e5aa2f75493a4fee8ec635d215f03c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MoveSpeed: 10
+--- !u!114 &9187250582412873179
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4079352819444256614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f6c0be61502bb534f922ebb746851216, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &6479012615216050269
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3519470446676406143}
+  - component: {fileID: 6858102498835906389}
+  - component: {fileID: 2780619303711114328}
+  m_Layer: 8
+  m_Name: PlayerSub
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3519470446676406143
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6479012615216050269}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.045, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4079352819444256611}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6858102498835906389
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6479012615216050269}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2780619303711114328
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6479012615216050269}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/PlayerClientAuthoritative.prefab.meta
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/PlayerClientAuthoritative.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3cc5d500f7b2e1245bfb8652adadb286
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/SceneTransitioningBase1.unity
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/SceneTransitioningBase1.unity
@@ -171,8 +171,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 475de064003ff104fb88b1fbccd0f417, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_ActivateOnLoad: 0
   m_SceneToLoad: AdditiveSceneMultiInstance
   m_SceneAsset: {fileID: 102900000, guid: 0ae94f636016d3b40bfbecad57d99553, type: 3}
@@ -224,12 +224,13 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 244f0414ea8419b41ac51adb305d64b0, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_SwitchSceneButtonObject: {fileID: 1347823141}
   m_SceneToSwitchTo: SceneTransitioningBase2
   m_EnableAutoSwitch: 0
   m_AutoSwitchTimeOut: 60
+  DisconnectClientUponLoadScene: 0
 --- !u!1 &37242881
 GameObject:
   m_ObjectHideFlags: 0
@@ -379,8 +380,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -455,8 +456,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -632,8 +633,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 475de064003ff104fb88b1fbccd0f417, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_ActivateOnLoad: 0
   m_SceneToLoad: AdditiveSceneMultiInstance
   m_SceneAsset: {fileID: 102900000, guid: 0ae94f636016d3b40bfbecad57d99553, type: 3}
@@ -686,8 +687,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -762,8 +763,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -823,8 +824,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -840,8 +841,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_UiScaleMode: 0
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -924,8 +925,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -941,8 +942,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -1055,8 +1056,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 475de064003ff104fb88b1fbccd0f417, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_ActivateOnLoad: 0
   m_SceneToLoad: AdditiveScene2
   m_SceneAsset: {fileID: 102900000, guid: c6a3d883c8253ee43bca4f2b03797d7b, type: 3}
@@ -1109,8 +1110,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -1156,7 +1157,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   m_IsOn: 0
@@ -1306,8 +1307,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -1353,7 +1354,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   m_IsOn: 0
@@ -1406,8 +1407,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1482,8 +1483,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1558,8 +1559,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.9811321, g: 0.9811321, b: 0.9811321, a: 1}
   m_RaycastTarget: 1
@@ -1722,8 +1723,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0.5058824, b: 0.003921569, a: 1}
   m_RaycastTarget: 1
@@ -1802,8 +1803,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1878,8 +1879,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1954,8 +1955,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -2030,8 +2031,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 475de064003ff104fb88b1fbccd0f417, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_ActivateOnLoad: 0
   m_SceneToLoad: AdditiveScene1
   m_SceneAsset: {fileID: 102900000, guid: 41a0239b0c49e2047b7063c822f0df8a, type: 3}
@@ -2041,8 +2042,8 @@ LightingSettings:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name:
-  serializedVersion: 3
+  m_Name: 
+  serializedVersion: 4
   m_GIWorkflowMode: 1
   m_EnableBakedLightmaps: 1
   m_EnableRealtimeLightmaps: 0
@@ -2145,8 +2146,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -2299,8 +2300,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 475de064003ff104fb88b1fbccd0f417, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_ActivateOnLoad: 0
   m_SceneToLoad: AdditiveSceneMultiInstance
   m_SceneAsset: {fileID: 102900000, guid: 0ae94f636016d3b40bfbecad57d99553, type: 3}
@@ -2313,10 +2314,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1024114720}
-  - component: {fileID: 1024114719}
   - component: {fileID: 1024114718}
   - component: {fileID: 1024114721}
   - component: {fileID: 1024114722}
+  - component: {fileID: 1024114723}
   m_Layer: 0
   m_Name: NetworkManager
   m_TagString: Untagged
@@ -2334,13 +2335,13 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 593a2fe42fa9d37498c96f9a383b6521, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   RunInBackground: 1
   LogLevel: 1
   NetworkConfig:
     ProtocolVersion: 0
-    NetworkTransport: {fileID: 1024114719}
+    NetworkTransport: {fileID: 1024114723}
     PlayerPrefab: {fileID: 4079352819444256614, guid: c16f03336b6104576a565ef79ad643c0,
       type: 3}
     NetworkPrefabs:
@@ -2397,7 +2398,7 @@ MonoBehaviour:
     TickRate: 30
     ClientConnectionBufferTimeout: 10
     ConnectionApproval: 0
-    ConnectionData:
+    ConnectionData: 
     EnableTimeResync: 0
     TimeResyncInterval: 30
     EnsureNetworkVariableLengthSafety: 0
@@ -2409,25 +2410,6 @@ MonoBehaviour:
     LoadSceneTimeOut: 120
     SpawnTimeout: 1
     EnableNetworkLogs: 1
---- !u!114 &1024114719
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1024114717}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b84c2d8dfe509a34fb59e2b81f8e1319, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
-  MessageBufferSize: 65535
-  MaxConnections: 100
-  MaxSentMessageQueueSize: 512
-  ConnectAddress: 127.0.0.1
-  ConnectPort: 7777
-  ServerListenPort: 7777
-  MessageSendMode: 0
 --- !u!4 &1024114720
 Transform:
   m_ObjectHideFlags: 0
@@ -2453,8 +2435,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0e6f8504d891fc44881b2d9703017d03, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &1024114722
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2465,10 +2447,38 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 71c52a32bd1c1c84691050b6d045ab4a, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   LogToConsole: 1
   TimeToLive: 10
+--- !u!114 &1024114723
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1024114717}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6960e84d07fb87f47956e7a81d71c4e6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ProtocolType: 0
+  m_MaxPacketQueueSize: 128
+  m_MaxPayloadSize: 512000
+  m_MaxSendQueueSize: 4096000
+  m_HeartbeatTimeoutMS: 500
+  m_ConnectTimeoutMS: 1000
+  m_MaxConnectAttempts: 60
+  m_DisconnectTimeoutMS: 30000
+  ConnectionData:
+    Address: 127.0.0.1
+    Port: 7777
+    ServerListenAddress: 
+  DebugSimulator:
+    PacketDelayMS: 0
+    PacketJitterMS: 0
+    PacketDropRate: 0
 --- !u!1 &1113539278
 GameObject:
   m_ObjectHideFlags: 0
@@ -2497,8 +2507,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8c48ea35c67e64f7fac22a3f6831ca88, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   AutoSpawnEnable: 1
   InitialSpawnDelay: 0.2
   SpawnsPerSecond: 1
@@ -2538,8 +2548,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   GlobalObjectIdHash: 1983031731
   AlwaysReplicateAsRoot: 0
   DontDestroyWithOwner: 0
@@ -2592,8 +2602,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 475de064003ff104fb88b1fbccd0f417, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_ActivateOnLoad: 0
   m_SceneToLoad: AdditiveSceneMultiInstance
   m_SceneAsset: {fileID: 102900000, guid: 0ae94f636016d3b40bfbecad57d99553, type: 3}
@@ -2645,8 +2655,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -2726,8 +2736,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -2935,8 +2945,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -3017,8 +3027,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -3060,7 +3070,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
 --- !u!114 &1347823144
@@ -3073,8 +3083,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.1981132, g: 0.1981132, b: 0.1981132, a: 1}
   m_RaycastTarget: 1
@@ -3150,8 +3160,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -3197,7 +3207,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   m_IsOn: 0
@@ -3249,8 +3259,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.990566, g: 0.990566, b: 0.990566, a: 1}
   m_RaycastTarget: 1
@@ -3367,8 +3377,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -3443,8 +3453,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -3519,8 +3529,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -3595,8 +3605,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -3673,8 +3683,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -3716,7 +3726,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
 --- !u!114 &1588117330
@@ -3729,8 +3739,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.1981132, g: 0.1981132, b: 0.1981132, a: 1}
   m_RaycastTarget: 1
@@ -3805,8 +3815,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -3886,8 +3896,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -3933,7 +3943,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   m_IsOn: 0
@@ -3986,8 +3996,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -4033,7 +4043,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   m_IsOn: 0
@@ -4086,8 +4096,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -4162,8 +4172,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -4218,8 +4228,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_HorizontalAxis: Horizontal
   m_VerticalAxis: Vertical
   m_SubmitButton: Submit
@@ -4237,8 +4247,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
@@ -4305,8 +4315,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0.5058824, b: 0.003921569, a: 1}
   m_RaycastTarget: 1
@@ -4645,8 +4655,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -4692,7 +4702,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   m_IsOn: 0
@@ -4744,8 +4754,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -4920,8 +4930,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -4970,7 +4980,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
 --- !u!1 &2107482020
@@ -5016,11 +5026,10 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: cb5f3e55f5dd247129d8a4979b80ebbb, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_ClientServerToggle: {fileID: 1588117327}
   m_TrackSceneEvents: 1
-  m_LogSceneEventsToConsole: 1
 --- !u!114 &2107482023
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5031,8 +5040,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   GlobalObjectIdHash: 3197939627
   AlwaysReplicateAsRoot: 0
   DontDestroyWithOwner: 0
@@ -5162,7 +5171,7 @@ PrefabInstance:
     - target: {fileID: 2848221157716786269, guid: 3200770c16e3b2b4ebe7f604154faac7,
         type: 3}
       propertyPath: m_FontData.m_Font
-      value:
+      value: 
       objectReference: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
     - target: {fileID: 2848221157716786269, guid: 3200770c16e3b2b4ebe7f604154faac7,
         type: 3}
@@ -5197,7 +5206,7 @@ PrefabInstance:
     - target: {fileID: 5266522511616468950, guid: 3200770c16e3b2b4ebe7f604154faac7,
         type: 3}
       propertyPath: m_SceneMenuToLoad
-      value:
+      value: 
       objectReference: {fileID: 11400000, guid: c10d995498e0c514a853c3506031d3fb,
         type: 2}
     m_RemovedComponents: []

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/SceneTransitioningBase1.unity
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/SceneTransitioningBase1.unity
@@ -2342,7 +2342,7 @@ MonoBehaviour:
   NetworkConfig:
     ProtocolVersion: 0
     NetworkTransport: {fileID: 1024114723}
-    PlayerPrefab: {fileID: 4079352819444256614, guid: c16f03336b6104576a565ef79ad643c0,
+    PlayerPrefab: {fileID: 4079352819444256614, guid: 3cc5d500f7b2e1245bfb8652adadb286,
       type: 3}
     NetworkPrefabs:
     - Override: 0

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/SceneTransitioningBase1.unity
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/SceneTransitioningBase1.unity
@@ -2395,7 +2395,7 @@ MonoBehaviour:
       SourcePrefabToOverride: {fileID: 0}
       SourceHashToOverride: 0
       OverridingTargetPrefab: {fileID: 0}
-    TickRate: 30
+    TickRate: 32
     ClientConnectionBufferTimeout: 10
     ConnectionApproval: 0
     ConnectionData: 
@@ -2418,7 +2418,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1024114717}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.000061035156, y: 0.000015258789, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/SceneTransitioningBase1.unity
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/SceneTransitioningBase1.unity
@@ -2342,7 +2342,7 @@ MonoBehaviour:
   NetworkConfig:
     ProtocolVersion: 0
     NetworkTransport: {fileID: 1024114723}
-    PlayerPrefab: {fileID: 4079352819444256614, guid: 3cc5d500f7b2e1245bfb8652adadb286,
+    PlayerPrefab: {fileID: 4079352819444256614, guid: c16f03336b6104576a565ef79ad643c0,
       type: 3}
     NetworkPrefabs:
     - Override: 0

--- a/testproject/Assets/Tests/Manual/Scripts/GenericNetworkObjectBehaviour.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/GenericNetworkObjectBehaviour.cs
@@ -53,26 +53,6 @@ namespace TestProject.ManualTests
         }
 
         /// <summary>
-        /// Handles disabling the MeshRenderer when the client despawns a NetworkObject
-        /// </summary>
-        public override void OnNetworkDespawn()
-        {
-            if (!IsServer)
-            {
-                if (m_MeshRenderer == null)
-                {
-                    m_MeshRenderer = GetComponent<MeshRenderer>();
-                }
-
-                if (m_MeshRenderer != null)
-                {
-                    m_MeshRenderer.enabled = false;
-                }
-            }
-            base.OnNetworkDespawn();
-        }
-
-        /// <summary>
         /// Makes mesh renderer visible again
         /// </summary>
         public void Reset()
@@ -82,28 +62,6 @@ namespace TestProject.ManualTests
                 m_MeshRenderer = GetComponent<MeshRenderer>();
             }
             m_MeshRenderer.enabled = true;
-        }
-
-        private float m_VisibilitySpawn;
-        /// <summary>
-        /// Handles setting a delay before the newly spawned object is visible
-        /// </summary>
-        public override void OnNetworkSpawn()
-        {
-            if (!IsServer)
-            {
-                if (m_MeshRenderer == null)
-                {
-                    m_MeshRenderer = GetComponent<MeshRenderer>();
-                }
-                m_MeshRenderer.enabled = false;
-                m_VisibilitySpawn = Time.realtimeSinceStartup + 0.12f;
-                if (NetworkObject.NetworkObjectId == 0)
-                {
-                    Debug.Log("Spawning NetworkObjectId 0!");
-                }
-            }
-            base.OnNetworkSpawn();
         }
 
         public void ShouldMoveRandomly(bool shouldMoveRandomly)
@@ -174,19 +132,6 @@ namespace TestProject.ManualTests
                 if (NetworkObject.NetworkManager != null)
                 {
                     NetworkObject.Despawn();
-                }
-            }
-            else if (!IsServer)
-            {
-                // This is here to handle any short term latency between the time
-                // an object becomes spawned to the time it takes to update its first
-                // position.
-                if (m_MeshRenderer != null && !m_MeshRenderer.enabled)
-                {
-                    if (m_VisibilitySpawn < Time.realtimeSinceStartup)
-                    {
-                        m_MeshRenderer.enabled = true;
-                    }
                 }
             }
         }

--- a/testproject/Assets/Tests/Manual/Scripts/GenericNetworkObjectBehaviour.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/GenericNetworkObjectBehaviour.cs
@@ -198,7 +198,7 @@ namespace TestProject.ManualTests
 
         private void OnTriggerEnter(Collider other)
         {
-            if (IsOwner && !m_ShouldDespawn)
+            if (IsSpawned && IsOwner && !m_ShouldDespawn)
             {
                 if (other.CompareTag("GenericObject") || other.CompareTag("Floor"))
                 {

--- a/testproject/Assets/Tests/Manual/Scripts/PlayerMovementManager.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/PlayerMovementManager.cs
@@ -25,9 +25,9 @@ namespace TestProject.ManualTests
                 return;
             }
 
-            if (IsOwner)
+            if (m_RandomMovement.HasAuthority())
             {
-                if (Input.GetKeyDown(KeyCode.Space))
+                if (Input.GetKeyDown(KeyCode.Space) && IsOwner)
                 {
                     m_RandomMovement.enabled = !m_RandomMovement.enabled;
                 }
@@ -36,6 +36,19 @@ namespace TestProject.ManualTests
                     m_RandomMovement.Move(MoveSpeed);
                 }
             }
+            else if (IsOwner)
+            {
+                if (Input.GetKeyDown(KeyCode.Space) && IsOwner)
+                {
+                    ToggleEnableDisableServerRpc();
+                }
+            }
+        }
+
+        [ServerRpc]
+        private void ToggleEnableDisableServerRpc()
+        {
+            m_RandomMovement.enabled = !m_RandomMovement.enabled;
         }
     }
 }

--- a/testproject/Assets/Tests/Manual/Scripts/PlayerMovementManager.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/PlayerMovementManager.cs
@@ -38,7 +38,7 @@ namespace TestProject.ManualTests
             }
             else if (IsOwner)
             {
-                if (Input.GetKeyDown(KeyCode.Space) && IsOwner)
+                if (Input.GetKeyDown(KeyCode.Space))
                 {
                     ToggleEnableDisableServerRpc();
                 }

--- a/testproject/Assets/Tests/Manual/Scripts/PlayerMovementManager.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/PlayerMovementManager.cs
@@ -20,22 +20,20 @@ namespace TestProject.ManualTests
 
         private void Update()
         {
-            if (NetworkObject != null)
+            if (!IsSpawned)
             {
-                if (IsOwner && Input.GetKeyDown(KeyCode.Space))
-                {
-                    if (m_RandomMovement)
-                    {
-                        m_RandomMovement.enabled = !m_RandomMovement.enabled;
-                    }
-                }
+                return;
+            }
 
-                if (NetworkObject != null && NetworkObject.NetworkManager != null && NetworkObject.NetworkManager.IsListening)
+            if (IsOwner)
+            {
+                if (Input.GetKeyDown(KeyCode.Space))
                 {
-                    if (m_RandomMovement.enabled)
-                    {
-                        m_RandomMovement.Move(MoveSpeed);
-                    }
+                    m_RandomMovement.enabled = !m_RandomMovement.enabled;
+                }
+                if (m_RandomMovement.enabled)
+                {
+                    m_RandomMovement.Move(MoveSpeed);
                 }
             }
         }

--- a/testproject/ProjectSettings/EditorBuildSettings.asset
+++ b/testproject/ProjectSettings/EditorBuildSettings.asset
@@ -107,6 +107,9 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Tests/Manual/NetworkAnimatorTests/NetworkAnimatorServerOwnerTest.unity
     guid: f88da8bb8d07e11418eaad6524d5cc12
+  - enabled: 1
+    path: Assets/Samples/Teleport/TeleportSample.unity
+    guid: efa247d1f78ca694f8d2dcb5672e8f8b
   m_configObjects:
     com.unity.addressableassets: {fileID: 11400000, guid: 5a3d5c53c25349c48912726ae850f3b0,
       type: 2}


### PR DESCRIPTION
This fixes the issue with NetworkTransform and Teleporting as well as can be considered a continuation of #2102 (_this branch started from the fix/networktransform-Bitset-not-being-properly-reset branch_)
This includes several edge case scenarios where non-authoritative instances were still using states that were no longer being set (due to bitset fix). This also cleans up how change in local space is handled internally.

[NCCBUG-166](https://jira.unity3d.com/browse/NCCBUG-166)
[MTT-3458](https://jira.unity3d.com/browse/MTT-3458)
[MTT-4275](https://jira.unity3d.com/browse/MTT-4275)
This also has a portion of the fix from user [xyxwangkai](https://github.com/xyxwangkai)'s [PR-2100](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/2100)

## Changelog
- Fixed: Issue with the internal `NetworkTransformState.m_Bitset` flag not getting cleared upon the next tick advancement.
- Fixed: Interpolation issue with `NetworkTransform.Teleport`.
- Fixed: Issue where the authoritative side was interpolating its transform.

## Testing and Documentation
- Includes updates to existing NetworkTransform integration tests.
- Includes new NetworkTransform integration tests.

### Notes:
While this PR does introduce a more accurate client authoritative model, it still preserves the server authoritative "client directed state" functionality prior to these fixes and updates.  A user can still derive from `NetworkTransform`, not override the `NetworkTransform.OnIsServerAuthoritative` method, and still use the `NetworkTransform.TryCommitTransformToServer` and/or the `NetworkTransform.SetState` methods when an owner is not authoritative but wants to be in control of the state.  This will still add a half RTT penalty for the RPC to make it to the authority before the state is updated (as it did before).  When operating in client authoritative mode, the server can still use both methods as well to preserve the server being the final authority.

The majority of the files in this PR are for manual testing purposes.  This PR can be broken into three parts:
1. The fixes and associated integration tests (4 files under com.unity.netcode.gameobjects)
2. The fix for the memory leak error that has been happening randomly in the editor test: NetworkTimeTests.
3. The manual test updates and additions (24 files under testproject)


The manual tests were left in this branch so anyone reviewing can visually/manually test the teleporting (Samples Menu -> Teleporting) as well as the rest of the scene loading tests to verify everything looks the same (and to run comparison and performance tests against develop branch).
