### PR TITLE
fix: disconnect event not being generated

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1285,10 +1285,10 @@ namespace Unity.Netcode.Transports.UTP
                 SendBatchedMessages(kvp.Key, kvp.Value);
             }
 
-            // The above flush only puts the message in UTP internal buffers, need the flush send
-            // job to execute to actually get things out on the wire. This will also ensure any
-            // disconnect messages are sent out.
-            m_Driver.ScheduleFlushSend(default).Complete();
+            // The above flush only puts the message in UTP internal buffers, need an update to
+            // actually get the messages on the wire. (Normally a flush send would be sufficient,
+            // but there might be disconnect messages and those require an update call.)
+            m_Driver.ScheduleUpdate().Complete();
 
             DisposeInternals();
 


### PR DESCRIPTION
Following UTP 2.0 tests, this was found to be a small necessary change to Netcode for GameObjects to support UTP 2.0. Contributed by @simon-lemay-unity .

[MTT-4166](https://jira.unity3d.com/browse/MTT-4166)



