### PR TITLE
Fix client authoritive `NetworkAnimator`

### DIFF
--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -769,7 +769,7 @@ namespace Unity.Netcode.Components
                     return;
                 }
                 UpdateParameters(parametersUpdate);
-                if (NetworkManager.ConnectedClientsIds.Count - 2 > 0)
+                if (NetworkManager.ConnectedClientsIds.Count > 1)
                 {
                     m_ClientSendList.Clear();
                     m_ClientSendList.AddRange(NetworkManager.ConnectedClientsIds);
@@ -812,7 +812,7 @@ namespace Unity.Netcode.Components
                     return;
                 }
                 UpdateAnimationState(animSnapshot);
-                if (NetworkManager.ConnectedClientsIds.Count - 2 > 0)
+                if (NetworkManager.ConnectedClientsIds.Count > 1)
                 {
                     m_ClientSendList.Clear();
                     m_ClientSendList.AddRange(NetworkManager.ConnectedClientsIds);
@@ -857,7 +857,7 @@ namespace Unity.Netcode.Components
                 //  trigger the animation locally on the server...
                 m_Animator.SetBool(animationTriggerMessage.Hash, animationTriggerMessage.IsTriggerSet);
 
-                if (NetworkManager.ConnectedClientsIds.Count - 2 > 0)
+                if (NetworkManager.ConnectedClientsIds.Count > 1)
                 {
                     m_ClientSendList.Clear();
                     m_ClientSendList.AddRange(NetworkManager.ConnectedClientsIds);

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -769,7 +769,7 @@ namespace Unity.Netcode.Components
                     return;
                 }
                 UpdateParameters(parametersUpdate);
-                if (IsHost && NetworkManager.ConnectedClientsIds.Count > 2 || NetworkManager.ConnectedClientsIds.Count > 1)
+                if (NetworkManager.ConnectedClientsIds.Count > (IsHost ? 2 : 1))
                 {
                     m_ClientSendList.Clear();
                     m_ClientSendList.AddRange(NetworkManager.ConnectedClientsIds);
@@ -812,7 +812,7 @@ namespace Unity.Netcode.Components
                     return;
                 }
                 UpdateAnimationState(animSnapshot);
-                if (IsHost && NetworkManager.ConnectedClientsIds.Count > 2 || NetworkManager.ConnectedClientsIds.Count > 1)
+                if (NetworkManager.ConnectedClientsIds.Count > (IsHost ? 2 : 1))
                 {
                     m_ClientSendList.Clear();
                     m_ClientSendList.AddRange(NetworkManager.ConnectedClientsIds);
@@ -857,7 +857,7 @@ namespace Unity.Netcode.Components
                 //  trigger the animation locally on the server...
                 m_Animator.SetBool(animationTriggerMessage.Hash, animationTriggerMessage.IsTriggerSet);
 
-                if (IsHost && NetworkManager.ConnectedClientsIds.Count > 2 || NetworkManager.ConnectedClientsIds.Count > 1)
+                if (NetworkManager.ConnectedClientsIds.Count > (IsHost ? 2 : 1))
                 {
                     m_ClientSendList.Clear();
                     m_ClientSendList.AddRange(NetworkManager.ConnectedClientsIds);

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -769,7 +769,7 @@ namespace Unity.Netcode.Components
                     return;
                 }
                 UpdateParameters(parametersUpdate);
-                if (NetworkManager.ConnectedClientsIds.Count > 1)
+                if (IsHost && NetworkManager.ConnectedClientsIds.Count > 2 || NetworkManager.ConnectedClientsIds.Count > 1)
                 {
                     m_ClientSendList.Clear();
                     m_ClientSendList.AddRange(NetworkManager.ConnectedClientsIds);
@@ -812,7 +812,7 @@ namespace Unity.Netcode.Components
                     return;
                 }
                 UpdateAnimationState(animSnapshot);
-                if (NetworkManager.ConnectedClientsIds.Count > 1)
+                if (IsHost && NetworkManager.ConnectedClientsIds.Count > 2 || NetworkManager.ConnectedClientsIds.Count > 1)
                 {
                     m_ClientSendList.Clear();
                     m_ClientSendList.AddRange(NetworkManager.ConnectedClientsIds);
@@ -857,7 +857,7 @@ namespace Unity.Netcode.Components
                 //  trigger the animation locally on the server...
                 m_Animator.SetBool(animationTriggerMessage.Hash, animationTriggerMessage.IsTriggerSet);
 
-                if (NetworkManager.ConnectedClientsIds.Count > 1)
+                if (IsHost && NetworkManager.ConnectedClientsIds.Count > 2 || NetworkManager.ConnectedClientsIds.Count > 1)
                 {
                     m_ClientSendList.Clear();
                     m_ClientSendList.AddRange(NetworkManager.ConnectedClientsIds);


### PR DESCRIPTION
When synchronising `Animator` with `NetworkAnimator` component the second client (if number of clients is greater than 2) was not synchronised when `IsServerAuthoritive()` is false.

## Changelog

- Fixed: `NetworkAnimator` was not synced correctly for second client when not server-authoritive.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

