### PR TITLE
perf: improved runtime performance, dirty objects 

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,6 +11,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 - When using `UnityTransport`, _reliable_ payloads are now allowed to exceed the configured 'Max Payload Size'. Unreliable payloads remain bounded by this setting. (#2081)
 
+- Preformance improvements for cases with large number of NetworkObjects, by not iterating over all unchanged NetworkObjects 
 
 ### Fixed
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -583,6 +583,8 @@ namespace Unity.Netcode
             {
                 NetworkVariableFields[NetworkVariableIndexesToReset[i]].ResetDirty();
             }
+
+            MarkVariablesDirty(false);
         }
 
         internal void VariableUpdate(ulong targetClientId)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -664,11 +664,11 @@ namespace Unity.Netcode
             return false;
         }
 
-        internal void MarkVariablesDirty()
+        internal void MarkVariablesDirty(bool dirty)
         {
             for (int j = 0; j < NetworkVariableFields.Count; j++)
             {
-                NetworkVariableFields[j].SetDirty(true);
+                NetworkVariableFields[j].SetDirty(dirty);
             }
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
@@ -85,11 +85,8 @@ namespace Unity.Netcode
                         {
                             sobj.ChildNetworkBehaviours[k].PostNetworkVariableWrite();
                         }
-                    }
-                    // This is not strictly needed for runtime, but it fails tests, otherwise.
-                    foreach (var networkObject in m_DirtyNetworkObjects)
-                    {
-                        networkObject.MarkVariablesDirty(false);
+                        // This is not strictly needed for runtime, but it fails tests, otherwise.
+                        sobj.MarkVariablesDirty(false);
                     }
                     m_DirtyNetworkObjects.Clear();
                 }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
@@ -5,11 +5,16 @@ namespace Unity.Netcode
 {
     public class NetworkBehaviourUpdater
     {
-        private HashSet<NetworkObject> m_Touched = new HashSet<NetworkObject>();
+        private HashSet<NetworkObject> m_DirtyNetworkObjects = new HashSet<NetworkObject>();
 
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
         private ProfilerMarker m_NetworkBehaviourUpdate = new ProfilerMarker($"{nameof(NetworkBehaviour)}.{nameof(NetworkBehaviourUpdate)}");
 #endif
+
+        internal void AddForUpdate(NetworkObject networkObject)
+        {
+            m_DirtyNetworkObjects.Add(networkObject);
+        }
 
         internal void NetworkBehaviourUpdate(NetworkManager networkManager)
         {
@@ -20,38 +25,42 @@ namespace Unity.Netcode
             {
                 if (networkManager.IsServer)
                 {
-                    m_Touched.Clear();
-                    for (int i = 0; i < networkManager.ConnectedClientsList.Count; i++)
+                    foreach (var dirtyObj in m_DirtyNetworkObjects)
                     {
-                        var client = networkManager.ConnectedClientsList[i];
-                        var spawnedObjs = networkManager.SpawnManager.SpawnedObjectsList;
-                        m_Touched.UnionWith(spawnedObjs);
-                        foreach (var sobj in spawnedObjs)
+                        for (int i = 0; i < networkManager.ConnectedClientsList.Count; i++)
                         {
-                            if (sobj.IsNetworkVisibleTo(client.ClientId))
+                            var client = networkManager.ConnectedClientsList[i];
+                            if (networkManager.IsHost && client.ClientId == networkManager.LocalClientId)
+                            {
+                                continue;
+                            }
+
+                            if (dirtyObj.IsNetworkVisibleTo(client.ClientId))
                             {
                                 // Sync just the variables for just the objects this client sees
-                                for (int k = 0; k < sobj.ChildNetworkBehaviours.Count; k++)
+                                for (int k = 0; k < dirtyObj.ChildNetworkBehaviours.Count; k++)
                                 {
-                                    sobj.ChildNetworkBehaviours[k].VariableUpdate(client.ClientId);
+                                    dirtyObj.ChildNetworkBehaviours[k].VariableUpdate(client.ClientId);
                                 }
                             }
+                            
                         }
                     }
 
                     // Now, reset all the no-longer-dirty variables
-                    foreach (var sobj in m_Touched)
+                    foreach (var dirtyObj in m_DirtyNetworkObjects)
                     {
-                        for (int k = 0; k < sobj.ChildNetworkBehaviours.Count; k++)
+                        for (int k = 0; k < dirtyObj.ChildNetworkBehaviours.Count; k++)
                         {
-                            sobj.ChildNetworkBehaviours[k].PostNetworkVariableWrite();
+                            dirtyObj.ChildNetworkBehaviours[k].PostNetworkVariableWrite();
                         }
                     }
+                    m_DirtyNetworkObjects.Clear();
                 }
                 else
                 {
                     // when client updates the server, it tells it about all its objects
-                    foreach (var sobj in networkManager.SpawnManager.SpawnedObjectsList)
+                    foreach (var sobj in m_DirtyNetworkObjects)
                     {
                         if (sobj.IsOwner)
                         {
@@ -63,13 +72,14 @@ namespace Unity.Netcode
                     }
 
                     // Now, reset all the no-longer-dirty variables
-                    foreach (var sobj in networkManager.SpawnManager.SpawnedObjectsList)
+                    foreach (var sobj in m_DirtyNetworkObjects)
                     {
                         for (int k = 0; k < sobj.ChildNetworkBehaviours.Count; k++)
                         {
                             sobj.ChildNetworkBehaviours[k].PostNetworkVariableWrite();
                         }
                     }
+                    m_DirtyNetworkObjects.Clear();
                 }
             }
             finally

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
@@ -48,16 +48,6 @@ namespace Unity.Netcode
                             }
                         }
                     }
-
-                    // Now, reset all the no-longer-dirty variables
-                    foreach (var dirtyObj in m_DirtyNetworkObjects)
-                    {
-                        for (int k = 0; k < dirtyObj.ChildNetworkBehaviours.Count; k++)
-                        {
-                            dirtyObj.ChildNetworkBehaviours[k].PostNetworkVariableWrite();
-                        }
-                    }
-                    m_DirtyNetworkObjects.Clear();
                 }
                 else
                 {
@@ -72,19 +62,16 @@ namespace Unity.Netcode
                             }
                         }
                     }
-
-                    // Now, reset all the no-longer-dirty variables
-                    foreach (var sobj in m_DirtyNetworkObjects)
-                    {
-                        for (int k = 0; k < sobj.ChildNetworkBehaviours.Count; k++)
-                        {
-                            sobj.ChildNetworkBehaviours[k].PostNetworkVariableWrite();
-                        }
-                        // This is not strictly needed for runtime, but it fails tests, otherwise.
-                        sobj.MarkVariablesDirty(false);
-                    }
-                    m_DirtyNetworkObjects.Clear();
                 }
+                // Now, reset all the no-longer-dirty variables
+                foreach (var dirtyobj in m_DirtyNetworkObjects)
+                {
+                    for (int k = 0; k < dirtyobj.ChildNetworkBehaviours.Count; k++)
+                    {
+                        dirtyobj.ChildNetworkBehaviours[k].PostNetworkVariableWrite();
+                    }
+                }
+                m_DirtyNetworkObjects.Clear();
             }
             finally
             {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
@@ -57,6 +57,11 @@ namespace Unity.Netcode
                             dirtyObj.ChildNetworkBehaviours[k].PostNetworkVariableWrite();
                         }
                     }
+                    // This is not strictly needed for runtime, but it fails tests, otherwise.
+                    foreach (var networkObject in m_DirtyNetworkObjects)
+                    {
+                        networkObject.MarkVariablesDirty(false);
+                    }
                     m_DirtyNetworkObjects.Clear();
                 }
                 else
@@ -80,6 +85,11 @@ namespace Unity.Netcode
                         {
                             sobj.ChildNetworkBehaviours[k].PostNetworkVariableWrite();
                         }
+                    }
+                    // This is not strictly needed for runtime, but it fails tests, otherwise.
+                    foreach (var networkObject in m_DirtyNetworkObjects)
+                    {
+                        networkObject.MarkVariablesDirty(false);
                     }
                     m_DirtyNetworkObjects.Clear();
                 }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
@@ -57,11 +57,6 @@ namespace Unity.Netcode
                             dirtyObj.ChildNetworkBehaviours[k].PostNetworkVariableWrite();
                         }
                     }
-                    // This is not strictly needed for runtime, but it fails tests, otherwise.
-                    foreach (var networkObject in m_DirtyNetworkObjects)
-                    {
-                        networkObject.MarkVariablesDirty(false);
-                    }
                     m_DirtyNetworkObjects.Clear();
                 }
                 else

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
@@ -46,7 +46,6 @@ namespace Unity.Netcode
                                     dirtyObj.ChildNetworkBehaviours[k].VariableUpdate(client.ClientId);
                                 }
                             }
-                            
                         }
                     }
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -54,7 +54,7 @@ namespace Unity.Netcode
             return $"{nameof(NetworkPrefab)} \"{networkPrefab.Prefab.gameObject.name}\"";
         }
 
-        internal NetworkBehaviourUpdater BehaviourUpdater { get; private set; }
+        internal NetworkBehaviourUpdater BehaviourUpdater { get; set; }
 
         internal void MarkNetworkObjectDirty(NetworkObject networkObject)
         {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -56,6 +56,11 @@ namespace Unity.Netcode
 
         internal NetworkBehaviourUpdater BehaviourUpdater { get; private set; }
 
+        internal void MarkNetworkObjectDirty(NetworkObject networkObject)
+        {
+            BehaviourUpdater.AddForUpdate(networkObject);
+        }
+
         internal MessagingSystem MessagingSystem { get; private set; }
 
         private NetworkPrefabHandler m_PrefabHandler;

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -868,12 +868,12 @@ namespace Unity.Netcode
             }
         }
 
-        internal void MarkVariablesDirty()
+        internal void MarkVariablesDirty(bool dirty)
         {
             for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
             {
                 var behavior = ChildNetworkBehaviours[i];
-                behavior.MarkVariablesDirty();
+                behavior.MarkVariablesDirty(dirty);
             }
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -63,7 +63,7 @@ namespace Unity.Netcode
             return base.IsDirty() || m_DirtyEvents.Length > 0;
         }
 
-        internal void ConsiderDirty()
+        internal void MarkNetworkObjectDirty()
         {
             m_NetworkBehaviour.NetworkManager.MarkNetworkObjectDirty(m_NetworkBehaviour.NetworkObject);
         }
@@ -194,7 +194,7 @@ namespace Unity.Netcode
                                     Index = m_List.Length - 1,
                                     Value = m_List[m_List.Length - 1]
                                 });
-                                ConsiderDirty();
+                                MarkNetworkObjectDirty();
                             }
                         }
                         break;
@@ -231,7 +231,7 @@ namespace Unity.Netcode
                                     Index = index,
                                     Value = m_List[index]
                                 });
-                                ConsiderDirty();
+                                MarkNetworkObjectDirty();
                             }
                         }
                         break;
@@ -264,7 +264,7 @@ namespace Unity.Netcode
                                     Index = index,
                                     Value = value
                                 });
-                                ConsiderDirty();
+                                MarkNetworkObjectDirty();
                             }
                         }
                         break;
@@ -292,7 +292,7 @@ namespace Unity.Netcode
                                     Index = index,
                                     Value = value
                                 });
-                                ConsiderDirty();
+                                MarkNetworkObjectDirty();
                             }
                         }
                         break;
@@ -328,7 +328,7 @@ namespace Unity.Netcode
                                     Value = value,
                                     PreviousValue = previousValue
                                 });
-                                ConsiderDirty();
+                                MarkNetworkObjectDirty();
                             }
                         }
                         break;
@@ -351,7 +351,7 @@ namespace Unity.Netcode
                                 {
                                     Type = eventType
                                 });
-                                ConsiderDirty();
+                                MarkNetworkObjectDirty();
                             }
                         }
                         break;
@@ -496,7 +496,7 @@ namespace Unity.Netcode
         private void HandleAddListEvent(NetworkListEvent<T> listEvent)
         {
             m_DirtyEvents.Add(listEvent);
-            ConsiderDirty();
+            MarkNetworkObjectDirty();
             OnListChanged?.Invoke(listEvent);
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -63,6 +63,11 @@ namespace Unity.Netcode
             return base.IsDirty() || m_DirtyEvents.Length > 0;
         }
 
+        internal void ConsiderDirty()
+        {
+            m_NetworkBehaviour.NetworkManager.MarkNetworkObjectDirty(m_NetworkBehaviour.NetworkObject);
+        }
+
         /// <inheritdoc />
         public override void WriteDelta(FastBufferWriter writer)
         {
@@ -189,6 +194,7 @@ namespace Unity.Netcode
                                     Index = m_List.Length - 1,
                                     Value = m_List[m_List.Length - 1]
                                 });
+                                ConsiderDirty();
                             }
                         }
                         break;
@@ -225,6 +231,7 @@ namespace Unity.Netcode
                                     Index = index,
                                     Value = m_List[index]
                                 });
+                                ConsiderDirty();
                             }
                         }
                         break;
@@ -257,6 +264,7 @@ namespace Unity.Netcode
                                     Index = index,
                                     Value = value
                                 });
+                                ConsiderDirty();
                             }
                         }
                         break;
@@ -284,6 +292,7 @@ namespace Unity.Netcode
                                     Index = index,
                                     Value = value
                                 });
+                                ConsiderDirty();
                             }
                         }
                         break;
@@ -319,6 +328,7 @@ namespace Unity.Netcode
                                     Value = value,
                                     PreviousValue = previousValue
                                 });
+                                ConsiderDirty();
                             }
                         }
                         break;
@@ -341,6 +351,7 @@ namespace Unity.Netcode
                                 {
                                     Type = eventType
                                 });
+                                ConsiderDirty();
                             }
                         }
                         break;
@@ -485,6 +496,7 @@ namespace Unity.Netcode
         private void HandleAddListEvent(NetworkListEvent<T> listEvent)
         {
             m_DirtyEvents.Add(listEvent);
+            ConsiderDirty();
             OnListChanged?.Invoke(listEvent);
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -74,7 +74,7 @@ namespace Unity.Netcode
 
         private protected void Set(T value)
         {
-            m_IsDirty = true;
+            SetDirty(true);
             T previousValue = m_InternalValue;
             m_InternalValue = value;
             OnValueChanged?.Invoke(previousValue, m_InternalValue);
@@ -106,7 +106,7 @@ namespace Unity.Netcode
 
             if (keepDirtyDelta)
             {
-                m_IsDirty = true;
+                SetDirty(true);
             }
 
             OnValueChanged?.Invoke(previousValue, m_InternalValue);

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
@@ -30,7 +30,7 @@ namespace Unity.Netcode
             WritePerm = writePerm;
         }
 
-        private protected bool m_IsDirty;
+        private bool m_IsDirty;
 
         /// <summary>
         /// Gets or sets the name of the network variable's instance
@@ -51,6 +51,7 @@ namespace Unity.Netcode
         public virtual void SetDirty(bool isDirty)
         {
             m_IsDirty = isDirty;
+            m_NetworkBehaviour.NetworkManager.MarkNetworkObjectDirty(m_NetworkBehaviour.NetworkObject);
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
@@ -79,7 +79,7 @@ namespace Unity.Netcode
         public virtual void SetDirty(bool isDirty)
         {
             m_IsDirty = isDirty;
-            if (m_NetworkBehaviour != null && m_IsDirty)
+            if (m_IsDirty)
             {
                 m_NetworkBehaviour.NetworkManager.MarkNetworkObjectDirty(m_NetworkBehaviour.NetworkObject);
             }

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
@@ -79,7 +79,10 @@ namespace Unity.Netcode
         public virtual void SetDirty(bool isDirty)
         {
             m_IsDirty = isDirty;
-            m_NetworkBehaviour.NetworkManager.MarkNetworkObjectDirty(m_NetworkBehaviour.NetworkObject);
+            if (m_NetworkBehaviour != null && m_IsDirty)
+            {
+                m_NetworkBehaviour.NetworkManager.MarkNetworkObjectDirty(m_NetworkBehaviour.NetworkObject);
+            }
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
@@ -54,7 +54,7 @@ namespace Unity.Netcode
         /// The <see cref="m_IsDirty"/> property is used to determine if the
         /// value of the `NetworkVariable` has changed.
         /// </summary>
-        private protected bool m_IsDirty;
+        private bool m_IsDirty;
 
         /// <summary>
         /// Gets or sets the name of the network variable's instance

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -576,7 +576,7 @@ namespace Unity.Netcode
             var size = NetworkManager.SendMessage(ref message, NetworkDelivery.ReliableFragmentedSequenced, clientId);
             NetworkManager.NetworkMetrics.TrackObjectSpawnSent(clientId, networkObject, size);
 
-            networkObject.MarkVariablesDirty();
+            networkObject.MarkVariablesDirty(true);
         }
 
         internal ulong? GetSpawnParentId(NetworkObject networkObject)

--- a/com.unity.netcode.gameobjects/Tests/Editor/NetworkVar/NetworkVarTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/NetworkVar/NetworkVarTests.cs
@@ -1,41 +1,55 @@
 using NUnit.Framework;
+using UnityEngine;
 
 namespace Unity.Netcode.EditorTests.NetworkVar
 {
     public class NetworkVarTests
     {
+        public class NetworkVarComponent : NetworkBehaviour
+        {
+            public NetworkVariable<int> NetworkVariable = new NetworkVariable<int>();
+        }
         [Test]
         public void TestAssignmentUnchanged()
         {
-            var intVar = new NetworkVariable<int>();
-
-            intVar.Value = 314159265;
-
-            intVar.OnValueChanged += (value, newValue) =>
+            var gameObjectMan = new GameObject();
+            var networkManager = gameObjectMan.AddComponent<NetworkManager>();
+            networkManager.BehaviourUpdater = new NetworkBehaviourUpdater();
+            var gameObject = new GameObject();
+            var networkObject = gameObject.AddComponent<NetworkObject>();
+            networkObject.NetworkManagerOwner = networkManager;
+            var networkVarComponent = gameObject.AddComponent<NetworkVarComponent>();
+            networkVarComponent.NetworkVariable.Initialize(networkVarComponent);
+            networkVarComponent.NetworkVariable.Value = 314159265;
+            networkVarComponent.NetworkVariable.OnValueChanged += (value, newValue) =>
             {
                 Assert.Fail("OnValueChanged was invoked when setting the same value");
             };
-
-            intVar.Value = 314159265;
+            networkVarComponent.NetworkVariable.Value = 314159265;
+            Object.DestroyImmediate(gameObject);
+            Object.DestroyImmediate(gameObjectMan);
         }
-
         [Test]
         public void TestAssignmentChanged()
         {
-            var intVar = new NetworkVariable<int>();
-
-            intVar.Value = 314159265;
-
+            var gameObjectMan = new GameObject();
+            var networkManager = gameObjectMan.AddComponent<NetworkManager>();
+            networkManager.BehaviourUpdater = new NetworkBehaviourUpdater();
+            var gameObject = new GameObject();
+            var networkObject = gameObject.AddComponent<NetworkObject>();
+            var networkVarComponent = gameObject.AddComponent<NetworkVarComponent>();
+            networkObject.NetworkManagerOwner = networkManager;
+            networkVarComponent.NetworkVariable.Initialize(networkVarComponent);
+            networkVarComponent.NetworkVariable.Value = 314159265;
             var changed = false;
-
-            intVar.OnValueChanged += (value, newValue) =>
+            networkVarComponent.NetworkVariable.OnValueChanged += (value, newValue) =>
             {
                 changed = true;
             };
-
-            intVar.Value = 314159266;
-
+            networkVarComponent.NetworkVariable.Value = 314159266;
             Assert.True(changed);
+            Object.DestroyImmediate(gameObject);
+            Object.DestroyImmediate(gameObjectMan);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Components/NetworkVariableTestComponent.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Components/NetworkVariableTestComponent.cs
@@ -53,7 +53,6 @@ namespace Unity.Netcode.RuntimeTests
 
 
         public bool EnableTesting;
-        private bool m_Initialized;
         private bool m_FinishedTests;
         private bool m_ChangesAppliedToNetworkVariables;
 
@@ -148,6 +147,11 @@ namespace Unity.Netcode.RuntimeTests
             return m_FinishedTests;
         }
 
+        public void Awake()
+        {
+            InitializeTest();
+        }
+
         // Update is called once per frame
         private void Update()
         {
@@ -164,37 +168,29 @@ namespace Unity.Netcode.RuntimeTests
                 {
                     if (NetworkManager != null && NetworkManager.IsListening)
                     {
-                        if (!m_Initialized)
-                        {
-                            InitializeTest();
-                            m_Initialized = true;
-                        }
-                        else
-                        {
-                            //Now change all of the values to make sure we are at least testing the local callback
-                            m_NetworkVariableBool.Value = false;
-                            m_NetworkVariableByte.Value = 255;
-                            m_NetworkVariableColor.Value = new Color(100, 100, 100);
-                            m_NetworkVariableColor32.Value = new Color32(100, 100, 100, 100);
-                            m_NetworkVariableDouble.Value = 1000;
-                            m_NetworkVariableFloat.Value = 1000.0f;
-                            m_NetworkVariableInt.Value = 1000;
-                            m_NetworkVariableLong.Value = 100000;
-                            m_NetworkVariableSByte.Value = -127;
-                            m_NetworkVariableQuaternion.Value = new Quaternion(100, 100, 100, 100);
-                            m_NetworkVariableShort.Value = short.MaxValue;
-                            m_NetworkVariableVector4.Value = new Vector4(1000, 1000, 1000, 1000);
-                            m_NetworkVariableVector3.Value = new Vector3(1000, 1000, 1000);
-                            m_NetworkVariableVector2.Value = new Vector2(1000, 1000);
-                            m_NetworkVariableRay.Value = new Ray(Vector3.one, Vector3.right);
-                            m_NetworkVariableULong.Value = ulong.MaxValue;
-                            m_NetworkVariableUInt.Value = uint.MaxValue;
-                            m_NetworkVariableUShort.Value = ushort.MaxValue;
+                        //Now change all of the values to make sure we are at least testing the local callback
+                        m_NetworkVariableBool.Value = false;
+                        m_NetworkVariableByte.Value = 255;
+                        m_NetworkVariableColor.Value = new Color(100, 100, 100);
+                        m_NetworkVariableColor32.Value = new Color32(100, 100, 100, 100);
+                        m_NetworkVariableDouble.Value = 1000;
+                        m_NetworkVariableFloat.Value = 1000.0f;
+                        m_NetworkVariableInt.Value = 1000;
+                        m_NetworkVariableLong.Value = 100000;
+                        m_NetworkVariableSByte.Value = -127;
+                        m_NetworkVariableQuaternion.Value = new Quaternion(100, 100, 100, 100);
+                        m_NetworkVariableShort.Value = short.MaxValue;
+                        m_NetworkVariableVector4.Value = new Vector4(1000, 1000, 1000, 1000);
+                        m_NetworkVariableVector3.Value = new Vector3(1000, 1000, 1000);
+                        m_NetworkVariableVector2.Value = new Vector2(1000, 1000);
+                        m_NetworkVariableRay.Value = new Ray(Vector3.one, Vector3.right);
+                        m_NetworkVariableULong.Value = ulong.MaxValue;
+                        m_NetworkVariableUInt.Value = uint.MaxValue;
+                        m_NetworkVariableUShort.Value = ushort.MaxValue;
 
-                            //Set the timeout (i.e. how long we will wait for all NetworkVariables to have registered their changes)
-                            m_WaitForChangesTimeout = Time.realtimeSinceStartup + 0.50f;
-                            m_ChangesAppliedToNetworkVariables = true;
-                        }
+                        //Set the timeout (i.e. how long we will wait for all NetworkVariables to have registered their changes)
+                        m_WaitForChangesTimeout = Time.realtimeSinceStartup + 0.50f;
+                        m_ChangesAppliedToNetworkVariables = true;
                     }
                 }
             }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/NetworkVariableMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/NetworkVariableMetricsTests.cs
@@ -25,10 +25,17 @@ namespace Unity.Netcode.RuntimeTests.Metrics
 
             var metricValues = waitForMetricValues.AssertMetricValuesHaveBeenFound();
 
-            var networkVariableDeltaSent = metricValues.First();
-            Assert.AreEqual(nameof(NetworkVariableComponent.MyNetworkVariable), networkVariableDeltaSent.Name);
-            Assert.AreEqual(Server.LocalClientId, networkVariableDeltaSent.Connection.Id);
-            Assert.AreNotEqual(0, networkVariableDeltaSent.BytesCount);
+            bool found = false;
+            foreach (var networkVariableDeltaSent in metricValues)
+            {
+                if (nameof(NetworkVariableComponent.MyNetworkVariable) == networkVariableDeltaSent.Name &&
+                    Client.LocalClientId == networkVariableDeltaSent.Connection.Id &&
+                    0 != networkVariableDeltaSent.BytesCount)
+                {
+                    found = true;
+                }
+            }
+            Assert.IsTrue(found);
         }
 
         [UnityTest]

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
@@ -50,7 +50,7 @@ namespace Unity.Netcode.RuntimeTests
 
         public NetworkVariable<int> MyNetworkVariable;
 
-        private void Start()
+        private void Awake()
         {
             MyNetworkVariable = new NetworkVariable<int>();
             MyNetworkVariable.OnValueChanged += Changed;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVarBufferCopyTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVarBufferCopyTest.cs
@@ -113,6 +113,7 @@ namespace Unity.Netcode.RuntimeTests
         }
 
         [UnityTest]
+        [Ignore("This test makes assumptions about the SDK that were broken for performance reasons. (#2116)")]
         public IEnumerator TestEntireBufferIsCopiedOnNetworkVariableDelta()
         {
             // This is the *SERVER VERSION* of the *CLIENT PLAYER*

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVarBufferCopyTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVarBufferCopyTest.cs
@@ -15,17 +15,6 @@ namespace Unity.Netcode.RuntimeTests
             public bool FieldWritten;
             public bool DeltaRead;
             public bool FieldRead;
-            public bool Dirty = false;
-
-            public override void ResetDirty()
-            {
-                Dirty = false;
-            }
-
-            public override bool IsDirty()
-            {
-                return Dirty;
-            }
 
             public override void WriteDelta(FastBufferWriter writer)
             {
@@ -113,7 +102,6 @@ namespace Unity.Netcode.RuntimeTests
         }
 
         [UnityTest]
-        [Ignore("This test makes assumptions about the SDK that were broken for performance reasons. (#2116)")]
         public IEnumerator TestEntireBufferIsCopiedOnNetworkVariableDelta()
         {
             // This is the *SERVER VERSION* of the *CLIENT PLAYER*
@@ -139,12 +127,12 @@ namespace Unity.Netcode.RuntimeTests
             Assert.IsFalse(s_GlobalTimeoutHelper.TimedOut, "Timed out waiting for client side DummyNetBehaviour to register it was spawned!");
 
             // Check that FieldWritten is written when dirty
-            serverComponent.NetVar.Dirty = true;
+            serverComponent.NetVar.SetDirty(true);
             yield return s_DefaultWaitForTick;
             Assert.True(serverComponent.NetVar.FieldWritten);
 
             // Check that DeltaWritten is written when dirty
-            serverComponent.NetVar.Dirty = true;
+            serverComponent.NetVar.SetDirty(true);
             yield return s_DefaultWaitForTick;
             Assert.True(serverComponent.NetVar.DeltaWritten);
 


### PR DESCRIPTION
Renames NetwoirkBehaviourUpdater's `m_Touched` to `m_DirtyNetworkObjects`
Instead of scanning all spawned objects, for each client, then checking visibility and updating,
we now scan only over the dirty objects and then over all clients for visibility.

Since few objects are dirty, typically, this improves performance.

## Changelog

- Preformance improvements for cases with large number of NetworkObjects, by not iterating over all unchanged NetworkObjects 
