### PR TITLE
fix: MessageSendingTests causing memory leak during editor tests.

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageSendingTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageSendingTests.cs
@@ -263,7 +263,7 @@ namespace Unity.Netcode.EditorTests
         [Test]
         public void WhenReceivingAMessageWithoutAHandler_ExceptionIsLogged()
         {
-            // If we are going to create a new MessagingSystem, dispose of the current one (if there is one)
+            // If a MessagingSystem already exists then dispose of it before creating a new MessagingSystem (otherwise memory leak)
             if (m_MessagingSystem != null)
             {
                 m_MessagingSystem.Dispose();
@@ -272,6 +272,7 @@ namespace Unity.Netcode.EditorTests
 
             // Since m_MessagingSystem is disposed during teardown we don't need to worry about that here.
             m_MessagingSystem = new MessagingSystem(new NopMessageSender(), this, new TestNoHandlerMessageProvider());
+            m_MessagingSystem.ClientConnected(0);
 
             var messageHeader = new MessageHeader
             {

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageSendingTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageSendingTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using NUnit.Framework;
@@ -43,11 +44,22 @@ namespace Unity.Netcode.EditorTests
             }
         }
 
-        private class TestMessageProvider : IMessageProvider
+        private class TestMessageProvider : IMessageProvider, IDisposable
         {
+            // Keep track of what we sent
+            private List<List<MessagingSystem.MessageWithHandler>> m_CachedMessages = new List<List<MessagingSystem.MessageWithHandler>>();
+            public void Dispose()
+            {
+                foreach (var cachedItem in m_CachedMessages)
+                {
+                    // Clear out any references to MessagingSystem.MessageWithHandlers
+                    cachedItem.Clear();
+                }
+                m_CachedMessages.Clear();
+            }
             public List<MessagingSystem.MessageWithHandler> GetMessages()
             {
-                return new List<MessagingSystem.MessageWithHandler>
+                var messageList = new List<MessagingSystem.MessageWithHandler>
                 {
                     new MessagingSystem.MessageWithHandler
                     {
@@ -55,9 +67,13 @@ namespace Unity.Netcode.EditorTests
                         Handler = MessagingSystem.ReceiveMessage<TestMessage>
                     }
                 };
+                // Track messages sent
+                m_CachedMessages.Add(messageList);
+                return messageList;
             }
         }
 
+        private TestMessageProvider m_TestMessageProvider;
         private TestMessageSender m_MessageSender;
         private MessagingSystem m_MessagingSystem;
         private ulong[] m_Clients = { 0 };
@@ -66,15 +82,16 @@ namespace Unity.Netcode.EditorTests
         public void SetUp()
         {
             TestMessage.Serialized = false;
-
             m_MessageSender = new TestMessageSender();
-            m_MessagingSystem = new MessagingSystem(m_MessageSender, this, new TestMessageProvider());
+            m_TestMessageProvider = new TestMessageProvider();
+            m_MessagingSystem = new MessagingSystem(m_MessageSender, this, m_TestMessageProvider);
             m_MessagingSystem.ClientConnected(0);
         }
 
         [TearDown]
         public void TearDown()
         {
+            m_TestMessageProvider.Dispose();
             m_MessagingSystem.Dispose();
         }
 
@@ -246,6 +263,14 @@ namespace Unity.Netcode.EditorTests
         [Test]
         public void WhenReceivingAMessageWithoutAHandler_ExceptionIsLogged()
         {
+            // If we are going to create a new MessagingSystem, dispose of the current one (if there is one)
+            if (m_MessagingSystem != null)
+            {
+                m_MessagingSystem.Dispose();
+                m_MessagingSystem = null;
+            }
+
+            // Since m_MessagingSystem is disposed during teardown we don't need to worry about that here.
             m_MessagingSystem = new MessagingSystem(new NopMessageSender(), this, new TestNoHandlerMessageProvider());
 
             var messageHeader = new MessageHeader

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageSendingTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageSendingTests.cs
@@ -48,6 +48,7 @@ namespace Unity.Netcode.EditorTests
         {
             // Keep track of what we sent
             private List<List<MessagingSystem.MessageWithHandler>> m_CachedMessages = new List<List<MessagingSystem.MessageWithHandler>>();
+
             public void Dispose()
             {
                 foreach (var cachedItem in m_CachedMessages)
@@ -57,6 +58,7 @@ namespace Unity.Netcode.EditorTests
                 }
                 m_CachedMessages.Clear();
             }
+
             public List<MessagingSystem.MessageWithHandler> GetMessages()
             {
                 var messageList = new List<MessagingSystem.MessageWithHandler>


### PR DESCRIPTION
This fixes the issues with the memory leak failing in the editor tests.
