### PR TITLE
fix: client authoritative NetworkAnimator skips sending to 2nd player when in server mode

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -19,7 +19,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - As a consequence of the above change, the `UnityTransport.InitialMaxSendQueueSize` field is now deprecated. There is no default value anymore since send queues are dynamically-sized. (#2212)
 - The debug simulator in `UnityTransport` is now non-deterministic. Its random number generator used to be seeded with a constant value, leading to the same pattern of packet drops, delays, and jitter in every run. (#2196)
 
-
 ### Fixed
 
 - Fixed issue #1924 where `UnityTransport` would fail to restart after a first failure (even if what caused the initial failure was addressed). (#2220)
@@ -28,7 +27,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Implicit conversion of NetworkObjectReference to GameObject will now return null instead of throwing an exception if the referenced object could not be found (i.e., was already despawned) (#2158)
 - Fixed warning resulting from a stray NetworkAnimator.meta file (#2153)
 - Fixed Connection Approval Timeout not working client side. (#2164)
-
 - Fixed ClientRpcs always reporting in the profiler view as going to all clients, even when limited to a subset of clients by `ClientRpcParams`. (#2144)
 - Fixed RPC codegen failing to choose the correct extension methods for `FastBufferReader` and `FastBufferWriter` when the parameters were a generic type (i.e., List<int>) and extensions for multiple instantiations of that type have been defined (i.e., List<int> and List<string>) (#2142)
 - Fixed the issue where running a server (i.e. not host) the second player would not receive updates (unless a third player joined). (#2127)
@@ -36,7 +34,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed throwing an exception in `OnNetworkUpdate` causing other `OnNetworkUpdate` calls to not be executed. (#1739)
 - Fixed synchronization when Time.timeScale is set to 0. This changes timing update to use unscaled deltatime. Now network updates rate are independent from the local time scale. (#2171)
 - Fixed not sending all NetworkVariables to all clients when a client connects to a server. (#1987)
-
 
 ## [1.0.2] - 2022-09-12
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -14,6 +14,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed the issue where running a server (i.e. not host) the second player would not receive updates (unless a third player joined). (#2127)
 - Fixed issue where a client owner of a `NetworkVariable` with both owner read and write permissions would not update the server side when changed. (#2097)
 - Fixed issue when attempting to spawn a parent `GameObject`, with `NetworkObject` component attached, that has one or more child `GameObject`s, that are inactive in the hierarchy, with `NetworkBehaviour` components it will no longer attempt to spawn the associated `NetworkBehaviour`(s) or invoke ownership changed notifications but will log a warning message. (#2096)
 - Fixed an issue where destroying a NetworkBehaviour would not deregister it from the parent NetworkObject, leading to exceptions when the parent was later destroyed. (#2091)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -19,6 +19,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - As a consequence of the above change, the `UnityTransport.InitialMaxSendQueueSize` field is now deprecated. There is no default value anymore since send queues are dynamically-sized. (#2212)
 - The debug simulator in `UnityTransport` is now non-deterministic. Its random number generator used to be seeded with a constant value, leading to the same pattern of packet drops, delays, and jitter in every run. (#2196)
 
+
 ### Fixed
 
 - Fixed issue #1924 where `UnityTransport` would fail to restart after a first failure (even if what caused the initial failure was addressed). (#2220)
@@ -27,11 +28,15 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Implicit conversion of NetworkObjectReference to GameObject will now return null instead of throwing an exception if the referenced object could not be found (i.e., was already despawned) (#2158)
 - Fixed warning resulting from a stray NetworkAnimator.meta file (#2153)
 - Fixed Connection Approval Timeout not working client side. (#2164)
+
 - Fixed ClientRpcs always reporting in the profiler view as going to all clients, even when limited to a subset of clients by `ClientRpcParams`. (#2144)
 - Fixed RPC codegen failing to choose the correct extension methods for `FastBufferReader` and `FastBufferWriter` when the parameters were a generic type (i.e., List<int>) and extensions for multiple instantiations of that type have been defined (i.e., List<int> and List<string>) (#2142)
+- Fixed the issue where running a server (i.e. not host) the second player would not receive updates (unless a third player joined). (#2127)
+- Fixed issue where late-joining client transition synchronization could fail when more than one transition was occurring.(#2127)
 - Fixed throwing an exception in `OnNetworkUpdate` causing other `OnNetworkUpdate` calls to not be executed. (#1739)
-- Fixed synchronisation when Time.timeScale is set to 0. This changes timing update to use unscaled deltatime. Now network updates rate are independant from the local time scale. (#2171)
+- Fixed synchronization when Time.timeScale is set to 0. This changes timing update to use unscaled deltatime. Now network updates rate are independent from the local time scale. (#2171)
 - Fixed not sending all NetworkVariables to all clients when a client connects to a server. (#1987)
+
 
 ## [1.0.2] - 2022-09-12
 
@@ -54,7 +59,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Fixed
 
 - Fixed an issue where reading/writing more than 8 bits at a time with BitReader/BitWriter would write/read from the wrong place, returning and incorrect result. (#2130)
-- Fixed the issue where running a server (i.e. not host) the second player would not receive updates (unless a third player joined). (#2127)
 - Fixed issue with the internal `NetworkTransformState.m_Bitset` flag not getting cleared upon the next tick advancement. (#2110)
 - Fixed interpolation issue with `NetworkTransform.Teleport`. (#2110)
 - Fixed issue where the authoritative side was interpolating its transform. (#2110)

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -324,27 +324,64 @@ namespace Unity.Netcode.Components
                 if (serializer.IsWriter)
                 {
                     var writer = serializer.GetFastBufferWriter();
-                    BytePacker.WriteValuePacked(writer, StateHash);
-                    BytePacker.WriteValuePacked(writer, NormalizedTime);
-                    BytePacker.WriteValuePacked(writer, Layer);
-                    BytePacker.WriteValuePacked(writer, Weight);
-                    BytePacker.WriteValuePacked(writer, Transition);
+                    var writeSize = FastBufferWriter.GetWriteSize(Transition);
+                    writeSize += FastBufferWriter.GetWriteSize(StateHash);
+                    writeSize += FastBufferWriter.GetWriteSize(NormalizedTime);
+                    writeSize += FastBufferWriter.GetWriteSize(Layer);
+                    writeSize += FastBufferWriter.GetWriteSize(Weight);
                     if (Transition)
                     {
-                        BytePacker.WriteValuePacked(writer, DestinationStateHash);
+                        writeSize += FastBufferWriter.GetWriteSize(DestinationStateHash);
+                    }
+
+                    if (!writer.TryBeginWrite(writeSize))
+                    {
+                        throw new OverflowException($"[{GetType().Name}] Could not serialize: Out of buffer space.");
+                    }
+
+                    writer.WriteValue(Transition);
+                    writer.WriteValue(StateHash);
+                    writer.WriteValue(NormalizedTime);
+                    writer.WriteValue(Layer);
+                    writer.WriteValue(Weight);
+                    if (Transition)
+                    {
+                        writer.WriteValue(DestinationStateHash);
                     }
                 }
                 else
                 {
                     var reader = serializer.GetFastBufferReader();
-                    ByteUnpacker.ReadValuePacked(reader, out StateHash);
-                    ByteUnpacker.ReadValuePacked(reader, out NormalizedTime);
-                    ByteUnpacker.ReadValuePacked(reader, out Layer);
-                    ByteUnpacker.ReadValuePacked(reader, out Weight);
-                    ByteUnpacker.ReadValuePacked(reader, out Transition);
+                    // Begin reading the Transition flag
+                    if (!reader.TryBeginRead(FastBufferWriter.GetWriteSize(Transition)))
+                    {
+                        throw new OverflowException($"[{GetType().Name}] Could not deserialize: Out of buffer space.");
+                    }
+                    reader.ReadValue(out Transition);
+
+                    // Now determine what remains to be read
+                    var readSize = FastBufferWriter.GetWriteSize(StateHash);
+                    readSize += FastBufferWriter.GetWriteSize(NormalizedTime);
+                    readSize += FastBufferWriter.GetWriteSize(Layer);
+                    readSize += FastBufferWriter.GetWriteSize(Weight);
                     if (Transition)
                     {
-                        ByteUnpacker.ReadValuePacked(reader, out DestinationStateHash);
+                        readSize += FastBufferWriter.GetWriteSize(DestinationStateHash);
+                    }
+
+                    // Now read the remaining information about this AnimationState
+                    if (!reader.TryBeginRead(readSize))
+                    {
+                        throw new OverflowException($"[{GetType().Name}] Could not deserialize: Out of buffer space.");
+                    }
+
+                    reader.ReadValue(out StateHash);
+                    reader.ReadValue(out NormalizedTime);
+                    reader.ReadValue(out Layer);
+                    reader.ReadValue(out Weight);
+                    if (Transition)
+                    {
+                        reader.ReadValue(out DestinationStateHash);
                     }
                 }
             }
@@ -502,10 +539,10 @@ namespace Unity.Netcode.Components
                 m_NetworkAnimatorStateChangeHandler = null;
             }
 
-            // The safest way to be assured that you get a NetworkManager instance when also
-            // taking integration testing into consideration (multiple NetworkManager instances)
-            var networkManager = HasNetworkObject ? NetworkManager : NetworkManager.Singleton;
-            networkManager.OnClientConnectedCallback -= OnClientConnectedCallback;
+            if (m_CachedNetworkManager != null)
+            {
+                m_CachedNetworkManager.OnClientConnectedCallback -= OnClientConnectedCallback;
+            }
 
             if (m_CachedAnimatorParameters != null && m_CachedAnimatorParameters.IsCreated)
             {
@@ -528,6 +565,9 @@ namespace Unity.Netcode.Components
         private ClientRpcParams m_ClientRpcParams;
         private List<AnimationState> m_AnimationMessageStates;
 
+        // Only used in Cleanup
+        private NetworkManager m_CachedNetworkManager;
+
         /// <inheritdoc/>
         public override void OnNetworkSpawn()
         {
@@ -545,6 +585,9 @@ namespace Unity.Netcode.Components
                 m_ClientRpcParams = new ClientRpcParams();
                 m_ClientRpcParams.Send = new ClientRpcSendParams();
                 m_ClientRpcParams.Send.TargetClientIds = m_ClientSendList;
+
+                // Cache the NetworkManager instance to remove the OnClientConnectedCallback subscription
+                m_CachedNetworkManager = NetworkManager;
                 NetworkManager.OnClientConnectedCallback += OnClientConnectedCallback;
             }
 
@@ -626,7 +669,6 @@ namespace Unity.Netcode.Components
             m_ClientSendList.Clear();
             m_ClientSendList.Add(playerId);
             m_ClientRpcParams.Send.TargetClientIds = m_ClientSendList;
-
             // With synchronization we send all parameters
             m_ParametersToUpdate.Clear();
             for (int i = 0; i < m_CachedAnimatorParameters.Length; i++)
@@ -648,7 +690,6 @@ namespace Unity.Netcode.Components
                 var normalizedTime = st.normalizedTime;
                 var isInTransition = m_Animator.IsInTransition(layer);
                 var animMsg = m_AnimationMessageStates[layer];
-
 
                 // Synchronizing transitions with trigger conditions for late joining clients is now
                 // handled by cross fading between the late joining client's current layer's AnimationState
@@ -728,7 +769,10 @@ namespace Unity.Netcode.Components
 
             if (m_Animator.runtimeAnimatorController == null)
             {
-                // TODO: While this should never happen, add a NetworkLog warning message
+                if (NetworkManager.LogLevel == LogLevel.Developer)
+                {
+                    Debug.LogError($"[{GetType().Name}] Could not find an assigned {nameof(RuntimeAnimatorController)}! Cannot check {nameof(Animator)} for changes in state!");
+                }
                 return;
             }
 

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -221,7 +221,7 @@ namespace Unity.Netcode.Components
                     if (animationState.TriggerHashValues != null && animationState.TriggerHashValues.Count > 0)
                     {
                         // Set all triggers associated with the state
-                        foreach(var triggerHash in animationState.TriggerHashValues)
+                        foreach (var triggerHash in animationState.TriggerHashValues)
                         {
                             // Set trigger
                             m_NetworkAnimator.SetTrigger(triggerHash);
@@ -308,7 +308,7 @@ namespace Unity.Netcode.Components
                     if (Transition)
                     {
                         BytePacker.WriteValuePacked(writer, TriggerHashValues.Count);
-                        foreach(var triggerHash in TriggerHashValues)
+                        foreach (var triggerHash in TriggerHashValues)
                         {
                             BytePacker.WriteValuePacked(writer, triggerHash);
                         }
@@ -328,7 +328,7 @@ namespace Unity.Netcode.Components
                         ByteUnpacker.ReadValuePacked(reader, out count);
                         TriggerHashValues = new List<int>(count);
                         var triggerHash = 0;
-                        for(int i = 0; i < count; i++)
+                        for (int i = 0; i < count; i++)
                         {
                             ByteUnpacker.ReadValuePacked(reader, out triggerHash);
                             TriggerHashValues.Add(triggerHash);
@@ -649,7 +649,7 @@ namespace Unity.Netcode.Components
                             var triggerStateInfo = triggerEntry.Value[layer];
                             if (triggerStateInfo.CurrentState.fullPathHash == stateHash || triggerStateInfo.NextState.fullPathHash == stateHash)
                             {
-                                if(!animMsg.TriggerHashValues.Contains(triggerEntry.Key))
+                                if (!animMsg.TriggerHashValues.Contains(triggerEntry.Key))
                                 {
                                     animMsg.TriggerHashValues.Add(triggerEntry.Key);
                                 }

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -156,10 +156,12 @@ namespace Unity.Netcode.Components
         /// </remarks>
         private void ProcessAnimationMessageQueue()
         {
+            // Early exit if nothing to process
             if (m_AnimationMessageQueue.Count == 0)
             {
                 return;
             }
+
             if (m_AnimationMessageBeingProcessed.HasBeenProcessed)
             {
                 m_AnimationMessageBeingProcessed = m_AnimationMessageQueue.Dequeue();
@@ -185,12 +187,10 @@ namespace Unity.Netcode.Components
             ProcessTransitionSynchronization();
         }
 
-        private bool ProcessTransitionSynchronization()
+        private void ProcessTransitionSynchronization()
         {
-            var stillProcessing = false;
             for (int i = 0; i < m_AnimationMessageBeingProcessed.AnimationStates.Count; i++)
             {
-
                 var animationState = m_AnimationMessageBeingProcessed.AnimationStates[i];
                 // Skip things already processed or are not transition states
                 if (animationState.HasBeenProcessed || !animationState.Transition)
@@ -198,6 +198,7 @@ namespace Unity.Netcode.Components
                     continue;
                 }
 
+                // Only occurs for newly joined clients
                 if (!animationState.TriggerProcessed)
                 {
                     // Trigger transition here
@@ -207,9 +208,6 @@ namespace Unity.Netcode.Components
 
                     // Apply the changes
                     m_AnimationMessageBeingProcessed.AnimationStates[i] = animationState;
-
-                    // Wait for the trigger to trigger before applying state, return true signifying we are still processing the transition
-                    stillProcessing = true;
 
                     // We break in order to allow the trigger to be processed by the animator first
                     // Next frame during PreUpdate the triggered transition state will be synchronized
@@ -224,7 +222,6 @@ namespace Unity.Netcode.Components
                     m_AnimationMessageBeingProcessed.AnimationStates[i] = animationState;
                 }
             }
-            return stillProcessing;
         }
 
         internal void AddAnimationMessageToProcessQueue(NetworkAnimator.AnimationMessage message)

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -769,7 +769,7 @@ namespace Unity.Netcode.Components
                     return;
                 }
                 UpdateParameters(parametersUpdate);
-                if (NetworkManager.ConnectedClientsIds.Count - 2 > 0)
+                if (NetworkManager.ConnectedClientsIds.Count > 1)
                 {
                     m_ClientSendList.Clear();
                     m_ClientSendList.AddRange(NetworkManager.ConnectedClientsIds);
@@ -812,7 +812,7 @@ namespace Unity.Netcode.Components
                     return;
                 }
                 UpdateAnimationState(animSnapshot);
-                if (NetworkManager.ConnectedClientsIds.Count - 2 > 0)
+                if (NetworkManager.ConnectedClientsIds.Count > 1)
                 {
                     m_ClientSendList.Clear();
                     m_ClientSendList.AddRange(NetworkManager.ConnectedClientsIds);
@@ -857,7 +857,7 @@ namespace Unity.Netcode.Components
                 //  trigger the animation locally on the server...
                 m_Animator.SetBool(animationTriggerMessage.Hash, animationTriggerMessage.IsTriggerSet);
 
-                if (NetworkManager.ConnectedClientsIds.Count - 2 > 0)
+                if (NetworkManager.ConnectedClientsIds.Count > 1)
                 {
                     m_ClientSendList.Clear();
                     m_ClientSendList.AddRange(NetworkManager.ConnectedClientsIds);

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -769,7 +769,7 @@ namespace Unity.Netcode.Components
                     return;
                 }
                 UpdateParameters(parametersUpdate);
-                if (IsHost && NetworkManager.ConnectedClientsIds.Count > 2 || NetworkManager.ConnectedClientsIds.Count > 1)
+                if (NetworkManager.ConnectedClientsIds.Count > (IsHost ? 2 : 1))
                 {
                     m_ClientSendList.Clear();
                     m_ClientSendList.AddRange(NetworkManager.ConnectedClientsIds);
@@ -812,7 +812,7 @@ namespace Unity.Netcode.Components
                     return;
                 }
                 UpdateAnimationState(animSnapshot);
-                if (IsHost && NetworkManager.ConnectedClientsIds.Count > 2 || NetworkManager.ConnectedClientsIds.Count > 1)
+                if (NetworkManager.ConnectedClientsIds.Count > (IsHost ? 2 : 1))
                 {
                     m_ClientSendList.Clear();
                     m_ClientSendList.AddRange(NetworkManager.ConnectedClientsIds);
@@ -857,7 +857,7 @@ namespace Unity.Netcode.Components
                 //  trigger the animation locally on the server...
                 m_Animator.SetBool(animationTriggerMessage.Hash, animationTriggerMessage.IsTriggerSet);
 
-                if (IsHost && NetworkManager.ConnectedClientsIds.Count > 2 || NetworkManager.ConnectedClientsIds.Count > 1)
+                if (NetworkManager.ConnectedClientsIds.Count > (IsHost ? 2 : 1))
                 {
                     m_ClientSendList.Clear();
                     m_ClientSendList.AddRange(NetworkManager.ConnectedClientsIds);

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -769,7 +769,7 @@ namespace Unity.Netcode.Components
                     return;
                 }
                 UpdateParameters(parametersUpdate);
-                if (NetworkManager.ConnectedClientsIds.Count > 1)
+                if (IsHost && NetworkManager.ConnectedClientsIds.Count > 2 || NetworkManager.ConnectedClientsIds.Count > 1)
                 {
                     m_ClientSendList.Clear();
                     m_ClientSendList.AddRange(NetworkManager.ConnectedClientsIds);
@@ -812,7 +812,7 @@ namespace Unity.Netcode.Components
                     return;
                 }
                 UpdateAnimationState(animSnapshot);
-                if (NetworkManager.ConnectedClientsIds.Count > 1)
+                if (IsHost && NetworkManager.ConnectedClientsIds.Count > 2 || NetworkManager.ConnectedClientsIds.Count > 1)
                 {
                     m_ClientSendList.Clear();
                     m_ClientSendList.AddRange(NetworkManager.ConnectedClientsIds);
@@ -857,7 +857,7 @@ namespace Unity.Netcode.Components
                 //  trigger the animation locally on the server...
                 m_Animator.SetBool(animationTriggerMessage.Hash, animationTriggerMessage.IsTriggerSet);
 
-                if (NetworkManager.ConnectedClientsIds.Count > 1)
+                if (IsHost && NetworkManager.ConnectedClientsIds.Count > 2 || NetworkManager.ConnectedClientsIds.Count > 1)
                 {
                     m_ClientSendList.Clear();
                     m_ClientSendList.AddRange(NetworkManager.ConnectedClientsIds);

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -462,6 +462,9 @@ namespace Unity.Netcode.Components
         public override void OnNetworkSpawn()
         {
             int layers = m_Animator.layerCount;
+
+            // Initializing the below arrays for everyone handles an issue
+            // when running in owner authoritative mode and the owner changes.
             m_TransitionHash = new int[layers];
             m_AnimationHash = new int[layers];
             m_LayerWeights = new float[layers];

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -182,12 +182,8 @@ namespace Unity.Netcode.Components
     /// </summary>
     [AddComponentMenu("Netcode/Network Animator")]
     [RequireComponent(typeof(Animator))]
-    // TODO: Enable the serialization callback receiver whenever we do a minor version update.
-#if USE_SERIALIZATION_CALLBACK_RECEIVER
     public class NetworkAnimator : NetworkBehaviour, ISerializationCallbackReceiver
-#else
-    public class NetworkAnimator : NetworkBehaviour
-#endif
+
     {
         [Serializable]
         internal class TransitionStateinfo
@@ -230,13 +226,12 @@ namespace Unity.Netcode.Components
             }
         }
 
-
-#if UNITY_EDITOR
         /// <summary>
         /// Creates the
         /// </summary>
         private void BuildTransitionStateInfoList()
         {
+#if UNITY_EDITOR
             TransitionStateInfoList = new List<TransitionStateinfo>();
             var animatorController = m_Animator.runtimeAnimatorController as AnimatorController;
             if (animatorController == null)
@@ -295,11 +290,9 @@ namespace Unity.Netcode.Components
                     }
                 }
             }
-        }
 #endif
+        }
 
-        // TODO: Enable the callback receiver when we do a minor version update
-#if USE_SERIALIZATION_CALLBACK_RECEIVER
         public void OnAfterDeserialize()
         {
             BuildDestinationToTransitionInfoTable();
@@ -309,28 +302,6 @@ namespace Unity.Netcode.Components
         {
             BuildTransitionStateInfoList();
         }
-#else
-        // For now, we can build this table during Awake
-        private void Awake()
-        {
-            BuildDestinationToTransitionInfoTable();
-        }
-
-#if UNITY_EDITOR
-        /// <summary>
-        /// For now we can build the TransitionState list during OnValidate
-        /// </summary>
-        private void OnValidate()
-        {
-            // Only if we are entering into play mode, about to update the asset database, or compiling/building do we want to build the transition state info list
-            if ((UnityEditor.EditorApplication.isPlaying || !UnityEditor.EditorApplication.isPlayingOrWillChangePlaymode) && !UnityEditor.EditorApplication.isUpdating && !UnityEditor.EditorApplication.isCompiling)
-            {
-                return;
-            }
-            BuildTransitionStateInfoList();
-        }
-#endif // UNITY_EDITOR
-#endif // USE_SERIALIZATION_CALLBACK_RECEIVER
 
         internal struct AnimationState : INetworkSerializable
         {

--- a/testproject/Assets/Tests/Manual/NetworkAnimatorTests/CheckStateEnterCount.cs
+++ b/testproject/Assets/Tests/Manual/NetworkAnimatorTests/CheckStateEnterCount.cs
@@ -9,12 +9,21 @@ namespace TestProject.RuntimeTests
         public static Dictionary<ulong, Dictionary<int, List<AnimatorStateInfo>>> OnStateEnterCounter = new Dictionary<ulong, Dictionary<int, List<AnimatorStateInfo>>>();
         public static bool IsIntegrationTest;
         public static bool IsManualTestEnabled = true;
+        public static bool IsVerboseDebug = false;
 
         public static void ResetTest(bool isIntegrationTest = true)
         {
             IsIntegrationTest = isIntegrationTest;
             IsManualTestEnabled = !isIntegrationTest;
             OnStateEnterCounter.Clear();
+        }
+
+        public static void LogMessage(string message)
+        {
+            if (IsVerboseDebug)
+            {
+                Debug.Log(message);
+            }
         }
 
         public static bool AllStatesEnteredMatch(List<ulong> clientIdsToCheck)
@@ -26,7 +35,7 @@ namespace TestProject.RuntimeTests
 
             if (!OnStateEnterCounter.ContainsKey(NetworkManager.ServerClientId))
             {
-                Debug.Log($"Server has not entered into any states! OnStateEntered Entry Count ({OnStateEnterCounter.Count})");
+                LogMessage($"Server has not entered into any states! OnStateEntered Entry Count ({OnStateEnterCounter.Count})");
                 return false;
             }
 
@@ -38,7 +47,11 @@ namespace TestProject.RuntimeTests
                 var layerStates = layerEntries.Value;
                 if (layerStates.Count > 1)
                 {
-                    Debug.Log($"Server layer ({layerIndex}) state was entered ({layerStates.Count}) times!");
+                    if (IsVerboseDebug)
+                    {
+
+                    }
+                    LogMessage($"Server layer ({layerIndex}) state was entered ({layerStates.Count}) times!");
                     return false;
                 }
 
@@ -46,7 +59,7 @@ namespace TestProject.RuntimeTests
                 {
                     if (!OnStateEnterCounter.ContainsKey(clientId))
                     {
-                        Debug.Log($"Client-{clientId} never entered into any state for layer index ({layerIndex})!");
+                        LogMessage($"Client-{clientId} never entered into any state for layer index ({layerIndex})!");
                         return false;
                     }
                     var clientStates = OnStateEnterCounter[clientId];
@@ -58,7 +71,7 @@ namespace TestProject.RuntimeTests
                     var clientLayerStateEntries = clientStates[layerIndex];
                     if (clientLayerStateEntries.Count > 1)
                     {
-                        Debug.Log($"Client-{clientId} layer ({layerIndex}) state was entered ({layerStates.Count}) times!");
+                        LogMessage($"Client-{clientId} layer ({layerIndex}) state was entered ({layerStates.Count}) times!");
                         return false;
                     }
                     // We should have only entered into the state once on the server
@@ -68,7 +81,7 @@ namespace TestProject.RuntimeTests
                     // We just need to make sure we are looking at the same state
                     if (clientAnimStateInfo.fullPathHash != serverAnimStateInfo.fullPathHash)
                     {
-                        Debug.Log($"Client-{clientId} full path hash ({clientAnimStateInfo.fullPathHash}) for layer ({layerIndex}) was not the same as the Server full path hash ({serverAnimStateInfo.fullPathHash})!");
+                        LogMessage($"Client-{clientId} full path hash ({clientAnimStateInfo.fullPathHash}) for layer ({layerIndex}) was not the same as the Server full path hash ({serverAnimStateInfo.fullPathHash})!");
                         return false;
                     }
                 }
@@ -91,11 +104,36 @@ namespace TestProject.RuntimeTests
                     OnStateEnterCounter[localClientId].Add(layerIndex, new List<AnimatorStateInfo>());
                 }
                 OnStateEnterCounter[localClientId][layerIndex].Add(stateInfo);
+                LogMessage($"[{layerIndex}][{stateInfo.shortNameHash}][{stateInfo.normalizedTime}][{animator.IsInTransition(layerIndex)}]");
             }
             else if (IsManualTestEnabled)
             {
                 Debug.Log($"[{layerIndex}][{stateInfo.shortNameHash}][{stateInfo.normalizedTime}][{animator.IsInTransition(layerIndex)}]");
             }
         }
+
+        //public override void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+        //{
+        //    if (IsIntegrationTest)
+        //    {
+        //        var networkObject = animator.GetComponent<NetworkObject>();
+        //        var localClientId = networkObject.NetworkManager.IsServer ? NetworkManager.ServerClientId : networkObject.NetworkManager.LocalClientId;
+        //        if (!OnStateEnterCounter.ContainsKey(localClientId))
+        //        {
+        //            OnStateEnterCounter.Add(localClientId, new Dictionary<int, List<AnimatorStateInfo>>());
+        //            if (!OnStateEnterCounter[localClientId].ContainsKey(layerIndex))
+        //            {
+        //                OnStateEnterCounter[localClientId].Add(layerIndex, new List<AnimatorStateInfo>());
+        //            }
+        //            OnStateEnterCounter[localClientId][layerIndex].Add(stateInfo);
+        //            LogMessage($"[{layerIndex}][{stateInfo.shortNameHash}][{stateInfo.normalizedTime}][{animator.IsInTransition(layerIndex)}]");
+        //        }
+        //    }
+        //    else if (IsManualTestEnabled)
+        //    {
+        //        Debug.Log($"[{layerIndex}][{stateInfo.shortNameHash}][{stateInfo.normalizedTime}][{animator.IsInTransition(layerIndex)}]");
+        //    }
+        //    base.OnStateUpdate(animator, stateInfo, layerIndex);
+        //}
     }
 }

--- a/testproject/Assets/Tests/Runtime/Animation/AnimatorTestHelper.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/AnimatorTestHelper.cs
@@ -108,9 +108,25 @@ namespace TestProject.RuntimeTests
             return m_Animator.GetBool("TestTrigger");
         }
 
-        public void SetTrigger(string name = "TestTrigger")
+        public void SetTrigger(string name = "TestTrigger", bool monitorTrigger = false)
         {
             m_NetworkAnimator.SetTrigger(name);
+            if (monitorTrigger && IsServer)
+            {
+                StartCoroutine(TriggerMonitor(name));
+            }
+        }
+
+        private System.Collections.IEnumerator TriggerMonitor(string triggerName)
+        {
+            var triggerStatus = m_Animator.GetBool(triggerName);
+            var waitTime = new WaitForSeconds(2 * (1.0f / NetworkManager.NetworkConfig.TickRate));
+            while (triggerStatus)
+            {
+                Debug.Log($"[{triggerName}] is still triggered.");
+                yield return waitTime;
+            }
+            Debug.Log($"[{triggerName}] is no longer triggered.");
         }
 
         public void SetLateJoinParam(bool isEnabled)

--- a/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
@@ -322,6 +322,7 @@ namespace TestProject.RuntimeTests
         {
             VerboseDebug($" ++++++++++++++++++ Late Join Trigger Test [{TriggerTest.Iteration}][{ownerShipMode}] Starting ++++++++++++++++++ ");
             TriggerTest.IsVerboseDebug = m_EnableVerboseDebug;
+            CheckStateEnterCount.IsVerboseDebug = m_EnableVerboseDebug;
             AnimatorTestHelper.IsTriggerTest = m_EnableVerboseDebug;
             bool isClientOwner = ownerShipMode == OwnerShipMode.ClientOwner;
 
@@ -346,7 +347,7 @@ namespace TestProject.RuntimeTests
             else
             {
                 // Set the animation trigger via the server
-                AnimatorTestHelper.ServerSideInstance.SetTrigger();
+                AnimatorTestHelper.ServerSideInstance.SetTrigger("TestTrigger", m_EnableVerboseDebug);
             }
 
             // Wait for all triggers to fire

--- a/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
@@ -18,18 +18,25 @@ namespace TestProject.RuntimeTests
     /// Possibly we could build this at runtime, but for now it uses the same animator controller as the manual
     /// test does.
     /// </summary>
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
     public class NetworkAnimatorTests : NetcodeIntegrationTest
     {
         private const string k_AnimatorObjectName = "AnimatorObject";
         private const string k_OwnerAnimatorObjectName = "OwnerAnimatorObject";
 
-        protected override int NumberOfClients => 1;
+        protected override int NumberOfClients => 2;
         private GameObject m_AnimationTestPrefab => m_AnimatorObjectPrefab ? m_AnimatorObjectPrefab as GameObject : null;
         private GameObject m_AnimationOwnerTestPrefab => m_OwnerAnimatorObjectPrefab ? m_OwnerAnimatorObjectPrefab as GameObject : null;
 
         private AnimatorTestHelper.ParameterValues m_ParameterValues;
         private Object m_AnimatorObjectPrefab;
         private Object m_OwnerAnimatorObjectPrefab;
+
+        public NetworkAnimatorTests(HostOrServer hostOrServer)
+        {
+            m_UseHost = hostOrServer == HostOrServer.Host;
+        }
 
         protected override void OnOneTimeSetup()
         {
@@ -352,14 +359,15 @@ namespace TestProject.RuntimeTests
 
             yield return CreateAndStartNewClient();
 
-            Assert.IsTrue(m_ClientNetworkManagers.Length == 2, $"Newly created and connected client was not added to {nameof(m_ClientNetworkManagers)}!");
+            Assert.IsTrue(m_ClientNetworkManagers.Length == NumberOfClients + 1, $"Newly created and connected client was not added to {nameof(m_ClientNetworkManagers)}!");
 
             // Wait for it to spawn client-side
             yield return WaitForConditionOrTimeOut(WaitForClientsToInitialize);
             AssertOnTimeout($"Timed out waiting for the late joining client-side instance of {GetNetworkAnimatorName(authoritativeMode)} to be spawned!");
 
-            // Make sure the AnimatorTestHelper client side instances (plus host) is the same as the TotalClients
-            Assert.True((AnimatorTestHelper.ClientSideInstances.Count + 1) == TotalClients);
+            // Make sure the AnimatorTestHelper client side instances is the same as the TotalClients
+            var calculatedClients = (AnimatorTestHelper.ClientSideInstances.Count + (m_UseHost ? 1 : 0));
+            Assert.True(calculatedClients == TotalClients, $"Number of client");
 
             // Now check that the late joining client and all other clients are synchronized to the trigger
             yield return WaitForConditionOrTimeOut(() => AllTriggersDetected(ownerShipMode));
@@ -378,7 +386,7 @@ namespace TestProject.RuntimeTests
             yield return WaitForConditionOrTimeOut(() => ParameterValuesMatch(ownerShipMode, authoritativeMode, m_EnableVerboseDebug));
             AssertOnTimeout($"Timed out waiting for the client-side parameters to match {m_ParameterValues.ValuesToString()}!");
 
-            var newlyJoinedClient = m_ClientNetworkManagers[1];
+            var newlyJoinedClient = m_ClientNetworkManagers[NumberOfClients];
             yield return StopOneClient(newlyJoinedClient);
             VerboseDebug($" ------------------ Late Join Trigger Test [{TriggerTest.Iteration}][{ownerShipMode}] Stopping ------------------ ");
         }
@@ -433,16 +441,17 @@ namespace TestProject.RuntimeTests
             // Create and join a new client (late joining client)
             yield return CreateAndStartNewClient();
 
-            Assert.IsTrue(m_ClientNetworkManagers.Length == 2, $"Newly created and connected client was not added to {nameof(m_ClientNetworkManagers)}!");
+            Assert.IsTrue(m_ClientNetworkManagers.Length == NumberOfClients + 1, $"Newly created and connected client was not added to {nameof(m_ClientNetworkManagers)}!");
 
             // Wait for the client to have spawned and the spawned prefab to be instantiated
             yield return WaitForConditionOrTimeOut(WaitForClientsToInitialize);
             AssertOnTimeout($"Timed out waiting for the late joining client-side instance of {GetNetworkAnimatorName(authoritativeMode)} to be spawned!");
 
-            // Make sure the AnimatorTestHelper client side instances (plus host) is the same as the TotalClients
-            Assert.True((AnimatorTestHelper.ClientSideInstances.Count + 1) == TotalClients);
+            // Make sure the AnimatorTestHelper client side instances is the same as the TotalClients
+            var calculatedClients = (AnimatorTestHelper.ClientSideInstances.Count + (m_UseHost ? 1 : 0));
+            Assert.True(calculatedClients == TotalClients, $"Number of client");
 
-            var lateJoinObjectInstance = AnimatorTestHelper.ClientSideInstances[m_ClientNetworkManagers[1].LocalClientId];
+            var lateJoinObjectInstance = AnimatorTestHelper.ClientSideInstances[m_ClientNetworkManagers[NumberOfClients].LocalClientId];
             yield return WaitForConditionOrTimeOut(() => Mathf.Approximately(lateJoinObjectInstance.transform.rotation.eulerAngles.y, 180.0f));
             AssertOnTimeout($"[Late Join] Timed out waiting for cube to reach 180.0f!");
 
@@ -480,17 +489,17 @@ namespace TestProject.RuntimeTests
         /// </summary>
         private bool LateJoinClientSynchronized()
         {
-            if (!StateSyncTest.StatesEntered.ContainsKey(m_ClientNetworkManagers[1].LocalClientId))
+            if (!StateSyncTest.StatesEntered.ContainsKey(m_ClientNetworkManagers[NumberOfClients].LocalClientId))
             {
                 return false;
             }
 
             var serverStates = StateSyncTest.StatesEntered[m_ServerNetworkManager.LocalClientId];
-            var clientStates = StateSyncTest.StatesEntered[m_ClientNetworkManagers[1].LocalClientId];
+            var clientStates = StateSyncTest.StatesEntered[m_ClientNetworkManagers[NumberOfClients].LocalClientId];
 
             if (serverStates.Count() != clientStates.Count())
             {
-                VerboseDebug($"[Count][Server] {serverStates.Count} | [Client-{m_ClientNetworkManagers[1].LocalClientId}]{clientStates.Count}");
+                VerboseDebug($"[Count][Server] {serverStates.Count} | [Client-{m_ClientNetworkManagers[NumberOfClients].LocalClientId}]{clientStates.Count}");
                 return false;
             }
 

--- a/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
@@ -26,7 +26,7 @@ namespace TestProject.RuntimeTests
         private const string k_AnimatorObjectName = "AnimatorObject";
         private const string k_OwnerAnimatorObjectName = "OwnerAnimatorObject";
 
-        protected override int NumberOfClients => 2;
+        protected override int NumberOfClients => 3;
         private GameObject m_AnimationTestPrefab => m_AnimatorObjectPrefab ? m_AnimatorObjectPrefab as GameObject : null;
         private GameObject m_AnimationOwnerTestPrefab => m_OwnerAnimatorObjectPrefab ? m_OwnerAnimatorObjectPrefab as GameObject : null;
 
@@ -475,7 +475,7 @@ namespace TestProject.RuntimeTests
             yield return WaitForConditionOrTimeOut(LateJoinClientSynchronized);
             AssertOnTimeout("[Late Join] Timed out waiting for newly joined client to have expected state synchronized!");
 
-            var newlyJoinedClient = m_ClientNetworkManagers[1];
+            var newlyJoinedClient = m_ClientNetworkManagers[NumberOfClients];
             yield return StopOneClient(newlyJoinedClient);
             VerboseDebug($" ------------------ Late Join Synchronization Test [{TriggerTest.Iteration}][{ownerShipMode}] Stopping ------------------ ");
         }


### PR DESCRIPTION
This PR is based off of [florius0](https://github.com/florius0)'s user-submitted [PR-2115](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/2115).  This resolves the issue where if only two clients were joined the second client would not be updated when running a server and not a host.

[MTT-4384](https://jira.unity3d.com/browse/MTT-4384)
This also pertains to #2114, #2134 

## Changelog
- Fixed: issue when running a server and not host the second player would not receive updates unless a third player joined.
- Fixed: issue where late-joining client transition synchronization could fail when more than one transition was occurring.

## Testing and Documentation
- Includes integration test updates.
