### PR TITLE
chore: Update UTP dependency to 1.2.0

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,7 +10,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
-- Updated dependency on `com.unity.transport` to 1.2.0.
+- Updated dependency on `com.unity.transport` to 1.2.0. (#2129)
 - When using `UnityTransport`, _reliable_ payloads are now allowed to exceed the configured 'Max Payload Size'. Unreliable payloads remain bounded by this setting. (#2081)
 - Preformance improvements for cases with large number of NetworkObjects, by not iterating over all unchanged NetworkObjects 
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -5,12 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
+
 ## [Unreleased]
 
 ### Changed
 
+- Updated dependency on `com.unity.transport` to 1.2.0.
 - When using `UnityTransport`, _reliable_ payloads are now allowed to exceed the configured 'Max Payload Size'. Unreliable payloads remain bounded by this setting. (#2081)
-
 - Preformance improvements for cases with large number of NetworkObjects, by not iterating over all unchanged NetworkObjects 
 
 ### Fixed

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -6,6 +6,6 @@
     "unity": "2020.3",
     "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",
-        "com.unity.transport": "1.1.0"
+        "com.unity.transport": "1.2.0"
     }
 }

--- a/testproject/Packages/manifest.json
+++ b/testproject/Packages/manifest.json
@@ -15,7 +15,6 @@
     "com.unity.test-framework.performance": "2.8.0-preview",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.6.2",
-    "com.unity.transport": "1.0.0-pre.4",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",


### PR DESCRIPTION
As the title says, this updates the UTP dependency to version 1.2.0. It's mostly a bug fix release, should pose no risk to NGO.

## Changelog

- Changed: Updated dependency on `com.unity.transport` to 1.2.0.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.