### PR TITLE
chore: Bump NGO version to 1.0.1

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -7,10 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
-## [Unreleased]
+## [1.0.1] - 2022-08-23
 
 ### Changed
 
+- Changed version to 1.0.1. (#2131)
 - Updated dependency on `com.unity.transport` to 1.2.0. (#2129)
 - When using `UnityTransport`, _reliable_ payloads are now allowed to exceed the configured 'Max Payload Size'. Unreliable payloads remain bounded by this setting. (#2081)
 - Preformance improvements for cases with large number of NetworkObjects, by not iterating over all unchanged NetworkObjects 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/com.unity.netcode.testhelpers.runtime.asmdef
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/com.unity.netcode.testhelpers.runtime.asmdef
@@ -11,6 +11,9 @@
     "optionalUnityReferences": [
         "TestAssemblies"
     ],
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
     "versionDefines": [
         {
             "name": "com.unity.multiplayer.tools",

--- a/com.unity.netcode.gameobjects/Tests/Editor/com.unity.netcode.editortests.asmdef
+++ b/com.unity.netcode.gameobjects/Tests/Editor/com.unity.netcode.editortests.asmdef
@@ -15,6 +15,9 @@
     "optionalUnityReferences": [
         "TestAssemblies"
     ],
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
     "includePlatforms": [
         "Editor"
     ],

--- a/com.unity.netcode.gameobjects/Tests/Runtime/com.unity.netcode.runtimetests.asmdef
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/com.unity.netcode.runtimetests.asmdef
@@ -16,6 +16,9 @@
     "optionalUnityReferences": [
         "TestAssemblies"
     ],
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
     "versionDefines": [
         {
             "name": "com.unity.multiplayer.tools",

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -2,7 +2,7 @@
     "name": "com.unity.netcode.gameobjects",
     "displayName": "Netcode for GameObjects",
     "description": "Netcode for GameObjects is a high-level netcode SDK that provides networking capabilities to GameObject/MonoBehaviour workflows within Unity and sits on top of underlying transport layer.",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "unity": "2020.3",
     "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",

--- a/minimalproject/Packages/packages-lock.json
+++ b/minimalproject/Packages/packages-lock.json
@@ -39,7 +39,7 @@
       "source": "local",
       "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",
-        "com.unity.transport": "1.0.0"
+        "com.unity.transport": "1.2.0"
       }
     },
     "com.unity.nuget.mono-cecil": {
@@ -61,7 +61,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.transport": {
-      "version": "1.0.0",
+      "version": "1.2.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/testproject-tools-integration/Packages/packages-lock.json
+++ b/testproject-tools-integration/Packages/packages-lock.json
@@ -61,7 +61,7 @@
       "source": "local",
       "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",
-        "com.unity.transport": "1.0.0"
+        "com.unity.transport": "1.2.0"
       }
     },
     "com.unity.nuget.mono-cecil": {
@@ -107,7 +107,7 @@
       "url": "https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-candidates"
     },
     "com.unity.transport": {
-      "version": "1.0.0",
+      "version": "1.2.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/testproject/Packages/packages-lock.json
+++ b/testproject/Packages/packages-lock.json
@@ -83,7 +83,7 @@
       "source": "local",
       "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",
-        "com.unity.transport": "1.1.0"
+        "com.unity.transport": "1.2.0"
       }
     },
     "com.unity.nuget.mono-cecil": {
@@ -195,7 +195,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.transport": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
Bump NGO version to 1.0.1. 
Update test project package-lock.json to use `com.unity.transport` 1.2.0

## Changelog

- Changed: Changed version to 1.0.1. (#2131)

## Testing and Documentation

- CI and Package validation. Will run APV on Unity PRs after publish. 
- BossRoom Playtest
- API docs will be updated by Docs after we promote the package.
