### PR TITLE
chore: Fix build test

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Editor/Build/BuildTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Build/BuildTests.cs
@@ -4,7 +4,6 @@ using NUnit.Framework;
 using UnityEditor;
 using UnityEditor.Build.Reporting;
 using UnityEngine;
-using UnityEngine.TestTools;
 
 namespace Unity.Netcode.EditorTests
 {
@@ -21,20 +20,20 @@ namespace Unity.Netcode.EditorTests
             var buildTargetGroup = BuildPipeline.GetBuildTargetGroup(buildTarget);
             var buildTargetSupported = BuildPipeline.IsBuildTargetSupported(buildTargetGroup, buildTarget);
 
-            var buildReport = BuildPipeline.BuildPlayer(
-                new[] { Path.Combine(packagePath, DefaultBuildScenePath) },
-                Path.Combine(Path.GetDirectoryName(Application.dataPath), "Builds", nameof(BuildTests)),
-                buildTarget,
-                BuildOptions.None
-            );
-
             if (buildTargetSupported)
             {
+                var buildReport = BuildPipeline.BuildPlayer(
+                    new[] { Path.Combine(packagePath, DefaultBuildScenePath) },
+                    Path.Combine(Path.GetDirectoryName(Application.dataPath), "Builds", nameof(BuildTests)),
+                    buildTarget,
+                    BuildOptions.None
+                );
+
                 Assert.AreEqual(BuildResult.Succeeded, buildReport.summary.result);
             }
             else
             {
-                LogAssert.Expect(LogType.Error, "Error building player because build target was unsupported");
+                Debug.Log($"Skipped building player due to Unsupported Build Target");
             }
         }
     }


### PR DESCRIPTION
Build test used to throw an error `LogAssert.Expect(LogType.Error, "Error building player because build target was unsupported");` when platform supports are not installed. This error is expected and correct, but it causes UTR to mark the entire suite as Failed on 2021.3 and 2020.3.

So, change the test slightly to build only if `buildTargetSupported` 

https://jira.unity3d.com/browse/MTT-4059

## Changelog

- None

## Testing and Documentation

- CI