### PR TITLE
fix: prevent exception in Boss Room with NetworkAnimator 

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
@@ -79,7 +79,7 @@ namespace Unity.Netcode
         public virtual void SetDirty(bool isDirty)
         {
             m_IsDirty = isDirty;
-            if (m_IsDirty)
+            if (m_IsDirty && m_NetworkBehaviour != null)
             {
                 m_NetworkBehaviour.NetworkManager.MarkNetworkObjectDirty(m_NetworkBehaviour.NetworkObject);
             }


### PR DESCRIPTION
Prevents an exception in Boss Room with NetworkAnimator due to `m_NetworkBehaviour` being null

Following a previous change for performance, a null exception is raised in Boss Room. This works around it.