### PR TITLE
fix: TransformInterpolationTests Threshold Adjustment

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Runtime/TransformInterpolationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TransformInterpolationTests.cs
@@ -11,7 +11,7 @@ namespace Unity.Netcode.RuntimeTests
     public class TransformInterpolationObject : NetworkBehaviour
     {
         // Set the minimum threshold which we will use as our margin of error
-        public const float MinThreshold = 0.001f;
+        public const float MinThreshold = 0.005f;
 
         public bool CheckPosition;
         public bool IsMoving;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TransformInterpolationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TransformInterpolationTests.cs
@@ -24,7 +24,7 @@ namespace Unity.Netcode.RuntimeTests
             {
                 if (transform.position.y < -MinThreshold || transform.position.y > 100.0f + MinThreshold)
                 {
-                    Debug.LogError($"Interpolation failure. transform.position.y is {transform.position.y}. Should be between 0.0 and 100.0");
+                    Debug.LogError($"Interpolation failure. transform.position.y is {transform.position.y}. Should be between 0.0 and 100.0. Current threshold is [+/- {MinThreshold}].");
                 }
             }
 


### PR DESCRIPTION
This adjusts the threshold for the interpolation test slightly higher for console tests.

## Testing and Documentation
- Includes integration tests adjustments.
