### PR TITLE
fix: #2147. Removing extra warning on despawning NetworkObjects with dirty NetworkVariables

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -509,6 +509,7 @@ namespace Unity.Netcode
         /// <param name="destroy">(true) the <see cref="GameObject"/> will be destroyed (false) the <see cref="GameObject"/> will persist after being despawned</param>
         public void Despawn(bool destroy = true)
         {
+            MarkVariablesDirty(false);
             NetworkManager.SpawnManager.DespawnObject(this, destroy);
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
@@ -81,15 +81,14 @@ namespace Unity.Netcode
         {
             m_IsDirty = isDirty;
 
-            if (m_NetworkBehaviour == null)
-            {
-                Debug.LogWarning($"NetworkVariable is written to, but doesn't know its NetworkBehaviour yet. " +
-                                 "Are you modifying a NetworkVariable before the NetworkObject is spawned?");
-                return;
-            }
-
             if (m_IsDirty)
             {
+                if (m_NetworkBehaviour == null)
+                {
+                    Debug.LogWarning($"NetworkVariable is written to, but doesn't know its NetworkBehaviour yet. " +
+                                     "Are you modifying a NetworkVariable before the NetworkObject is spawned?");
+                    return;
+                }
                 m_NetworkBehaviour.NetworkManager.MarkNetworkObjectDirty(m_NetworkBehaviour.NetworkObject);
             }
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
@@ -17,6 +17,7 @@ namespace Unity.Netcode.RuntimeTests
     {
         public static List<ShowHideObject> ClientTargetedNetworkObjects = new List<ShowHideObject>();
         public static ulong ClientIdToTarget;
+        public static bool Silent;
 
         public static NetworkObject GetNetworkObjectById(ulong networkObjectId)
         {
@@ -58,7 +59,10 @@ namespace Unity.Netcode.RuntimeTests
 
         public void Changed(int before, int after)
         {
-            Debug.Log($"Value changed from {before} to {after}");
+            if (!Silent)
+            {
+                Debug.Log($"Value changed from {before} to {after}");
+            }
         }
     }
 
@@ -263,6 +267,30 @@ namespace Unity.Netcode.RuntimeTests
                 // verify they become visible
                 yield return CheckVisible(true);
             }
+        }
+
+        [UnityTest]
+        public IEnumerator NetworkHideDespawnTest()
+        {
+            m_ClientId0 = m_ClientNetworkManagers[0].LocalClientId;
+            ShowHideObject.ClientTargetedNetworkObjects.Clear();
+            ShowHideObject.ClientIdToTarget = m_ClientId0;
+            ShowHideObject.Silent = true;
+
+            var spawnedObject1 = SpawnObject(m_PrefabToSpawn, m_ServerNetworkManager);
+            var spawnedObject2 = SpawnObject(m_PrefabToSpawn, m_ServerNetworkManager);
+            var spawnedObject3 = SpawnObject(m_PrefabToSpawn, m_ServerNetworkManager);
+            m_NetSpawnedObject1 = spawnedObject1.GetComponent<NetworkObject>();
+            m_NetSpawnedObject2 = spawnedObject2.GetComponent<NetworkObject>();
+            m_NetSpawnedObject3 = spawnedObject3.GetComponent<NetworkObject>();
+
+            m_NetSpawnedObject1.GetComponent<ShowHideObject>().MyNetworkVariable.Value++;
+            m_NetSpawnedObject1.NetworkHide(m_ClientId0);
+            m_NetSpawnedObject1.Despawn();
+
+            yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ServerNetworkManager, 5);
+
+            LogAssert.NoUnexpectedReceived();
         }
     }
 }


### PR DESCRIPTION
MTT-4464 follow-up