### PR TITLE
fix: Delete stray NetworkAnimator.meta file [MTT-4024]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -13,6 +13,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 - Fixed RPC codegen failing to choose the correct extension methods for FastBufferReader and FastBufferWriter when the parameters were a generic type (i.e., List<int>) and extensions for multiple instantiations of that type have been defined (i.e., List<int> and List<string>) (#2142)
 - Fixed throwing an exception in OnNetworkUpdate causing other OnNetworkUpdate calls to not be executed. (#1739)
+- Fixed warning resulting from a stray NetworkAnimator.meta file (#2153)
 
 ## [1.0.1] - 2022-08-23
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkAnimator.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 3acde7838205d4b09ae3a035554c51c5
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
NetworkAnimator tests were removed from Tests/Runtime folder as part of MTT-4024 and it looks like the NetworkAnimator.meta file was leftover. Delete this file to get rid of the warning in the console.

## Changelog

- Fixed: Fix warning resulting from a stray NetworkAnimator.meta file.

## Testing and Documentation

- No tests have been added.
