### PR TITLE
fix: Adds a null check for NetworkObjectReference => GameObject conversion [NCCBUG-172]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Fixed
 
 - Fixed RPC codegen failing to choose the correct extension methods for FastBufferReader and FastBufferWriter when the parameters were a generic type (i.e., List<int>) and extensions for multiple instantiations of that type have been defined (i.e., List<int> and List<string>) (#2142)
+- Implicit conversion of NetworkObjectReference to GameObject will now return null instead of throwing an exception if the referenced object could not be found (i.e., was already despawned)
 
 ## [1.0.1] - 2022-08-23
 

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/NetworkObjectReference.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/NetworkObjectReference.cs
@@ -139,7 +139,7 @@ namespace Unity.Netcode
         /// </summary>
         /// <param name="networkObjectRef">The <see cref="NetworkObjectReference"/> to convert from.</param>
         /// <returns>This returns the <see cref="GameObject"/> that the <see cref="NetworkObject"/> is attached to and is referenced by the <see cref="NetworkObjectReference"/> passed in as a parameter</returns>
-        public static implicit operator GameObject(NetworkObjectReference networkObjectRef) => Resolve(networkObjectRef).gameObject;
+        public static implicit operator GameObject(NetworkObjectReference networkObjectRef) => Resolve(networkObjectRef)?.gameObject;
 
         /// <summary>
         /// Implicitly convert <see cref="GameObject"/> to <see cref="NetworkObject"/>.

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/NetworkObjectReference.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/NetworkObjectReference.cs
@@ -139,7 +139,16 @@ namespace Unity.Netcode
         /// </summary>
         /// <param name="networkObjectRef">The <see cref="NetworkObjectReference"/> to convert from.</param>
         /// <returns>This returns the <see cref="GameObject"/> that the <see cref="NetworkObject"/> is attached to and is referenced by the <see cref="NetworkObjectReference"/> passed in as a parameter</returns>
-        public static implicit operator GameObject(NetworkObjectReference networkObjectRef) => Resolve(networkObjectRef)?.gameObject;
+        public static implicit operator GameObject(NetworkObjectReference networkObjectRef)
+        {
+            var networkObject = Resolve(networkObjectRef);
+            if (networkObject != null)
+            {
+                return networkObject.gameObject;
+            }
+
+            return null;
+        }
 
         /// <summary>
         /// Implicitly convert <see cref="GameObject"/> to <see cref="NetworkObject"/>.

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/NetworkObjectReferenceTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/NetworkObjectReferenceTests.cs
@@ -25,12 +25,9 @@ namespace Unity.Netcode.RuntimeTests
 
             public GameObject RpcReceivedGameObject;
 
-            public bool ReceivedRpc;
-
             [ServerRpc]
             public void SendReferenceServerRpc(NetworkObjectReference value)
             {
-                ReceivedRpc = true;
                 RpcReceivedGameObject = value;
                 RpcReceivedNetworkObject = value;
             }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/NetworkObjectReferenceTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/NetworkObjectReferenceTests.cs
@@ -118,7 +118,7 @@ namespace Unity.Netcode.RuntimeTests
         {
             using var networkObjectContext = UnityObjectContext.CreateNetworkObject();
             networkObjectContext.Object.Spawn();
-            
+
             var outWriter = new FastBufferWriter(1300, Allocator.Temp);
             try
             {
@@ -126,9 +126,9 @@ namespace Unity.Netcode.RuntimeTests
                 var outSerializer = new BufferSerializer<BufferSerializerWriter>(new BufferSerializerWriter(outWriter));
                 NetworkObjectReference outReference = networkObjectContext.Object.gameObject;
                 outReference.NetworkSerialize(outSerializer);
-                
+
                 networkObjectContext.Object.Despawn();
-                GameObject.DestroyImmediate(networkObjectContext.Object.gameObject);
+                Object.DestroyImmediate(networkObjectContext.Object.gameObject);
 
                 // deserialize
                 NetworkObjectReference inReference = default;


### PR DESCRIPTION
## Changelog

- Fixed: Implicit conversion of NetworkObjectReference to GameObject will now return null instead of throwing an exception if the referenced object could not be found (i.e., was already despawned)

## Testing and Documentation

- Includes integration tests.
- No documentation changes or additions were necessary.
