### PR TITLE
fix: Fixed ConnectionApprovalTimeout not working on the client side [MTT-3451]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -15,6 +15,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed RPC codegen failing to choose the correct extension methods for FastBufferReader and FastBufferWriter when the parameters were a generic type (i.e., List<int>) and extensions for multiple instantiations of that type have been defined (i.e., List<int> and List<string>) (#2142)
 - Fixed throwing an exception in OnNetworkUpdate causing other OnNetworkUpdate calls to not be executed. (#1739)
 - Fixed warning resulting from a stray NetworkAnimator.meta file (#2153)
+- Fixed Connection Approval Timeout not working client side. (#2164)
 
 ## [1.0.1] - 2022-08-23
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1623,23 +1623,56 @@ namespace Unity.Netcode
 
         private IEnumerator ApprovalTimeout(ulong clientId)
         {
-            NetworkTime timeStarted = LocalTime;
-
-            //We yield every frame incase a pending client disconnects and someone else gets its connection id
-            while ((LocalTime - timeStarted).Time < NetworkConfig.ClientConnectionBufferTimeout && PendingClients.ContainsKey(clientId))
+            if (IsServer)
             {
-                yield return null;
-            }
+                NetworkTime timeStarted = LocalTime;
 
-            if (PendingClients.ContainsKey(clientId) && !ConnectedClients.ContainsKey(clientId))
-            {
-                // Timeout
-                if (NetworkLog.CurrentLogLevel <= LogLevel.Developer)
+                //We yield every frame incase a pending client disconnects and someone else gets its connection id
+                while (IsListening && (LocalTime - timeStarted).Time < NetworkConfig.ClientConnectionBufferTimeout && PendingClients.ContainsKey(clientId))
                 {
-                    NetworkLog.LogInfo($"Client {clientId} Handshake Timed Out");
+                    yield return null;
                 }
 
-                DisconnectClient(clientId);
+                if (!IsListening)
+                {
+                    yield break;
+                }
+
+                if (PendingClients.ContainsKey(clientId) && !ConnectedClients.ContainsKey(clientId))
+                {
+                    // Timeout
+                    if (NetworkLog.CurrentLogLevel <= LogLevel.Developer)
+                    {
+                        NetworkLog.LogInfo($"Client {clientId} Handshake Timed Out");
+                    }
+
+                    DisconnectClient(clientId);
+                }
+            }
+            else
+            {
+                float timeStarted = Time.realtimeSinceStartup;
+
+                //We yield every frame incase a pending client disconnects and someone else gets its connection id
+                while (IsListening && (Time.realtimeSinceStartup - timeStarted) < NetworkConfig.ClientConnectionBufferTimeout && !IsConnectedClient)
+                {
+                    yield return null;
+                }
+
+                if (!IsListening)
+                {
+                    yield break;
+                }
+
+                if (!IsConnectedClient)
+                {
+                    // Timeout
+                    if (NetworkLog.CurrentLogLevel <= LogLevel.Developer)
+                    {
+                        NetworkLog.LogInfo("Server Handshake Timed Out");
+                    }
+                    Shutdown(true);
+                }
             }
         }
 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -25,7 +25,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         protected static TimeoutHelper s_GlobalTimeoutHelper = new TimeoutHelper(8.0f);
         protected static WaitForSeconds s_DefaultWaitForTick = new WaitForSeconds(1.0f / k_DefaultTickRate);
 
-        protected NetcodeLogAssert NetcodeLogAssert;
+        public NetcodeLogAssert NetcodeLogAssert;
 
         /// <summary>
         /// Registered list of all NetworkObjects spawned.

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 using System.Runtime.CompilerServices;
-
+using Unity.Netcode.RuntimeTests;
 using Object = UnityEngine.Object;
 
 namespace Unity.Netcode.TestHelpers.Runtime
@@ -24,6 +24,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
         internal static bool IsRunning { get; private set; }
         protected static TimeoutHelper s_GlobalTimeoutHelper = new TimeoutHelper(8.0f);
         protected static WaitForSeconds s_DefaultWaitForTick = new WaitForSeconds(1.0f / k_DefaultTickRate);
+
+        protected NetcodeLogAssert NetcodeLogAssert;
 
         /// <summary>
         /// Registered list of all NetworkObjects spawned.
@@ -207,6 +209,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         {
             VerboseDebug($"Entering {nameof(SetUp)}");
 
+            NetcodeLogAssert = new NetcodeLogAssert();
             yield return OnSetup();
             if (m_NetworkManagerInstatiationMode == NetworkManagerInstatiationMode.AllTests && m_ServerNetworkManager == null ||
                 m_NetworkManagerInstatiationMode == NetworkManagerInstatiationMode.PerTest)
@@ -596,6 +599,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             }
 
             VerboseDebug($"Exiting {nameof(TearDown)}");
+            NetcodeLogAssert.Dispose();
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeLogAssert.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeLogAssert.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    public class NetcodeLogAssert
+    {
+        private struct LogData
+        {
+            public LogType LogType;
+            public string Message;
+            public string StackTrace;
+        }
+
+        private readonly object m_Lock = new object();
+        private bool m_Disposed;
+
+        private List<LogData> AllLogs { get; }
+
+        public NetcodeLogAssert()
+        {
+            AllLogs = new List<LogData>();
+            Activate();
+        }
+
+        private void Activate()
+        {
+            Application.logMessageReceivedThreaded += AddLog;
+        }
+
+        private void Deactivate()
+        {
+            Application.logMessageReceivedThreaded -= AddLog;
+        }
+
+        public void AddLog(string message, string stacktrace, LogType type)
+        {
+            lock (m_Lock)
+            {
+                var log = new LogData
+                {
+                    LogType = type,
+                    Message = message,
+                    StackTrace = stacktrace,
+                };
+
+                AllLogs.Add(log);
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (m_Disposed)
+            {
+                return;
+            }
+
+            m_Disposed = true;
+
+            if (disposing)
+            {
+                Deactivate();
+            }
+        }
+
+        public void LogWasNotReceived(LogType type, string message)
+        {
+            lock (m_Lock)
+            {
+                foreach (var logEvent in AllLogs)
+                {
+                    if (logEvent.LogType == type && message.Equals(logEvent.Message))
+                    {
+                        Assert.Fail($"Unexpected log: [{logEvent.LogType}] {logEvent.Message}");
+                    }
+                }
+            }
+        }
+
+        public void LogWasNotReceived(LogType type, Regex messageRegex)
+        {
+            lock (m_Lock)
+            {
+                foreach (var logEvent in AllLogs)
+                {
+                    if (logEvent.LogType == type && messageRegex.IsMatch(logEvent.Message))
+                    {
+                        Assert.Fail($"Unexpected log: [{logEvent.LogType}] {logEvent.Message}");
+                    }
+                }
+            }
+        }
+
+        public void LogWasReceived(LogType type, string message)
+        {
+            lock (m_Lock)
+            {
+                var found = false;
+                foreach (var logEvent in AllLogs)
+                {
+                    if (logEvent.LogType == type && message.Equals(logEvent.Message))
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found)
+                {
+                    Assert.Fail($"Expected log was not received: [{type}] {message}");
+                }
+            }
+        }
+
+        public void LogWasReceived(LogType type, Regex messageRegex)
+        {
+            lock (m_Lock)
+            {
+                var found = false;
+                foreach (var logEvent in AllLogs)
+                {
+                    if (logEvent.LogType == type && messageRegex.IsMatch(logEvent.Message))
+                    {
+                        found = true;
+                    }
+                }
+
+                if (!found)
+                {
+                    Assert.Fail($"Expected log was not received: [{type}] {messageRegex}");
+                }
+            }
+        }
+
+        public void Reset()
+        {
+            lock (m_Lock)
+            {
+                AllLogs.Clear();
+            }
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeLogAssert.cs.meta
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeLogAssert.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 61774c54cd14423ca4de6d56c9fd0fe8
+timeCreated: 1661800793

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApprovalTimeoutTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApprovalTimeoutTests.cs
@@ -1,0 +1,104 @@
+using System.Collections;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    [TestFixture(true)]
+    [TestFixture(false)]
+    public class ConnectionApprovalTimeoutTests : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 1;
+
+        protected override bool CanStartServerAndClients() => false;
+
+        private bool m_UseSceneManagement;
+        public ConnectionApprovalTimeoutTests(bool useSceneManagement)
+        {
+            m_UseSceneManagement = useSceneManagement;
+        }
+
+        // Must be >= 2 since this is an int value and the test waits for timeout - 1 to try to verify it doesn't
+        // time out early
+        private const int k_TestTimeoutPeriod = 2;
+
+        private void Start()
+        {
+            m_ServerNetworkManager.NetworkConfig.EnableSceneManagement = m_UseSceneManagement;
+            m_ClientNetworkManagers[0].NetworkConfig.EnableSceneManagement = m_UseSceneManagement;
+            if (!NetcodeIntegrationTestHelpers.Start(false, m_ServerNetworkManager, m_ClientNetworkManagers))
+            {
+                Debug.LogError("Failed to start instances");
+                Assert.Fail("Failed to start instances");
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator WhenClientDoesntRequestApproval_ServerTimesOut()
+        {
+            Start();
+            var hook = new MessageCatcher<ConnectionRequestMessage>(m_ServerNetworkManager);
+            m_ServerNetworkManager.MessagingSystem.Hook(hook); ;
+
+            m_ServerNetworkManager.NetworkConfig.ClientConnectionBufferTimeout = k_TestTimeoutPeriod;
+            m_ServerNetworkManager.LogLevel = LogLevel.Developer;
+            m_ClientNetworkManagers[0].LogLevel = LogLevel.Developer;
+
+            yield return new WaitForSeconds(m_ServerNetworkManager.NetworkConfig.ClientConnectionBufferTimeout - 1);
+
+            Assert.AreEqual(0, m_ServerNetworkManager.ConnectedClients.Count);
+            Assert.AreEqual(1, m_ServerNetworkManager.PendingClients.Count);
+
+            var expectedLogMessage = new Regex($"Client {m_ServerNetworkManager.PendingClients.FirstOrDefault().Key} Handshake Timed Out");
+
+            NetcodeLogAssert.LogWasNotReceived(LogType.Log, expectedLogMessage);
+
+            yield return new WaitForSeconds(2);
+
+            NetcodeLogAssert.LogWasReceived(LogType.Log, expectedLogMessage);
+
+            Assert.AreEqual(0, m_ServerNetworkManager.ConnectedClients.Count);
+            Assert.AreEqual(0, m_ServerNetworkManager.PendingClients.Count);
+        }
+
+        [UnityTest]
+        public IEnumerator WhenServerDoesntRespondWithApproval_ClientTimesOut()
+        {
+            Start();
+
+            if (m_UseSceneManagement)
+            {
+                var sceneEventHook = new MessageCatcher<SceneEventMessage>(m_ClientNetworkManagers[0]);
+                m_ClientNetworkManagers[0].MessagingSystem.Hook(sceneEventHook);
+            }
+            else
+            {
+                var approvalHook = new MessageCatcher<ConnectionApprovedMessage>(m_ClientNetworkManagers[0]);
+                m_ClientNetworkManagers[0].MessagingSystem.Hook(approvalHook);
+            }
+
+            m_ClientNetworkManagers[0].NetworkConfig.ClientConnectionBufferTimeout = k_TestTimeoutPeriod;
+            m_ServerNetworkManager.LogLevel = LogLevel.Developer;
+            m_ClientNetworkManagers[0].LogLevel = LogLevel.Developer;
+
+            yield return new WaitForSeconds(m_ClientNetworkManagers[0].NetworkConfig.ClientConnectionBufferTimeout - 1);
+
+            Assert.IsFalse(m_ClientNetworkManagers[0].IsConnectedClient);
+            Assert.IsTrue(m_ClientNetworkManagers[0].IsListening);
+
+            var expectedLogMessage = new Regex("Server Handshake Timed Out");
+            NetcodeLogAssert.LogWasNotReceived(LogType.Log, expectedLogMessage);
+
+            yield return new WaitForSeconds(2);
+
+            NetcodeLogAssert.LogWasReceived(LogType.Log, expectedLogMessage);
+
+            Assert.IsFalse(m_ClientNetworkManagers[0].IsConnectedClient);
+            Assert.IsFalse(m_ClientNetworkManagers[0].IsListening);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApprovalTimeoutTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApprovalTimeoutTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b0c4159ea234415fa9497860e6ef4fc2
+timeCreated: 1661796642

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1f398e1797944b5db4d3aa473629f46e
+timeCreated: 1661800773

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/MessageCatcher.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/MessageCatcher.cs
@@ -21,19 +21,19 @@ namespace Unity.Netcode.RuntimeTests
             public float Timestamp;
             public int SerializedHeaderSize;
         }
-        private readonly List<TriggerData> CaughtMessages = new List<TriggerData>();
+        private readonly List<TriggerData> m_CaughtMessages = new List<TriggerData>();
 
         public void ReleaseMessages()
         {
 
-            foreach (var caughtSpawn in CaughtMessages)
+            foreach (var caughtSpawn in m_CaughtMessages)
             {
                 // Reader will be disposed within HandleMessage
                 m_OwnerNetworkManager.MessagingSystem.HandleMessage(caughtSpawn.Header, caughtSpawn.Reader, caughtSpawn.SenderId, caughtSpawn.Timestamp, caughtSpawn.SerializedHeaderSize);
             }
         }
 
-        public int CaughtMessageCount => CaughtMessages.Count;
+        public int CaughtMessageCount => m_CaughtMessages.Count;
 
         public void OnBeforeSendMessage<T>(ulong clientId, ref T message, NetworkDelivery delivery) where T : INetworkMessage
         {
@@ -76,7 +76,7 @@ namespace Unity.Netcode.RuntimeTests
         {
             if (messageType == typeof(TMessageType))
             {
-                CaughtMessages.Add(new TriggerData
+                m_CaughtMessages.Add(new TriggerData
                 {
                     Reader = new FastBufferReader(messageContent, Allocator.Persistent),
                     Header = context.Header,

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/MessageCatcher.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/MessageCatcher.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using Unity.Collections;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    internal class MessageCatcher<TMessageType> : INetworkHooks where TMessageType : INetworkMessage
+    {
+        private NetworkManager m_OwnerNetworkManager;
+
+        public MessageCatcher(NetworkManager ownerNetworkManager)
+        {
+            m_OwnerNetworkManager = ownerNetworkManager;
+        }
+
+        private struct TriggerData
+        {
+            public FastBufferReader Reader;
+            public MessageHeader Header;
+            public ulong SenderId;
+            public float Timestamp;
+            public int SerializedHeaderSize;
+        }
+        private readonly List<TriggerData> CaughtMessages = new List<TriggerData>();
+
+        public void ReleaseMessages()
+        {
+
+            foreach (var caughtSpawn in CaughtMessages)
+            {
+                // Reader will be disposed within HandleMessage
+                m_OwnerNetworkManager.MessagingSystem.HandleMessage(caughtSpawn.Header, caughtSpawn.Reader, caughtSpawn.SenderId, caughtSpawn.Timestamp, caughtSpawn.SerializedHeaderSize);
+            }
+        }
+
+        public int CaughtMessageCount => CaughtMessages.Count;
+
+        public void OnBeforeSendMessage<T>(ulong clientId, ref T message, NetworkDelivery delivery) where T : INetworkMessage
+        {
+        }
+
+        public void OnAfterSendMessage<T>(ulong clientId, ref T message, NetworkDelivery delivery, int messageSizeBytes) where T : INetworkMessage
+        {
+        }
+
+        public void OnBeforeReceiveMessage(ulong senderId, Type messageType, int messageSizeBytes)
+        {
+        }
+
+        public void OnAfterReceiveMessage(ulong senderId, Type messageType, int messageSizeBytes)
+        {
+        }
+
+        public void OnBeforeSendBatch(ulong clientId, int messageCount, int batchSizeInBytes, NetworkDelivery delivery)
+        {
+        }
+
+        public void OnAfterSendBatch(ulong clientId, int messageCount, int batchSizeInBytes, NetworkDelivery delivery)
+        {
+        }
+
+        public void OnBeforeReceiveBatch(ulong senderId, int messageCount, int batchSizeInBytes)
+        {
+        }
+
+        public void OnAfterReceiveBatch(ulong senderId, int messageCount, int batchSizeInBytes)
+        {
+        }
+
+        public bool OnVerifyCanSend(ulong destinationId, Type messageType, NetworkDelivery delivery)
+        {
+            return true;
+        }
+
+        public bool OnVerifyCanReceive(ulong senderId, Type messageType, FastBufferReader messageContent, ref NetworkContext context)
+        {
+            if (messageType == typeof(TMessageType))
+            {
+                CaughtMessages.Add(new TriggerData
+                {
+                    Reader = new FastBufferReader(messageContent, Allocator.Persistent),
+                    Header = context.Header,
+                    Timestamp = context.Timestamp,
+                    SenderId = context.SenderId,
+                    SerializedHeaderSize = context.SerializedHeaderSize
+                });
+                return false;
+            }
+
+            return true;
+        }
+
+        public void OnBeforeHandleMessage<T>(ref T message, ref NetworkContext context) where T : INetworkMessage
+        {
+        }
+
+        public void OnAfterHandleMessage<T>(ref T message, ref NetworkContext context) where T : INetworkMessage
+        {
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/MessageCatcher.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/MessageCatcher.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f008d074bcb841ae90b1949f9e2f0854
+timeCreated: 1661796973

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/MessageLogger.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/MessageLogger.cs
@@ -1,0 +1,69 @@
+using System;
+using UnityEngine;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    internal class MessageLogger : INetworkHooks
+    {
+        private NetworkManager m_OwningNetworkManager;
+        public MessageLogger(NetworkManager owningNetworkManager)
+        {
+            m_OwningNetworkManager = owningNetworkManager;
+        }
+
+        public void OnBeforeSendMessage<T>(ulong clientId, ref T message, NetworkDelivery delivery) where T : INetworkMessage
+        {
+            Debug.Log($"{(m_OwningNetworkManager.IsServer ? "Server" : "Client")} {m_OwningNetworkManager.LocalClientId}: Sending {message.GetType().FullName} to {clientId} with {delivery}");
+        }
+
+        public void OnAfterSendMessage<T>(ulong clientId, ref T message, NetworkDelivery delivery, int messageSizeBytes) where T : INetworkMessage
+        {
+        }
+
+        public void OnBeforeReceiveMessage(ulong senderId, Type messageType, int messageSizeBytes)
+        {
+            Debug.Log($"{(m_OwningNetworkManager.IsServer ? "Server" : "Client")} {m_OwningNetworkManager.LocalClientId}: Receiving {messageType.FullName} from {senderId}");
+        }
+
+        public void OnAfterReceiveMessage(ulong senderId, Type messageType, int messageSizeBytes)
+        {
+        }
+
+        public void OnBeforeSendBatch(ulong clientId, int messageCount, int batchSizeInBytes, NetworkDelivery delivery)
+        {
+            Debug.Log($"{(m_OwningNetworkManager.IsServer ? "Server" : "Client")} {m_OwningNetworkManager.LocalClientId}: Sending a batch of to {clientId}: {messageCount} messages, {batchSizeInBytes} bytes, with {delivery}");
+        }
+
+        public void OnAfterSendBatch(ulong clientId, int messageCount, int batchSizeInBytes, NetworkDelivery delivery)
+        {
+        }
+
+        public void OnBeforeReceiveBatch(ulong senderId, int messageCount, int batchSizeInBytes)
+        {
+            Debug.Log($"{(m_OwningNetworkManager.IsServer ? "Server" : "Client")} {m_OwningNetworkManager.LocalClientId}: Received a batch from {senderId}, {messageCount} messages, {batchSizeInBytes} bytes");
+        }
+
+        public void OnAfterReceiveBatch(ulong senderId, int messageCount, int batchSizeInBytes)
+        {
+        }
+
+        public bool OnVerifyCanSend(ulong destinationId, Type messageType, NetworkDelivery delivery)
+        {
+            return true;
+        }
+
+        public bool OnVerifyCanReceive(ulong senderId, Type messageType, FastBufferReader messageContent, ref NetworkContext context)
+        {
+            return true;
+        }
+
+        public void OnBeforeHandleMessage<T>(ref T message, ref NetworkContext context) where T : INetworkMessage
+        {
+            Debug.Log($"{(m_OwningNetworkManager.IsServer ? "Server" : "Client")} {m_OwningNetworkManager.LocalClientId}: Handling message {message.GetType().FullName}");
+        }
+
+        public void OnAfterHandleMessage<T>(ref T message, ref NetworkContext context) where T : INetworkMessage
+        {
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/MessageLogger.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/MessageLogger.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4dbf404fdf544a409bf1bcab2c3f8b3e
+timeCreated: 1661799489


### PR DESCRIPTION

fixes #1928 

## Changelog

- Fixed: Fixed Connection Approval Timeout not working client side.

## Testing and Documentation

- Includes integration tests.
- No documentation changes or additions were necessary.
