### PR TITLE
perf: Improve testproject DrawRay.cs performance

### DIFF
--- a/testproject/Assets/Scripts/DrawRay.cs
+++ b/testproject/Assets/Scripts/DrawRay.cs
@@ -3,23 +3,26 @@ using UnityEngine;
 [RequireComponent(typeof(LineRenderer))]
 public class DrawRay : MonoBehaviour
 {
+    private const float RayLength = 10;
+    
+    private Transform m_Transform;
     private LineRenderer m_LineRenderer;
 
     private void Awake()
     {
-        m_LineRenderer = GetComponent<LineRenderer>();
+        TryGetComponent(out m_Transform);
+        TryGetComponent(out m_LineRenderer);
         m_LineRenderer.SetPosition(0, transform.position);
     }
 
     private void FixedUpdate()
     {
-        if (Physics.Raycast(new Ray(transform.position, transform.forward * 10), out RaycastHit hit, 10, Physics.DefaultRaycastLayers))
-        {
-            m_LineRenderer.SetPosition(1, hit.point);
-        }
-        else
-        {
-            m_LineRenderer.SetPosition(1, transform.position + transform.forward * 10);
-        }
+        var ray = new Ray(m_Transform.position, m_Transform.forward * RayLength);
+
+        var point = Physics.Raycast(ray, out var hit, RayLength, Physics.DefaultRaycastLayers)
+            ? hit.point
+            : m_Transform.position + m_Transform.forward * RayLength;
+
+        m_LineRenderer.SetPosition(1, point);
     }
 }

--- a/testproject/Assets/Scripts/DrawRay.cs
+++ b/testproject/Assets/Scripts/DrawRay.cs
@@ -3,8 +3,8 @@ using UnityEngine;
 [RequireComponent(typeof(LineRenderer))]
 public class DrawRay : MonoBehaviour
 {
-    private const float RayLength = 10;
-    
+    private const float k_RayLength = 10;
+
     private Transform m_Transform;
     private LineRenderer m_LineRenderer;
 
@@ -17,11 +17,11 @@ public class DrawRay : MonoBehaviour
 
     private void FixedUpdate()
     {
-        var ray = new Ray(m_Transform.position, m_Transform.forward * RayLength);
+        var ray = new Ray(m_Transform.position, m_Transform.forward * k_RayLength);
 
-        var point = Physics.Raycast(ray, out var hit, RayLength, Physics.DefaultRaycastLayers)
+        var point = Physics.Raycast(ray, out var hit, k_RayLength, Physics.DefaultRaycastLayers)
             ? hit.point
-            : m_Transform.position + m_Transform.forward * RayLength;
+            : m_Transform.position + m_Transform.forward * k_RayLength;
 
         m_LineRenderer.SetPosition(1, point);
     }


### PR DESCRIPTION
Achieves a more readable and GC friendly DrawRay debug code through caching the gameobject transform, reducing the amount of getTransform() engine calls.

Internal copy of #2165 for CI run
closes #2165 