### PR TITLE
fix: preventing exception from NetworkList, when modified before spawn.

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Unity.Collections;
+using UnityEngine;
 
 namespace Unity.Netcode
 {
@@ -65,6 +66,13 @@ namespace Unity.Netcode
 
         internal void MarkNetworkObjectDirty()
         {
+            if (m_NetworkBehaviour == null)
+            {
+                Debug.LogWarning($"NetworkList is written to, but doesn't know its NetworkBehaviour yet. " +
+                                 "Are you modifying a NetworkList before the NetworkObject is spawned?");
+                return;
+            }
+
             m_NetworkBehaviour.NetworkManager.MarkNetworkObjectDirty(m_NetworkBehaviour.NetworkObject);
         }
 


### PR DESCRIPTION
Instead, a warning message is logged.

[MTT-4516](https://jira.unity3d.com/browse/MTT-4516)
#2163 

Tested manually with:
```    
        private NetworkList<int> listInt;

        public void Awake()
        {
            listInt = new NetworkList<int>();
            listInt.Add(4);
        }
```