### PR TITLE
fix: Rework packet loss metric tests to work with UTP 2.0 [MTT-4535]

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -337,6 +337,8 @@ namespace Unity.Netcode.Transports.UTP
             PacketDropRate = 0
         };
 
+        internal uint DebugSimulatorRandomSeed { get; set; } = 0;
+
         private struct PacketLossCache
         {
             public int PacketsReceived;
@@ -1322,7 +1324,8 @@ namespace Unity.Netcode.Transports.UTP
                 maxPacketSize: NetworkParameterConstants.MTU,
                 packetDelayMs: DebugSimulator.PacketDelayMS,
                 packetJitterMs: DebugSimulator.PacketJitterMS,
-                packetDropPercentage: DebugSimulator.PacketDropRate
+                packetDropPercentage: DebugSimulator.PacketDropRate,
+                randomSeed: DebugSimulatorRandomSeed
 #if UTP_TRANSPORT_2_0_ABOVE
                 , mode: ApplyMode.AllPackets
 #endif

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/PacketLossMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/PacketLossMetricsTests.cs
@@ -28,8 +28,13 @@ namespace Unity.Netcode.RuntimeTests.Metrics
         protected override void OnServerAndClientsCreated()
         {
             var clientTransport = (UnityTransport)m_ClientNetworkManagers[0].NetworkConfig.NetworkTransport;
-            clientTransport.DebugSimulatorRandomSeed = 4; // Determined through trial and error.
             clientTransport.SetDebugSimulatorParameters(0, 0, m_PacketLossRate);
+
+            // Determined through trial and error. With both UTP 1.2 and 2.0, this random seed
+            // results in an effective packet loss percentage between 22% and 28%. Future UTP
+            // updates may change the RNG call patterns and cause this test to fail, in which
+            // case the value should be modified again.
+            clientTransport.DebugSimulatorRandomSeed = 4;
 
             base.OnServerAndClientsCreated();
         }


### PR DESCRIPTION
The packet loss test is sending 1000 messages and expecting about 25% of them to be dropped. Issue is, these 1000 messages will get batched together into roughly a dozen packets on the wire. By chance, the UTP simulator stage has bug where it always uses the same seed for its RNG. In UTP 1.X, this seed led to 4 packets being dropped, which was enough to get the test to pass. In UTP 2.0, this seed is only getting 2 packets to be dropped (because the call patterns to the RNG are different) and this causes the test to fail.

UTP is getting fixed to not always use the same seed by default, so soon this test will become unstable since it will be at the mercy of the RNG. But UTP does support fixing the seed for just these kinds of scenarios. This PR exposes this functionality to NGO (internal API only) and makes use of it in the packet loss test. The size of the messages being sent is also increased to avoid only sending a dozen packets on the wire.

## Changelog

N/A

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.