### PR TITLE
Performance Improvement

### DIFF
--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -277,14 +277,7 @@ namespace Unity.Netcode.Components
                 {
                     // Go ahead and mark the local state dirty or not dirty as well
                     /// <see cref="TryCommitTransformToServer"/>
-                    if (HasPositionChange || HasRotAngleChange || HasScaleChange)
-                    {
-                        IsDirty = true;
-                    }
-                    else
-                    {
-                        IsDirty = false;
-                    }
+                    IsDirty = HasPositionChange || HasRotAngleChange || HasScaleChange;
                 }
             }
         }
@@ -1115,8 +1108,7 @@ namespace Unity.Netcode.Components
             }
             else
             {
-                transform.position = pos;
-                transform.rotation = rot;
+                transform.SetPositionAndRotation(pos, rot);
             }
             transform.localScale = scale;
             m_LocalAuthoritativeNetworkState.IsTeleportingNextFrame = shouldTeleport;
@@ -1134,8 +1126,7 @@ namespace Unity.Netcode.Components
         private void SetStateClientRpc(Vector3 pos, Quaternion rot, Vector3 scale, bool shouldTeleport, ClientRpcParams clientRpcParams = default)
         {
             // Server dictated state is always applied
-            transform.position = pos;
-            transform.rotation = rot;
+            transform.SetPositionAndRotation(pos, rot);
             transform.localScale = scale;
             m_LocalAuthoritativeNetworkState.IsTeleportingNextFrame = shouldTeleport;
             TryCommitTransform(transform, m_CachedNetworkManager.LocalTime.Time);
@@ -1156,8 +1147,7 @@ namespace Unity.Netcode.Components
                 (pos, rot, scale) = OnClientRequestChange(pos, rot, scale);
             }
 
-            transform.position = pos;
-            transform.rotation = rot;
+            transform.SetPositionAndRotation(pos, rot);
             transform.localScale = scale;
             m_LocalAuthoritativeNetworkState.IsTeleportingNextFrame = shouldTeleport;
             TryCommitTransform(transform, m_CachedNetworkManager.LocalTime.Time);

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
@@ -60,7 +60,7 @@ namespace Unity.Netcode.Editor.CodeGen
                     }
                     catch (Exception e)
                     {
-                        m_Diagnostics.AddError((e.ToString() + e.StackTrace.ToString()).Replace("\n", "|").Replace("\r", "|"));
+                        m_Diagnostics.AddError((e.ToString() + e.StackTrace).Replace("\n", "|").Replace("\r", "|"));
                     }
                 }
                 else

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkSerializableILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkSerializableILPP.cs
@@ -92,7 +92,7 @@ namespace Unity.Netcode.Editor.CodeGen
                 }
                 catch (Exception e)
                 {
-                    m_Diagnostics.AddError((e.ToString() + e.StackTrace.ToString()).Replace("\n", "|").Replace("\r", "|"));
+                    m_Diagnostics.AddError((e.ToString() + e.StackTrace).Replace("\n", "|").Replace("\r", "|"));
                 }
             }
             else

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -63,7 +63,7 @@ namespace Unity.Netcode.Editor.CodeGen
                     }
                     catch (Exception e)
                     {
-                        m_Diagnostics.AddError((e.ToString() + e.StackTrace.ToString()).Replace("\n", "|").Replace("\r", "|"));
+                        m_Diagnostics.AddError((e.ToString() + e.StackTrace).Replace("\n", "|").Replace("\r", "|"));
                     }
                 }
                 else

--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -263,8 +263,7 @@ namespace Unity.Netcode.Editor
 
             // Now get the root parent transform to the current GameObject (or itself)
             var rootTransform = GetRootParentTransform(gameObject.transform);
-            var networkManager = rootTransform.GetComponent<NetworkManager>();
-            if (networkManager == null)
+            if (!rootTransform.TryGetComponent<NetworkManager>(out var networkManager))
             {
                 networkManager = rootTransform.GetComponentInChildren<NetworkManager>();
             }
@@ -299,8 +298,7 @@ namespace Unity.Netcode.Editor
 
             // Otherwise, check to see if there is any NetworkObject from the root GameObject down to all children.
             // If not, notify the user that NetworkBehaviours require that the relative GameObject has a NetworkObject component.
-            var networkObject = rootTransform.GetComponent<NetworkObject>();
-            if (networkObject == null)
+            if (!rootTransform.TryGetComponent<NetworkObject>(out var networkObject))
             {
                 networkObject = rootTransform.GetComponentInChildren<NetworkObject>();
 

--- a/com.unity.netcode.gameobjects/Editor/NetworkManagerHelper.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkManagerHelper.cs
@@ -64,7 +64,7 @@ namespace Unity.Netcode.Editor
         {
             var scenesList = EditorBuildSettings.scenes.ToList();
             var activeScene = SceneManager.GetActiveScene();
-            var isSceneInBuildSettings = scenesList.Where((c) => c.path == activeScene.path).Count() == 1;
+            var isSceneInBuildSettings = scenesList.Count((c) => c.path == activeScene.path) == 1;
             var networkManager = Object.FindObjectOfType<NetworkManager>();
             if (!isSceneInBuildSettings && networkManager != null)
             {
@@ -109,9 +109,8 @@ namespace Unity.Netcode.Editor
         public void CheckAndNotifyUserNetworkObjectRemoved(NetworkManager networkManager, bool editorTest = false)
         {
             // Check for any NetworkObject at the same gameObject relative layer
-            var networkObject = networkManager.gameObject.GetComponent<NetworkObject>();
-
-            if (networkObject == null)
+            
+            if (!networkManager.gameObject.TryGetComponent<NetworkObject>(out var networkObject))
             {
                 // if none is found, check to see if any children have a NetworkObject
                 networkObject = networkManager.gameObject.GetComponentInChildren<NetworkObject>();

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -51,7 +51,7 @@ namespace Unity.Netcode
 
         internal static string PrefabDebugHelper(NetworkPrefab networkPrefab)
         {
-            return $"{nameof(NetworkPrefab)} \"{networkPrefab.Prefab.gameObject.name}\"";
+            return $"{nameof(NetworkPrefab)} \"{networkPrefab.Prefab.name}\"";
         }
 
         internal NetworkBehaviourUpdater BehaviourUpdater { get; set; }
@@ -187,8 +187,7 @@ namespace Unity.Netcode
         /// <returns>a <see cref="GameObject"/> that is either the override or if no overrides exist it returns the same as the one passed in as a parameter</returns>
         public GameObject GetNetworkPrefabOverride(GameObject gameObject)
         {
-            var networkObject = gameObject.GetComponent<NetworkObject>();
-            if (networkObject != null)
+            if (gameObject.TryGetComponent<NetworkObject>(out var networkObject))
             {
                 if (NetworkConfig.NetworkPrefabOverrideLinks.ContainsKey(networkObject.GlobalObjectIdHash))
                 {
@@ -519,8 +518,7 @@ namespace Unity.Netcode
                 var networkPrefabGo = networkPrefab?.Prefab;
                 if (networkPrefabGo != null)
                 {
-                    var networkObject = networkPrefabGo.GetComponent<NetworkObject>();
-                    if (networkObject == null)
+                    if (!networkPrefabGo.TryGetComponent<NetworkObject>(out var networkObject))
                     {
                         if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
                         {
@@ -695,8 +693,7 @@ namespace Unity.Netcode
             }
             else if (networkPrefab.Override == NetworkPrefabOverride.None)
             {
-                networkObject = networkPrefab.Prefab.GetComponent<NetworkObject>();
-                if (networkObject == null)
+                if (!networkPrefab.Prefab.TryGetComponent<NetworkObject>(out networkObject))
                 {
                     if (NetworkLog.CurrentLogLevel <= LogLevel.Error)
                     {
@@ -742,8 +739,7 @@ namespace Unity.Netcode
                             }
                             else
                             {
-                                networkObject = networkPrefab.SourcePrefabToOverride.GetComponent<NetworkObject>();
-                                if (networkObject == null)
+                                if (!networkPrefab.SourcePrefabToOverride.TryGetComponent<NetworkObject>(out networkObject))
                                 {
                                     if (NetworkLog.CurrentLogLevel <= LogLevel.Error)
                                     {
@@ -968,8 +964,7 @@ namespace Unity.Netcode
             // If we have a player prefab, then we need to verify it is in the list of NetworkPrefabOverrideLinks for client side spawning.
             if (NetworkConfig.PlayerPrefab != null)
             {
-                var playerPrefabNetworkObject = NetworkConfig.PlayerPrefab.GetComponent<NetworkObject>();
-                if (playerPrefabNetworkObject != null)
+                if (NetworkConfig.PlayerPrefab.TryGetComponent<NetworkObject>(out var playerPrefabNetworkObject))
                 {
                     //In the event there is no NetworkPrefab entry (i.e. no override for default player prefab)
                     if (!NetworkConfig.NetworkPrefabOverrideLinks.ContainsKey(playerPrefabNetworkObject

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -435,7 +435,7 @@ namespace Unity.Netcode
         private void OnDestroy()
         {
             if (NetworkManager != null && NetworkManager.IsListening && NetworkManager.IsServer == false && IsSpawned &&
-                (IsSceneObject == null || (IsSceneObject != null && IsSceneObject.Value != true)))
+                (IsSceneObject == null || (IsSceneObject.Value != true)))
             {
                 throw new NotServerException($"Destroy a spawned {nameof(NetworkObject)} on a non-host client is not valid. Call {nameof(Destroy)} or {nameof(Despawn)} on the server/host instead.");
             }
@@ -690,8 +690,7 @@ namespace Unity.Netcode
             var parentTransform = transform.parent;
             if (parentTransform != null)
             {
-                var parentObject = transform.parent.GetComponent<NetworkObject>();
-                if (parentObject == null)
+                if (!transform.parent.TryGetComponent<NetworkObject>(out var parentObject))
                 {
                     transform.parent = m_CachedParent;
                     Debug.LogException(new InvalidParentException($"Invalid parenting, {nameof(NetworkObject)} moved under a non-{nameof(NetworkObject)} parent"));

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
@@ -398,9 +398,9 @@ namespace Unity.Netcode
             int totalBytes = 0;
 
             // Write the number of NetworkObjects we are serializing
-            BytePacker.WriteValuePacked(writer, m_NetworkObjectsSync.Count());
+            BytePacker.WriteValuePacked(writer, m_NetworkObjectsSync.Count);
             // Serialize all NetworkObjects that are spawned
-            for (var i = 0; i < m_NetworkObjectsSync.Count(); ++i)
+            for (var i = 0; i < m_NetworkObjectsSync.Count; ++i)
             {
                 var noStart = writer.Position;
                 var sceneObject = m_NetworkObjectsSync[i].GetMessageSceneObject(TargetClientId);
@@ -411,9 +411,9 @@ namespace Unity.Netcode
             }
 
             // Write the number of despawned in-scene placed NetworkObjects
-            writer.WriteValueSafe(m_DespawnedInSceneObjectsSync.Count());
+            writer.WriteValueSafe(m_DespawnedInSceneObjectsSync.Count);
             // Write the scene handle and GlobalObjectIdHash value
-            for (var i = 0; i < m_DespawnedInSceneObjectsSync.Count(); ++i)
+            for (var i = 0; i < m_DespawnedInSceneObjectsSync.Count; ++i)
             {
                 var noStart = writer.Position;
                 var sceneObject = m_DespawnedInSceneObjectsSync[i].GetMessageSceneObject(TargetClientId);

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkPrefabHandler.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkPrefabHandler.cs
@@ -119,8 +119,7 @@ namespace Unity.Netcode
                         // Now we register all
                         foreach (var gameObject in networkPrefabOverrides)
                         {
-                            var targetNetworkObject = gameObject.GetComponent<NetworkObject>();
-                            if (targetNetworkObject != null)
+                            if (gameObject.TryGetComponent<NetworkObject>(out var targetNetworkObject))
                             {
                                 if (!m_PrefabInstanceToPrefabAsset.ContainsKey(targetNetworkObject.GlobalObjectIdHash))
                                 {

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -286,7 +286,7 @@ namespace Unity.Netcode.Transports.UTP
             /// <summary>
             /// Endpoint (IP address and port) server will listen/bind on.
             /// </summary>
-            public NetworkEndpoint ListenEndPoint => ParseNetworkEndpoint((ServerListenAddress == string.Empty) ? Address : ServerListenAddress, Port);
+            public NetworkEndpoint ListenEndPoint => ParseNetworkEndpoint((ServerListenAddress?.Length == 0) ? Address : ServerListenAddress, Port);
         }
 
         /// <summary>


### PR DESCRIPTION
- Merge if else into return
- Merge .rotation and .position into .SetPositionAndRotation
- Remove .ToString() call on strings
- Use TryGetComponent to reduce garbage allocation
- Merge .Where().Count() calls into .Count() call
- Remove indirect gameObject call 
- Remove redundant null check
- Use native .Count instead of LINQ method
- Use faster string comparison


## Changelog

- Fixed: Improved performance


## Testing and Documentation

No functionality changed

