### PR TITLE
style: fixing the 'tools' part of the SDK to pass standards checks.

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkMetrics.cs
@@ -5,17 +5,14 @@ using Unity.Multiplayer.Tools;
 using Unity.Multiplayer.Tools.MetricTypes;
 using Unity.Multiplayer.Tools.NetStats;
 using Unity.Profiling;
-using UnityEngine;
 
 namespace Unity.Netcode
 {
     internal class NetworkMetrics : INetworkMetrics
     {
-        const ulong k_MaxMetricsPerFrame = 1000L;
-
-        static Dictionary<uint, string> s_SceneEventTypeNames;
-
-        static ProfilerMarker s_FrameDispatch = new ProfilerMarker($"{nameof(NetworkMetrics)}.DispatchFrame");
+        private const ulong k_MaxMetricsPerFrame = 1000L;
+        private static Dictionary<uint, string> s_SceneEventTypeNames;
+        private static ProfilerMarker s_FrameDispatch = new ProfilerMarker($"{nameof(NetworkMetrics)}.DispatchFrame");
 
         static NetworkMetrics()
         {
@@ -531,7 +528,7 @@ namespace Unity.Netcode
         }
     }
 
-        internal class NetcodeObserver
+    internal class NetcodeObserver
     {
         public static IMetricObserver Observer { get; } = MetricObserverFactory.Construct();
     }

--- a/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkObjectProvider.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Metrics/NetworkObjectProvider.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace Unity.Netcode
 {
-    class NetworkObjectProvider : INetworkObjectProvider
+    internal class NetworkObjectProvider : INetworkObjectProvider
     {
         private readonly NetworkManager m_NetworkManager;
 
@@ -15,7 +15,7 @@ namespace Unity.Netcode
 
         public Object GetNetworkObject(ulong networkObjectId)
         {
-            if(m_NetworkManager.SpawnManager.SpawnedObjects.TryGetValue(networkObjectId, out NetworkObject value))
+            if (m_NetworkManager.SpawnManager.SpawnedObjects.TryGetValue(networkObjectId, out NetworkObject value))
             {
                 return value;
             }

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/NetworkMetricsPipelineStage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/NetworkMetricsPipelineStage.cs
@@ -4,25 +4,24 @@ using AOT;
 using Unity.Burst;
 using Unity.Collections.LowLevel.Unsafe;
 using Unity.Networking.Transport;
-using UnityEngine;
 
 namespace Unity.Netcode.Transports.UTP
 {
     [BurstCompile]
     internal unsafe struct NetworkMetricsPipelineStage : INetworkPipelineStage
     {
-        static TransportFunctionPointer<NetworkPipelineStage.ReceiveDelegate> ReceiveFunction = new TransportFunctionPointer<NetworkPipelineStage.ReceiveDelegate>(Receive);
-        static TransportFunctionPointer<NetworkPipelineStage.SendDelegate> SendFunction = new TransportFunctionPointer<NetworkPipelineStage.SendDelegate>(Send);
-        static TransportFunctionPointer<NetworkPipelineStage.InitializeConnectionDelegate> InitializeConnectionFunction = new TransportFunctionPointer<NetworkPipelineStage.InitializeConnectionDelegate>(InitializeConnection);
+        private static TransportFunctionPointer<NetworkPipelineStage.ReceiveDelegate> s_ReceiveFunction = new TransportFunctionPointer<NetworkPipelineStage.ReceiveDelegate>(Receive);
+        private static TransportFunctionPointer<NetworkPipelineStage.SendDelegate> s_SendFunction = new TransportFunctionPointer<NetworkPipelineStage.SendDelegate>(Send);
+        private static TransportFunctionPointer<NetworkPipelineStage.InitializeConnectionDelegate> s_InitializeConnectionFunction = new TransportFunctionPointer<NetworkPipelineStage.InitializeConnectionDelegate>(InitializeConnection);
 
         public NetworkPipelineStage StaticInitialize(byte* staticInstanceBuffer,
             int staticInstanceBufferLength,
             NetworkSettings settings)
         {
             return new NetworkPipelineStage(
-                ReceiveFunction,
-                SendFunction,
-                InitializeConnectionFunction,
+                s_ReceiveFunction,
+                s_SendFunction,
+                s_InitializeConnectionFunction,
                 ReceiveCapacity: 0,
                 SendCapacity: 0,
                 HeaderCapacity: 0,

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -895,7 +895,7 @@ namespace Unity.Netcode.Transports.UTP
 
         private void ExtractNetworkMetricsForClient(ulong transportClientId)
         {
-            var networkConnection =  ParseClientId(transportClientId);
+            var networkConnection = ParseClientId(transportClientId);
             ExtractNetworkMetricsFromPipeline(m_UnreliableFragmentedPipeline, networkConnection);
             ExtractNetworkMetricsFromPipeline(m_UnreliableSequencedFragmentedPipeline, networkConnection);
             ExtractNetworkMetricsFromPipeline(m_ReliableSequencedPipeline, networkConnection);
@@ -1391,7 +1391,7 @@ namespace Unity.Netcode.Transports.UTP
                     , typeof(SimulatorPipelineStageInSend)
 #endif
 #if MULTIPLAYER_TOOLS_1_0_0_PRE_7
-                    ,typeof(NetworkMetricsPipelineStage)
+                    , typeof(NetworkMetricsPipelineStage)
 #endif
                 );
                 reliableSequencedPipeline = driver.CreatePipeline(
@@ -1401,7 +1401,7 @@ namespace Unity.Netcode.Transports.UTP
                     , typeof(SimulatorPipelineStageInSend)
 #endif
 #if MULTIPLAYER_TOOLS_1_0_0_PRE_7
-                    ,typeof(NetworkMetricsPipelineStage)
+                    , typeof(NetworkMetricsPipelineStage)
 #endif
                 );
             }
@@ -1411,20 +1411,20 @@ namespace Unity.Netcode.Transports.UTP
                 unreliableFragmentedPipeline = driver.CreatePipeline(
                     typeof(FragmentationPipelineStage)
 #if MULTIPLAYER_TOOLS_1_0_0_PRE_7
-                    ,typeof(NetworkMetricsPipelineStage)
+                    , typeof(NetworkMetricsPipelineStage)
 #endif
                 );
                 unreliableSequencedFragmentedPipeline = driver.CreatePipeline(
                     typeof(FragmentationPipelineStage),
                     typeof(UnreliableSequencedPipelineStage)
 #if MULTIPLAYER_TOOLS_1_0_0_PRE_7
-                    ,typeof(NetworkMetricsPipelineStage)
+                    , typeof(NetworkMetricsPipelineStage)
 #endif
                 );
                 reliableSequencedPipeline = driver.CreatePipeline(
                     typeof(ReliableSequencedPipelineStage)
 #if MULTIPLAYER_TOOLS_1_0_0_PRE_7
-                    ,typeof(NetworkMetricsPipelineStage)
+                    , typeof(NetworkMetricsPipelineStage)
 #endif
                 );
             }

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/Metrics/WaitForEventMetricValues.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/Metrics/WaitForEventMetricValues.cs
@@ -1,10 +1,6 @@
 #if MULTIPLAYER_TOOLS
-using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using NUnit.Framework;
 using Unity.Multiplayer.Tools.MetricTypes;
 using Unity.Multiplayer.Tools.NetStats;
 
@@ -12,10 +8,11 @@ namespace Unity.Netcode.TestHelpers.Runtime.Metrics
 {
     internal class WaitForEventMetricValues<TMetric> : WaitForMetricValues<TMetric>
     {
-        IReadOnlyCollection<TMetric> m_EventValues;
+        private IReadOnlyCollection<TMetric> m_EventValues;
 
         public delegate bool EventFilter(TMetric metric);
-        EventFilter m_EventFilterDelegate;
+
+        private EventFilter m_EventFilterDelegate;
 
         public WaitForEventMetricValues(IMetricDispatcher dispatcher, DirectionalMetricInfo directionalMetricName)
             : base(dispatcher, directionalMetricName)

--- a/com.unity.netcode.gameobjects/Tests/Editor/Metrics/NetworkMetricsRegistrationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Metrics/NetworkMetricsRegistrationTests.cs
@@ -10,12 +10,13 @@ namespace Unity.Netcode.EditorTests.Metrics
 {
     public class NetworkMetricsRegistrationTests
     {
-        static Type[] s_MetricTypes = AppDomain.CurrentDomain.GetAssemblies()
+        private static Type[] s_MetricTypes = AppDomain.CurrentDomain.GetAssemblies()
             .SelectMany(x => x.GetTypes())
             .Where(x => x.GetInterfaces().Contains(typeof(INetworkMetricEvent)))
             .ToArray();
 
-        [TestCaseSource(nameof(s_MetricTypes))][Ignore("Disable test while we reevaluate the assumption that INetworkMetricEvent interfaces must be reported from MLAPI.")]
+        [TestCaseSource(nameof(s_MetricTypes))]
+        [Ignore("Disable test while we reevaluate the assumption that INetworkMetricEvent interfaces must be reported from MLAPI.")]
         public void ValidateThatAllMetricTypesAreRegistered(Type metricType)
         {
             var dispatcher = new NetworkMetrics().Dispatcher as MetricDispatcher;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/ConnectionMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/ConnectionMetricsTests.cs
@@ -2,7 +2,6 @@
 #if MULTIPLAYER_TOOLS_1_0_0_PRE_7
 
 using System.Collections;
-using System.Collections.Generic;
 using NUnit.Framework;
 using Unity.Multiplayer.Tools.MetricTypes;
 using Unity.Netcode.TestHelpers.Runtime;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/MetricsDispatchTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/MetricsDispatchTests.cs
@@ -5,7 +5,6 @@ using NUnit.Framework;
 using Unity.Multiplayer.Tools.NetStats;
 using UnityEngine.TestTools;
 using Unity.Netcode.TestHelpers.Runtime;
-using Unity.Netcode.TestHelpers.Runtime.Metrics;
 
 namespace Unity.Netcode.RuntimeTests.Metrics
 {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/OwnershipChangeMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/OwnershipChangeMetricsTests.cs
@@ -1,5 +1,4 @@
 #if MULTIPLAYER_TOOLS
-using System;
 using System.Collections;
 using System.Linq;
 using NUnit.Framework;
@@ -36,7 +35,7 @@ namespace Unity.Netcode.RuntimeTests.Metrics
         private NetworkObject SpawnNetworkObject()
         {
             // Spawn another network object so we can hide multiple.
-            var gameObject = UnityEngine.Object.Instantiate(m_NewNetworkPrefab); // new GameObject(NewNetworkObjectName);
+            var gameObject = Object.Instantiate(m_NewNetworkPrefab); // new GameObject(NewNetworkObjectName);
             var networkObject = gameObject.GetComponent<NetworkObject>();
             networkObject.NetworkManagerOwner = Server;
             networkObject.Spawn();

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/PacketLossMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/PacketLossMetricsTests.cs
@@ -1,7 +1,6 @@
 #if MULTIPLAYER_TOOLS
 #if MULTIPLAYER_TOOLS_1_0_0_PRE_7
 
-using System;
 using System.Collections;
 using NUnit.Framework;
 using Unity.Collections;
@@ -9,7 +8,6 @@ using Unity.Multiplayer.Tools.MetricTypes;
 using Unity.Netcode.TestHelpers.Runtime;
 using Unity.Netcode.TestHelpers.Runtime.Metrics;
 using Unity.Netcode.Transports.UTP;
-using UnityEngine;
 using UnityEngine.TestTools;
 
 namespace Unity.Netcode.RuntimeTests.Metrics
@@ -22,7 +20,7 @@ namespace Unity.Netcode.RuntimeTests.Metrics
 
         public PacketLossMetricsTests()
             : base(HostOrServer.Server)
-        {}
+        { }
 
         protected override void OnServerAndClientsCreated()
         {
@@ -41,11 +39,9 @@ namespace Unity.Netcode.RuntimeTests.Metrics
 
             for (int i = 0; i < 1000; ++i)
             {
-                using (var writer = new FastBufferWriter(sizeof(byte), Allocator.Persistent))
-                {
-                    writer.WriteByteSafe(42);
-                    m_ServerNetworkManager.CustomMessagingManager.SendNamedMessage("Test", m_ServerNetworkManager.ConnectedClientsIds, writer);
-                }
+                using var writer = new FastBufferWriter(sizeof(byte), Allocator.Persistent);
+                writer.WriteByteSafe(42);
+                m_ServerNetworkManager.CustomMessagingManager.SendNamedMessage("Test", m_ServerNetworkManager.ConnectedClientsIds, writer);
             }
 
             yield return waitForPacketLossMetric.WaitForMetricsReceived();
@@ -60,7 +56,7 @@ namespace Unity.Netcode.RuntimeTests.Metrics
 #endif
         public IEnumerator TrackPacketLossAsClient()
         {
-            double packetLossRateMinRange = (m_PacketLossRate-m_PacketLossRangeDelta) / 100d;
+            double packetLossRateMinRange = (m_PacketLossRate - m_PacketLossRangeDelta) / 100d;
             double packetLossRateMaxrange = (m_PacketLossRate + m_PacketLossRangeDelta) / 100d;
             var clientNetworkManager = m_ClientNetworkManagers[0];
             var waitForPacketLossMetric = new WaitForGaugeMetricValues((clientNetworkManager.NetworkMetrics as NetworkMetrics).Dispatcher,
@@ -69,11 +65,9 @@ namespace Unity.Netcode.RuntimeTests.Metrics
 
             for (int i = 0; i < 1000; ++i)
             {
-                using (var writer = new FastBufferWriter(sizeof(byte), Allocator.Persistent))
-                {
-                    writer.WriteByteSafe(42);
-                    m_ServerNetworkManager.CustomMessagingManager.SendNamedMessage("Test", m_ServerNetworkManager.ConnectedClientsIds, writer);
-                }
+                using var writer = new FastBufferWriter(sizeof(byte), Allocator.Persistent);
+                writer.WriteByteSafe(42);
+                m_ServerNetworkManager.CustomMessagingManager.SendNamedMessage("Test", m_ServerNetworkManager.ConnectedClientsIds, writer);
             }
 
             yield return waitForPacketLossMetric.WaitForMetricsReceived();

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/PacketMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/PacketMetricsTests.cs
@@ -5,7 +5,6 @@ using NUnit.Framework;
 using Unity.Collections;
 using Unity.Multiplayer.Tools.MetricTypes;
 using UnityEngine.TestTools;
-using Unity.Netcode.TestHelpers.Runtime;
 using Unity.Netcode.TestHelpers.Runtime.Metrics;
 
 namespace Unity.Netcode.RuntimeTests.Metrics

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/RpcMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/RpcMetricsTests.cs
@@ -26,7 +26,7 @@ namespace Unity.Netcode.RuntimeTests.Metrics
             {
                 Send = new ClientRpcSendParams
                 {
-                    TargetClientIds = new []{FirstClient.LocalClientId}
+                    TargetClientIds = new[] { FirstClient.LocalClientId }
                 }
             });
 
@@ -50,7 +50,7 @@ namespace Unity.Netcode.RuntimeTests.Metrics
             {
                 Send = new ClientRpcSendParams
                 {
-                    TargetClientIdsNativeArray = new NativeArray<ulong>(new []{FirstClient.LocalClientId}, Allocator.Temp)
+                    TargetClientIdsNativeArray = new NativeArray<ulong>(new[] { FirstClient.LocalClientId }, Allocator.Temp)
                 }
             });
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/TransportBytesMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/TransportBytesMetricsTests.cs
@@ -1,7 +1,6 @@
 #if MULTIPLAYER_TOOLS
 using System;
 using System.Collections;
-using System.IO;
 using NUnit.Framework;
 using Unity.Collections;
 using Unity.Multiplayer.Tools.MetricTypes;
@@ -15,7 +14,7 @@ namespace Unity.Netcode.RuntimeTests.Metrics
     {
         // Header is dynamically sized due to packing, will be 2 bytes for all test messages.
         private const int k_MessageHeaderSize = 2;
-        static readonly long MessageOverhead = 8 + FastBufferWriter.GetWriteSize<BatchHeader>() + k_MessageHeaderSize;
+        private static readonly long k_MessageOverhead = 8 + FastBufferWriter.GetWriteSize<BatchHeader>() + k_MessageHeaderSize;
 
         [UnityTest]
         public IEnumerator TrackTotalNumberOfBytesSent()
@@ -42,7 +41,7 @@ namespace Unity.Netcode.RuntimeTests.Metrics
             }
 
             Assert.True(observer.Found);
-            Assert.AreEqual(FastBufferWriter.GetWriteSize(messageName) + MessageOverhead, observer.Value);
+            Assert.AreEqual(FastBufferWriter.GetWriteSize(messageName) + k_MessageOverhead, observer.Value);
         }
 
         [UnityTest]
@@ -72,7 +71,7 @@ namespace Unity.Netcode.RuntimeTests.Metrics
             }
 
             Assert.True(observer.Found);
-            Assert.AreEqual(FastBufferWriter.GetWriteSize(messageName) + MessageOverhead, observer.Value);
+            Assert.AreEqual(FastBufferWriter.GetWriteSize(messageName) + k_MessageOverhead, observer.Value);
         }
 
         private class TotalBytesObserver : IMetricObserver


### PR DESCRIPTION
When adding the tools packages, some parts of Netcode for GameObjects fail our standards check. This is due to code that is ifdef'ed out.

This PR addresses these stylistic concerns, without changing the functionality.