### PR TITLE
fix: mtt-4516 NetworkList change inside OnNetworkSpawn

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
@@ -75,10 +75,7 @@ namespace Unity.Netcode
                 // Now, reset all the no-longer-dirty variables
                 foreach (var dirtyobj in m_DirtyNetworkObjects)
                 {
-                    for (int k = 0; k < dirtyobj.ChildNetworkBehaviours.Count; k++)
-                    {
-                        dirtyobj.ChildNetworkBehaviours[k].PostNetworkVariableWrite();
-                    }
+                    dirtyobj.PostNetworkVariableWrite();
                 }
                 m_DirtyNetworkObjects.Clear();
             }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1094,6 +1094,14 @@ namespace Unity.Netcode
             }
         }
 
+        internal void PostNetworkVariableWrite()
+        {
+            for (int k = 0; k < ChildNetworkBehaviours.Count; k++)
+            {
+                ChildNetworkBehaviours[k].PostNetworkVariableWrite();
+            }
+        }
+
         internal SceneObject GetMessageSceneObject(ulong targetClientId)
         {
             var obj = new SceneObject

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -53,7 +53,6 @@ namespace Unity.Netcode
             {
                 m_DirtyEvents.Clear();
             }
-            Debug.Log("NetworkList got cleared");
         }
 
         /// <inheritdoc />

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1450,12 +1450,6 @@ namespace Unity.Netcode
                         m_NetworkManager.SpawnManager.SpawnNetworkObjectLocally(keyValuePairBySceneHandle.Value,
                             m_NetworkManager.SpawnManager.GetNetworkObjectId(), true, false, NetworkManager.ServerClientId, true);
                     }
-
-                    // Since we just spawned the object and since user code might have modified their NetworkVariable, esp.
-                    // NetworkList, we need to mark the object as free of updates.
-                    // This should happen for all objects on the machine triggering the spawn.
-                    Debug.Log($"Calling PostNetworkVariableWrite on {keyValuePairBySceneHandle.Value.name}");
-                    keyValuePairBySceneHandle.Value.PostNetworkVariableWrite();
                 }
             }
 

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1450,6 +1450,12 @@ namespace Unity.Netcode
                         m_NetworkManager.SpawnManager.SpawnNetworkObjectLocally(keyValuePairBySceneHandle.Value,
                             m_NetworkManager.SpawnManager.GetNetworkObjectId(), true, false, NetworkManager.ServerClientId, true);
                     }
+
+                    // Since we just spawned the object and since user code might have modified their NetworkVariable, esp.
+                    // NetworkList, we need to mark the object as free of updates.
+                    // This should happen for all objects on the machine triggering the spawn.
+                    Debug.Log($"Calling PostNetworkVariableWrite on {keyValuePairBySceneHandle.Value.name}");
+                    keyValuePairBySceneHandle.Value.PostNetworkVariableWrite();
                 }
             }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
@@ -37,6 +37,17 @@ namespace Unity.Netcode.RuntimeTests
             {
                 ClientTargetedNetworkObjects.Add(this);
             }
+
+            if (IsServer)
+            {
+                MyListSetOnSpawn.Add(45);
+            }
+            else
+            {
+                Debug.Assert(MyListSetOnSpawn.Count == 1);
+                Debug.Assert(MyListSetOnSpawn[0] == 45);
+            }
+
             base.OnNetworkSpawn();
         }
 
@@ -50,11 +61,14 @@ namespace Unity.Netcode.RuntimeTests
         }
 
         public NetworkVariable<int> MyNetworkVariable;
+        public NetworkList<int> MyListSetOnSpawn;
 
         private void Awake()
         {
             MyNetworkVariable = new NetworkVariable<int>();
             MyNetworkVariable.OnValueChanged += Changed;
+
+            MyListSetOnSpawn = new NetworkList<int>();
         }
 
         public void Changed(int before, int after)


### PR DESCRIPTION
changes to the NetworkList inside OnNetworkSpawn results in other clients not catching the change of the values
mtt-4516
#2163

This removes the hack that was need for NetworkList: `ListAtLastReset`. This hack was needed because the order of operations differed between in-scene placed objects and dynamically spawned object. However, the flow is now the same.

However, fixing this exposed another issue. Upon modifying a NetworkList during spawning, even though the correct list would now be sent, the modify operation would be re-applied at the next modification. So, we added a clear of the dirty state of NetworkVariables upon spawn, on the server.