### PR TITLE
fix: Removing objects that got deleted from list of Dirty NetworkObjects

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
@@ -26,6 +26,10 @@ namespace Unity.Netcode
 #endif
             try
             {
+                // NetworkObject references can become null, when hidden or despawned. Once NUll, there is no point
+                // trying to process them, even if they were previously marked as dirty.
+                m_DirtyNetworkObjects.RemoveWhere((sobj) => sobj == null);
+
                 if (networkManager.IsServer)
                 {
                     foreach (var dirtyObj in m_DirtyNetworkObjects)


### PR DESCRIPTION
This addresses issues such as #2136 where objects added to the list of dirty NetworkObject get deleted before we process the list.

The issue refuses to show in our test setup, so there sadly isn't any test for it. However, the code is simple enough and there would clearly be a null reference exception without it.

https://jira.unity3d.com/browse/MTT-4459