### PR TITLE
fix: Use Time.unscaledDeltaTime instead of Time.deltaTime as time step

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -20,6 +20,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed ClientRpcs always reporting in the profiler view as going to all clients, even when limited to a subset of clients by `ClientRpcParams`. (#2144)
 - Fixed RPC codegen failing to choose the correct extension methods for `FastBufferReader` and `FastBufferWriter` when the parameters were a generic type (i.e., List<int>) and extensions for multiple instantiations of that type have been defined (i.e., List<int> and List<string>) (#2142)
 - Fixed throwing an exception in `OnNetworkUpdate` causing other `OnNetworkUpdate` calls to not be executed. (#1739)
+- Fixed synchronisation when Time.timeScale is set to 0. This changes timing update to use unscaled deltatime. Now network updates rate are independant from the local time scale. (#2171)
 
 ## [1.0.1] - 2022-08-23
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1292,6 +1292,11 @@ namespace Unity.Netcode
             ShutdownInternal();
 
             UnityEngine.SceneManagement.SceneManager.sceneUnloaded -= OnSceneUnloaded;
+
+            if (Singleton == this)
+            {
+                Singleton = null;
+            }
         }
 
         private void DisconnectRemoteClient(ulong clientId)
@@ -1401,11 +1406,6 @@ namespace Unity.Netcode
             IsClient = false;
 
             this.UnregisterAllNetworkUpdates();
-
-            if (Singleton == this)
-            {
-                Singleton = null;
-            }
 
             if (NetworkTickSystem != null)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1548,7 +1548,7 @@ namespace Unity.Netcode
         // TODO Once we have a way to subscribe to NetworkUpdateLoop with order we can move this out of NetworkManager but for now this needs to be here because we need strict ordering.
         private void OnNetworkPreUpdate()
         {
-            if (!IsServer && !IsConnectedClient)
+            if (IsServer == false && IsConnectedClient == false)
             {
                 // As a client wait to run the time system until we are connected.
                 return;
@@ -1560,14 +1560,14 @@ namespace Unity.Netcode
             }
 
             // Only update RTT here, server time is updated by time sync messages
-            bool reset = NetworkTimeSystem.Advance(Time.unscaledDeltaTime);
+            var reset = NetworkTimeSystem.Advance(Time.unscaledDeltaTime);
             if (reset)
             {
                 NetworkTickSystem.Reset(NetworkTimeSystem.LocalTime, NetworkTimeSystem.ServerTime);
             }
             NetworkTickSystem.UpdateTick(NetworkTimeSystem.LocalTime, NetworkTimeSystem.ServerTime);
 
-            if (!IsServer)
+            if (IsServer == false)
             {
                 NetworkTimeSystem.Sync(NetworkTimeSystem.LastSyncedServerTimeSec + Time.unscaledDeltaTime, NetworkConfig.NetworkTransport.GetCurrentRtt(ServerClientId) / 1000d);
             }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1548,7 +1548,7 @@ namespace Unity.Netcode
         // TODO Once we have a way to subscribe to NetworkUpdateLoop with order we can move this out of NetworkManager but for now this needs to be here because we need strict ordering.
         private void OnNetworkPreUpdate()
         {
-            if (IsServer == false && IsConnectedClient == false)
+            if (!IsServer && !IsConnectedClient)
             {
                 // As a client wait to run the time system until we are connected.
                 return;
@@ -1560,16 +1560,16 @@ namespace Unity.Netcode
             }
 
             // Only update RTT here, server time is updated by time sync messages
-            var reset = NetworkTimeSystem.Advance(Time.deltaTime);
+            bool reset = NetworkTimeSystem.Advance(Time.unscaledDeltaTime);
             if (reset)
             {
                 NetworkTickSystem.Reset(NetworkTimeSystem.LocalTime, NetworkTimeSystem.ServerTime);
             }
             NetworkTickSystem.UpdateTick(NetworkTimeSystem.LocalTime, NetworkTimeSystem.ServerTime);
 
-            if (IsServer == false)
+            if (!IsServer)
             {
-                NetworkTimeSystem.Sync(NetworkTimeSystem.LastSyncedServerTimeSec + Time.deltaTime, NetworkConfig.NetworkTransport.GetCurrentRtt(ServerClientId) / 1000d);
+                NetworkTimeSystem.Sync(NetworkTimeSystem.LastSyncedServerTimeSec + Time.unscaledDeltaTime, NetworkConfig.NetworkTransport.GetCurrentRtt(ServerClientId) / 1000d);
             }
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1292,11 +1292,6 @@ namespace Unity.Netcode
             ShutdownInternal();
 
             UnityEngine.SceneManagement.SceneManager.sceneUnloaded -= OnSceneUnloaded;
-
-            if (Singleton == this)
-            {
-                Singleton = null;
-            }
         }
 
         private void DisconnectRemoteClient(ulong clientId)
@@ -1406,6 +1401,11 @@ namespace Unity.Netcode
             IsClient = false;
 
             this.UnregisterAllNetworkUpdates();
+
+            if (Singleton == this)
+            {
+                Singleton = null;
+            }
 
             if (NetworkTickSystem != null)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTime.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTime.cs
@@ -25,7 +25,7 @@ namespace Unity.Netcode
         public double TickOffset => m_CachedTickOffset;
 
         /// <summary>
-        /// Gets the current time. This is a non fixed time value and similar to <see cref="Time.time"/>
+        /// Gets the current time. This is a non fixed time value and similar to <see cref="Time.time"/>.
         /// </summary>
         public double Time => m_TimeSec;
 
@@ -35,13 +35,13 @@ namespace Unity.Netcode
         public float TimeAsFloat => (float)m_TimeSec;
 
         /// <summary>
-        /// Gets he current fixed network time. This is the time value of the last network tick. Similar to <see cref="Time.fixedTime"/>
+        /// Gets he current fixed network time. This is the time value of the last network tick. Similar to <see cref="Time.fixedUnscaledTime"/>.
         /// </summary>
         public double FixedTime => m_CachedTick * m_TickInterval;
 
         /// <summary>
         /// Gets the fixed delta time. This value is based on the <see cref="TickRate"/> and stays constant.
-        /// Similar to <see cref="Time.fixedDeltaTime"/> There is no equivalent to <see cref="Time.deltaTime"/>
+        /// Similar to <see cref="Time.fixedUnscaledTime"/> There is no equivalent to <see cref="Time.deltaTime"/>.
         /// </summary>
         public float FixedDeltaTime => (float)m_TickInterval;
 

--- a/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTimeSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTimeSystem.cs
@@ -76,7 +76,7 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// Advances the time system by a certain amount of time. Should be called once per frame with Time.deltaTime or similar.
+        /// Advances the time system by a certain amount of time. Should be called once per frame with Time.unscaledDeltaTime or similar.
         /// </summary>
         /// <param name="deltaTimeSec">The amount of time to advance. The delta time which passed since Advance was last called.</param>
         /// <returns></returns>

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -23,7 +23,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// </summary>
         internal static bool IsRunning { get; private set; }
         protected static TimeoutHelper s_GlobalTimeoutHelper = new TimeoutHelper(8.0f);
-        protected static WaitForSeconds s_DefaultWaitForTick = new WaitForSeconds(1.0f / k_DefaultTickRate);
+        protected static WaitForSecondsRealtime s_DefaultWaitForTick = new WaitForSecondsRealtime(1.0f / k_DefaultTickRate);
 
         /// <summary>
         /// Registered list of all NetworkObjects spawned.
@@ -336,7 +336,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
             if (m_ServerNetworkManager != null)
             {
-                s_DefaultWaitForTick = new WaitForSeconds(1.0f / m_ServerNetworkManager.NetworkConfig.TickRate);
+                s_DefaultWaitForTick = new WaitForSecondsRealtime(1.0f / m_ServerNetworkManager.NetworkConfig.TickRate);
             }
 
             // Set the player prefab for the server and clients
@@ -571,7 +571,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             UnloadRemainingScenes();
 
             // reset the m_ServerWaitForTick for the next test to initialize
-            s_DefaultWaitForTick = new WaitForSeconds(1.0f / k_DefaultTickRate);
+            s_DefaultWaitForTick = new WaitForSecondsRealtime(1.0f / k_DefaultTickRate);
             VerboseDebug($"Exiting {nameof(ShutdownAndCleanUp)}");
         }
 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
@@ -309,7 +309,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
             foreach (var networkManager in NetworkManagerInstances)
             {
                 networkManager.Shutdown();
-                networkManager.ShutdownInternal();
                 s_Hooks.Remove(networkManager);
             }
 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
@@ -309,6 +309,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             foreach (var networkManager in NetworkManagerInstances)
             {
                 networkManager.Shutdown();
+                networkManager.ShutdownInternal();
                 s_Hooks.Remove(networkManager);
             }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/AddNetworkPrefabTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/AddNetworkPrefabTests.cs
@@ -22,17 +22,18 @@ namespace Unity.Netcode.RuntimeTests
             // Host is irrelevant, messages don't get sent to the host "client"
             m_UseHost = false;
 
+            yield return null;
+        }
+
+        protected override void OnServerAndClientsCreated()
+        {
             m_Prefab = new GameObject("Object");
             var networkObject = m_Prefab.AddComponent<NetworkObject>();
             m_Prefab.AddComponent<EmptyComponent>();
 
             // Make it a prefab
             NetcodeIntegrationTestHelpers.MakeNetworkObjectTestPrefab(networkObject);
-            yield return null;
-        }
 
-        protected override void OnServerAndClientsCreated()
-        {
             m_ServerNetworkManager.NetworkConfig.SpawnTimeout = 0;
             m_ServerNetworkManager.NetworkConfig.ForceSamePrefabs = false;
             foreach (var client in m_ClientNetworkManagers)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/AddNetworkPrefabTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/AddNetworkPrefabTests.cs
@@ -11,6 +11,7 @@ namespace Unity.Netcode.RuntimeTests
     {
         public class EmptyComponent : NetworkBehaviour
         {
+
         }
         protected override int NumberOfClients => 1;
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/AddNetworkPrefabTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/AddNetworkPrefabTests.cs
@@ -11,7 +11,6 @@ namespace Unity.Netcode.RuntimeTests
     {
         public class EmptyComponent : NetworkBehaviour
         {
-
         }
         protected override int NumberOfClients => 1;
 
@@ -22,11 +21,6 @@ namespace Unity.Netcode.RuntimeTests
             // Host is irrelevant, messages don't get sent to the host "client"
             m_UseHost = false;
 
-            yield return null;
-        }
-
-        protected override void OnServerAndClientsCreated()
-        {
             m_Prefab = new GameObject("Object");
             var networkObject = m_Prefab.AddComponent<NetworkObject>();
             m_Prefab.AddComponent<EmptyComponent>();
@@ -34,6 +28,11 @@ namespace Unity.Netcode.RuntimeTests
             // Make it a prefab
             NetcodeIntegrationTestHelpers.MakeNetworkObjectTestPrefab(networkObject);
 
+            yield return null;
+        }
+
+        protected override void OnServerAndClientsCreated()
+        {
             m_ServerNetworkManager.NetworkConfig.SpawnTimeout = 0;
             m_ServerNetworkManager.NetworkConfig.ForceSamePrefabs = false;
             foreach (var client in m_ClientNetworkManagers)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/AddNetworkPrefabTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/AddNetworkPrefabTests.cs
@@ -22,17 +22,19 @@ namespace Unity.Netcode.RuntimeTests
             // Host is irrelevant, messages don't get sent to the host "client"
             m_UseHost = false;
 
+            yield return null;
+        }
+
+        protected override void OnServerAndClientsCreated()
+        {
+            m_Prefab = CreateNetworkObjectPrefab("object");
             m_Prefab = new GameObject("Object");
             var networkObject = m_Prefab.AddComponent<NetworkObject>();
             m_Prefab.AddComponent<EmptyComponent>();
 
             // Make it a prefab
             NetcodeIntegrationTestHelpers.MakeNetworkObjectTestPrefab(networkObject);
-            yield return null;
-        }
 
-        protected override void OnServerAndClientsCreated()
-        {
             m_ServerNetworkManager.NetworkConfig.SpawnTimeout = 0;
             m_ServerNetworkManager.NetworkConfig.ForceSamePrefabs = false;
             foreach (var client in m_ClientNetworkManagers)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/AddNetworkPrefabTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/AddNetworkPrefabTests.cs
@@ -22,6 +22,11 @@ namespace Unity.Netcode.RuntimeTests
             // Host is irrelevant, messages don't get sent to the host "client"
             m_UseHost = false;
 
+            yield return null;
+        }
+
+        protected override void OnServerAndClientsCreated()
+        {
             m_Prefab = new GameObject("Object");
             var networkObject = m_Prefab.AddComponent<NetworkObject>();
             m_Prefab.AddComponent<EmptyComponent>();
@@ -29,11 +34,6 @@ namespace Unity.Netcode.RuntimeTests
             // Make it a prefab
             NetcodeIntegrationTestHelpers.MakeNetworkObjectTestPrefab(networkObject);
 
-            yield return null;
-        }
-
-        protected override void OnServerAndClientsCreated()
-        {
             m_ServerNetworkManager.NetworkConfig.SpawnTimeout = 0;
             m_ServerNetworkManager.NetworkConfig.ForceSamePrefabs = false;
             foreach (var client in m_ClientNetworkManagers)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -777,9 +777,18 @@ namespace Unity.Netcode.RuntimeTests
         }
         #endregion
 
+        private float m_OriginalTimeScale = 1.0f;
+
+        protected override IEnumerator OnSetup()
+        {
+            m_OriginalTimeScale = Time.timeScale;
+            yield return null;
+        }
 
         protected override IEnumerator OnTearDown()
         {
+            Time.timeScale = m_OriginalTimeScale;
+
             m_NetworkListPredicateHandler = null;
             yield return base.OnTearDown();
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -536,6 +536,25 @@ namespace Unity.Netcode.RuntimeTests
             Assert.Throws<InvalidOperationException>(() => m_Player1OnClient1.TheScalar.Value = k_TestVal1);
         }
 
+        /// <summary>
+        /// Runs tests that network variables sync on client whatever the local value of <see cref="Time.timeScale"/>.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator NetworkVariableSync_WithDifferentTimeScale([Values(true, false)] bool useHost, [Values(0.0f, 0.1f, 0.5f, 1.0f, 2.0f, 5.0f)] float timeScale)
+        {
+            Time.timeScale = timeScale;
+
+            yield return InitializeServerAndClients(useHost);
+
+            m_Player1OnServer.TheScalar.Value = k_TestVal1;
+
+            // Now wait for the client side version to be updated to k_TestVal1
+            yield return WaitForConditionOrTimeOut(() => m_Player1OnClient1.TheScalar.Value == k_TestVal1);
+            Assert.IsFalse(s_GlobalTimeoutHelper.TimedOut, "Timed out waiting for client-side NetworkVariable to update!");
+
+            Time.timeScale = 1.0f;
+        }
+
         [UnityTest]
         public IEnumerator FixedString32Test([Values(true, false)] bool useHost)
         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -551,8 +551,6 @@ namespace Unity.Netcode.RuntimeTests
             // Now wait for the client side version to be updated to k_TestVal1
             yield return WaitForConditionOrTimeOut(() => m_Player1OnClient1.TheScalar.Value == k_TestVal1);
             Assert.IsFalse(s_GlobalTimeoutHelper.TimedOut, "Timed out waiting for client-side NetworkVariable to update!");
-
-            Time.timeScale = 1.0f;
         }
 
         [UnityTest]

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -540,7 +540,7 @@ namespace Unity.Netcode.RuntimeTests
         /// Runs tests that network variables sync on client whatever the local value of <see cref="Time.timeScale"/>.
         /// </summary>
         [UnityTest]
-        public IEnumerator NetworkVariableSync_WithDifferentTimeScale([Values(true, false)] bool useHost, [Values(0.0f, 0.1f, 0.5f, 1.0f, 2.0f, 5.0f)] float timeScale)
+        public IEnumerator NetworkVariableSync_WithDifferentTimeScale([Values(true, false)] bool useHost, [Values(0.0f, 1.0f, 2.0f)] float timeScale)
         {
             Time.timeScale = timeScale;
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Timing/NetworkTimeSystemTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Timing/NetworkTimeSystemTests.cs
@@ -99,12 +99,14 @@ namespace Unity.Netcode.RuntimeTests
 
             Time.timeScale = 1.0f;
 
-            if (m_PlayerLoopFixedTimeTestComponent != null) {
+            if (m_PlayerLoopFixedTimeTestComponent != null)
+            {
                 Object.DestroyImmediate(m_PlayerLoopFixedTimeTestComponent.gameObject);
                 m_PlayerLoopFixedTimeTestComponent = null;
             }
 
-            if (m_PlayerLoopTimeTestComponent != null) {
+            if (m_PlayerLoopTimeTestComponent != null)
+            {
                 Object.DestroyImmediate(m_PlayerLoopTimeTestComponent.gameObject);
                 m_PlayerLoopTimeTestComponent = null;
             }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Timing/NetworkTimeSystemTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Timing/NetworkTimeSystemTests.cs
@@ -15,9 +15,13 @@ namespace Unity.Netcode.RuntimeTests
         private MonoBehaviourTest<PlayerLoopFixedTimeTestComponent> m_PlayerLoopFixedTimeTestComponent; // cache for teardown
         private MonoBehaviourTest<PlayerLoopTimeTestComponent> m_PlayerLoopTimeTestComponent; // cache for teardown
 
+        private float m_OriginalTimeScale = 1.0f;
+
         [SetUp]
         public void Setup()
         {
+            m_OriginalTimeScale = Time.timeScale;
+
             // Create, instantiate, and host
             Assert.IsTrue(NetworkManagerHelper.StartNetworkManager(out _));
         }
@@ -97,7 +101,7 @@ namespace Unity.Netcode.RuntimeTests
             // Stop, shutdown, and destroy
             NetworkManagerHelper.ShutdownNetworkManager();
 
-            Time.timeScale = 1.0f;
+            Time.timeScale = m_OriginalTimeScale;
 
             if (m_PlayerLoopFixedTimeTestComponent != null)
             {


### PR DESCRIPTION
This PR fixes the case of Time.timeScale = 0 that stops the NetworkManager to send updates.
It only change the NetworkManager to use Time.unscaledDeltaTime instead of Time.deltaTime (scaled) when advancing the time system.
It has no influence on all projects that always use Time.timeScale = 1.

Changelog

- Fixed synchronisation when Time.timeScale is set to 0. This changes timing update to use unscaled deltatime. Now network updates rate are independent from the local time scale. (https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/2171)

Testing and Documentation

- Includes unit tests (+ improve existing test).
- Includes integration tests.
- Documentation changes may be necessary.
