### PR TITLE
chore: Add CI to test minimal project with different versions of transport

### DIFF
--- a/.yamato/_run-all.yml
+++ b/.yamato/_run-all.yml
@@ -18,6 +18,17 @@ run_all_tests:
     - .yamato/project-tests.yml#test_{{ project.name }}_{{ editor }}_{{ platform.name }}
 {% endif -%}
 {% endfor -%}
+
+## Test minimal project with different versions of dependencies
+{% if project.name == "minimalproject" -%}
+{% for dependency in dependencies -%}
+{% for depeditor in dependency.test_editors -%}
+{% if depeditor != "trunk" -%}
+    - .yamato/package-tests.yml#test_compatibility_{{ project.name }}_{{ project.packages.first.name }}_with_{{ dependency.name }}@{{ dependency.version }}_{{ depeditor }}_{{ platform.name }}
+{% endif -%}
+{% endfor -%}
+{% endfor -%}
+{% endif -%}
 {% endfor -%}
 {% endfor -%}
 
@@ -34,6 +45,17 @@ run_all_tests_trunk:
     - .yamato/project-tests.yml#test_{{ project.name }}_{{ editor }}_{{ platform.name }}
 {% endif -%}
 {% endfor -%}
+
+## Test minimal project with different versions of dependencies on trunk
+{% if project.name == "minimalproject" -%}
+{% for dependency in dependencies -%}
+{% for depeditor in dependency.test_editors -%}
+{% if depeditor == "trunk" -%}
+    - .yamato/package-tests.yml#test_compatibility_{{ project.name }}_{{ project.packages.first.name }}_with_{{ dependency.name }}@{{ dependency.version }}_{{ depeditor }}_{{ platform.name }}
+{% endif -%}
+{% endfor -%}
+{% endfor -%}
+{% endif -%}
 {% endfor -%}
 {% endfor -%}
 
@@ -60,6 +82,22 @@ all_package_tests:
     - .yamato/package-tests.yml#test_{{ project.name}}_{{ package.name }}_{{ editor }}_{{ platform.name }}
 {% endfor -%}
 {% endfor -%}
+{% endfor -%}
+{% endfor -%}
+
+# Test minimal project with different versions of dependencies
+all_compatibility_tests:
+  name: Run All Compatibility Tests
+  dependencies:
+{% for platform in test_platforms -%}
+{% for project in projects -%}
+{% if project.name == "minimalproject" -%}
+{% for dependency in dependencies -%}
+{% for editor in dependency.test_editors -%}
+    - .yamato/package-tests.yml#test_compatibility_{{ project.name }}_{{ project.packages.first.name }}_with_{{ dependency.name }}@{{ dependency.version }}_{{ editor }}_{{ platform.name }}
+{% endfor -%}
+{% endfor -%}
+{% endif -%}
 {% endfor -%}
 {% endfor -%}
 

--- a/.yamato/package-tests.yml
+++ b/.yamato/package-tests.yml
@@ -28,3 +28,30 @@ test_{{project.name}}_{{  package.name }}_{{ editor }}_{{ platform.name }}:
 {% endfor -%}
 {% endfor -%}
 {% endfor -%}
+
+# Test minimal project with different versions of dependencies
+{% for project in projects -%}
+{% if project.name == "minimalproject" -%}
+{% for dependency in dependencies -%}
+{% for editor in dependency.test_editors -%}
+{% for platform in test_platforms -%}
+test_compatibility_{{project.name}}_{{ project.packages.first.name }}_with_{{ dependency.name }}@{{ dependency.version }}_{{ editor }}_{{ platform.name }}:
+  name : {{ project.name }} - {{ project.packages.first.name }} with {{ dependency.name }}@{{ dependency.version }} - {{ editor }} on {{ platform.name }}
+  agent:
+    type: {{ platform.type }}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor}}
+  commands:
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    - {% if platform.name == "ubuntu" %}DISPLAY=:0 {% endif %}upm-ci project test -u {{ editor }} --type project-tests --project-path {{ project.name }} --package-filter {{ project.packages.first.name }}
+  artifacts:
+    logs:
+      paths:
+        - "upm-ci~/test-results/**/*"
+  dependencies:
+    - .yamato/project-pack.yml#pack_{{ project.name }}_{{ dependency.name }}@{{ dependency.version }}
+{% endfor -%}
+{% endfor -%}
+{% endfor -%}
+{% endif -%}
+{% endfor -%}

--- a/.yamato/project-pack.yml
+++ b/.yamato/project-pack.yml
@@ -15,3 +15,30 @@ pack_{{ project.name }}:
       paths:
         - "upm-ci~/packages/**/*"
 {% endfor -%}
+
+# Pack minimal project with different versions of dependencies
+{% for project in projects -%}
+{% if project.name == "minimalproject" -%}
+{% for dependency in dependencies -%}
+pack_{{ project.name }}_{{ dependency.name }}@{{ dependency.version }}:
+  name: Pack {{ project.name }} with {{ dependency.name }}@{{ dependency.version }}
+  agent:
+    type: Unity::VM
+    image: package-ci/ubuntu:stable
+    flavor: b1.small
+  commands:
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    - curl -L https://artifactory.prd.it.unity3d.com/artifactory/api/gpg/key/public | sudo apt-key add -
+    - sudo sh -c "echo 'deb https://artifactory.prd.it.unity3d.com/artifactory/unity-apt-local bionic main' > /etc/apt/sources.list.d/unity.list"
+    - sudo apt update
+    - sudo apt install -y unity-config
+    - unity-config settings project-path {{ project.path }}
+    - unity-config project add dependency {{ dependency.name }}@{{ dependency.version }}
+    - upm-ci project pack --project-path {{ project.path }}
+  artifacts:
+    packages:
+      paths:
+        - "upm-ci~/packages/**/*"
+{% endfor -%}
+{% endif -%}
+{% endfor -%}

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -66,6 +66,14 @@ projects:
       - 2022.2
       - trunk
 
+# Package dependencies
+dependencies: 
+  - name: com.unity.transport
+    version: 2.0.0-exp.6
+    test_editors:
+      - 2022.2
+      - trunk
+
 # Scripting backends used by Standalone Playmode Tests
 scripting_backends: 
   - mono


### PR DESCRIPTION
Add CI to test minimal project with different versions of transport:

- Add a config to `Pack minimal project` with the dependency package version from the `project.metafile`, using `unity-config`. In this case, we have UTP `2.0.0-exp.6` for now. 

- Add a config for running upm-ci on the packed-project above.

- Add a new Run All Compatibility Tests config

<img width="765" alt="image" src="https://user-images.githubusercontent.com/36935028/189460153-13f360aa-c498-4267-b760-57d9992d1176.png">


- Add to Run All (trunk and non-trunk)

## Changelog

None

## Testing and Documentation

- New CI configs for testing minimalproject with UTP 2.0 on 2022.2 and trunk passes.
https://unity-ci.cds.internal.unity3d.com/job/16714211/dependency-graph

Verified that [upm-ci log](https://yamato-artifactviewer.prd.cds.internal.unity3d.com/f1e00ba4-cb59-40a7-a2fa-b51ed2f2195b%2Flogs%2Fupm-ci~%2Ftest-results%2Fminimalproject%2Feditor%2Fminimalproject/UpmLog.txt) for these tests shows UTP 2.0.0-pre.6 is being used.

