### PR TITLE
fix: Update Add Component menu structure [MTT-4078]

### DIFF
--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -156,7 +156,7 @@ namespace Unity.Netcode.Components
     /// <summary>
     /// NetworkAnimator enables remote synchronization of <see cref="UnityEngine.Animator"/> state for on network objects.
     /// </summary>
-    [AddComponentMenu("Netcode/" + nameof(NetworkAnimator))]
+    [AddComponentMenu("Netcode/Network Animator")]
     [RequireComponent(typeof(Animator))]
     public class NetworkAnimator : NetworkBehaviour
     {

--- a/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
@@ -9,6 +9,7 @@ namespace Unity.Netcode.Components
     /// </summary>
     [RequireComponent(typeof(Rigidbody))]
     [RequireComponent(typeof(NetworkTransform))]
+    [AddComponentMenu("Netcode/Network Rigidbody")]
     public class NetworkRigidbody : NetworkBehaviour
     {
         /// <summary>

--- a/com.unity.netcode.gameobjects/Components/NetworkRigidbody2D.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkRigidbody2D.cs
@@ -9,6 +9,7 @@ namespace Unity.Netcode.Components
     /// </summary>
     [RequireComponent(typeof(Rigidbody2D))]
     [RequireComponent(typeof(NetworkTransform))]
+    [AddComponentMenu("Netcode/Network Rigidbody 2D")]
     public class NetworkRigidbody2D : NetworkBehaviour
     {
         private Rigidbody2D m_Rigidbody;

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -10,7 +10,7 @@ namespace Unity.Netcode.Components
     /// The replicated value will be automatically be interpolated (if active) and applied to the underlying GameObject's transform.
     /// </summary>
     [DisallowMultipleComponent]
-    [AddComponentMenu("Netcode/" + nameof(NetworkTransform))]
+    [AddComponentMenu("Netcode/Network Transform")]
     [DefaultExecutionOrder(100000)] // this is needed to catch the update time after the transform was updated by user scripts
     public class NetworkTransform : NetworkBehaviour
     {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -20,7 +20,7 @@ namespace Unity.Netcode
     /// <summary>
     /// The main component of the library
     /// </summary>
-    [AddComponentMenu("Netcode/" + nameof(NetworkManager), -100)]
+    [AddComponentMenu("Netcode/Network Manager", -100)]
     public class NetworkManager : MonoBehaviour, INetworkUpdateSystem
     {
 #pragma warning disable IDE1006 // disable naming rule violation check

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -9,7 +9,7 @@ namespace Unity.Netcode
     /// <summary>
     /// A component used to identify that a GameObject in the network
     /// </summary>
-    [AddComponentMenu("Netcode/" + nameof(NetworkObject), -99)]
+    [AddComponentMenu("Netcode/Network Object", -99)]
     [DisallowMultipleComponent]
     public sealed class NetworkObject : MonoBehaviour
     {

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UNET/UNetTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UNET/UNetTransport.cs
@@ -7,6 +7,7 @@ using UnityEngine.Networking;
 
 namespace Unity.Netcode.Transports.UNET
 {
+    [AddComponentMenu("Netcode/UNet Transport")]
     public class UNetTransport : NetworkTransport
     {
         public enum SendMode

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -92,6 +92,7 @@ namespace Unity.Netcode.Transports.UTP
     /// The Netcode for GameObjects NetworkTransport for UnityTransport.
     /// Note: This is highly recommended to use over UNet.
     /// </summary>
+    [AddComponentMenu("Netcode/Unity Transport")]
     public partial class UnityTransport : NetworkTransport, INetworkStreamDriverConstructor
     {
         /// <summary>


### PR DESCRIPTION
Put components into a common sub-folder of the Add Component menu, and also fixed word spacing inconsistencies in the entries

fixes #2053 

## Changelog

- Fixed: All components have consistent naming pattern and folder structure in Add Components menu

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.