### PR TITLE
feat: Non-deterministic debug simulator in UnityTransport [MTT-4592]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,7 +11,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
-- The debug simulator in `UnityTransport` is now non-deterministic. Its random number generator used to be seeded with a constant value, leading to the same pattern of packet drops, delays, and jitter in every run.
+- The debug simulator in `UnityTransport` is now non-deterministic. Its random number generator used to be seeded with a constant value, leading to the same pattern of packet drops, delays, and jitter in every run. (#2196)
 
 ### Fixed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -9,6 +9,10 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ## [Unreleased]
 
+### Changed
+
+- The debug simulator in `UnityTransport` is now non-deterministic. Its random number generator used to be seeded with a constant value, leading to the same pattern of packet drops, delays, and jitter in every run.
+
 ### Fixed
 
 - Fixed issue where `NetworkTransform` was not ending extrapolation for the previous state causing non-authoritative instances to become out of synch. (#2170)

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -337,7 +337,7 @@ namespace Unity.Netcode.Transports.UTP
             PacketDropRate = 0
         };
 
-        internal uint DebugSimulatorRandomSeed { get; set; } = 0;
+        internal uint? DebugSimulatorRandomSeed { get; set; } = null;
 
         private struct PacketLossCache
         {
@@ -1325,7 +1325,7 @@ namespace Unity.Netcode.Transports.UTP
                 packetDelayMs: DebugSimulator.PacketDelayMS,
                 packetJitterMs: DebugSimulator.PacketJitterMS,
                 packetDropPercentage: DebugSimulator.PacketDropRate,
-                randomSeed: DebugSimulatorRandomSeed
+                randomSeed: DebugSimulatorRandomSeed ?? (uint)System.Diagnostics.Stopwatch.GetTimestamp()
 #if UTP_TRANSPORT_2_0_ABOVE
                 , mode: ApplyMode.AllPackets
 #endif


### PR DESCRIPTION
Unlike what the code seemed to imply, setting the random seed to 0 in the simulator pipeline stage parameters would not result in its value being determined non-deterministically. It would just pick a hardcoded constant instead.

This PR makes the default seed value be `Stopwatch.GetMilliseconds`, while preserving the ability to hardcode a constant for testing purposes. Having a non-deterministic simulator is preferable to a deterministic one, since it better represents the behavior of real networks.

## Changelog

- Changed: The debug simulator in `UnityTransport` is now non-deterministic. Its random number generator used to be seeded with a constant value, leading to the same pattern of packet drops, delays, and jitter in every run.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.