### PR TITLE
refactor: ILPP to import references from companion modules

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,6 +11,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- - Fixed ILPP `TypeLoadException` on WebGL on MacOS Editor and potentially other platforms. (#2199)
 - Fixed issue where `NetworkTransform` was not ending extrapolation for the previous state causing non-authoritative instances to become out of synch. (#2170)
 - Fixed issue where `NetworkTransform` was not continuing to interpolate for the remainder of the associated tick period. (#2170)
 - Fixed issue during `NetworkTransform.OnNetworkSpawn` for non-authoritative instances where it was initializing interpolators with the replicated network state which now only contains the transform deltas that occurred during a network tick and not the entire transform state. (#2170)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,8 +11,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- - Fixed ILPP `TypeLoadException` on WebGL on MacOS Editor and potentially other platforms. (#2199)
-- Fixed issue where `NetworkTransform` was not ending extrapolation for the previous state causing non-authoritative instances to become out of synch. (#2170)
+- Fixed ILPP `TypeLoadException` on WebGL on MacOS Editor and potentially other platforms. (#2199)
+- Fixed issue where `NetworkTransform` was not ending extrapolation for the previous state causing non-authoritative instances to become out of sync. (#2170)
 - Fixed issue where `NetworkTransform` was not continuing to interpolate for the remainder of the associated tick period. (#2170)
 - Fixed issue during `NetworkTransform.OnNetworkSpawn` for non-authoritative instances where it was initializing interpolators with the replicated network state which now only contains the transform deltas that occurred during a network tick and not the entire transform state. (#2170)
 - Fixed issue where `NetworkTransform` was not honoring the InLocalSpace property on the authority side during OnNetworkSpawn. (#2170)

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/CodeGenHelpers.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/CodeGenHelpers.cs
@@ -56,12 +56,6 @@ namespace Unity.Netcode.Editor.CodeGen
             }
         }
 
-        public static bool TypeNameMatch<T>(this TypeDefinition typeDefinition)
-        {
-            var type = typeof(T);
-            return typeDefinition.Name == type.Name && (string.IsNullOrEmpty(type.Namespace) || typeDefinition.FullName.StartsWith(type.Namespace));
-        }
-
         public static bool IsSubclassOf(this TypeDefinition typeDefinition, string classTypeFullName)
         {
             if (!typeDefinition.IsClass)

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/CodeGenHelpers.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/CodeGenHelpers.cs
@@ -15,6 +15,10 @@ namespace Unity.Netcode.Editor.CodeGen
 {
     internal static class CodeGenHelpers
     {
+        public const string DotnetModuleName = "netstandard.dll";
+        public const string UnityModuleName = "UnityEngine.CoreModule.dll";
+        public const string NetcodeModuleName = "Unity.Netcode.Runtime.dll";
+
         public const string RuntimeAssemblyName = "Unity.Netcode.Runtime";
 
         public static readonly string NetworkBehaviour_FullName = typeof(NetworkBehaviour).FullName;
@@ -50,6 +54,12 @@ namespace Unity.Netcode.Editor.CodeGen
                     return XXHash.Hash32(sigPtr, sigLen);
                 }
             }
+        }
+
+        public static bool TypeNameMatch<T>(this TypeDefinition typeDefinition)
+        {
+            var type = typeof(T);
+            return typeDefinition.Name == type.Name && (string.IsNullOrEmpty(type.Namespace) || typeDefinition.FullName.StartsWith(type.Namespace));
         }
 
         public static bool IsSubclassOf(this TypeDefinition typeDefinition, string classTypeFullName)
@@ -379,6 +389,69 @@ namespace Unity.Netcode.Editor.CodeGen
             assemblyResolver.AddAssemblyDefinitionBeingOperatedOn(assemblyDefinition);
 
             return assemblyDefinition;
+        }
+
+        public static (ModuleDefinition DotnetModule, ModuleDefinition UnityModule, ModuleDefinition NetcodeModule) FindBaseModules(AssemblyDefinition assemblyDefinition, PostProcessorAssemblyResolver assemblyResolver)
+        {
+            ModuleDefinition dotnetModule = null;
+            ModuleDefinition unityModule = null;
+            ModuleDefinition netcodeModule = null;
+
+            foreach (var module in assemblyDefinition.Modules)
+            {
+                if (dotnetModule == null && module.Name == DotnetModuleName)
+                {
+                    dotnetModule = module;
+                    continue;
+                }
+
+                if (unityModule == null && module.Name == UnityModuleName)
+                {
+                    unityModule = module;
+                    continue;
+                }
+
+                if (netcodeModule == null && module.Name == NetcodeModuleName)
+                {
+                    netcodeModule = module;
+                    continue;
+                }
+            }
+
+            if (dotnetModule != null && unityModule != null && netcodeModule != null)
+            {
+                return (dotnetModule, unityModule, netcodeModule);
+            }
+
+            foreach (var assemblyNameReference in assemblyDefinition.MainModule.AssemblyReferences)
+            {
+                foreach (var module in assemblyResolver.Resolve(assemblyNameReference).Modules)
+                {
+                    if (dotnetModule == null && module.Name == DotnetModuleName)
+                    {
+                        dotnetModule = module;
+                        continue;
+                    }
+                    if (unityModule == null && module.Name == UnityModuleName)
+                    {
+                        unityModule = module;
+                        continue;
+                    }
+
+                    if (netcodeModule == null && module.Name == NetcodeModuleName)
+                    {
+                        netcodeModule = module;
+                        continue;
+                    }
+                }
+
+                if (dotnetModule != null && unityModule != null && netcodeModule != null)
+                {
+                    return (dotnetModule, unityModule, netcodeModule);
+                }
+            }
+
+            return (dotnetModule, unityModule, netcodeModule);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
@@ -18,7 +18,7 @@ namespace Unity.Netcode.Editor.CodeGen
 
         public override bool WillProcess(ICompiledAssembly compiledAssembly) => compiledAssembly.Name == CodeGenHelpers.RuntimeAssemblyName;
 
-        private readonly List<DiagnosticMessage> m_Diagnostics = new();
+        private readonly List<DiagnosticMessage> m_Diagnostics = new List<DiagnosticMessage>();
 
         public override ILPostProcessResult Process(ICompiledAssembly compiledAssembly)
         {

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Collections.Generic;
-using System.Reflection;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Cecil.Rocks;
@@ -17,10 +16,9 @@ namespace Unity.Netcode.Editor.CodeGen
     {
         public override ILPPInterface GetInstance() => this;
 
-        public override bool WillProcess(ICompiledAssembly compiledAssembly) =>
-            compiledAssembly.Name == CodeGenHelpers.RuntimeAssemblyName;
+        public override bool WillProcess(ICompiledAssembly compiledAssembly) => compiledAssembly.Name == CodeGenHelpers.RuntimeAssemblyName;
 
-        private readonly List<DiagnosticMessage> m_Diagnostics = new List<DiagnosticMessage>();
+        private readonly List<DiagnosticMessage> m_Diagnostics = new();
 
         public override ILPostProcessResult Process(ICompiledAssembly compiledAssembly)
         {
@@ -32,10 +30,25 @@ namespace Unity.Netcode.Editor.CodeGen
             m_Diagnostics.Clear();
 
             // read
-            var assemblyDefinition = CodeGenHelpers.AssemblyDefinitionFor(compiledAssembly, out var resolver);
+            var assemblyDefinition = CodeGenHelpers.AssemblyDefinitionFor(compiledAssembly, out m_AssemblyResolver);
             if (assemblyDefinition == null)
             {
                 m_Diagnostics.AddError($"Cannot read assembly definition: {compiledAssembly.Name}");
+                return null;
+            }
+
+            // modules
+            (m_DotnetModule, _, m_NetcodeModule) = CodeGenHelpers.FindBaseModules(assemblyDefinition, m_AssemblyResolver);
+
+            if (m_DotnetModule == null)
+            {
+                m_Diagnostics.AddError($"Cannot find .NET module: {CodeGenHelpers.DotnetModuleName}");
+                return null;
+            }
+
+            if (m_NetcodeModule == null)
+            {
+                m_Diagnostics.AddError($"Cannot find Netcode module: {CodeGenHelpers.NetcodeModuleName}");
                 return null;
             }
 
@@ -91,6 +104,9 @@ namespace Unity.Netcode.Editor.CodeGen
             return new ILPostProcessResult(new InMemoryAssembly(pe.ToArray(), pdb.ToArray()), m_Diagnostics);
         }
 
+        private ModuleDefinition m_DotnetModule;
+        private ModuleDefinition m_NetcodeModule;
+        private PostProcessorAssemblyResolver m_AssemblyResolver;
 
         private MethodReference m_MessagingSystem_ReceiveMessage_MethodRef;
         private TypeReference m_MessagingSystem_MessageWithHandler_TypeRef;
@@ -105,63 +121,108 @@ namespace Unity.Netcode.Editor.CodeGen
 
         private bool ImportReferences(ModuleDefinition moduleDefinition)
         {
-            m_MessagingSystem_MessageHandler_Constructor_TypeRef = moduleDefinition.ImportReference(typeof(MessagingSystem.MessageHandler).GetConstructors()[0]);
-
-            var messageWithHandlerType = typeof(MessagingSystem.MessageWithHandler);
-            m_MessagingSystem_MessageWithHandler_TypeRef = moduleDefinition.ImportReference(messageWithHandlerType);
-            foreach (var fieldInfo in messageWithHandlerType.GetFields())
+            TypeDefinition typeTypeDef = null;
+            TypeDefinition listTypeDef = null;
+            foreach (var dotnetTypeDef in m_DotnetModule.GetAllTypes())
             {
-                switch (fieldInfo.Name)
+                if (typeTypeDef == null && dotnetTypeDef.Name == typeof(Type).Name)
+                {
+                    typeTypeDef = dotnetTypeDef;
+                    continue;
+                }
+
+                if (listTypeDef == null && dotnetTypeDef.Name == typeof(List<>).Name)
+                {
+                    listTypeDef = dotnetTypeDef;
+                    continue;
+                }
+            }
+
+            TypeDefinition messageHandlerTypeDef = null;
+            TypeDefinition messageWithHandlerTypeDef = null;
+            TypeDefinition ilppMessageProviderTypeDef = null;
+            TypeDefinition messagingSystemTypeDef = null;
+            foreach (var netcodeTypeDef in m_NetcodeModule.GetAllTypes())
+            {
+                if (messageHandlerTypeDef == null && netcodeTypeDef.TypeNameMatch<MessagingSystem.MessageHandler>())
+                {
+                    messageHandlerTypeDef = netcodeTypeDef;
+                    continue;
+                }
+
+                if (messageWithHandlerTypeDef == null && netcodeTypeDef.TypeNameMatch<MessagingSystem.MessageWithHandler>())
+                {
+                    messageWithHandlerTypeDef = netcodeTypeDef;
+                    continue;
+                }
+
+                if (ilppMessageProviderTypeDef == null && netcodeTypeDef.TypeNameMatch<ILPPMessageProvider>())
+                {
+                    ilppMessageProviderTypeDef = netcodeTypeDef;
+                    continue;
+                }
+
+                if (messagingSystemTypeDef == null && netcodeTypeDef.TypeNameMatch<MessagingSystem>())
+                {
+                    messagingSystemTypeDef = netcodeTypeDef;
+                    continue;
+                }
+            }
+
+            m_MessagingSystem_MessageHandler_Constructor_TypeRef = moduleDefinition.ImportReference(messageHandlerTypeDef.GetConstructors().First());
+
+            m_MessagingSystem_MessageWithHandler_TypeRef = moduleDefinition.ImportReference(messageWithHandlerTypeDef);
+            foreach (var fieldDef in messageWithHandlerTypeDef.Fields)
+            {
+                switch (fieldDef.Name)
                 {
                     case nameof(MessagingSystem.MessageWithHandler.MessageType):
-                        m_MessagingSystem_MessageWithHandler_MessageType_FieldRef = moduleDefinition.ImportReference(fieldInfo);
+                        m_MessagingSystem_MessageWithHandler_MessageType_FieldRef = moduleDefinition.ImportReference(fieldDef);
                         break;
                     case nameof(MessagingSystem.MessageWithHandler.Handler):
-                        m_MessagingSystem_MessageWithHandler_Handler_FieldRef = moduleDefinition.ImportReference(fieldInfo);
+                        m_MessagingSystem_MessageWithHandler_Handler_FieldRef = moduleDefinition.ImportReference(fieldDef);
                         break;
                 }
             }
 
-            var typeType = typeof(Type);
-            foreach (var methodInfo in typeType.GetMethods())
+            foreach (var methodDef in typeTypeDef.Methods)
             {
-                switch (methodInfo.Name)
+                switch (methodDef.Name)
                 {
                     case nameof(Type.GetTypeFromHandle):
-                        m_Type_GetTypeFromHandle_MethodRef = moduleDefinition.ImportReference(methodInfo);
+                        m_Type_GetTypeFromHandle_MethodRef = moduleDefinition.ImportReference(methodDef);
                         break;
                 }
             }
 
-            var ilppMessageProviderType = typeof(ILPPMessageProvider);
-            foreach (var fieldInfo in ilppMessageProviderType.GetFields(BindingFlags.Static | BindingFlags.NonPublic))
+            foreach (var fieldDef in ilppMessageProviderTypeDef.Fields)
             {
-                switch (fieldInfo.Name)
+                switch (fieldDef.Name)
                 {
                     case nameof(ILPPMessageProvider.__network_message_types):
-                        m_ILPPMessageProvider___network_message_types_FieldRef = moduleDefinition.ImportReference(fieldInfo);
+                        m_ILPPMessageProvider___network_message_types_FieldRef = moduleDefinition.ImportReference(fieldDef);
                         break;
                 }
             }
 
-            var listType = typeof(List<MessagingSystem.MessageWithHandler>);
-            foreach (var methodInfo in listType.GetMethods())
+            foreach (var methodDef in listTypeDef.Methods)
             {
-                switch (methodInfo.Name)
+                switch (methodDef.Name)
                 {
-                    case nameof(List<MessagingSystem.MessageWithHandler>.Add):
-                        m_List_Add_MethodRef = moduleDefinition.ImportReference(methodInfo);
+                    case "Add":
+                        m_List_Add_MethodRef = methodDef;
+                        m_List_Add_MethodRef.DeclaringType = listTypeDef.MakeGenericInstanceType(messageWithHandlerTypeDef);
+                        m_List_Add_MethodRef = moduleDefinition.ImportReference(m_List_Add_MethodRef);
                         break;
                 }
             }
 
-            var messagingSystemType = typeof(MessagingSystem);
-            foreach (var methodInfo in messagingSystemType.GetMethods(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public))
+            foreach (var methodDef in messagingSystemTypeDef.Methods)
             {
-                switch (methodInfo.Name)
+                switch (methodDef.Name)
                 {
                     case k_ReceiveMessageName:
-                        m_MessagingSystem_ReceiveMessage_MethodRef = moduleDefinition.ImportReference(methodInfo);
+                        m_MessagingSystem_ReceiveMessage_MethodRef = moduleDefinition.ImportReference(methodDef);
                         break;
                 }
             }
@@ -217,10 +278,8 @@ namespace Unity.Netcode.Editor.CodeGen
             instructions.Add(processor.Create(OpCodes.Callvirt, m_List_Add_MethodRef));
         }
 
-        // Creates a static module constructor (which is executed when the module is loaded) that registers all the
-        // message types in the assembly with MessagingSystem.
-        // This is the same behavior as annotating a static method with [ModuleInitializer] in standardized
-        // C# (that attribute doesn't exist in Unity, but the static module constructor still works)
+        // Creates a static module constructor (which is executed when the module is loaded) that registers all the message types in the assembly with MessagingSystem.
+        // This is the same behavior as annotating a static method with [ModuleInitializer] in standardized C# (that attribute doesn't exist in Unity, but the static module constructor still works).
         // https://docs.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.moduleinitializerattribute?view=net-5.0
         // https://web.archive.org/web/20100212140402/http://blogs.msdn.com/junfeng/archive/2005/11/19/494914.aspx
         private void CreateModuleInitializer(AssemblyDefinition assembly, List<TypeDefinition> networkMessageTypes)

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
@@ -144,25 +144,25 @@ namespace Unity.Netcode.Editor.CodeGen
             TypeDefinition messagingSystemTypeDef = null;
             foreach (var netcodeTypeDef in m_NetcodeModule.GetAllTypes())
             {
-                if (messageHandlerTypeDef == null && netcodeTypeDef.TypeNameMatch<MessagingSystem.MessageHandler>())
+                if (messageHandlerTypeDef == null && netcodeTypeDef.Name == nameof(MessagingSystem.MessageHandler))
                 {
                     messageHandlerTypeDef = netcodeTypeDef;
                     continue;
                 }
 
-                if (messageWithHandlerTypeDef == null && netcodeTypeDef.TypeNameMatch<MessagingSystem.MessageWithHandler>())
+                if (messageWithHandlerTypeDef == null && netcodeTypeDef.Name == nameof(MessagingSystem.MessageWithHandler))
                 {
                     messageWithHandlerTypeDef = netcodeTypeDef;
                     continue;
                 }
 
-                if (ilppMessageProviderTypeDef == null && netcodeTypeDef.TypeNameMatch<ILPPMessageProvider>())
+                if (ilppMessageProviderTypeDef == null && netcodeTypeDef.Name == nameof(ILPPMessageProvider))
                 {
                     ilppMessageProviderTypeDef = netcodeTypeDef;
                     continue;
                 }
 
-                if (messagingSystemTypeDef == null && netcodeTypeDef.TypeNameMatch<MessagingSystem>())
+                if (messagingSystemTypeDef == null && netcodeTypeDef.Name == nameof(MessagingSystem))
                 {
                     messagingSystemTypeDef = netcodeTypeDef;
                     continue;

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkSerializableILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkSerializableILPP.cs
@@ -18,7 +18,7 @@ namespace Unity.Netcode.Editor.CodeGen
             compiledAssembly.Name == CodeGenHelpers.RuntimeAssemblyName ||
             compiledAssembly.References.Any(filePath => Path.GetFileNameWithoutExtension(filePath) == CodeGenHelpers.RuntimeAssemblyName);
 
-        private readonly List<DiagnosticMessage> m_Diagnostics = new();
+        private readonly List<DiagnosticMessage> m_Diagnostics = new List<DiagnosticMessage>();
 
         private TypeReference ResolveGenericType(TypeReference type, List<TypeReference> typeStack)
         {

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkSerializableILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkSerializableILPP.cs
@@ -10,7 +10,6 @@ using ILPPInterface = Unity.CompilationPipeline.Common.ILPostProcessing.ILPostPr
 
 namespace Unity.Netcode.Editor.CodeGen
 {
-
     internal sealed class INetworkSerializableILPP : ILPPInterface
     {
         public override ILPPInterface GetInstance() => this;
@@ -19,7 +18,7 @@ namespace Unity.Netcode.Editor.CodeGen
             compiledAssembly.Name == CodeGenHelpers.RuntimeAssemblyName ||
             compiledAssembly.References.Any(filePath => Path.GetFileNameWithoutExtension(filePath) == CodeGenHelpers.RuntimeAssemblyName);
 
-        private readonly List<DiagnosticMessage> m_Diagnostics = new List<DiagnosticMessage>();
+        private readonly List<DiagnosticMessage> m_Diagnostics = new();
 
         private TypeReference ResolveGenericType(TypeReference type, List<TypeReference> typeStack)
         {

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -185,6 +185,23 @@ namespace Unity.Netcode.Editor.CodeGen
                 }
             }
 
+            TypeDefinition networkManagerTypeDef = null;
+            TypeDefinition networkBehaviourTypeDef = null;
+            foreach (var netcodeTypeDef in m_NetcodeModule.GetAllTypes())
+            {
+                if (networkManagerTypeDef == null && netcodeTypeDef.TypeNameMatch<NetworkManager>())
+                {
+                    networkManagerTypeDef = netcodeTypeDef;
+                    continue;
+                }
+
+                if (networkBehaviourTypeDef == null && netcodeTypeDef.TypeNameMatch<NetworkBehaviour>())
+                {
+                    networkBehaviourTypeDef = netcodeTypeDef;
+                    continue;
+                }
+            }
+
             foreach (var methodDef in debugTypeDef.Methods)
             {
                 switch (methodDef.Name)
@@ -199,26 +216,26 @@ namespace Unity.Netcode.Editor.CodeGen
                 }
             }
 
-            var networkManagerType = typeof(NetworkManager);
-            m_NetworkManager_TypeRef = moduleDefinition.ImportReference(networkManagerType);
-            foreach (var propertyInfo in networkManagerType.GetProperties())
+            var networkManagerType = typeof(NetworkManager); // todo: remove entirely
+            m_NetworkManager_TypeRef = moduleDefinition.ImportReference(networkManagerTypeDef);
+            foreach (var propertyDef in networkManagerTypeDef.Properties)
             {
-                switch (propertyInfo.Name)
+                switch (propertyDef.Name)
                 {
                     case k_NetworkManager_LocalClientId:
-                        m_NetworkManager_getLocalClientId_MethodRef = moduleDefinition.ImportReference(propertyInfo.GetMethod);
+                        m_NetworkManager_getLocalClientId_MethodRef = moduleDefinition.ImportReference(propertyDef.GetMethod);
                         break;
                     case k_NetworkManager_IsListening:
-                        m_NetworkManager_getIsListening_MethodRef = moduleDefinition.ImportReference(propertyInfo.GetMethod);
+                        m_NetworkManager_getIsListening_MethodRef = moduleDefinition.ImportReference(propertyDef.GetMethod);
                         break;
                     case k_NetworkManager_IsHost:
-                        m_NetworkManager_getIsHost_MethodRef = moduleDefinition.ImportReference(propertyInfo.GetMethod);
+                        m_NetworkManager_getIsHost_MethodRef = moduleDefinition.ImportReference(propertyDef.GetMethod);
                         break;
                     case k_NetworkManager_IsServer:
-                        m_NetworkManager_getIsServer_MethodRef = moduleDefinition.ImportReference(propertyInfo.GetMethod);
+                        m_NetworkManager_getIsServer_MethodRef = moduleDefinition.ImportReference(propertyDef.GetMethod);
                         break;
                     case k_NetworkManager_IsClient:
-                        m_NetworkManager_getIsClient_MethodRef = moduleDefinition.ImportReference(propertyInfo.GetMethod);
+                        m_NetworkManager_getIsClient_MethodRef = moduleDefinition.ImportReference(propertyDef.GetMethod);
                         break;
                 }
             }
@@ -241,46 +258,45 @@ namespace Unity.Netcode.Editor.CodeGen
                 }
             }
 
-            var networkBehaviourType = typeof(NetworkBehaviour);
-            m_NetworkBehaviour_TypeRef = moduleDefinition.ImportReference(networkBehaviourType);
-            foreach (var propertyInfo in networkBehaviourType.GetProperties())
+            m_NetworkBehaviour_TypeRef = moduleDefinition.ImportReference(networkBehaviourTypeDef);
+            foreach (var propertyDef in networkBehaviourTypeDef.Properties)
             {
-                switch (propertyInfo.Name)
+                switch (propertyDef.Name)
                 {
                     case k_NetworkBehaviour_NetworkManager:
-                        m_NetworkBehaviour_getNetworkManager_MethodRef = moduleDefinition.ImportReference(propertyInfo.GetMethod);
+                        m_NetworkBehaviour_getNetworkManager_MethodRef = moduleDefinition.ImportReference(propertyDef.GetMethod);
                         break;
                     case k_NetworkBehaviour_OwnerClientId:
-                        m_NetworkBehaviour_getOwnerClientId_MethodRef = moduleDefinition.ImportReference(propertyInfo.GetMethod);
+                        m_NetworkBehaviour_getOwnerClientId_MethodRef = moduleDefinition.ImportReference(propertyDef.GetMethod);
                         break;
                 }
             }
 
-            foreach (var methodInfo in networkBehaviourType.GetMethods(BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public))
+            foreach (var methodDef in networkBehaviourTypeDef.Methods)
             {
-                switch (methodInfo.Name)
+                switch (methodDef.Name)
                 {
                     case k_NetworkBehaviour_beginSendServerRpc:
-                        m_NetworkBehaviour_beginSendServerRpc_MethodRef = moduleDefinition.ImportReference(methodInfo);
+                        m_NetworkBehaviour_beginSendServerRpc_MethodRef = moduleDefinition.ImportReference(methodDef);
                         break;
                     case k_NetworkBehaviour_endSendServerRpc:
-                        m_NetworkBehaviour_endSendServerRpc_MethodRef = moduleDefinition.ImportReference(methodInfo);
+                        m_NetworkBehaviour_endSendServerRpc_MethodRef = moduleDefinition.ImportReference(methodDef);
                         break;
                     case k_NetworkBehaviour_beginSendClientRpc:
-                        m_NetworkBehaviour_beginSendClientRpc_MethodRef = moduleDefinition.ImportReference(methodInfo);
+                        m_NetworkBehaviour_beginSendClientRpc_MethodRef = moduleDefinition.ImportReference(methodDef);
                         break;
                     case k_NetworkBehaviour_endSendClientRpc:
-                        m_NetworkBehaviour_endSendClientRpc_MethodRef = moduleDefinition.ImportReference(methodInfo);
+                        m_NetworkBehaviour_endSendClientRpc_MethodRef = moduleDefinition.ImportReference(methodDef);
                         break;
                 }
             }
 
-            foreach (var fieldInfo in networkBehaviourType.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public))
+            foreach (var fieldDef in networkBehaviourTypeDef.Fields)
             {
-                switch (fieldInfo.Name)
+                switch (fieldDef.Name)
                 {
                     case k_NetworkBehaviour_rpc_exec_stage:
-                        m_NetworkBehaviour_rpc_exec_stage_FieldRef = moduleDefinition.ImportReference(fieldInfo);
+                        m_NetworkBehaviour_rpc_exec_stage_FieldRef = moduleDefinition.ImportReference(fieldDef);
                         break;
                 }
             }

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -24,7 +24,7 @@ namespace Unity.Netcode.Editor.CodeGen
 
         public override bool WillProcess(ICompiledAssembly compiledAssembly) => compiledAssembly.References.Any(filePath => Path.GetFileNameWithoutExtension(filePath) == CodeGenHelpers.RuntimeAssemblyName);
 
-        private readonly List<DiagnosticMessage> m_Diagnostics = new();
+        private readonly List<DiagnosticMessage> m_Diagnostics = new List<DiagnosticMessage>();
 
         public override ILPostProcessResult Process(ICompiledAssembly compiledAssembly)
         {
@@ -140,12 +140,12 @@ namespace Unity.Netcode.Editor.CodeGen
         private TypeReference m_ClientRpcParams_TypeRef;
 
         private TypeReference m_FastBufferWriter_TypeRef;
-        private readonly Dictionary<string, MethodReference> m_FastBufferWriter_WriteValue_MethodRefs = new();
-        private readonly List<MethodReference> m_FastBufferWriter_ExtensionMethodRefs = new();
+        private readonly Dictionary<string, MethodReference> m_FastBufferWriter_WriteValue_MethodRefs = new Dictionary<string, MethodReference>();
+        private readonly List<MethodReference> m_FastBufferWriter_ExtensionMethodRefs = new List<MethodReference>();
 
         private TypeReference m_FastBufferReader_TypeRef;
-        private readonly Dictionary<string, MethodReference> m_FastBufferReader_ReadValue_MethodRefs = new();
-        private readonly List<MethodReference> m_FastBufferReader_ExtensionMethodRefs = new();
+        private readonly Dictionary<string, MethodReference> m_FastBufferReader_ReadValue_MethodRefs = new Dictionary<string, MethodReference>();
+        private readonly List<MethodReference> m_FastBufferReader_ExtensionMethodRefs = new List<MethodReference>();
 
         private const string k_Debug_LogError = nameof(Debug.LogError);
         private const string k_NetworkManager_LocalClientId = nameof(NetworkManager.LocalClientId);

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -178,7 +178,7 @@ namespace Unity.Netcode.Editor.CodeGen
             TypeDefinition debugTypeDef = null;
             foreach (var unityTypeDef in m_UnityModule.GetAllTypes())
             {
-                if (debugTypeDef == null && unityTypeDef.TypeNameMatch<Debug>())
+                if (debugTypeDef == null && unityTypeDef.FullName == typeof(Debug).FullName)
                 {
                     debugTypeDef = unityTypeDef;
                     continue;
@@ -189,13 +189,13 @@ namespace Unity.Netcode.Editor.CodeGen
             TypeDefinition networkBehaviourTypeDef = null;
             foreach (var netcodeTypeDef in m_NetcodeModule.GetAllTypes())
             {
-                if (networkManagerTypeDef == null && netcodeTypeDef.TypeNameMatch<NetworkManager>())
+                if (networkManagerTypeDef == null && netcodeTypeDef.Name == nameof(NetworkManager))
                 {
                     networkManagerTypeDef = netcodeTypeDef;
                     continue;
                 }
 
-                if (networkBehaviourTypeDef == null && netcodeTypeDef.TypeNameMatch<NetworkBehaviour>())
+                if (networkBehaviourTypeDef == null && netcodeTypeDef.Name == nameof(NetworkBehaviour))
                 {
                     networkBehaviourTypeDef = netcodeTypeDef;
                     continue;

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
@@ -14,7 +14,7 @@ namespace Unity.Netcode.Editor.CodeGen
 
         public override bool WillProcess(ICompiledAssembly compiledAssembly) => compiledAssembly.Name == CodeGenHelpers.RuntimeAssemblyName;
 
-        private readonly List<DiagnosticMessage> m_Diagnostics = new();
+        private readonly List<DiagnosticMessage> m_Diagnostics = new List<DiagnosticMessage>();
 
         public override ILPostProcessResult Process(ICompiledAssembly compiledAssembly)
         {

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
@@ -14,7 +14,7 @@ namespace Unity.Netcode.Editor.CodeGen
 
         public override bool WillProcess(ICompiledAssembly compiledAssembly) => compiledAssembly.Name == CodeGenHelpers.RuntimeAssemblyName;
 
-        private readonly List<DiagnosticMessage> m_Diagnostics = new List<DiagnosticMessage>();
+        private readonly List<DiagnosticMessage> m_Diagnostics = new();
 
         public override ILPostProcessResult Process(ICompiledAssembly compiledAssembly)
         {


### PR DESCRIPTION
Supersedes #2192

Basically, ILPP imports type references from companion (already loaded and associated) modules instead of resolving them from `typeof(XXX)` types which could be from non-release, debug/editor assemblies.

## Changelog

- Fixed: ILPP `TypeLoadException` on WebGL on MacOS Editor and potentially other platforms.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
