### PR TITLE
chore: expose websockets

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,7 +11,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
-- WebSocket supports. When using UTP 2.0, a property `UseWebSockets` in the `UnityTransport` component of the `NetworkManager` allows picking WebSockets for communication. When building for WebGL, this selection happens automatically.
+- Added WebSocket support when using UTP 2.0 with `UseWebSockets` property in the `UnityTransport` component of the `NetworkManager` allowing to pick WebSockets for communication. When building for WebGL, this selection happens automatically. (#2201)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,7 +11,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
-- WebSocket supports. When using UTP 2.0, a property `UseWebSockets` in the `UtpTransport` component of the `NetworkManager` allows picking WebSockets for communication. When building for WebGL, this selection happens automatically.
+- WebSocket supports. When using UTP 2.0, a property `UseWebSockets` in the `UnityTransport` component of the `NetworkManager` allows picking WebSockets for communication. When building for WebGL, this selection happens automatically.
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -9,6 +9,10 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ## [Unreleased]
 
+### Added
+
+- WebSocket supports. When using UTP 2.0, a property `UseWebSockets` in the `UtpTransport` component of the `NetworkManager` allows picking WebSockets for communication. When building for WebGL, this selection happens automatically.
+
 ### Changed
 
 - The debug simulator in `UnityTransport` is now non-deterministic. Its random number generator used to be seeded with a constant value, leading to the same pattern of packet drops, delays, and jitter in every run. (#2196)

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1383,10 +1383,12 @@ namespace Unity.Netcode.Transports.UTP
                 driver = NetworkDriver.Create(new WebSocketNetworkInterface(), m_NetworkSettings);
             }
             else
-#endif
             {
-                driver = NetworkDriver.Create(new BaselibNetworkInterface(), m_NetworkSettings);
+                driver = NetworkDriver.Create(new UDPNetworkInterface(), m_NetworkSettings);
             }
+#else
+            driver = NetworkDriver.Create(m_NetworkSettings);
+#endif
 
 #if MULTIPLAYER_TOOLS_1_0_0_PRE_7
 #if UTP_TRANSPORT_2_0_ABOVE

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1384,7 +1384,11 @@ namespace Unity.Netcode.Transports.UTP
             }
             else
             {
+#if UNITY_WEBGL
+                driver = NetworkDriver.Create(new BaselibNetworkInterface(), m_NetworkSettings);
+#else
                 driver = NetworkDriver.Create(new UDPNetworkInterface(), m_NetworkSettings);
+#endif
             }
 #else
             driver = NetworkDriver.Create(m_NetworkSettings);

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1385,7 +1385,8 @@ namespace Unity.Netcode.Transports.UTP
             else
             {
 #if UNITY_WEBGL
-                driver = NetworkDriver.Create(new BaselibNetworkInterface(), m_NetworkSettings);
+                Debug.LogWarning("WebSockets were used even though they're not selected in NetworkManager. You should adjust the setting, to silence this warning.");
+                driver = NetworkDriver.Create(new WebSocketNetworkInterface(), m_NetworkSettings);
 #else
                 driver = NetworkDriver.Create(new UDPNetworkInterface(), m_NetworkSettings);
 #endif

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -150,6 +150,18 @@ namespace Unity.Netcode.Transports.UTP
         [SerializeField]
         private ProtocolType m_ProtocolType;
 
+#if UTP_TRANSPORT_2_0_ABOVE
+        [Tooltip("Whether or not to use WebSockets as Network Interface")]
+        [SerializeField]
+        private bool m_UseWebSockets = false;
+
+        public bool UseWebSockets
+        {
+            set => m_UseWebSockets = value;
+            get => m_UseWebSockets;
+        }
+#endif
+
         [Tooltip("The maximum amount of packets that can be in the internal send/receive queues. Basically this is how many packets can be sent/received in a single update/frame.")]
         [SerializeField]
         private int m_MaxPacketQueueSize = InitialMaxPacketQueueSize;
@@ -1362,7 +1374,16 @@ namespace Unity.Netcode.Transports.UTP
 #endif
                 heartbeatTimeoutMS: transport.m_HeartbeatTimeoutMS);
 
-            driver = NetworkDriver.Create(m_NetworkSettings);
+#if UTP_TRANSPORT_2_0_ABOVE
+            if (m_UseWebSockets)
+            {
+                driver = NetworkDriver.Create(new WebSocketNetworkInterface(), m_NetworkSettings);
+            }
+            else
+#endif
+            {
+                driver = NetworkDriver.Create(new BaselibNetworkInterface(), m_NetworkSettings);
+            }
 
 #if MULTIPLAYER_TOOLS_1_0_0_PRE_7
 #if UTP_TRANSPORT_2_0_ABOVE

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1385,7 +1385,7 @@ namespace Unity.Netcode.Transports.UTP
             else
             {
 #if UNITY_WEBGL
-                Debug.LogWarning("WebSockets were used even though they're not selected in NetworkManager. You should adjust the setting, to silence this warning.");
+                Debug.LogWarning($"WebSockets were used even though they're not selected in NetworkManager. You should check {nameof(UseWebSockets)}', on the Unity Transport component, to silence this warning.");
                 driver = NetworkDriver.Create(new WebSocketNetworkInterface(), m_NetworkSettings);
 #else
                 driver = NetworkDriver.Create(new UDPNetworkInterface(), m_NetworkSettings);


### PR DESCRIPTION
This PR is another step for https://jira.unity3d.com/browse/MTT-4522

It brings us to a point where

- Users can use WebSocket connections on platforms where it is supported (including WebGL.)
- WebSocket-based connection works on Desktop platforms
- WebSocket-based connection works on WebGL platform
- Additive-only changes, no breaking changes, are introduced

It doesn't yet cover:

- WebSocket works with Unity Relay

As this is not ready on the Relay side.

In order to use WebSockets, user must check "Use Web Sockets":

![image](https://user-images.githubusercontent.com/24359051/189996116-069d3a59-dcfb-48d6-b67e-b5813543c26f.png)

