### PR TITLE
fix: Set state private RPC handlers were not honoring local vs world space assignment of position and rotation

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -19,7 +19,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where the `SetStateServerRpc` and `SetStateClientRpc` were not honoring local vs world space settings when applying the position and rotation. (#2203)
+- Fixed issue where `NetworkTransform.SetStateServerRpc` and `NetworkTransform.SetStateClientRpc` were not honoring local vs world space settings when applying the position and rotation. (#2203)
 - Fixed ILPP `TypeLoadException` on WebGL on MacOS Editor and potentially other platforms. (#2199)
 - Implicit conversion of NetworkObjectReference to GameObject will now return null instead of throwing an exception if the referenced object could not be found (i.e., was already despawned) (#2158)
 - Fixed warning resulting from a stray NetworkAnimator.meta file (#2153)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -19,7 +19,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where the `SetStateServerRpc` and `SetStateClientRpc` were not honoring local vs world space settings when applying the position and rotation.
+- Fixed issue where the `SetStateServerRpc` and `SetStateClientRpc` were not honoring local vs world space settings when applying the position and rotation. (#2203)
 - Fixed ILPP `TypeLoadException` on WebGL on MacOS Editor and potentially other platforms. (#2199)
 - Implicit conversion of NetworkObjectReference to GameObject will now return null instead of throwing an exception if the referenced object could not be found (i.e., was already despawned) (#2158)
 - Fixed warning resulting from a stray NetworkAnimator.meta file (#2153)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -19,6 +19,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where the `SetStateServerRpc` and `SetStateClientRpc` were not honoring local vs world space settings when applying the position and rotation.
 - Fixed ILPP `TypeLoadException` on WebGL on MacOS Editor and potentially other platforms. (#2199)
 - Implicit conversion of NetworkObjectReference to GameObject will now return null instead of throwing an exception if the referenced object could not be found (i.e., was already despawned) (#2158)
 - Fixed warning resulting from a stray NetworkAnimator.meta file (#2153)

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -1169,11 +1169,7 @@ namespace Unity.Netcode.Components
         private void SetStateClientRpc(Vector3 pos, Quaternion rot, Vector3 scale, bool shouldTeleport, ClientRpcParams clientRpcParams = default)
         {
             // Server dictated state is always applied
-            transform.position = pos;
-            transform.rotation = rot;
-            transform.localScale = scale;
-            m_LocalAuthoritativeNetworkState.IsTeleportingNextFrame = shouldTeleport;
-            TryCommitTransform(transform, m_CachedNetworkManager.LocalTime.Time);
+            SetStateInternal(pos, rot, scale, shouldTeleport);
         }
 
         /// <summary>
@@ -1190,12 +1186,7 @@ namespace Unity.Netcode.Components
             {
                 (pos, rot, scale) = OnClientRequestChange(pos, rot, scale);
             }
-
-            transform.position = pos;
-            transform.rotation = rot;
-            transform.localScale = scale;
-            m_LocalAuthoritativeNetworkState.IsTeleportingNextFrame = shouldTeleport;
-            TryCommitTransform(transform, m_CachedNetworkManager.LocalTime.Time);
+            SetStateInternal(pos, rot, scale, shouldTeleport);
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -531,7 +531,7 @@ namespace Unity.Netcode.RuntimeTests
                 authPlayerTransform.position = nextPosition;
                 m_OwnerTransform.CommitToTransform();
             }
-            else if (overideState == OverrideState.SetState)
+            else
             {
                 m_OwnerTransform.SetState(nextPosition, null, null, m_AuthoritativeTransform.Interpolate);
             }


### PR DESCRIPTION
Noticed the SetStateServerRpc and SetStateClientRpc were not honoring local vs world position and rotation.  This just replaces that legacy code with the SetStateInternal method that does honor local vs world space.

## Changelog
- Fixed issue where the `SetStateServerRpc` and `SetStateClientRpc` were not honoring local vs world space settings when applying the position and rotation.

## Testing and Documentation
- Includes modifications to existing integration tests.
