### PR TITLE
fix: Allow restarting UnityTransport (MTT-3452)

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -19,6 +19,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue #1924 where restarting `UnityTransport` (e.g. calling `UnityTransport.StartServer` after it had first failed) would always fail.
 - Fixed issue where `NetworkTransform.SetStateServerRpc` and `NetworkTransform.SetStateClientRpc` were not honoring local vs world space settings when applying the position and rotation. (#2203)
 - Fixed ILPP `TypeLoadException` on WebGL on MacOS Editor and potentially other platforms. (#2199)
 - Implicit conversion of NetworkObjectReference to GameObject will now return null instead of throwing an exception if the referenced object could not be found (i.e., was already despawned) (#2158)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -19,7 +19,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue #1924 where restarting `UnityTransport` (e.g. calling `UnityTransport.StartServer` after it had first failed) would always fail.
+- Fixed issue #1924 where restarting `UnityTransport` (e.g. calling `UnityTransport.StartServer` after it had first failed) would always fail. (#2210)
 - Fixed issue where `NetworkTransform.SetStateServerRpc` and `NetworkTransform.SetStateClientRpc` were not honoring local vs world space settings when applying the position and rotation. (#2203)
 - Fixed ILPP `TypeLoadException` on WebGL on MacOS Editor and potentially other platforms. (#2199)
 - Implicit conversion of NetworkObjectReference to GameObject will now return null instead of throwing an exception if the referenced object could not be found (i.e., was already despawned) (#2158)

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -411,14 +411,23 @@ namespace Unity.Netcode.Transports.UTP
                 m_Driver.Dispose();
             }
 
-            m_NetworkSettings.Dispose();
-
             foreach (var queue in m_SendQueue.Values)
             {
                 queue.Dispose();
             }
 
             m_SendQueue.Clear();
+        }
+
+        ~UnityTransport()
+        {
+            // Safeguard if we didn't dispose of the driver/settings through OnDestroy.
+            if (m_Driver.IsCreated)
+            {
+                m_Driver.Dispose();
+            }
+
+            m_NetworkSettings.Dispose();
         }
 
         private NetworkPipeline SelectSendPipeline(NetworkDelivery delivery)
@@ -881,6 +890,7 @@ namespace Unity.Netcode.Transports.UTP
         private void OnDestroy()
         {
             DisposeInternals();
+            m_NetworkSettings.Dispose();
         }
 
 #if MULTIPLAYER_TOOLS_1_0_0_PRE_7

--- a/com.unity.netcode.gameobjects/Tests/Editor/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Transports/UnityTransportTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using Unity.Netcode.Transports.UTP;
 using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace Unity.Netcode.EditorTests
 {
@@ -8,7 +9,7 @@ namespace Unity.Netcode.EditorTests
     {
         // Check that starting a server doesn't immediately result in faulted tasks.
         [Test]
-        public void BasicInitServer()
+        public void UnityTransport_BasicInitServer()
         {
             UnityTransport transport = new GameObject().AddComponent<UnityTransport>();
             transport.Initialize();
@@ -20,7 +21,7 @@ namespace Unity.Netcode.EditorTests
 
         // Check that starting a client doesn't immediately result in faulted tasks.
         [Test]
-        public void BasicInitClient()
+        public void UnityTransport_BasicInitClient()
         {
             UnityTransport transport = new GameObject().AddComponent<UnityTransport>();
             transport.Initialize();
@@ -32,7 +33,7 @@ namespace Unity.Netcode.EditorTests
 
         // Check that we can't restart a server.
         [Test]
-        public void NoRestartServer()
+        public void UnityTransport_NoRestartServer()
         {
             UnityTransport transport = new GameObject().AddComponent<UnityTransport>();
             transport.Initialize();
@@ -45,7 +46,7 @@ namespace Unity.Netcode.EditorTests
 
         // Check that we can't restart a client.
         [Test]
-        public void NoRestartClient()
+        public void UnityTransport_NoRestartClient()
         {
             UnityTransport transport = new GameObject().AddComponent<UnityTransport>();
             transport.Initialize();
@@ -58,7 +59,7 @@ namespace Unity.Netcode.EditorTests
 
         // Check that we can't start both a server and client on the same transport.
         [Test]
-        public void NotBothServerAndClient()
+        public void UnityTransport_NotBothServerAndClient()
         {
             UnityTransport transport;
 
@@ -77,6 +78,25 @@ namespace Unity.Netcode.EditorTests
 
             transport.StartClient();
             Assert.False(transport.StartServer());
+
+            transport.Shutdown();
+        }
+
+        // Check that restarting after failure succeeds.
+        [Test]
+        public void UnityTransport_RestartSucceedsAfterFailure()
+        {
+            UnityTransport transport = new GameObject().AddComponent<UnityTransport>();
+            transport.Initialize();
+
+            transport.SetConnectionData("127.0.0.", 4242);
+            Assert.False(transport.StartServer());
+
+            LogAssert.Expect(LogType.Error, "Invalid network endpoint: 127.0.0.:4242.");
+            LogAssert.Expect(LogType.Error, "Server failed to bind");
+
+            transport.SetConnectionData("127.0.0.1", 4242);
+            Assert.True(transport.StartServer());
 
             transport.Shutdown();
         }


### PR DESCRIPTION
This fixes issue #1924.

The cause of the issue is that after a first failure to start a server, the transport was shut down, which involved disposing of the `NetworkSettings`. But these settings are created in `Initialize` and expected to be allocated when we call `StartServer`. So when we called it again, we'd attempt to modify settings that have been disposed of.

So ultimately, the root cause of the issue is that the driver and settings have different lifetimes. Ideally, their lifetimes would be the same. But we can't do that because some users rely on the settings being created before the driver to modify them. The fix that this PR implements is to preserve the originally-intended lifetime of the settings, which means that they're not disposed of in the settings anymore. They're only disposed of in `OnDestroy`, and in a new finalizer that acts as a safeguard in case they were not disposed of otherwise (e.g. if destroyed with `DestroyImmediate`).

## Changelog

- Fixed: Fixed issue #1924 where restarting `UnityTransport` (e.g. calling `UnityTransport.StartServer` after it had first failed) would always fail.

## Testing and Documentation

- Includes unit test.
- No documentation changes or additions were necessary.