### PR TITLE
feat: Dynamically size the UnityTransport send queues [MTT-2816]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -15,8 +15,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
-- The send queues of `UnityTransport` are now dynamically-sized. This means that there shouldn't be any need anymore to tweak the 'Max Send Queue Size' value. In fact, this field is now removed from the inspector and will not be serialized anymore. It is still possible to set it manually using the `MaxSendQueueSize` property, but it is not recommended to do so aside from some specific needs (e.g. limiting the amount of memory used by the send queues in very constrained environments).
-- As a consequence of the above change, the `UnityTransport.InitialMaxSendQueueSize` field is now deprecated. There is no default value anymore since send queues are dynamically-sized.
+- The send queues of `UnityTransport` are now dynamically-sized. This means that there shouldn't be any need anymore to tweak the 'Max Send Queue Size' value. In fact, this field is now removed from the inspector and will not be serialized anymore. It is still possible to set it manually using the `MaxSendQueueSize` property, but it is not recommended to do so aside from some specific needs (e.g. limiting the amount of memory used by the send queues in very constrained environments). (#2212)
+- As a consequence of the above change, the `UnityTransport.InitialMaxSendQueueSize` field is now deprecated. There is no default value anymore since send queues are dynamically-sized. (#2212)
 - The debug simulator in `UnityTransport` is now non-deterministic. Its random number generator used to be seeded with a constant value, leading to the same pattern of packet drops, delays, and jitter in every run. (#2196)
 
 ### Fixed

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -15,6 +15,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+- The send queues of `UnityTransport` are now dynamically-sized. This means that there shouldn't be any need anymore to tweak the 'Max Send Queue Size' value. In fact, this field is now removed from the inspector and will not be serialized anymore. It is still possible to set it manually using the `MaxSendQueueSize` property, but it is not recommended to do so aside from some specific needs (e.g. limiting the amount of memory used by the send queues in very constrained environments).
+- As a consequence of the above change, the `UnityTransport.InitialMaxSendQueueSize` field is now deprecated. There is no default value anymore since send queues are dynamically-sized.
 - The debug simulator in `UnityTransport` is now non-deterministic. Its random number generator used to be seeded with a constant value, leading to the same pattern of packet drops, delays, and jitter in every run. (#2196)
 
 ### Fixed

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/BatchedSendQueue.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/BatchedSendQueue.cs
@@ -18,7 +18,7 @@ namespace Unity.Netcode.Transports.UTP
     /// </remarks>
     internal struct BatchedSendQueue : IDisposable
     {
-        internal NativeList<byte> m_Data;
+        private NativeList<byte> m_Data;
         private NativeArray<int> m_HeadTailIndices;
         private int m_MaximumCapacity;
         private int m_MinimumCapacity;
@@ -26,11 +26,14 @@ namespace Unity.Netcode.Transports.UTP
         /// <summary>Overhead that is added to each message in the queue.</summary>
         public const int PerMessageOverhead = sizeof(int);
 
-        internal const int k_MinimumMinimumCapacity = 4096;
+        internal const int MinimumMinimumCapacity = 4096;
 
         // Indices into m_HeadTailIndicies.
         private const int k_HeadInternalIndex = 0;
         private const int k_TailInternalIndex = 1;
+
+        // Only used for testing purposes.
+        internal int BackingListLength => m_Data.Length;
 
         /// <summary>Index of the first byte of the oldest data in the queue.</summary>
         private int HeadIndex
@@ -63,7 +66,7 @@ namespace Unity.Netcode.Transports.UTP
             // since we expect maximum capacities to be in the megabytes range). The approach taken
             // here avoids this issue, at the cost of not having allocations of nice round sizes.
             m_MinimumCapacity = m_MaximumCapacity;
-            while (m_MinimumCapacity / 2 >= k_MinimumMinimumCapacity)
+            while (m_MinimumCapacity / 2 >= MinimumMinimumCapacity)
             {
                 m_MinimumCapacity /= 2;
             }

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/BatchedSendQueue.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/BatchedSendQueue.cs
@@ -73,8 +73,6 @@ namespace Unity.Netcode.Transports.UTP
 
             m_Data.ResizeUninitialized(m_MinimumCapacity);
 
-            UnityEngine.Debug.Log($"min: {m_MinimumCapacity}, max: {m_MaximumCapacity}");
-
             HeadIndex = 0;
             TailIndex = 0;
         }

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/BatchedSendQueue.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/BatchedSendQueue.cs
@@ -8,21 +8,25 @@ namespace Unity.Netcode.Transports.UTP
     /// <summary>Queue for batched messages meant to be sent through UTP.</summary>
     /// <remarks>
     /// Messages should be pushed on the queue with <see cref="PushMessage"/>. To send batched
-    /// messages, call <see cref="FillWriter"> with the <see cref="DataStreamWriter"/> obtained from
-    /// <see cref="NetworkDriver.BeginSend"/>. This will fill the writer with as many messages as
-    /// possible. If the send is successful, call <see cref="Consume"/> to remove the data from the
-    /// queue.
+    /// messages, call <see cref="FillWriterWithMessages"/> or <see cref="FillWriterWithBytes"/>
+    /// with the <see cref="DataStreamWriter"/> obtained from <see cref="NetworkDriver.BeginSend"/>.
+    /// This will fill the writer with as many messages/bytes as possible. If the send is
+    /// successful, call <see cref="Consume"/> to remove the data from the queue.
     ///
     /// This is meant as a companion to <see cref="BatchedReceiveQueue"/>, which should be used to
     /// read messages sent with this queue.
     /// </remarks>
     internal struct BatchedSendQueue : IDisposable
     {
-        private NativeArray<byte> m_Data;
+        private NativeList<byte> m_Data;
         private NativeArray<int> m_HeadTailIndices;
+        private int m_MaximumCapacity;
+        private int m_MinimumCapacity;
 
         /// <summary>Overhead that is added to each message in the queue.</summary>
         public const int PerMessageOverhead = sizeof(int);
+
+        private const int k_MinimumMinimumCapacity = 4096;
 
         // Indices into m_HeadTailIndicies.
         private const int k_HeadInternalIndex = 0;
@@ -43,17 +47,33 @@ namespace Unity.Netcode.Transports.UTP
         }
 
         public int Length => TailIndex - HeadIndex;
-
         public bool IsEmpty => HeadIndex == TailIndex;
-
         public bool IsCreated => m_Data.IsCreated;
 
         /// <summary>Construct a new empty send queue.</summary>
         /// <param name="capacity">Maximum capacity of the send queue.</param>
         public BatchedSendQueue(int capacity)
         {
-            m_Data = new NativeArray<byte>(capacity, Allocator.Persistent);
+            // Make sure the maximum capacity will be even.
+            m_MaximumCapacity = capacity + (capacity & 1);
+
+            // We pick the minimum capacity such that if we keep doubling it, we'll eventually hit
+            // the maximum capacity exactly. The alternative would be to use capacities that are
+            // powers of 2, but this can lead to over-allocating quite a bit of memory (especially
+            // since we expect maximum capacities to be in the megabytes range). The approach taken
+            // here avoids this issue, at the cost of not having allocations of nice round sizes.
+            m_MinimumCapacity = m_MaximumCapacity;
+            while (m_MinimumCapacity / 2 >= k_MinimumMinimumCapacity)
+            {
+                m_MinimumCapacity /= 2;
+            }
+
+            m_Data = new NativeList<byte>(m_MinimumCapacity, Allocator.Persistent);
             m_HeadTailIndices = new NativeArray<int>(2, Allocator.Persistent);
+
+            m_Data.ResizeUninitialized(m_MinimumCapacity);
+
+            UnityEngine.Debug.Log($"min: {m_MinimumCapacity}, max: {m_MaximumCapacity}");
 
             HeadIndex = 0;
             TailIndex = 0;
@@ -68,6 +88,16 @@ namespace Unity.Netcode.Transports.UTP
             }
         }
 
+        /// <summary>Write a raw buffer to a DataStreamWriter.</summary>
+        private unsafe void WriteBytes(ref DataStreamWriter writer, byte* data, int length)
+        {
+#if UTP_TRANSPORT_2_0_ABOVE
+            writer.WriteBytesUnsafe(data, length);
+#else
+            writer.WriteBytes(data, length);
+#endif
+        }
+
         /// <summary>Append data at the tail of the queue. No safety checks.</summary>
         private void AppendDataAtTail(ArraySegment<byte> data)
         {
@@ -79,11 +109,7 @@ namespace Unity.Netcode.Transports.UTP
 
                 fixed (byte* dataPtr = data.Array)
                 {
-#if UTP_TRANSPORT_2_0_ABOVE
-                    writer.WriteBytesUnsafe(dataPtr + data.Offset, data.Count);
-#else
-                    writer.WriteBytes(dataPtr + data.Offset, data.Count);
-#endif
+                    WriteBytes(ref writer, dataPtr + data.Offset, data.Count);
                 }
             }
 
@@ -110,10 +136,10 @@ namespace Unity.Netcode.Transports.UTP
                 return true;
             }
 
-            // Check if there would be enough room if we moved data at the beginning of m_Data.
-            if (m_Data.Length - TailIndex + HeadIndex >= sizeof(int) + message.Count)
+            // Move the data at the beginning of of m_Data. Either it will leave enough space for
+            // the message, or we'll grow m_Data and will want the data at the beginning anyway.
+            if (HeadIndex > 0 && Length > 0)
             {
-                // Move the data back at the beginning of m_Data.
                 unsafe
                 {
                     UnsafeUtility.MemMove(m_Data.GetUnsafePtr(), (byte*)m_Data.GetUnsafePtr() + HeadIndex, Length);
@@ -121,12 +147,38 @@ namespace Unity.Netcode.Transports.UTP
 
                 TailIndex = Length;
                 HeadIndex = 0;
+            }
 
+            // If there's enough space left at the end for the message, now is a good time to trim
+            // the capacity of m_Data if it got very large. We define "very large" here as having
+            // more than 75% of m_Data unused after adding the new message.
+            if (m_Data.Length - TailIndex >= sizeof(int) + message.Count)
+            {
                 AppendDataAtTail(message);
+
+                while (TailIndex < m_Data.Length / 4 && m_Data.Length > m_MinimumCapacity)
+                {
+                    m_Data.ResizeUninitialized(m_Data.Length / 2);
+                }
+
                 return true;
             }
 
-            return false;
+            // If we get here we need to grow m_Data until the data fits (or it's too large).
+            while (m_Data.Length - TailIndex < sizeof(int) + message.Count)
+            {
+                // Can't grow m_Data anymore. Message simply won't fit.
+                if (m_Data.Length * 2 > m_MaximumCapacity)
+                {
+                    return false;
+                }
+
+                m_Data.ResizeUninitialized(m_Data.Length * 2);
+            }
+
+            // If we get here we know there's now enough room for the message.
+            AppendDataAtTail(message);
+            return true;
         }
 
         /// <summary>
@@ -153,11 +205,13 @@ namespace Unity.Netcode.Transports.UTP
 
             unsafe
             {
+                var dataPtr = (byte*)m_Data.GetUnsafePtr() + HeadIndex;
+
 #if UTP_TRANSPORT_2_0_ABOVE
-                var slice = m_Data.GetSubArray(HeadIndex, Length);
+                var slice = NativeArray.ConvertExistingDataToNativeArray<byte>(dataPtr, Length, Allocator.None);
                 var reader = new DataStreamReader(slice);
 #else
-                var reader = new DataStreamReader((byte*)m_Data.GetUnsafePtr() + HeadIndex, Length);
+                var reader = new DataStreamReader(dataPtr, Length);
 #endif
 
                 var writerAvailable = writer.Capacity;
@@ -177,11 +231,7 @@ namespace Unity.Netcode.Transports.UTP
                         writer.WriteInt(messageLength);
 
                         var messageOffset = HeadIndex + reader.GetBytesRead();
-#if UTP_TRANSPORT_2_0_ABOVE
-                        writer.WriteBytesUnsafe((byte*)m_Data.GetUnsafePtr() + messageOffset, messageLength);
-#else
-                        writer.WriteBytes((byte*)m_Data.GetUnsafePtr() + messageOffset, messageLength);
-#endif
+                        WriteBytes(ref writer, (byte*)m_Data.GetUnsafePtr() + messageOffset, messageLength);
 
                         writerAvailable -= sizeof(int) + messageLength;
                         readerOffset += sizeof(int) + messageLength;
@@ -218,11 +268,7 @@ namespace Unity.Netcode.Transports.UTP
 
             unsafe
             {
-#if UTP_TRANSPORT_2_0_ABOVE
-                writer.WriteBytesUnsafe((byte*)m_Data.GetUnsafePtr() + HeadIndex, copyLength);
-#else
-                writer.WriteBytes((byte*)m_Data.GetUnsafePtr() + HeadIndex, copyLength);
-#endif
+                WriteBytes(ref writer, (byte*)m_Data.GetUnsafePtr() + HeadIndex, copyLength);
             }
 
             return copyLength;
@@ -236,10 +282,14 @@ namespace Unity.Netcode.Transports.UTP
         /// <param name="size">Number of bytes to consume from the queue.</param>
         public void Consume(int size)
         {
+            // Adjust the head/tail indices such that we consume the given size.
             if (size >= Length)
             {
                 HeadIndex = 0;
                 TailIndex = 0;
+
+                // This is a no-op if m_Data is already at minimum capacity.
+                m_Data.ResizeUninitialized(m_MinimumCapacity);
             }
             else
             {

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/BatchedSendQueue.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/BatchedSendQueue.cs
@@ -18,7 +18,7 @@ namespace Unity.Netcode.Transports.UTP
     /// </remarks>
     internal struct BatchedSendQueue : IDisposable
     {
-        private NativeList<byte> m_Data;
+        internal NativeList<byte> m_Data;
         private NativeArray<int> m_HeadTailIndices;
         private int m_MaximumCapacity;
         private int m_MinimumCapacity;
@@ -26,7 +26,7 @@ namespace Unity.Netcode.Transports.UTP
         /// <summary>Overhead that is added to each message in the queue.</summary>
         public const int PerMessageOverhead = sizeof(int);
 
-        private const int k_MinimumMinimumCapacity = 4096;
+        internal const int k_MinimumMinimumCapacity = 4096;
 
         // Indices into m_HeadTailIndicies.
         private const int k_HeadInternalIndex = 0;

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -130,6 +130,7 @@ namespace Unity.Netcode.Transports.UTP
         /// <summary>
         /// The default maximum send queue size
         /// </summary>
+        [Obsolete("MaxSendQueueSize is now determined dynamically. This initial value is not used anymore.", false)]
         public const int InitialMaxSendQueueSize = 16 * InitialMaxPayloadSize;
 
         private static ConnectionAddressData s_DefaultConnectionAddressData = new ConnectionAddressData { Address = "127.0.0.1", Port = 7777, ServerListenAddress = string.Empty };
@@ -186,15 +187,17 @@ namespace Unity.Netcode.Transports.UTP
             set => m_MaxPayloadSize = value;
         }
 
-        [Tooltip("The maximum size in bytes of the transport send queue. The send queue accumulates messages for batching and stores messages when other internal send queues are full. If you routinely observe an error about too many in-flight packets, try increasing this.")]
-        [SerializeField]
-        private int m_MaxSendQueueSize = InitialMaxSendQueueSize;
+        private int m_MaxSendQueueSize = 0;
 
         /// <summary>The maximum size in bytes of the transport send queue.</summary>
         /// <remarks>
         /// The send queue accumulates messages for batching and stores messages when other internal
-        /// send queues are full. If you routinely observe an error about too many in-flight packets,
-        /// try increasing this.
+        /// send queues are full. Note that there should not be any need to set this value manually
+        /// since the send queue size is dynamically sized based on need.
+        ///
+        /// This value should only be set if you have particular requirements (e.g. if you want to
+        /// limit the memory usage of the send queues). Note however that setting this value too low
+        /// can easily lead to disconnections under heavy traffic.
         /// </remarks>
         public int MaxSendQueueSize
         {
@@ -531,11 +534,6 @@ namespace Unity.Netcode.Transports.UTP
                     return RelayConnectionData.FromBytePointer(ptr, RelayConnectionData.k_Length);
                 }
             }
-        }
-
-        internal void SetMaxPayloadSize(int maxPayloadSize)
-        {
-            m_MaxPayloadSize = maxPayloadSize;
         }
 
         private void SetProtocol(ProtocolType inProtocol)
@@ -1191,7 +1189,23 @@ namespace Unity.Netcode.Transports.UTP
             var sendTarget = new SendTarget(clientId, pipeline);
             if (!m_SendQueue.TryGetValue(sendTarget, out var queue))
             {
-                queue = new BatchedSendQueue(Math.Max(m_MaxSendQueueSize, m_MaxPayloadSize));
+                // The maximum size of a send queue is determined according to the disconnection
+                // timeout. The idea being that if the send queue contains enough reliable data that
+                // sending it all out would take longer than the disconnection timeout, then there's
+                // no point storing even more in the queue (it would be like having a ping higher
+                // than the disconnection timeout, which is far into the realm of unplayability).
+                //
+                // The throughput used to determine what consists the maximum send queue size is
+                // the maximum theoritical throughput of the reliable pipeline assuming we only send
+                // on each update at 60 FPS, which turns out to be around 2.688 MB/s.
+                //
+                // Note that we only care about reliable throughput for send queues because that's
+                // the only case where a full send queue causes a connection loss. Full unreliable
+                // send queues are dealt with by flushing it out to the network or simply dropping
+                // new messages if that fails.
+                var maxCapacity = m_MaxSendQueueSize > 0 ? m_MaxSendQueueSize : m_DisconnectTimeoutMS * 2688;
+
+                queue = new BatchedSendQueue(Math.Max(maxCapacity, m_MaxPayloadSize));
                 m_SendQueue.Add(sendTarget, queue);
             }
 
@@ -1205,8 +1219,7 @@ namespace Unity.Netcode.Transports.UTP
 
                     var ngoClientId = NetworkManager?.TransportIdToClientId(clientId) ?? clientId;
                     Debug.LogError($"Couldn't add payload of size {payload.Count} to reliable send queue. " +
-                        $"Closing connection {ngoClientId} as reliability guarantees can't be maintained. " +
-                        $"Perhaps 'Max Send Queue Size' ({m_MaxSendQueueSize}) is too small for workload.");
+                        $"Closing connection {ngoClientId} as reliability guarantees can't be maintained.");
 
                     if (clientId == m_ServerClientId)
                     {

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -130,8 +130,12 @@ namespace Unity.Netcode.Transports.UTP
         /// <summary>
         /// The default maximum send queue size
         /// </summary>
-        [Obsolete("MaxSendQueueSize is now determined dynamically. This initial value is not used anymore.", false)]
+        [Obsolete("MaxSendQueueSize is now determined dynamically (can still be set programmatically using the MaxSendQueueSize property). This initial value is not used anymore.", false)]
         public const int InitialMaxSendQueueSize = 16 * InitialMaxPayloadSize;
+
+        // Maximum reliable throughput, assuming the full reliable window can be sent on every
+        // frame at 60 FPS. This will be a large over-estimation in any realistic scenario.
+        private const int k_MaxReliableThroughput = (NetworkParameterConstants.MTU * 32 * 60) / 1000; // bytes per millisecond
 
         private static ConnectionAddressData s_DefaultConnectionAddressData = new ConnectionAddressData { Address = "127.0.0.1", Port = 7777, ServerListenAddress = string.Empty };
 
@@ -1203,7 +1207,7 @@ namespace Unity.Netcode.Transports.UTP
                 // the only case where a full send queue causes a connection loss. Full unreliable
                 // send queues are dealt with by flushing it out to the network or simply dropping
                 // new messages if that fails.
-                var maxCapacity = m_MaxSendQueueSize > 0 ? m_MaxSendQueueSize : m_DisconnectTimeoutMS * 2688;
+                var maxCapacity = m_MaxSendQueueSize > 0 ? m_MaxSendQueueSize : m_DisconnectTimeoutMS * k_MaxReliableThroughput;
 
                 queue = new BatchedSendQueue(Math.Max(maxCapacity, m_MaxPayloadSize));
                 m_SendQueue.Add(sendTarget, queue);

--- a/com.unity.netcode.gameobjects/Tests/Editor/Transports/BatchedSendQueueTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Transports/BatchedSendQueueTests.cs
@@ -56,7 +56,7 @@ namespace Unity.Netcode.EditorTests
         public void BatchedSendQueue_InitialCapacityLessThanMaximum()
         {
             using var q = new BatchedSendQueue(k_TestQueueCapacity);
-            Assert.AreEqual(q.BackingListLength, BatchedSendQueue.MinimumMinimumCapacity);
+            Assert.AreEqual(q.Capacity, BatchedSendQueue.MinimumMinimumCapacity);
         }
 
         [Test]
@@ -102,7 +102,7 @@ namespace Unity.Netcode.EditorTests
             using var q = new BatchedSendQueue(k_TestQueueCapacity);
             var messageLength = k_TestMessageSize + BatchedSendQueue.PerMessageOverhead;
 
-            Assert.AreEqual(q.BackingListLength, BatchedSendQueue.MinimumMinimumCapacity);
+            Assert.AreEqual(q.Capacity, BatchedSendQueue.MinimumMinimumCapacity);
 
             var numMessagesToFillMinimum = BatchedSendQueue.MinimumMinimumCapacity / messageLength;
             for (int i = 0; i < numMessagesToFillMinimum; i++)
@@ -110,11 +110,11 @@ namespace Unity.Netcode.EditorTests
                 q.PushMessage(m_TestMessage);
             }
 
-            Assert.AreEqual(q.BackingListLength, BatchedSendQueue.MinimumMinimumCapacity);
+            Assert.AreEqual(q.Capacity, BatchedSendQueue.MinimumMinimumCapacity);
 
             q.PushMessage(m_TestMessage);
 
-            Assert.AreEqual(q.BackingListLength, BatchedSendQueue.MinimumMinimumCapacity * 2);
+            Assert.AreEqual(q.Capacity, BatchedSendQueue.MinimumMinimumCapacity * 2);
         }
 
         [Test]
@@ -127,9 +127,9 @@ namespace Unity.Netcode.EditorTests
                 Assert.IsTrue(q.PushMessage(m_TestMessage));
             }
 
-            Assert.AreEqual(q.BackingListLength, k_TestQueueCapacity);
+            Assert.AreEqual(q.Capacity, k_TestQueueCapacity);
             Assert.IsFalse(q.PushMessage(m_TestMessage));
-            Assert.AreEqual(q.BackingListLength, k_TestQueueCapacity);
+            Assert.AreEqual(q.Capacity, k_TestQueueCapacity);
         }
 
         [Test]
@@ -143,11 +143,11 @@ namespace Unity.Netcode.EditorTests
                 Assert.IsTrue(q.PushMessage(m_TestMessage));
             }
 
-            Assert.AreEqual(q.BackingListLength, k_TestQueueCapacity);
+            Assert.AreEqual(q.Capacity, k_TestQueueCapacity);
             q.Consume(messageLength * (k_NumMessagesToFillQueue - 1));
             Assert.IsTrue(q.PushMessage(m_TestMessage));
             Assert.AreEqual(messageLength * 2, q.Length);
-            Assert.AreEqual(q.BackingListLength, BatchedSendQueue.MinimumMinimumCapacity * 2);
+            Assert.AreEqual(q.Capacity, BatchedSendQueue.MinimumMinimumCapacity * 2);
         }
 
         [Test]
@@ -334,9 +334,9 @@ namespace Unity.Netcode.EditorTests
                 q.PushMessage(m_TestMessage);
             }
 
-            Assert.AreEqual(q.BackingListLength, k_TestQueueCapacity);
+            Assert.AreEqual(q.Capacity, k_TestQueueCapacity);
             q.Consume(k_TestQueueCapacity);
-            Assert.AreEqual(q.BackingListLength, BatchedSendQueue.MinimumMinimumCapacity);
+            Assert.AreEqual(q.Capacity, BatchedSendQueue.MinimumMinimumCapacity);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Editor/Transports/BatchedSendQueueTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Transports/BatchedSendQueueTests.cs
@@ -8,7 +8,7 @@ namespace Unity.Netcode.EditorTests
 {
     public class BatchedSendQueueTests
     {
-        private const int k_TestQueueCapacity = 1024;
+        private const int k_TestQueueCapacity = 16 * 1024;
         private const int k_TestMessageSize = 42;
 
         private ArraySegment<byte> m_TestMessage;

--- a/com.unity.netcode.gameobjects/Tests/Editor/Transports/BatchedSendQueueTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Transports/BatchedSendQueueTests.cs
@@ -56,7 +56,7 @@ namespace Unity.Netcode.EditorTests
         public void BatchedSendQueue_InitialCapacityLessThanMaximum()
         {
             using var q = new BatchedSendQueue(k_TestQueueCapacity);
-            Assert.AreEqual(q.m_Data.Length, BatchedSendQueue.k_MinimumMinimumCapacity);
+            Assert.AreEqual(q.BackingListLength, BatchedSendQueue.MinimumMinimumCapacity);
         }
 
         [Test]
@@ -102,19 +102,19 @@ namespace Unity.Netcode.EditorTests
             using var q = new BatchedSendQueue(k_TestQueueCapacity);
             var messageLength = k_TestMessageSize + BatchedSendQueue.PerMessageOverhead;
 
-            Assert.AreEqual(q.m_Data.Length, BatchedSendQueue.k_MinimumMinimumCapacity);
+            Assert.AreEqual(q.BackingListLength, BatchedSendQueue.MinimumMinimumCapacity);
 
-            var numMessagesToFillMinimum = BatchedSendQueue.k_MinimumMinimumCapacity / messageLength;
+            var numMessagesToFillMinimum = BatchedSendQueue.MinimumMinimumCapacity / messageLength;
             for (int i = 0; i < numMessagesToFillMinimum; i++)
             {
                 q.PushMessage(m_TestMessage);
             }
 
-            Assert.AreEqual(q.m_Data.Length, BatchedSendQueue.k_MinimumMinimumCapacity);
+            Assert.AreEqual(q.BackingListLength, BatchedSendQueue.MinimumMinimumCapacity);
 
             q.PushMessage(m_TestMessage);
 
-            Assert.AreEqual(q.m_Data.Length, BatchedSendQueue.k_MinimumMinimumCapacity * 2);
+            Assert.AreEqual(q.BackingListLength, BatchedSendQueue.MinimumMinimumCapacity * 2);
         }
 
         [Test]
@@ -127,9 +127,9 @@ namespace Unity.Netcode.EditorTests
                 Assert.IsTrue(q.PushMessage(m_TestMessage));
             }
 
-            Assert.AreEqual(q.m_Data.Length, k_TestQueueCapacity);
+            Assert.AreEqual(q.BackingListLength, k_TestQueueCapacity);
             Assert.IsFalse(q.PushMessage(m_TestMessage));
-            Assert.AreEqual(q.m_Data.Length, k_TestQueueCapacity);
+            Assert.AreEqual(q.BackingListLength, k_TestQueueCapacity);
         }
 
         [Test]
@@ -143,11 +143,11 @@ namespace Unity.Netcode.EditorTests
                 Assert.IsTrue(q.PushMessage(m_TestMessage));
             }
 
-            Assert.AreEqual(q.m_Data.Length, k_TestQueueCapacity);
+            Assert.AreEqual(q.BackingListLength, k_TestQueueCapacity);
             q.Consume(messageLength * (k_NumMessagesToFillQueue - 1));
             Assert.IsTrue(q.PushMessage(m_TestMessage));
             Assert.AreEqual(messageLength * 2, q.Length);
-            Assert.AreEqual(q.m_Data.Length, BatchedSendQueue.k_MinimumMinimumCapacity * 2);
+            Assert.AreEqual(q.BackingListLength, BatchedSendQueue.MinimumMinimumCapacity * 2);
         }
 
         [Test]
@@ -334,9 +334,9 @@ namespace Unity.Netcode.EditorTests
                 q.PushMessage(m_TestMessage);
             }
 
-            Assert.AreEqual(q.m_Data.Length, k_TestQueueCapacity);
+            Assert.AreEqual(q.BackingListLength, k_TestQueueCapacity);
             q.Consume(k_TestQueueCapacity);
-            Assert.AreEqual(q.m_Data.Length, BatchedSendQueue.k_MinimumMinimumCapacity);
+            Assert.AreEqual(q.BackingListLength, BatchedSendQueue.MinimumMinimumCapacity);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTestHelpers.cs
@@ -36,14 +36,16 @@ namespace Unity.Netcode.RuntimeTests
         }
 
         // Common code to initialize a UnityTransport that logs its events.
-        public static void InitializeTransport(out UnityTransport transport, out List<TransportEvent> events, int maxPayloadSize = UnityTransport.InitialMaxPayloadSize)
+        public static void InitializeTransport(out UnityTransport transport, out List<TransportEvent> events,
+            int maxPayloadSize = UnityTransport.InitialMaxPayloadSize, int maxSendQueueSize = 0)
         {
             var logger = new TransportEventLogger();
             events = logger.Events;
 
             transport = new GameObject().AddComponent<UnityTransport>();
             transport.OnTransportEvent += logger.HandleEvent;
-            transport.SetMaxPayloadSize(maxPayloadSize);
+            transport.MaxPayloadSize = maxPayloadSize;
+            transport.MaxSendQueueSize = maxSendQueueSize;
             transport.Initialize();
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
@@ -273,10 +273,10 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator DisconnectOnReliableSendQueueOverflow()
         {
-            const int MaxSendQueueSize = 16 * 1024;
+            const int maxSendQueueSize = 16 * 1024;
 
-            InitializeTransport(out m_Server, out m_ServerEvents, maxSendQueueSize: MaxSendQueueSize);
-            InitializeTransport(out m_Client1, out m_Client1Events, maxSendQueueSize: MaxSendQueueSize);
+            InitializeTransport(out m_Server, out m_ServerEvents, maxSendQueueSize: maxSendQueueSize);
+            InitializeTransport(out m_Client1, out m_Client1Events, maxSendQueueSize: maxSendQueueSize);
 
             m_Server.StartServer();
             m_Client1.StartClient();
@@ -285,7 +285,7 @@ namespace Unity.Netcode.RuntimeTests
 
             m_Server.Shutdown();
 
-            var numSends = (MaxSendQueueSize / 1024);
+            var numSends = (maxSendQueueSize / 1024);
 
             for (int i = 0; i < numSends; i++)
             {
@@ -309,17 +309,17 @@ namespace Unity.Netcode.RuntimeTests
         [UnityPlatform(exclude = new[] { RuntimePlatform.Switch, RuntimePlatform.PS4, RuntimePlatform.PS5 })]
         public IEnumerator SendCompletesOnUnreliableSendQueueOverflow()
         {
-            const int MaxSendQueueSize = 16 * 1024;
+            const int maxSendQueueSize = 16 * 1024;
 
-            InitializeTransport(out m_Server, out m_ServerEvents, maxSendQueueSize: MaxSendQueueSize);
-            InitializeTransport(out m_Client1, out m_Client1Events, maxSendQueueSize: MaxSendQueueSize);
+            InitializeTransport(out m_Server, out m_ServerEvents, maxSendQueueSize: maxSendQueueSize);
+            InitializeTransport(out m_Client1, out m_Client1Events, maxSendQueueSize: maxSendQueueSize);
 
             m_Server.StartServer();
             m_Client1.StartClient();
 
             yield return WaitForNetworkEvent(NetworkEvent.Connect, m_Client1Events);
 
-            var numSends = (MaxSendQueueSize / 1024) + 1;
+            var numSends = (maxSendQueueSize / 1024) + 1;
 
             for (int i = 0; i < numSends; i++)
             {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
@@ -273,8 +273,10 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator DisconnectOnReliableSendQueueOverflow()
         {
-            InitializeTransport(out m_Server, out m_ServerEvents);
-            InitializeTransport(out m_Client1, out m_Client1Events);
+            const int MaxSendQueueSize = 16 * 1024;
+
+            InitializeTransport(out m_Server, out m_ServerEvents, maxSendQueueSize: MaxSendQueueSize);
+            InitializeTransport(out m_Client1, out m_Client1Events, maxSendQueueSize: MaxSendQueueSize);
 
             m_Server.StartServer();
             m_Client1.StartClient();
@@ -283,7 +285,7 @@ namespace Unity.Netcode.RuntimeTests
 
             m_Server.Shutdown();
 
-            var numSends = (UnityTransport.InitialMaxSendQueueSize / 1024);
+            var numSends = (MaxSendQueueSize / 1024);
 
             for (int i = 0; i < numSends; i++)
             {
@@ -292,8 +294,7 @@ namespace Unity.Netcode.RuntimeTests
             }
 
             LogAssert.Expect(LogType.Error, "Couldn't add payload of size 1024 to reliable send queue. " +
-                $"Closing connection {m_Client1.ServerClientId} as reliability guarantees can't be maintained. " +
-                $"Perhaps 'Max Send Queue Size' ({UnityTransport.InitialMaxSendQueueSize}) is too small for workload.");
+                $"Closing connection {m_Client1.ServerClientId} as reliability guarantees can't be maintained.");
 
             Assert.AreEqual(2, m_Client1Events.Count);
             Assert.AreEqual(NetworkEvent.Disconnect, m_Client1Events[1].Type);
@@ -308,15 +309,17 @@ namespace Unity.Netcode.RuntimeTests
         [UnityPlatform(exclude = new[] { RuntimePlatform.Switch, RuntimePlatform.PS4, RuntimePlatform.PS5 })]
         public IEnumerator SendCompletesOnUnreliableSendQueueOverflow()
         {
-            InitializeTransport(out m_Server, out m_ServerEvents);
-            InitializeTransport(out m_Client1, out m_Client1Events);
+            const int MaxSendQueueSize = 16 * 1024;
+
+            InitializeTransport(out m_Server, out m_ServerEvents, maxSendQueueSize: MaxSendQueueSize);
+            InitializeTransport(out m_Client1, out m_Client1Events, maxSendQueueSize: MaxSendQueueSize);
 
             m_Server.StartServer();
             m_Client1.StartClient();
 
             yield return WaitForNetworkEvent(NetworkEvent.Connect, m_Client1Events);
 
-            var numSends = (UnityTransport.InitialMaxSendQueueSize / 1024) + 1;
+            var numSends = (MaxSendQueueSize / 1024) + 1;
 
             for (int i = 0; i < numSends; i++)
             {


### PR DESCRIPTION
This PR (finally!) makes the send queues in `UnityTransport` dynamically-sized.

This means that there should be no need to tweak the 'Max Send Queue Size' property anymore. Send queues will be grown automatically to accommodate new messages. This should also reduce the overall memory footprint since with this change we don't allocate large amounts of memory for "nothing" (e.g. for the unreliable send queues which never grow that large).

There is still a maximum size to these send queues. They won't be grown to some extreme ridiculous sizes. A long comment in `UnityTransport.cs` explains how this value is picked and the rationale for this choice. There is still a way for users to specify their own value if they so desire through the existing `MaxSendQueueSize` property (although it is not recommended).

Because tuning that parameter shouldn't be required anymore, this PR removes the 'Max Send Queue Size' field from the inspector. This will be one less obscure setting users will have to care about. This PR also removes the serialization of that parameter to avoid having a "phantom" serialized field possibly limiting the size of the send queues without having a clear indication of what's going on. Users that desire a custom value should explicitly set the `MaxSendQueueSize` property.

This PR also obsoletes the `InitialMaxSendQueueSize` property of `UnityTransport`. Despite what the name indicates, it was actually just the default value. And since send queues don't really have a default size anymore, having this property around doesn't make much sense.

## Changelog

- Changed: The send queues of `UnityTransport` are now dynamically-sized. This means that there shouldn't be any need anymore to tweak the 'Max Send Queue Size' value. In fact, this field is now removed from the inspector and will not be serialized anymore. It is still possible to set it manually using the `MaxSendQueueSize` property, but it is not recommended to do so aside from some specific needs (e.g. limiting the amount of memory used by the send queues in very constrained environments).
- Deprecated: As a consequence of the above change, the `UnityTransport.InitialMaxSendQueueSize` field is now deprecated. There is no default value anymore since send queues are dynamically-sized.

## Testing and Documentation

- No tests have been added (existing tests exercise the new code).
- No documentation changes or additions were necessary.