### PR TITLE
chore: Remove soon-to-be-deprecated API from UnityTransport

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -579,7 +579,6 @@ namespace Unity.Netcode.Transports.UTP
             }
 
             m_RelayServerData = new RelayServerData(ref serverEndpoint, 0, ref allocationId, ref connectionData, ref hostConnectionData, ref key, isSecure);
-            m_RelayServerData.ComputeNewNonce();
 
             SetProtocol(ProtocolType.RelayUnityTransport);
         }


### PR DESCRIPTION
Minor patch to remove `ComputeNewNonce`. That API is getting deprecated in UTP 1.3, and it will be removed in the next 2.0 experimental release. Usage of this API isn't really required since it just selects a new nonce at random. The Relay team has advised us that it's fine to start our nonces at 0, so there's no real need to generate one at random.

## Changelog

N/A

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.