### PR TITLE
Make TransportInitialized and TransportDisposed public

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Added
 
 - Added WebSocket support when using UTP 2.0 with `UseWebSockets` property in the `UnityTransport` component of the `NetworkManager` allowing to pick WebSockets for communication. When building for WebGL, this selection happens automatically. (#2201)
+- Added `TransportInitialized` and `TransportDisposed` events into the `UnityTransport` class. (#2215)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/AssemblyInfo.cs
+++ b/com.unity.netcode.gameobjects/Runtime/AssemblyInfo.cs
@@ -12,4 +12,3 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Unity.Netcode.RuntimeTests")]
 [assembly: InternalsVisibleTo("Unity.Netcode.TestHelpers.Runtime")]
 [assembly: InternalsVisibleTo("Unity.Netcode.Adapter.UTP")]
-[assembly: InternalsVisibleTo("Unity.Multiplayer.Tools.Adapters.Ngo1WithUtp2")]

--- a/com.unity.netcode.gameobjects/Runtime/AssemblyInfo.cs
+++ b/com.unity.netcode.gameobjects/Runtime/AssemblyInfo.cs
@@ -12,3 +12,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Unity.Netcode.RuntimeTests")]
 [assembly: InternalsVisibleTo("Unity.Netcode.TestHelpers.Runtime")]
 [assembly: InternalsVisibleTo("Unity.Netcode.Adapter.UTP")]
+[assembly: InternalsVisibleTo("Unity.Multiplayer.Tools.Adapters.Ngo1WithUtp2")]

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1,3 +1,12 @@
+// NetSim Implementation compilation boilerplate
+// All references to UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED should be defined in the same way,
+// as any discrepancies are likely to result in build failures
+// ---------------------------------------------------------------------------------------------------------------------
+#if UNITY_EDITOR || ((DEVELOPMENT_BUILD && !UNITY_MP_TOOLS_NETSIM_DISABLED_IN_DEVELOP) || (!DEVELOPMENT_BUILD && UNITY_MP_TOOLS_NETSIM_ENABLED_IN_RELEASE))
+    #define UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
+#endif
+// ---------------------------------------------------------------------------------------------------------------------
+
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -1332,7 +1341,8 @@ namespace Unity.Netcode.Transports.UTP
                 maxPacketSize: NetworkParameterConstants.MTU,
                 packetDelayMs: DebugSimulator.PacketDelayMS,
                 packetJitterMs: DebugSimulator.PacketJitterMS,
-                packetDropPercentage: DebugSimulator.PacketDropRate
+                packetDropPercentage: DebugSimulator.PacketDropRate,
+                randomSeed: DebugSimulatorRandomSeed
 #if UTP_TRANSPORT_2_0_ABOVE
                 , mode: ApplyMode.AllPackets
 #endif
@@ -1362,7 +1372,7 @@ namespace Unity.Netcode.Transports.UTP
 #endif
 #endif
 
-#if UNITY_EDITOR || DEVELOPMENT_BUILD || MULTIPLAYER_TOOLS_1_1_0
+#if UNITY_EDITOR || DEVELOPMENT_BUILD || UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             ConfigureSimulator();
 #endif
 
@@ -1384,7 +1394,7 @@ namespace Unity.Netcode.Transports.UTP
 #endif
 #endif
 
-#if UNITY_EDITOR || DEVELOPMENT_BUILD || MULTIPLAYER_TOOLS_1_1_0
+#if UNITY_EDITOR || DEVELOPMENT_BUILD || UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             if (DebugSimulator.PacketDelayMS > 0 || DebugSimulator.PacketDropRate > 0)
             {
                 unreliableFragmentedPipeline = driver.CreatePipeline(

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -666,11 +666,13 @@ namespace Unity.Netcode.Transports.UTP
             SetConnectionData(serverAddress, endPoint.Port, listenAddress);
         }
 
-#if !UTP_TRANSPORT_2_0_ABOVE
         /// <summary>Set the parameters for the debug simulator.</summary>
         /// <param name="packetDelay">Packet delay in milliseconds.</param>
         /// <param name="packetJitter">Packet jitter in milliseconds.</param>
         /// <param name="dropRate">Packet drop percentage.</param>
+#if UTP_TRANSPORT_2_0_ABOVE
+        [Obsolete("SetDebugSimulatorParameters is no longer supported and has no effect.")]
+#endif
         public void SetDebugSimulatorParameters(int packetDelay, int packetJitter, int dropRate)
         {
             if (m_Driver.IsCreated)
@@ -686,7 +688,6 @@ namespace Unity.Netcode.Transports.UTP
                 PacketDropRate = dropRate
             };
         }
-#endif
 
         private bool StartRelayServer()
         {

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -2,7 +2,7 @@
 // All references to UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED should be defined in the same way,
 // as any discrepancies are likely to result in build failures
 #if UNITY_EDITOR || (DEVELOPMENT_BUILD && !UNITY_MP_TOOLS_NETSIM_DISABLED_IN_DEVELOP) || (!DEVELOPMENT_BUILD && UNITY_MP_TOOLS_NETSIM_ENABLED_IN_RELEASE)
-    #define UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
+#define UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
 #endif
 
 using System;
@@ -1451,7 +1451,7 @@ namespace Unity.Netcode.Transports.UTP
         }
 
 #if !UTP_TRANSPORT_2_0_ABOVE
-        void SetupPipelinesForUtp1(NetworkDriver driver,
+        private void SetupPipelinesForUtp1(NetworkDriver driver,
             out NetworkPipeline unreliableFragmentedPipeline,
             out NetworkPipeline unreliableSequencedFragmentedPipeline,
             out NetworkPipeline reliableSequencedPipeline)
@@ -1510,7 +1510,7 @@ namespace Unity.Netcode.Transports.UTP
             }
         }
 #else
-        void SetupPipelinesForUtp2(NetworkDriver driver,
+        private void SetupPipelinesForUtp2(NetworkDriver driver,
             out NetworkPipeline unreliableFragmentedPipeline,
             out NetworkPipeline unreliableSequencedFragmentedPipeline,
             out NetworkPipeline reliableSequencedPipeline)

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -315,7 +315,6 @@ namespace Unity.Netcode.Transports.UTP
         /// </summary>
         public ConnectionAddressData ConnectionData = s_DefaultConnectionAddressData;
 
-#if !UTP_TRANSPORT_2_0_ABOVE
         /// <summary>
         /// Parameters for the Network Simulator
         /// </summary>
@@ -350,13 +349,15 @@ namespace Unity.Netcode.Transports.UTP
         /// - packet jitter (variances in latency, see: https://en.wikipedia.org/wiki/Jitter)
         /// - packet drop rate (packet loss)
         /// </summary>
+#if UTP_TRANSPORT_2_0_ABOVE
+        [Obsolete("DebugSimulator is no longer supported and has no effect.")]
+#endif
         public SimulatorParameters DebugSimulator = new SimulatorParameters
         {
             PacketDelayMS = 0,
             PacketJitterMS = 0,
             PacketDropRate = 0
         };
-#endif
 
         internal uint? DebugSimulatorRandomSeed { get; set; } = null;
 

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1354,11 +1354,11 @@ namespace Unity.Netcode.Transports.UTP
 #if UTP_TRANSPORT_2_0_ABOVE
         private void ConfigureSimulatorForUtp2()
         {
+            // As DebugSimulator is deprecated, the 'packetDelayMs', 'packetJitterMs' and 'packetDropPercentage'
+            // parameters are set to the default and are supposed to be changed using Network Simulator tool instead.
             m_NetworkSettings.WithSimulatorStageParameters(
                 maxPacketCount: 300, // TODO Is there any way to compute a better value?
                 maxPacketSize: NetworkParameterConstants.MTU,
-                // As DebugSimulator is deprecated, the following values are set to the default and are
-                // supposed to be changed using Network Simulator tool instead.
                 packetDelayMs: 0,
                 packetJitterMs: 0,
                 packetDropPercentage: 0,

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -369,8 +369,16 @@ namespace Unity.Netcode.Transports.UTP
             public float PacketLoss;
         };
 
-        internal static event Action<int, NetworkDriver> TransportInitialized;
-        internal static event Action<int> TransportDisposed;
+        /// <summary>
+        ///  This event is invoked each after the Server or Client starts.
+        /// </summary>
+        public static event Action<int, NetworkDriver> TransportInitialized;
+
+        /// <summary>
+        ///  This event is invoked each after the Server or Client stops running.
+        /// </summary>
+        public static event Action<int> TransportDisposed;
+
         internal NetworkDriver NetworkDriver => m_Driver;
 
         private PacketLossCache m_PacketLossCache = new PacketLossCache();

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -672,7 +672,7 @@ namespace Unity.Netcode.Transports.UTP
         /// <param name="packetJitter">Packet jitter in milliseconds.</param>
         /// <param name="dropRate">Packet drop percentage.</param>
 #if UTP_TRANSPORT_2_0_ABOVE
-        [Obsolete("SetDebugSimulatorParameters is no longer supported and has no effect.")]
+        [Obsolete("SetDebugSimulatorParameters is no longer supported and has no effect. Use Network Simulator from the Multiplayer Tools package.", false)]
 #endif
         public void SetDebugSimulatorParameters(int packetDelay, int packetJitter, int dropRate)
         {
@@ -1357,6 +1357,8 @@ namespace Unity.Netcode.Transports.UTP
             m_NetworkSettings.WithSimulatorStageParameters(
                 maxPacketCount: 300, // TODO Is there any way to compute a better value?
                 maxPacketSize: NetworkParameterConstants.MTU,
+                // As DebugSimulator is deprecated, the following values are set to the default and are
+                // supposed to be changed using Network Simulator tool instead.
                 packetDelayMs: 0,
                 packetJitterMs: 0,
                 packetDropPercentage: 0,

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -351,7 +351,7 @@ namespace Unity.Netcode.Transports.UTP
         /// - packet drop rate (packet loss)
         /// </summary>
 #if UTP_TRANSPORT_2_0_ABOVE
-        [Obsolete("DebugSimulator is no longer supported and has no effect.")]
+        [Obsolete("DebugSimulator is no longer supported and has no effect. Use Network Simulator from the Multiplayer Tools package.", false)]
 #endif
         public SimulatorParameters DebugSimulator = new SimulatorParameters
         {

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1,11 +1,9 @@
 // NetSim Implementation compilation boilerplate
 // All references to UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED should be defined in the same way,
 // as any discrepancies are likely to result in build failures
-// ---------------------------------------------------------------------------------------------------------------------
-#if UNITY_EDITOR || ((DEVELOPMENT_BUILD && !UNITY_MP_TOOLS_NETSIM_DISABLED_IN_DEVELOP) || (!DEVELOPMENT_BUILD && UNITY_MP_TOOLS_NETSIM_ENABLED_IN_RELEASE))
+#if UNITY_EDITOR || (DEVELOPMENT_BUILD && !UNITY_MP_TOOLS_NETSIM_DISABLED_IN_DEVELOP) || (!DEVELOPMENT_BUILD && UNITY_MP_TOOLS_NETSIM_ENABLED_IN_RELEASE)
     #define UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
 #endif
-// ---------------------------------------------------------------------------------------------------------------------
 
 using System;
 using System.Collections.Generic;

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1369,12 +1369,12 @@ namespace Unity.Netcode.Transports.UTP
 #if MULTIPLAYER_TOOLS_1_0_0_PRE_7
 #if !UTP_TRANSPORT_2_0_ABOVE
             NetworkPipelineStageCollection.RegisterPipelineStage(new NetworkMetricsPipelineStage());
-#endif
-#endif
+#endif //!UTP_TRANSPORT_2_0_ABOVE
+#endif //MULTIPLAYER_TOOLS_1_0_0_PRE_7
 
 #if UNITY_EDITOR || DEVELOPMENT_BUILD || UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             ConfigureSimulator();
-#endif
+#endif //UNITY_EDITOR || DEVELOPMENT_BUILD || UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
 
             m_NetworkSettings.WithNetworkConfigParameters(
                 maxConnectAttempts: transport.m_MaxConnectAttempts,
@@ -1383,7 +1383,7 @@ namespace Unity.Netcode.Transports.UTP
 #if UTP_TRANSPORT_2_0_ABOVE
                 sendQueueCapacity: m_MaxPacketQueueSize,
                 receiveQueueCapacity: m_MaxPacketQueueSize,
-#endif
+#endif //UTP_TRANSPORT_2_0_ABOVE
                 heartbeatTimeoutMS: transport.m_HeartbeatTimeoutMS);
 
             driver = NetworkDriver.Create(m_NetworkSettings);
@@ -1391,21 +1391,23 @@ namespace Unity.Netcode.Transports.UTP
 #if MULTIPLAYER_TOOLS_1_0_0_PRE_7
 #if UTP_TRANSPORT_2_0_ABOVE
             driver.RegisterPipelineStage<NetworkMetricsPipelineStage>(new NetworkMetricsPipelineStage());
-#endif
-#endif
+#endif //UTP_TRANSPORT_2_0_ABOVE
+#endif //MULTIPLAYER_TOOLS_1_0_0_PRE_7
 
-#if UNITY_EDITOR || DEVELOPMENT_BUILD || UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+#if !UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             if (DebugSimulator.PacketDelayMS > 0 || DebugSimulator.PacketDropRate > 0)
+#endif //!UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             {
                 unreliableFragmentedPipeline = driver.CreatePipeline(
                     typeof(FragmentationPipelineStage),
                     typeof(SimulatorPipelineStage)
 #if !UTP_TRANSPORT_2_0_ABOVE
                     , typeof(SimulatorPipelineStageInSend)
-#endif
+#endif //!UTP_TRANSPORT_2_0_ABOVE
 #if MULTIPLAYER_TOOLS_1_0_0_PRE_7
                     , typeof(NetworkMetricsPipelineStage)
-#endif
+#endif //MULTIPLAYER_TOOLS_1_0_0_PRE_7
                 );
                 unreliableSequencedFragmentedPipeline = driver.CreatePipeline(
                     typeof(FragmentationPipelineStage),
@@ -1413,45 +1415,48 @@ namespace Unity.Netcode.Transports.UTP
                     typeof(SimulatorPipelineStage)
 #if !UTP_TRANSPORT_2_0_ABOVE
                     , typeof(SimulatorPipelineStageInSend)
-#endif
+#endif //!UTP_TRANSPORT_2_0_ABOVE
 #if MULTIPLAYER_TOOLS_1_0_0_PRE_7
                     , typeof(NetworkMetricsPipelineStage)
-#endif
+#endif //MULTIPLAYER_TOOLS_1_0_0_PRE_7
                 );
                 reliableSequencedPipeline = driver.CreatePipeline(
                     typeof(ReliableSequencedPipelineStage),
                     typeof(SimulatorPipelineStage)
 #if !UTP_TRANSPORT_2_0_ABOVE
                     , typeof(SimulatorPipelineStageInSend)
-#endif
+#endif //!UTP_TRANSPORT_2_0_ABOVE
 #if MULTIPLAYER_TOOLS_1_0_0_PRE_7
                     , typeof(NetworkMetricsPipelineStage)
-#endif
+#endif //MULTIPLAYER_TOOLS_1_0_0_PRE_7
                 );
             }
+#if !UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
             else
-#endif
             {
                 unreliableFragmentedPipeline = driver.CreatePipeline(
                     typeof(FragmentationPipelineStage)
 #if MULTIPLAYER_TOOLS_1_0_0_PRE_7
                     , typeof(NetworkMetricsPipelineStage)
-#endif
+#endif //MULTIPLAYER_TOOLS_1_0_0_PRE_7
                 );
                 unreliableSequencedFragmentedPipeline = driver.CreatePipeline(
                     typeof(FragmentationPipelineStage),
                     typeof(UnreliableSequencedPipelineStage)
 #if MULTIPLAYER_TOOLS_1_0_0_PRE_7
                     , typeof(NetworkMetricsPipelineStage)
-#endif
+#endif //MULTIPLAYER_TOOLS_1_0_0_PRE_7
                 );
                 reliableSequencedPipeline = driver.CreatePipeline(
                     typeof(ReliableSequencedPipelineStage)
 #if MULTIPLAYER_TOOLS_1_0_0_PRE_7
                     , typeof(NetworkMetricsPipelineStage)
-#endif
+#endif //MULTIPLAYER_TOOLS_1_0_0_PRE_7
                 );
             }
+        }
+#endif //UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
+#endif //UNITY_EDITOR || DEVELOPMENT_BUILD
         }
 
         // -------------- Utility Types -------------------------------------------------------------------------------

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1433,7 +1433,7 @@ namespace Unity.Netcode.Transports.UTP
 #endif
 
 #if !UTP_TRANSPORT_2_0_ABOVE
-            SetupPipelinesForUtp1(river,
+            SetupPipelinesForUtp1(driver,
                 out unreliableFragmentedPipeline,
                 out unreliableSequencedFragmentedPipeline,
                 out reliableSequencedPipeline);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/PacketLossMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/PacketLossMetricsTests.cs
@@ -8,6 +8,9 @@ using Unity.Multiplayer.Tools.MetricTypes;
 using Unity.Netcode.TestHelpers.Runtime;
 using Unity.Netcode.TestHelpers.Runtime.Metrics;
 using Unity.Netcode.Transports.UTP;
+#if UTP_TRANSPORT_2_0_ABOVE
+using Unity.Networking.Transport.Utilities;
+#endif
 using UnityEngine.TestTools;
 
 namespace Unity.Netcode.RuntimeTests.Metrics
@@ -26,13 +29,15 @@ namespace Unity.Netcode.RuntimeTests.Metrics
         protected override void OnServerAndClientsCreated()
         {
             var clientTransport = (UnityTransport)m_ClientNetworkManagers[0].NetworkConfig.NetworkTransport;
+#if !UTP_TRANSPORT_2_0_ABOVE
             clientTransport.SetDebugSimulatorParameters(0, 0, m_PacketLossRate);
+#endif
 
             // Determined through trial and error. With both UTP 1.2 and 2.0, this random seed
             // results in an effective packet loss percentage between 22% and 28%. Future UTP
             // updates may change the RNG call patterns and cause this test to fail, in which
             // case the value should be modified again.
-            clientTransport.DebugSimulatorRandomSeed = 4;
+            clientTransport.NetworkSimulatorRandomSeed = 4;
 
             base.OnServerAndClientsCreated();
         }
@@ -63,6 +68,14 @@ namespace Unity.Netcode.RuntimeTests.Metrics
             double packetLossRateMinRange = (m_PacketLossRate - m_PacketLossRangeDelta) / 100d;
             double packetLossRateMaxrange = (m_PacketLossRate + m_PacketLossRangeDelta) / 100d;
             var clientNetworkManager = m_ClientNetworkManagers[0];
+
+#if UTP_TRANSPORT_2_0_ABOVE
+            var clientTransport = (UnityTransport)clientNetworkManager.NetworkConfig.NetworkTransport;
+            clientTransport.NetworkDriver.CurrentSettings.TryGet<SimulatorUtility.Parameters>(out var parameters);
+            parameters.PacketDropPercentage = m_PacketLossRate;
+            clientTransport.NetworkDriver.ModifySimulatorStageParameters(parameters);
+#endif
+
             var waitForPacketLossMetric = new WaitForGaugeMetricValues((clientNetworkManager.NetworkMetrics as NetworkMetrics).Dispatcher,
                 NetworkMetricTypes.PacketLoss,
                 metric => packetLossRateMinRange <= metric && metric <= packetLossRateMaxrange);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/PacketLossMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/PacketLossMetricsTests.cs
@@ -37,7 +37,7 @@ namespace Unity.Netcode.RuntimeTests.Metrics
             // results in an effective packet loss percentage between 22% and 28%. Future UTP
             // updates may change the RNG call patterns and cause this test to fail, in which
             // case the value should be modified again.
-            clientTransport.NetworkSimulatorRandomSeed = 4;
+            clientTransport.DebugSimulatorRandomSeed = 4;
 
             base.OnServerAndClientsCreated();
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
@@ -340,6 +340,7 @@ namespace Unity.Netcode.RuntimeTests
             yield return null;
         }
 
+#if !UTP_TRANSPORT_2_0_ABOVE
         // Check that simulator parameters are effective. We only check with the drop rate, because
         // that's easy to check and we only really want to make sure the simulator parameters are
         // configured properly (the simulator pipeline stage is already well-tested in UTP).
@@ -394,6 +395,7 @@ namespace Unity.Netcode.RuntimeTests
 
             yield return null;
         }
+#endif
 
         [UnityTest]
         public IEnumerator SendQueuesFlushedOnShutdown([ValueSource("k_DeliveryParameters")] NetworkDelivery delivery)


### PR DESCRIPTION
As discussed with @JesseOlmer, in order to reduce the use of `InternalsVisibleTo` and start simplifying the compatibility testing matrices, this PR makes `TransportInitialized` and `TransportDisposed` events public and removes the AssemblyInfo.cs entry added speficially to allow Tools to use them.

## Changelog

- Added: `TransportInitialized` and `TransportDisposed` events into the `UnityTransport` class.

## Testing and Documentation

- No tests have been added.
- Includes documentation for new public API entry points.