### PR TITLE
fix: UNetTransportEditor compiler error

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/HiddenScriptEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/HiddenScriptEditor.cs
@@ -1,5 +1,4 @@
 using Unity.Netcode.Components;
-using Unity.Netcode.Transports.UNET;
 using Unity.Netcode.Transports.UTP;
 using UnityEditor;
 
@@ -21,14 +20,16 @@ namespace Unity.Netcode.Editor
         }
     }
 
+#if UNITY_UNET_PRESENT
     /// <summary>
     /// Internal use. Hides the script field for UNetTransport.
     /// </summary>
-    [CustomEditor(typeof(UNetTransport), true)]
+    [CustomEditor(typeof(Unity.Netcode.Transports.UNET), true)]
     public class UNetTransportEditor : HiddenScriptEditor
     {
 
     }
+#endif
 
     /// <summary>
     /// Internal use. Hides the script field for UnityTransport.


### PR DESCRIPTION
When `UNet` isn't present, it currently throws these compiler errors:

```
c:\com.unity.netcode.gameobjects-4\com.unity.netcode.gameobjects\Editor\HiddenScriptEditor.cs(2,32): error CS0234: The type or namespace name 'UNET' does not exist in the namespace 'Unity.Netcode.Transports' (are you missing an assembly reference?)
 ```

```
c:\com.unity.netcode.gameobjects-4\com.unity.netcode.gameobjects\Editor\HiddenScriptEditor.cs(27,26): error CS0246: The type or namespace name 'UNetTransport' could not be found (are you missing a using directive or an assembly reference?)
```

This PR fixes that by wrapping the dependency in an `ifdef`.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.