### PR TITLE
fix: NetworkBehaviours don't update their NetworkBehaviourId after a NetworkBehaviour is deleted [MTT-4718]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -19,6 +19,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where the `NetworkBehaviour` children of a GameObject would not have their NetworkBehaviourId updated when one is deleted. 
 - Fixed issue where `NetworkTransform.SetStateServerRpc` and `NetworkTransform.SetStateClientRpc` were not honoring local vs world space settings when applying the position and rotation. (#2203)
 - Fixed ILPP `TypeLoadException` on WebGL on MacOS Editor and potentially other platforms. (#2199)
 - Implicit conversion of NetworkObjectReference to GameObject will now return null instead of throwing an exception if the referenced object could not be found (i.e., was already despawned) (#2158)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -19,7 +19,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where the `NetworkBehaviour` children of a GameObject would not have their NetworkBehaviourId updated when one is deleted. 
+- Fixed issue where `NetworkBehaviour` children of a `NetworkObject` would not update their NetworkBehaviourId when one is deleted and the associated `NetworkObject` remains spawned. (#2218)
 - Fixed issue where `NetworkTransform.SetStateServerRpc` and `NetworkTransform.SetStateClientRpc` were not honoring local vs world space settings when applying the position and rotation. (#2203)
 - Fixed ILPP `TypeLoadException` on WebGL on MacOS Editor and potentially other platforms. (#2199)
 - Implicit conversion of NetworkObjectReference to GameObject will now return null instead of throwing an exception if the referenced object could not be found (i.e., was already despawned) (#2158)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1248,6 +1248,11 @@ namespace Unity.Netcode
                     NetworkLog.LogWarning($"{nameof(NetworkBehaviour)}-{networkBehaviour.name} is being destroyed while {nameof(NetworkObject)}-{name} is still spawned! (could break state synchronization)");
                 }
                 ChildNetworkBehaviours.Remove(networkBehaviour);
+                for(ushort i = 0; i < ChildNetworkBehaviours.Count; i++)
+                {
+                    var childBehaviour = ChildNetworkBehaviours[i];
+                    childBehaviour.NetworkBehaviourId = childBehaviour.NetworkBehaviourIdCache = i;
+                }
             }
         }
     }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1248,7 +1248,7 @@ namespace Unity.Netcode
                     NetworkLog.LogWarning($"{nameof(NetworkBehaviour)}-{networkBehaviour.name} is being destroyed while {nameof(NetworkObject)}-{name} is still spawned! (could break state synchronization)");
                 }
                 ChildNetworkBehaviours.Remove(networkBehaviour);
-                for(ushort i = 0; i < ChildNetworkBehaviours.Count; i++)
+                for (ushort i = 0; i < ChildNetworkBehaviours.Count; i++)
                 {
                     var childBehaviour = ChildNetworkBehaviours[i];
                     childBehaviour.NetworkBehaviourId = childBehaviour.NetworkBehaviourIdCache = i;


### PR DESCRIPTION
**_This needs to be further discussed and mapped out further before continuing._**
When a NetworkBehaviour is deleted and removed from a NetworkObject's ChildNetworkBehaviours the remaining NetworkBehaviours' NetworkBehaviourId is not updated.

[MTT-4718](https://jira.unity3d.com/browse/MTT-4718)
#2188

## Changelog
- Fixed issue where `NetworkBehaviour` children of a `NetworkObject` would not update their `NetworkBehaviourId` when one is deleted and the associated `NetworkObject` remains spawned.

## Testing and Documentation
- Includes integration tests (on hold)
- Possible documentation update required (TBD)
