### PR TITLE
fix: Restarting UnityTransport after it failed to start [MTT-3452]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -19,6 +19,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue #1924 where `UnityTransport` would fail to restart after a first failure (even if what caused the initial failure was addressed).
 - Fixed issue where `NetworkTransform.SetStateServerRpc` and `NetworkTransform.SetStateClientRpc` were not honoring local vs world space settings when applying the position and rotation. (#2203)
 - Fixed ILPP `TypeLoadException` on WebGL on MacOS Editor and potentially other platforms. (#2199)
 - Implicit conversion of NetworkObjectReference to GameObject will now return null instead of throwing an exception if the referenced object could not be found (i.e., was already despawned) (#2158)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -19,7 +19,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue #1924 where `UnityTransport` would fail to restart after a first failure (even if what caused the initial failure was addressed).
+- Fixed issue #1924 where `UnityTransport` would fail to restart after a first failure (even if what caused the initial failure was addressed). (#2220)
 - Fixed issue where `NetworkTransform.SetStateServerRpc` and `NetworkTransform.SetStateClientRpc` were not honoring local vs world space settings when applying the position and rotation. (#2203)
 - Fixed ILPP `TypeLoadException` on WebGL on MacOS Editor and potentially other platforms. (#2199)
 - Implicit conversion of NetworkObjectReference to GameObject will now return null instead of throwing an exception if the referenced object could not be found (i.e., was already despawned) (#2158)

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1275,9 +1275,9 @@ namespace Unity.Netcode.Transports.UTP
             }
 
             var succeeded = ClientBindAndConnect();
-            if (!succeeded)
+            if (!succeeded && m_Driver.IsCreated)
             {
-                Shutdown();
+                m_Driver.Dispose();
             }
             return succeeded;
         }
@@ -1302,16 +1302,16 @@ namespace Unity.Netcode.Transports.UTP
             {
                 case ProtocolType.UnityTransport:
                     succeeded = ServerBindAndListen(ConnectionData.ListenEndPoint);
-                    if (!succeeded)
+                    if (!succeeded && m_Driver.IsCreated)
                     {
-                        Shutdown();
+                        m_Driver.Dispose();
                     }
                     return succeeded;
                 case ProtocolType.RelayUnityTransport:
                     succeeded = StartRelayServer();
-                    if (!succeeded)
+                    if (!succeeded && m_Driver.IsCreated)
                     {
-                        Shutdown();
+                        m_Driver.Dispose();
                     }
                     return succeeded;
                 default:

--- a/com.unity.netcode.gameobjects/Tests/Editor/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Transports/UnityTransportTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using Unity.Netcode.Transports.UTP;
 using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace Unity.Netcode.EditorTests
 {
@@ -8,7 +9,7 @@ namespace Unity.Netcode.EditorTests
     {
         // Check that starting a server doesn't immediately result in faulted tasks.
         [Test]
-        public void BasicInitServer()
+        public void UnityTransport_BasicInitServer()
         {
             UnityTransport transport = new GameObject().AddComponent<UnityTransport>();
             transport.Initialize();
@@ -20,7 +21,7 @@ namespace Unity.Netcode.EditorTests
 
         // Check that starting a client doesn't immediately result in faulted tasks.
         [Test]
-        public void BasicInitClient()
+        public void UnityTransport_BasicInitClient()
         {
             UnityTransport transport = new GameObject().AddComponent<UnityTransport>();
             transport.Initialize();
@@ -32,7 +33,7 @@ namespace Unity.Netcode.EditorTests
 
         // Check that we can't restart a server.
         [Test]
-        public void NoRestartServer()
+        public void UnityTransport_NoRestartServer()
         {
             UnityTransport transport = new GameObject().AddComponent<UnityTransport>();
             transport.Initialize();
@@ -45,7 +46,7 @@ namespace Unity.Netcode.EditorTests
 
         // Check that we can't restart a client.
         [Test]
-        public void NoRestartClient()
+        public void UnityTransport_NoRestartClient()
         {
             UnityTransport transport = new GameObject().AddComponent<UnityTransport>();
             transport.Initialize();
@@ -58,7 +59,7 @@ namespace Unity.Netcode.EditorTests
 
         // Check that we can't start both a server and client on the same transport.
         [Test]
-        public void NotBothServerAndClient()
+        public void UnityTransport_NotBothServerAndClient()
         {
             UnityTransport transport;
 
@@ -77,6 +78,25 @@ namespace Unity.Netcode.EditorTests
 
             transport.StartClient();
             Assert.False(transport.StartServer());
+
+            transport.Shutdown();
+        }
+
+        // Check that restarting after failure succeeds.
+        [Test]
+        public void UnityTransport_RestartSucceedsAfterFailure()
+        {
+            UnityTransport transport = new GameObject().AddComponent<UnityTransport>();
+            transport.Initialize();
+
+            transport.SetConnectionData("127.0.0.", 4242);
+            Assert.False(transport.StartServer());
+
+            LogAssert.Expect(LogType.Error, "Invalid network endpoint: 127.0.0.:4242.");
+            LogAssert.Expect(LogType.Error, "Server failed to bind");
+
+            transport.SetConnectionData("127.0.0.1", 4242);
+            Assert.True(transport.StartServer());
 
             transport.Shutdown();
         }


### PR DESCRIPTION
Fixes #1924. The issue was that we shut down the transport when it failed to be started, which disposed of the network settings. So when restarting the transport, there would be errors when configuring the settings. The fix was to _not_ shut down when failing to start. The start process only ends up creating the network driver, so to revert to the state before we started, we just need to dispose of the driver.

## Changelog

- Fixed: Fixed issue #1924 where `UnityTransport` would fail to restart after a first failure (even if what caused the initial failure was addressed).

## Testing and Documentation

- Includes unit test.
- No documentation changes or additions were necessary.