### PR TITLE
fix: SceneEventProgress OnComplete not invoked on timeouts [MTT-4772]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -21,6 +21,9 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where `SceneEventProgress` would not complete if a client late joins while it is still in progress. (#2222)
+- Fixed issue where `SceneEventProgress` would not complete if a client disconnects. (#2222)
+- Fixed issues with detecting if a `SceneEventProgress` has timed out. (#2222)
 - Fixed issue #1924 where `UnityTransport` would fail to restart after a first failure (even if what caused the initial failure was addressed). (#2220)
 - Fixed issue where `NetworkTransform.SetStateServerRpc` and `NetworkTransform.SetStateClientRpc` were not honoring local vs world space settings when applying the position and rotation. (#2203)
 - Fixed ILPP `TypeLoadException` on WebGL on MacOS Editor and potentially other platforms. (#2199)

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs
@@ -11,7 +11,7 @@ namespace Unity.Netcode
     internal interface ISceneManagerHandler
     {
         // Generic action to call when a scene is finished loading/unloading
-        struct SceneEventAction
+        class SceneEventAction
         {
             internal uint SceneEventId;
             internal Action<uint> EventAction;

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs
@@ -1,4 +1,3 @@
-using System;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -10,25 +9,8 @@ namespace Unity.Netcode
     /// </summary>
     internal interface ISceneManagerHandler
     {
-        // Generic action to call when a scene is finished loading/unloading
-        class SceneEventAction
-        {
-            internal uint SceneEventId;
-            internal Action<uint> EventAction;
-            /// <summary>
-            /// Used server-side for integration testing in order to
-            /// invoke the SceneEventProgress once done loading
-            /// </summary>
-            internal Action Completed;
-            internal void Invoke()
-            {
-                Completed?.Invoke();
-                EventAction.Invoke(SceneEventId);
-            }
-        }
+        AsyncOperation LoadSceneAsync(string sceneName, LoadSceneMode loadSceneMode, SceneEventProgress sceneEventProgress);
 
-        AsyncOperation LoadSceneAsync(string sceneName, LoadSceneMode loadSceneMode, SceneEventAction sceneEventAction);
-
-        AsyncOperation UnloadSceneAsync(Scene scene, SceneEventAction sceneEventAction);
+        AsyncOperation UnloadSceneAsync(Scene scene, SceneEventProgress sceneEventProgress);
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -341,14 +341,14 @@ namespace Unity.Netcode
             public AsyncOperation LoadSceneAsync(string sceneName, LoadSceneMode loadSceneMode, SceneEventProgress sceneEventProgress)
             {
                 var operation = SceneManager.LoadSceneAsync(sceneName, loadSceneMode);
-                sceneEventProgress.SetSceneAsyncOperation(operation);
+                sceneEventProgress.SetAsyncOperation(operation);
                 return operation;
             }
 
             public AsyncOperation UnloadSceneAsync(Scene scene, SceneEventProgress sceneEventProgress)
             {
                 var operation = SceneManager.UnloadSceneAsync(scene);
-                sceneEventProgress.SetSceneAsyncOperation(operation);
+                sceneEventProgress.SetAsyncOperation(operation);
                 return operation;
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1072,7 +1072,7 @@ namespace Unity.Netcode
                 //Only if we are a host do we want register having loaded for the associated SceneEventProgress
                 if (SceneEventProgressTracking.ContainsKey(sceneEventData.SceneEventProgressId) && m_NetworkManager.IsHost)
                 {
-                    SceneEventProgressTracking[sceneEventData.SceneEventProgressId].MarkClientAsDone(NetworkManager.ServerClientId);
+                    SceneEventProgressTracking[sceneEventData.SceneEventProgressId].ClientFinishedSceneEvent(NetworkManager.ServerClientId);
                 }
             }
 
@@ -1490,7 +1490,7 @@ namespace Unity.Netcode
             //Second, only if we are a host do we want register having loaded for the associated SceneEventProgress
             if (SceneEventProgressTracking.ContainsKey(sceneEventData.SceneEventProgressId) && m_NetworkManager.IsHost)
             {
-                SceneEventProgressTracking[sceneEventData.SceneEventProgressId].MarkClientAsDone(NetworkManager.ServerClientId);
+                SceneEventProgressTracking[sceneEventData.SceneEventProgressId].ClientFinishedSceneEvent(NetworkManager.ServerClientId);
             }
             EndSceneEvent(sceneEventId);
         }
@@ -1882,7 +1882,7 @@ namespace Unity.Netcode
 
                         if (SceneEventProgressTracking.ContainsKey(sceneEventData.SceneEventProgressId))
                         {
-                            SceneEventProgressTracking[sceneEventData.SceneEventProgressId].MarkClientAsDone(clientId);
+                            SceneEventProgressTracking[sceneEventData.SceneEventProgressId].ClientFinishedSceneEvent(clientId);
                         }
                         EndSceneEvent(sceneEventId);
                         break;
@@ -1891,7 +1891,7 @@ namespace Unity.Netcode
                     {
                         if (SceneEventProgressTracking.ContainsKey(sceneEventData.SceneEventProgressId))
                         {
-                            SceneEventProgressTracking[sceneEventData.SceneEventProgressId].MarkClientAsDone(clientId);
+                            SceneEventProgressTracking[sceneEventData.SceneEventProgressId].ClientFinishedSceneEvent(clientId);
                         }
                         // Notify the local server that the client has finished unloading a scene
                         OnSceneEvent?.Invoke(new SceneEvent()

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1649,10 +1649,10 @@ namespace Unity.Netcode
 
             if (!shouldPassThrough)
             {
+                // If not, then load the scene
                 var sceneEventProgress = new SceneEventProgress(m_NetworkManager);
                 sceneEventProgress.SceneEventId = sceneEventId;
                 sceneEventProgress.OnSceneEventCompleted = ClientLoadedSynchronization;
-                // If not, then load the scene
                 sceneLoad = SceneManagerHandler.LoadSceneAsync(sceneName, loadSceneMode, sceneEventProgress);
 
                 // Notify local client that a scene load has begun

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
@@ -215,9 +215,8 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// Sets the AsyncOperation from for the scene load/unload event
+        /// Sets the AsyncOperation for the scene load/unload event
         /// </summary>
-        /// <param name="sceneLoadOperation"></param>
         internal void SetSceneAsyncOperation(AsyncOperation asyncOperation)
         {
             m_SceneLoadOperation = asyncOperation;

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
@@ -59,6 +59,7 @@ namespace Unity.Netcode
         /// List of clientIds of those clients that is done loading the scene.
         /// </summary>
         internal Dictionary<ulong, bool> ClientsProcessingSceneEvent { get; } = new Dictionary<ulong, bool>();
+        internal List<ulong> ClientsThatDisconnected = new List<ulong>();
 
         /// <summary>
         /// This is the time when the current scene event will have timed out
@@ -85,7 +86,7 @@ namespace Unity.Netcode
         /// </summary>
         internal bool HasTimedOut()
         {
-            return !IsCompleted && WhenSceneEventHasTimedOut <= Time.realtimeSinceStartup;
+            return WhenSceneEventHasTimedOut <= Time.realtimeSinceStartup;
         }
 
         /// <summary>
@@ -116,6 +117,10 @@ namespace Unity.Netcode
                     clients.Add(clientStatus.Key);
                 }
             }
+            if (!completedSceneEvent)
+            {
+                clients.AddRange(ClientsThatDisconnected);
+            }
             return clients;
         }
 
@@ -140,6 +145,7 @@ namespace Unity.Netcode
         {
             if (ClientsProcessingSceneEvent.ContainsKey(clientId))
             {
+                ClientsThatDisconnected.Add(clientId);
                 ClientsProcessingSceneEvent.Remove(clientId);
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
@@ -95,7 +95,7 @@ namespace Unity.Netcode
         internal uint SceneEventId;
 
         private Coroutine m_TimeOutCoroutine;
-        private AsyncOperation m_SceneLoadOperation;
+        private AsyncOperation m_AsyncOperation;
 
         private NetworkManager m_NetworkManager { get; }
 
@@ -211,16 +211,16 @@ namespace Unity.Netcode
             }
 
             // Return the local scene event's AsyncOperation status
-            return m_SceneLoadOperation.isDone;
+            return m_AsyncOperation.isDone;
         }
 
         /// <summary>
         /// Sets the AsyncOperation for the scene load/unload event
         /// </summary>
-        internal void SetSceneAsyncOperation(AsyncOperation asyncOperation)
+        internal void SetAsyncOperation(AsyncOperation asyncOperation)
         {
-            m_SceneLoadOperation = asyncOperation;
-            m_SceneLoadOperation.completed += new Action<AsyncOperation>(asyncOp2 =>
+            m_AsyncOperation = asyncOperation;
+            m_AsyncOperation.completed += new Action<AsyncOperation>(asyncOp2 =>
             {
                 OnSceneEventCompleted?.Invoke(SceneEventId);
                 TryFinishingSceneEventProgress();

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
@@ -62,7 +62,7 @@ namespace Unity.Netcode
         internal List<ulong> ClientsThatDisconnected = new List<ulong>();
 
         /// <summary>
-        /// This is the time when the current scene event will have timed out
+        /// This is when the current scene event will have timed out
         /// </summary>
         internal float WhenSceneEventHasTimedOut;
 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
@@ -107,7 +107,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
             SceneManager.sceneLoaded += SceneManager_sceneLoaded;
             // We always load additively for all scenes during integration tests
             var asyncOperation = SceneManager.LoadSceneAsync(queuedSceneJob.SceneName, LoadSceneMode.Additive);
-
             queuedSceneJob.SceneEventProgress.SetSceneAsyncOperation(asyncOperation);
 
             // Wait for it to finish
@@ -179,7 +178,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
             {
                 var asyncOperation = SceneManager.UnloadSceneAsync(queuedSceneJob.Scene);
                 queuedSceneJob.SceneEventProgress.SetSceneAsyncOperation(asyncOperation);
-
             }
             else
             {

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
@@ -48,7 +48,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             public JobTypes JobType;
             public string SceneName;
             public Scene Scene;
-            public ISceneManagerHandler.SceneEventAction SceneAction;
+            public SceneEventProgress SceneEventProgress;
             public IntegrationTestSceneHandler IntegrationTestSceneHandler;
         }
 
@@ -106,7 +106,9 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
             SceneManager.sceneLoaded += SceneManager_sceneLoaded;
             // We always load additively for all scenes during integration tests
-            SceneManager.LoadSceneAsync(queuedSceneJob.SceneName, LoadSceneMode.Additive);
+            var asyncOperation = SceneManager.LoadSceneAsync(queuedSceneJob.SceneName, LoadSceneMode.Additive);
+
+            queuedSceneJob.SceneEventProgress.SetSceneAsyncOperation(asyncOperation);
 
             // Wait for it to finish
             while (queuedSceneJob.JobType != QueuedSceneJob.JobTypes.Completed)
@@ -114,7 +116,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 yield return s_WaitForSeconds;
             }
             yield return s_WaitForSeconds;
-            CurrentQueuedSceneJob.SceneAction.Invoke();
         }
 
         /// <summary>
@@ -176,7 +177,9 @@ namespace Unity.Netcode.TestHelpers.Runtime
             SceneManager.sceneUnloaded += SceneManager_sceneUnloaded;
             if (queuedSceneJob.Scene.IsValid() && queuedSceneJob.Scene.isLoaded && !queuedSceneJob.Scene.name.Contains(NetcodeIntegrationTestHelpers.FirstPartOfTestRunnerSceneName))
             {
-                SceneManager.UnloadSceneAsync(queuedSceneJob.Scene);
+                var asyncOperation = SceneManager.UnloadSceneAsync(queuedSceneJob.Scene);
+                queuedSceneJob.SceneEventProgress.SetSceneAsyncOperation(asyncOperation);
+
             }
             else
             {
@@ -188,7 +191,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
             {
                 yield return s_WaitForSeconds;
             }
-            CurrentQueuedSceneJob.SceneAction.Invoke();
         }
 
         /// <summary>
@@ -246,7 +248,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// <summary>
         /// Server always loads like it normally would
         /// </summary>
-        public AsyncOperation GenericLoadSceneAsync(string sceneName, LoadSceneMode loadSceneMode, ISceneManagerHandler.SceneEventAction sceneEventAction)
+        public AsyncOperation GenericLoadSceneAsync(string sceneName, LoadSceneMode loadSceneMode, SceneEventProgress sceneEventProgress)
         {
             m_ServerSceneBeingLoaded = sceneName;
             if (NetcodeIntegrationTest.IsRunning)
@@ -254,8 +256,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 SceneManager.sceneLoaded += Sever_SceneLoaded;
             }
             var operation = SceneManager.LoadSceneAsync(sceneName, loadSceneMode);
-
-            operation.completed += new Action<AsyncOperation>(asyncOp2 => { sceneEventAction.Invoke(); });
+            sceneEventProgress.SetSceneAsyncOperation(operation);
             return operation;
         }
 
@@ -271,39 +272,39 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// <summary>
         /// Server always unloads like it normally would
         /// </summary>
-        public AsyncOperation GenericUnloadSceneAsync(Scene scene, ISceneManagerHandler.SceneEventAction sceneEventAction)
+        public AsyncOperation GenericUnloadSceneAsync(Scene scene, SceneEventProgress sceneEventProgress)
         {
             var operation = SceneManager.UnloadSceneAsync(scene);
-            operation.completed += new Action<AsyncOperation>(asyncOp2 => { sceneEventAction.Invoke(); });
+            sceneEventProgress.SetSceneAsyncOperation(operation);
             return operation;
         }
 
 
-        public AsyncOperation LoadSceneAsync(string sceneName, LoadSceneMode loadSceneMode, ISceneManagerHandler.SceneEventAction sceneEventAction)
+        public AsyncOperation LoadSceneAsync(string sceneName, LoadSceneMode loadSceneMode, SceneEventProgress sceneEventProgress)
         {
             // Server and non NetcodeIntegrationTest tests use the generic load scene method
             if (!NetcodeIntegrationTest.IsRunning)
             {
-                return GenericLoadSceneAsync(sceneName, loadSceneMode, sceneEventAction);
+                return GenericLoadSceneAsync(sceneName, loadSceneMode, sceneEventProgress);
             }
             else // NetcodeIntegrationTest Clients always get added to the jobs queue
             {
-                AddJobToQueue(new QueuedSceneJob() { IntegrationTestSceneHandler = this, SceneName = sceneName, SceneAction = sceneEventAction, JobType = QueuedSceneJob.JobTypes.Loading });
+                AddJobToQueue(new QueuedSceneJob() { IntegrationTestSceneHandler = this, SceneName = sceneName, SceneEventProgress = sceneEventProgress, JobType = QueuedSceneJob.JobTypes.Loading });
             }
 
             return null;
         }
 
-        public AsyncOperation UnloadSceneAsync(Scene scene, ISceneManagerHandler.SceneEventAction sceneEventAction)
+        public AsyncOperation UnloadSceneAsync(Scene scene, SceneEventProgress sceneEventProgress)
         {
             // Server and non NetcodeIntegrationTest tests use the generic unload scene method
             if (!NetcodeIntegrationTest.IsRunning)
             {
-                return GenericUnloadSceneAsync(scene, sceneEventAction);
+                return GenericUnloadSceneAsync(scene, sceneEventProgress);
             }
             else // NetcodeIntegrationTest Clients always get added to the jobs queue
             {
-                AddJobToQueue(new QueuedSceneJob() { IntegrationTestSceneHandler = this, Scene = scene, SceneAction = sceneEventAction, JobType = QueuedSceneJob.JobTypes.Unloading });
+                AddJobToQueue(new QueuedSceneJob() { IntegrationTestSceneHandler = this, Scene = scene, SceneEventProgress = sceneEventProgress, JobType = QueuedSceneJob.JobTypes.Unloading });
             }
             // This is OK to return a "nothing" AsyncOperation since we are simulating client loading
             return null;

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
@@ -107,7 +107,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             SceneManager.sceneLoaded += SceneManager_sceneLoaded;
             // We always load additively for all scenes during integration tests
             var asyncOperation = SceneManager.LoadSceneAsync(queuedSceneJob.SceneName, LoadSceneMode.Additive);
-            queuedSceneJob.SceneEventProgress.SetSceneAsyncOperation(asyncOperation);
+            queuedSceneJob.SceneEventProgress.SetAsyncOperation(asyncOperation);
 
             // Wait for it to finish
             while (queuedSceneJob.JobType != QueuedSceneJob.JobTypes.Completed)
@@ -177,7 +177,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             if (queuedSceneJob.Scene.IsValid() && queuedSceneJob.Scene.isLoaded && !queuedSceneJob.Scene.name.Contains(NetcodeIntegrationTestHelpers.FirstPartOfTestRunnerSceneName))
             {
                 var asyncOperation = SceneManager.UnloadSceneAsync(queuedSceneJob.Scene);
-                queuedSceneJob.SceneEventProgress.SetSceneAsyncOperation(asyncOperation);
+                queuedSceneJob.SceneEventProgress.SetAsyncOperation(asyncOperation);
             }
             else
             {
@@ -254,7 +254,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 SceneManager.sceneLoaded += Sever_SceneLoaded;
             }
             var operation = SceneManager.LoadSceneAsync(sceneName, loadSceneMode);
-            sceneEventProgress.SetSceneAsyncOperation(operation);
+            sceneEventProgress.SetAsyncOperation(operation);
             return operation;
         }
 
@@ -273,7 +273,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         public AsyncOperation GenericUnloadSceneAsync(Scene scene, SceneEventProgress sceneEventProgress)
         {
             var operation = SceneManager.UnloadSceneAsync(scene);
-            sceneEventProgress.SetSceneAsyncOperation(operation);
+            sceneEventProgress.SetAsyncOperation(operation);
             return operation;
         }
 

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/SceneEventProgressTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/SceneEventProgressTests.cs
@@ -1,0 +1,194 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+using Unity.Netcode;
+using Unity.Netcode.TestHelpers.Runtime;
+using Random = UnityEngine.Random;
+
+namespace TestProject.RuntimeTests
+{
+    public class SceneEventProgressTests : NetcodeIntegrationTest
+    {
+        private const string k_SceneUsedToGetAsyncOperation = "EmptyScene";
+        protected override int NumberOfClients => 4;
+
+        private bool m_SceneEventProgressCompleted;
+        private SceneEventProgress m_CurrentSceneEventProgress;
+
+        private List<ulong> m_ClientThatShouldNotHaveCompleted = new List<ulong>();
+        private List<ulong> m_ClientThatShouldHaveCompleted = new List<ulong>();
+
+        private bool SceneEventProgressComplete(SceneEventProgress sceneEventProgress)
+        {
+            m_SceneEventProgressCompleted = true;
+            return true;
+        }
+
+        private void SetClientFinished(ulong clientId, bool finished)
+        {
+            if (finished)
+            {
+                m_ClientThatShouldHaveCompleted.Add(clientId);
+                m_CurrentSceneEventProgress.ClientFinishedSceneEvent(clientId);
+            }
+            else
+            {
+                m_ClientThatShouldNotHaveCompleted.Add(clientId);
+            }
+        }
+
+        private void StartNewSceneEventProgress()
+        {
+            m_SceneEventProgressCompleted = false;
+            m_ClientThatShouldNotHaveCompleted.Clear();
+            m_ClientThatShouldHaveCompleted.Clear();
+            m_CurrentSceneEventProgress = new SceneEventProgress(m_ServerNetworkManager, SceneEventProgressStatus.Started);
+            m_CurrentSceneEventProgress.OnComplete = SceneEventProgressComplete;
+            SceneManager.sceneLoaded += MockServerLoadedSene;
+            m_CurrentSceneEventProgress.SetSceneLoadOperation(SceneManager.LoadSceneAsync(k_SceneUsedToGetAsyncOperation, LoadSceneMode.Additive));
+        }
+
+        private void MockServerLoadedSene(Scene scene, LoadSceneMode loadSceneMode)
+        {
+            if (scene.name == k_SceneUsedToGetAsyncOperation)
+            {
+                SetClientFinished(NetworkManager.ServerClientId, true);
+                SceneManager.sceneLoaded -= MockServerLoadedSene;
+            }
+        }
+
+        private void VerifyClientsThatCompleted()
+        {
+            var clientsDidComplete = m_CurrentSceneEventProgress.GetClientsWithStatus(true);
+            var clientsDidNotComplete = m_CurrentSceneEventProgress.GetClientsWithStatus(false);
+
+            foreach (var clientId in clientsDidComplete)
+            {
+                Assert.IsTrue(m_ClientThatShouldHaveCompleted.Contains(clientId), $"Client-{clientId} was not in the SceneEventProgress completed list!");
+            }
+
+            foreach (var clientId in clientsDidNotComplete)
+            {
+                Assert.IsTrue(m_ClientThatShouldNotHaveCompleted.Contains(clientId), $"Client-{clientId} was not in the SceneEventProgress did not complete list!");
+            }
+        }
+
+        /// <summary>
+        /// This verifies when all clients finish, the SceneEventProgress
+        /// completes as well.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator AllClientsFinish()
+        {
+            StartNewSceneEventProgress();
+
+            for (int i = 0; i < NumberOfClients; i++)
+            {
+                var currentClientNetworkManager = m_ClientNetworkManagers[i];
+                SetClientFinished(currentClientNetworkManager.LocalClientId, true);
+
+                // stagger when the clients mock finish loading by 1 network tick
+                yield return s_DefaultWaitForTick;
+            }
+
+            yield return WaitForConditionOrTimeOut(() => m_SceneEventProgressCompleted);
+            AssertOnTimeout($"Timed out waiting for SceneEventProgress to time out!");
+
+            VerifyClientsThatCompleted();
+        }
+
+        /// <summary>
+        /// This verifies that SceneEventProgress will still invoke the
+        /// OnComplete delegate handler when it times out
+        /// </summary>
+        [UnityTest]
+        public IEnumerator CompletesWhenTimedOut()
+        {
+            // Adjust the timeout for 2 seconds for this test
+            m_ServerNetworkManager.NetworkConfig.LoadSceneTimeOut = 2;
+            StartNewSceneEventProgress();
+
+            for (int i = 0; i < NumberOfClients; i++)
+            {
+                var shouldFinish = Random.Range(0, 100);
+                var currentClientNetworkManager = m_ClientNetworkManagers[i];
+                // Only let two clients finish
+                var clientFinished = shouldFinish >= 50 && m_ClientThatShouldNotHaveCompleted.Count < 2;
+                SetClientFinished(currentClientNetworkManager.LocalClientId, clientFinished);
+            }
+
+            yield return WaitForConditionOrTimeOut(() => m_SceneEventProgressCompleted);
+            AssertOnTimeout($"Timed out waiting for SceneEventProgress to time out!");
+
+            VerifyClientsThatCompleted();
+        }
+
+        /// <summary>
+        /// This verifies that SceneEventProgress will still complete
+        /// even when some of the originally connected clients disconnect
+        /// during a SceneEventProgress.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ClientsDisconnectDuring()
+        {
+            StartNewSceneEventProgress();
+
+            for (int i = 0; i < NumberOfClients; i++)
+            {
+                var shouldDisconnect = Random.Range(0, 100);
+                var currentClientNetworkManager = m_ClientNetworkManagers[i];
+                // Two clients will disconnect
+                var clientFinished = shouldDisconnect >= 50 && m_ClientThatShouldNotHaveCompleted.Count < 2;
+                SetClientFinished(currentClientNetworkManager.LocalClientId, clientFinished);
+
+                if (!clientFinished)
+                {
+                    currentClientNetworkManager.Shutdown();
+                }
+                // wait anywhere from 100-500ms until processing next client
+                var randomWaitPeriod = Random.Range(0.1f, 0.5f);
+                yield return new WaitForSeconds(randomWaitPeriod);
+            }
+            yield return WaitForConditionOrTimeOut(() => m_SceneEventProgressCompleted);
+            AssertOnTimeout($"Timed out waiting for SceneEventProgress to time out!");
+            VerifyClientsThatCompleted();
+        }
+
+        /// <summary>
+        /// This verifies that SceneEventProgress will still complete
+        /// even when clients late join.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ClientsLateJoinDuring()
+        {
+            StartNewSceneEventProgress();
+
+            for (int i = 0; i < NumberOfClients; i++)
+            {
+                var shouldNewClientJoin = Random.Range(0, 100);
+                var currentClientNetworkManager = m_ClientNetworkManagers[i];
+                // Two clients will connect during a SceneEventProgress
+                var joinNewClient = shouldNewClientJoin >= 50 && m_ClientThatShouldNotHaveCompleted.Count < 2;
+
+                // All connected clients will finish their SceneEventProgress
+                SetClientFinished(currentClientNetworkManager.LocalClientId, true);
+
+                if (joinNewClient)
+                {
+                    yield return CreateAndStartNewClient();
+                }
+                // wait anywhere from 100-500ms until processing next client
+                var randomWaitPeriod = Random.Range(0.1f, 0.5f);
+                yield return new WaitForSeconds(randomWaitPeriod);
+            }
+
+            yield return WaitForConditionOrTimeOut(() => m_SceneEventProgressCompleted);
+            AssertOnTimeout($"Timed out waiting for SceneEventProgress to finish!");
+
+            VerifyClientsThatCompleted();
+        }
+    }
+}

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/SceneEventProgressTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/SceneEventProgressTests.cs
@@ -113,10 +113,9 @@ namespace TestProject.RuntimeTests
 
             for (int i = 0; i < NumberOfClients; i++)
             {
-                var shouldFinish = Random.Range(0, 100);
+                // Every other client fails to finish
+                var clientFinished = i % 2 == 0;
                 var currentClientNetworkManager = m_ClientNetworkManagers[i];
-                // Only let two clients finish
-                var clientFinished = shouldFinish >= 50 && m_ClientThatShouldNotHaveCompleted.Count < 2;
                 SetClientFinished(currentClientNetworkManager.LocalClientId, clientFinished);
             }
 
@@ -138,10 +137,9 @@ namespace TestProject.RuntimeTests
 
             for (int i = 0; i < NumberOfClients; i++)
             {
-                var shouldDisconnect = Random.Range(0, 100);
                 var currentClientNetworkManager = m_ClientNetworkManagers[i];
                 // Two clients will disconnect
-                var clientFinished = shouldDisconnect >= 50 && m_ClientThatShouldNotHaveCompleted.Count < 2;
+                var clientFinished = i % 2 == 0;
                 SetClientFinished(currentClientNetworkManager.LocalClientId, clientFinished);
 
                 if (!clientFinished)
@@ -168,15 +166,14 @@ namespace TestProject.RuntimeTests
 
             for (int i = 0; i < NumberOfClients; i++)
             {
-                var shouldNewClientJoin = Random.Range(0, 100);
-                var currentClientNetworkManager = m_ClientNetworkManagers[i];
                 // Two clients will connect during a SceneEventProgress
-                var joinNewClient = shouldNewClientJoin >= 50 && m_ClientThatShouldNotHaveCompleted.Count < 2;
+                var shouldNewClientJoin = i % 2 == 0;
+                var currentClientNetworkManager = m_ClientNetworkManagers[i];
 
                 // All connected clients will finish their SceneEventProgress
                 SetClientFinished(currentClientNetworkManager.LocalClientId, true);
 
-                if (joinNewClient)
+                if (shouldNewClientJoin)
                 {
                     yield return CreateAndStartNewClient();
                 }

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/SceneEventProgressTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/SceneEventProgressTests.cs
@@ -48,7 +48,7 @@ namespace TestProject.RuntimeTests
             m_CurrentSceneEventProgress = new SceneEventProgress(m_ServerNetworkManager, SceneEventProgressStatus.Started);
             m_CurrentSceneEventProgress.OnComplete = SceneEventProgressComplete;
             SceneManager.sceneLoaded += MockServerLoadedSene;
-            m_CurrentSceneEventProgress.SetSceneLoadOperation(SceneManager.LoadSceneAsync(k_SceneUsedToGetAsyncOperation, LoadSceneMode.Additive));
+            m_CurrentSceneEventProgress.SetSceneAsyncOperation(SceneManager.LoadSceneAsync(k_SceneUsedToGetAsyncOperation, LoadSceneMode.Additive));
         }
 
         private void MockServerLoadedSene(Scene scene, LoadSceneMode loadSceneMode)

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/SceneEventProgressTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/SceneEventProgressTests.cs
@@ -48,7 +48,7 @@ namespace TestProject.RuntimeTests
             m_CurrentSceneEventProgress = new SceneEventProgress(m_ServerNetworkManager, SceneEventProgressStatus.Started);
             m_CurrentSceneEventProgress.OnComplete = SceneEventProgressComplete;
             SceneManager.sceneLoaded += MockServerLoadedSene;
-            m_CurrentSceneEventProgress.SetSceneAsyncOperation(SceneManager.LoadSceneAsync(k_SceneUsedToGetAsyncOperation, LoadSceneMode.Additive));
+            m_CurrentSceneEventProgress.SetAsyncOperation(SceneManager.LoadSceneAsync(k_SceneUsedToGetAsyncOperation, LoadSceneMode.Additive));
         }
 
         private void MockServerLoadedSene(Scene scene, LoadSceneMode loadSceneMode)

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/SceneEventProgressTests.cs.meta
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/SceneEventProgressTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 319d8f12c0057694b954c877e69103c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR addresses several issues with `SceneEventProgress` that could result in it never completing as well as several scenarios where it would never time out.

[MTT-4772](https://jira.unity3d.com/browse/MTT-4772)

## Changelog
- Fixed: issue where `SceneEventProgress` would not complete if a client late joins while it is still in progress.
- Fixed: issue where `SceneEventProgress` would not complete if a client disconnects.
- Fixed: issues with detecting if a `SceneEventProgress` has timed out. 

## Testing and Documentation
- Includes `SceneEventProgress` specific integration tests.
- No documentation changes or additions were necessary.
