### PR TITLE
fix: Issues when using UTP 2.0.0-exp.6

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/BatchedSendQueue.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/BatchedSendQueue.cs
@@ -208,19 +208,12 @@ namespace Unity.Netcode.Transports.UTP
 
             unsafe
             {
-                var dataPtr = (byte*)m_Data.GetUnsafePtr() + HeadIndex;
-
-#if UTP_TRANSPORT_2_0_ABOVE
-                var slice = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<byte>(dataPtr, Length, Allocator.None);
-                var reader = new DataStreamReader(slice);
-#else
-                var reader = new DataStreamReader(dataPtr, Length);
-#endif
+                var reader = new DataStreamReader(m_Data.AsArray());
 
                 var writerAvailable = writer.Capacity;
-                var readerOffset = 0;
+                var readerOffset = HeadIndex;
 
-                while (readerOffset < Length)
+                while (readerOffset < TailIndex)
                 {
                     reader.SeekSet(readerOffset);
                     var messageLength = reader.ReadInt();

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/BatchedSendQueue.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/BatchedSendQueue.cs
@@ -211,7 +211,7 @@ namespace Unity.Netcode.Transports.UTP
                 var dataPtr = (byte*)m_Data.GetUnsafePtr() + HeadIndex;
 
 #if UTP_TRANSPORT_2_0_ABOVE
-                var slice = NativeArray.ConvertExistingDataToNativeArray<byte>(dataPtr, Length, Allocator.None);
+                var slice = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<byte>(dataPtr, Length, Allocator.None);
                 var reader = new DataStreamReader(slice);
 #else
                 var reader = new DataStreamReader(dataPtr, Length);

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -482,6 +482,7 @@ namespace Unity.Netcode.Transports.UTP
                 }
 
                 m_NetworkSettings.WithRelayParameters(ref m_RelayServerData, m_HeartbeatTimeoutMS);
+                serverEndpoint = m_RelayServerData.Endpoint;
             }
             else
             {


### PR DESCRIPTION
This PR fixes two issues that occurred if UTP 2.0.0-exp.6 was installed:

- Clients using Relay would fail to connect because in exp.6 we consider connecting to endpoints other than the Relay server to be an error. This was reverted in exp.7 but that's not available yet.
- Simplified the creation of `DataStreamReader` in `BatchedSendQueue` so that it works the same way with UTP 1.X and 2.0. This avoids an issue where the temporary native array didn't have an atomic safety handle, causing an exception when creating the stream reader.

## Changelog

N/A (None of the issues should be observable by users on released versions of NGO.)

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.