### PR TITLE
fix: NetworkConfig cached hash was not being regenerated on clients for each unique ConnectionRequestMessage [MTT-4605]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -21,7 +21,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where clients were not rebuilding the NetworkConfig hash value for each unique connection request.
+- Fixed issue where clients were not rebuilding the `NetworkConfig` hash value for each unique connection request. (#2226)
 - Fixed issue #1924 where `UnityTransport` would fail to restart after a first failure (even if what caused the initial failure was addressed). (#2220)
 - Fixed issue where `NetworkTransform.SetStateServerRpc` and `NetworkTransform.SetStateClientRpc` were not honoring local vs world space settings when applying the position and rotation. (#2203)
 - Fixed ILPP `TypeLoadException` on WebGL on MacOS Editor and potentially other platforms. (#2199)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -21,6 +21,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where clients were not rebuilding the NetworkConfig hash value for each unique connection request.
 - Fixed issue #1924 where `UnityTransport` would fail to restart after a first failure (even if what caused the initial failure was addressed). (#2220)
 - Fixed issue where `NetworkTransform.SetStateServerRpc` and `NetworkTransform.SetStateClientRpc` were not honoring local vs world space settings when applying the position and rotation. (#2203)
 - Fixed ILPP `TypeLoadException` on WebGL on MacOS Editor and potentially other platforms. (#2199)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1609,7 +1609,9 @@ namespace Unity.Netcode
         {
             var message = new ConnectionRequestMessage
             {
-                ConfigHash = NetworkConfig.GetConfig(),
+                // Since only a remote client will send a connection request,
+                // we should always force the rebuilding of the NetworkConfig hash value
+                ConfigHash = NetworkConfig.GetConfig(false),
                 ShouldSendConnectionData = NetworkConfig.ConnectionApproval,
                 ConnectionData = NetworkConfig.ConnectionData
             };

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApproval.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApproval.cs
@@ -62,11 +62,27 @@ namespace Unity.Netcode.RuntimeTests
             response.PlayerPrefabHash = null;
         }
 
+
+        [Test]
+        public void VerifyUniqueNetworkConfigPerRequest()
+        {
+            var networkConfig = new NetworkConfig();
+            networkConfig.EnableSceneManagement = true;
+            networkConfig.TickRate = 30;
+            var currentHash = networkConfig.GetConfig();
+            networkConfig.EnableSceneManagement = false;
+            networkConfig.TickRate = 60;
+            var newHash = networkConfig.GetConfig(false);
+
+            Assert.True(currentHash != newHash, $"Hashed {nameof(NetworkConfig)} values {currentHash} and {newHash} should not be the same!");
+        }
+
         [TearDown]
         public void TearDown()
         {
             // Stop, shutdown, and destroy
             NetworkManagerHelper.ShutdownNetworkManager();
         }
+
     }
 }


### PR DESCRIPTION
If a client first connects to one server, then later disconnects from that server, and then in the same runtime instance tries to connect to another server the NetworkConfig hash value would not be regenerated.  This resolves that issue.

[MTT-4605](https://jira.unity3d.com/browse/MTT-4605)
#2175

## Changelog
- Fixed: Issue where clients were not rebuilding the `NetworkConfig` hash value for each unique connection request.

## Testing and Documentation
- Includes unit test.

