### PR TITLE
fix: test project physics sample

### DIFF
--- a/testproject/Assets/Prefabs/PhysicsPlayer.prefab
+++ b/testproject/Assets/Prefabs/PhysicsPlayer.prefab
@@ -14,7 +14,6 @@ GameObject:
   - component: {fileID: 4079352819444256612}
   - component: {fileID: -3775814466963834669}
   - component: {fileID: 1750810845806302260}
-  - component: {fileID: -6757728931092222887}
   - component: {fileID: 4053684789567975459}
   - component: {fileID: 3885376173097824340}
   - component: {fileID: 1991357795387791033}
@@ -35,6 +34,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 5, y: 0.5, z: 5}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -58,6 +58,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -133,33 +134,6 @@ Rigidbody:
   m_Interpolate: 1
   m_Constraints: 112
   m_CollisionDetection: 1
---- !u!114 &-6757728931092222887
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4079352819444256614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e96cb6065543e43c4a752faaa1468eb1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  SyncPositionX: 1
-  SyncPositionY: 1
-  SyncPositionZ: 1
-  SyncRotAngleX: 1
-  SyncRotAngleY: 1
-  SyncRotAngleZ: 1
-  SyncScaleX: 1
-  SyncScaleY: 1
-  SyncScaleZ: 1
-  PositionThreshold: 0
-  RotAngleThreshold: 0
-  ScaleThreshold: 0
-  InLocalSpace: 0
-  Interpolate: 1
-  FixedSendsPerSecond: 5
 --- !u!114 &4053684789567975459
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -184,8 +158,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 82b41b172a31546ffba450f1418f4e69, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Speed: 5
-  m_RotSpeed: 2.5
+  SyncPositionX: 1
+  SyncPositionY: 1
+  SyncPositionZ: 1
+  SyncRotAngleX: 1
+  SyncRotAngleY: 1
+  SyncRotAngleZ: 1
+  SyncScaleX: 1
+  SyncScaleY: 1
+  SyncScaleZ: 1
+  PositionThreshold: 0.001
+  RotAngleThreshold: 0.01
+  ScaleThreshold: 0.01
+  InLocalSpace: 0
+  Interpolate: 1
+  Speed: 4
+  RotSpeed: 1
 --- !u!114 &1991357795387791033
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/testproject/Assets/Samples/SamplesMenu.unity
+++ b/testproject/Assets/Samples/SamplesMenu.unity
@@ -2526,11 +2526,11 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 0509eb053ce4ef749afd8495f13128f1, type: 2}
   - {fileID: 11400000, guid: 9a8d9296fb33f794f95514bf38de3cf9, type: 2}
   - {fileID: 11400000, guid: 7fdc32fee173cca45a4601ba234954d0, type: 2}
-  - {fileID: 11400000, guid: 21aae92071ad50448a45b013d8346639, type: 2}
+  - {fileID: 11400000, guid: 7289196bc52552d458b24c94498df352, type: 2}
   - {fileID: 11400000, guid: 660535b6e155b5b4bbede52313fcb32e, type: 2}
   - {fileID: 11400000, guid: d2e34ed37c087154dbd7f89fd463801b, type: 2}
   - {fileID: 11400000, guid: 138603ab28f532140b48a57bea0e54b0, type: 2}
-  - {fileID: 11400000, guid: 7289196bc52552d458b24c94498df352, type: 2}
+  - {fileID: 11400000, guid: 21aae92071ad50448a45b013d8346639, type: 2}
   m_SceneMenusDropDownList: {fileID: 1362704539}
   m_OptionsList:
     m_Options:


### PR DESCRIPTION
Removed the no longer needed NetworkTransform from the PhysicsPlayer. 
[MTT-4083](https://jira.unity3d.com/browse/MTT-4083)
#1998

## Changelog
- Fixed: test project PhysicsPlayer prefab no longer needed the `NetworkTransform` component since `PlayerMovement` derives from `NetworkTransform`.


## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.
