### PR TITLE
chore: Update UTP dependency to 1.3.0

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -15,6 +15,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+- Updated `UnityTransport` dependency on `com.unity.transport` to 1.3.0. (#630)
 - The debug simulator in `UnityTransport` is now non-deterministic. Its random number generator used to be seeded with a constant value, leading to the same pattern of packet drops, delays, and jitter in every run. (#2196)
 
 ### Fixed

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -15,7 +15,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
-- Updated `UnityTransport` dependency on `com.unity.transport` to 1.3.0. (#630)
+- Updated `UnityTransport` dependency on `com.unity.transport` to 1.3.0. (#2231)
 - The debug simulator in `UnityTransport` is now non-deterministic. Its random number generator used to be seeded with a constant value, leading to the same pattern of packet drops, delays, and jitter in every run. (#2196)
 
 ### Fixed

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -6,6 +6,6 @@
     "unity": "2020.3",
     "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",
-        "com.unity.transport": "1.2.0"
+        "com.unity.transport": "1.3.0"
     }
 }

--- a/minimalproject/Packages/packages-lock.json
+++ b/minimalproject/Packages/packages-lock.json
@@ -39,7 +39,7 @@
       "source": "local",
       "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",
-        "com.unity.transport": "1.2.0"
+        "com.unity.transport": "1.3.0"
       }
     },
     "com.unity.nuget.mono-cecil": {
@@ -61,7 +61,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.transport": {
-      "version": "1.2.0",
+      "version": "1.3.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/testproject-tools-integration/Packages/packages-lock.json
+++ b/testproject-tools-integration/Packages/packages-lock.json
@@ -61,7 +61,7 @@
       "source": "local",
       "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",
-        "com.unity.transport": "1.2.0"
+        "com.unity.transport": "1.3.0"
       }
     },
     "com.unity.nuget.mono-cecil": {
@@ -107,7 +107,7 @@
       "url": "https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-candidates"
     },
     "com.unity.transport": {
-      "version": "1.2.0",
+      "version": "1.3.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/testproject/Packages/packages-lock.json
+++ b/testproject/Packages/packages-lock.json
@@ -83,7 +83,7 @@
       "source": "local",
       "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",
-        "com.unity.transport": "1.2.0"
+        "com.unity.transport": "1.3.0"
       }
     },
     "com.unity.nuget.mono-cecil": {
@@ -195,7 +195,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.transport": {
-      "version": "1.2.0",
+      "version": "1.3.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
as the title says

## Changelog

- Changed: Updated UnityTransport dependency on com.unity.transport to 1.3.0.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.
