### PR TITLE
feat: IPv6 support in UnityTransport [MTT-4801]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,7 +11,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
-- IPv6 is now supported for direction connections when using `UnityTransport`. However, note that Unity Relay is still limited to IPv4.
+- IPv6 is now supported for direct connections when using `UnityTransport`. (#2232)
 - Added WebSocket support when using UTP 2.0 with `UseWebSockets` property in the `UnityTransport` component of the `NetworkManager` allowing to pick WebSockets for communication. When building for WebGL, this selection happens automatically. (#2201)
 
 ### Changed

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,6 +11,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
+- IPv6 is now supported for direction connections when using `UnityTransport`. However, note that Unity Relay is still limited to IPv4.
 - Added WebSocket support when using UTP 2.0 with `UseWebSockets` property in the `UnityTransport` component of the `NetworkManager` allowing to pick WebSockets for communication. When building for WebGL, this selection happens automatically. (#2201)
 
 ### Changed

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -296,10 +296,12 @@ namespace Unity.Netcode.Transports.UTP
 
             private static NetworkEndpoint ParseNetworkEndpoint(string ip, ushort port)
             {
-                if (!NetworkEndpoint.TryParse(ip, port, out var endpoint))
+                NetworkEndpoint endpoint = default;
+
+                if (!NetworkEndpoint.TryParse(ip, port, out endpoint, NetworkFamily.Ipv4) &&
+                    !NetworkEndpoint.TryParse(ip, port, out endpoint, NetworkFamily.Ipv6))
                 {
                     Debug.LogError($"Invalid network endpoint: {ip}:{port}.");
-                    return default;
                 }
 
                 return endpoint;
@@ -491,7 +493,8 @@ namespace Unity.Netcode.Transports.UTP
 
             InitDriver();
 
-            int result = m_Driver.Bind(NetworkEndpoint.AnyIpv4);
+            var bindEndpoint = serverEndpoint.Family == NetworkFamily.Ipv6 ? NetworkEndpoint.AnyIpv6 : NetworkEndpoint.AnyIpv4;
+            int result = m_Driver.Bind(bindEndpoint);
             if (result != 0)
             {
                 Debug.LogError("Client failed to bind");
@@ -632,7 +635,7 @@ namespace Unity.Netcode.Transports.UTP
         /// <summary>
         /// Sets IP and Port information. This will be ignored if using the Unity Relay and you should call <see cref="SetRelayServerData"/>
         /// </summary>
-        /// <param name="ipv4Address">The remote IP address</param>
+        /// <param name="ipv4Address">The remote IP address (despite the name, can be an IPv6 address)</param>
         /// <param name="port">The remote port</param>
         /// <param name="listenAddress">The local listen address</param>
         public void SetConnectionData(string ipv4Address, ushort port, string listenAddress = null)

--- a/com.unity.netcode.gameobjects/Tests/Editor/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Transports/UnityTransportTests.cs
@@ -7,9 +7,9 @@ namespace Unity.Netcode.EditorTests
 {
     public class UnityTransportTests
     {
-        // Check that starting a server doesn't immediately result in faulted tasks.
+        // Check that starting an IPv4 server succeeds.
         [Test]
-        public void UnityTransport_BasicInitServer()
+        public void UnityTransport_BasicInitServer_IPv4()
         {
             UnityTransport transport = new GameObject().AddComponent<UnityTransport>();
             transport.Initialize();
@@ -19,12 +19,38 @@ namespace Unity.Netcode.EditorTests
             transport.Shutdown();
         }
 
-        // Check that starting a client doesn't immediately result in faulted tasks.
+        // Check that starting an IPv4 client succeeds.
         [Test]
-        public void UnityTransport_BasicInitClient()
+        public void UnityTransport_BasicInitClient_IPv4()
         {
             UnityTransport transport = new GameObject().AddComponent<UnityTransport>();
             transport.Initialize();
+
+            Assert.True(transport.StartClient());
+
+            transport.Shutdown();
+        }
+
+        // Check that starting an IPv6 server succeeds.
+        [Test]
+        public void UnityTransport_BasicInitServer_IPv6()
+        {
+            UnityTransport transport = new GameObject().AddComponent<UnityTransport>();
+            transport.Initialize();
+            transport.SetConnectionData("::1", 7777);
+
+            Assert.True(transport.StartServer());
+
+            transport.Shutdown();
+        }
+
+        // Check that starting an IPv6 client succeeds.
+        [Test]
+        public void UnityTransport_BasicInitClient_IPv6()
+        {
+            UnityTransport transport = new GameObject().AddComponent<UnityTransport>();
+            transport.Initialize();
+            transport.SetConnectionData("::1", 7777);
 
             Assert.True(transport.StartClient());
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTestHelpers.cs
@@ -3,10 +3,13 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Unity.Netcode.Transports.UTP;
+using Unity.Networking.Transport;
 using UnityEngine;
 
 namespace Unity.Netcode.RuntimeTests
 {
+    using NetworkEvent = Unity.Netcode.NetworkEvent;
+
     public static class UnityTransportTestHelpers
     {
         // Half a second might seem like a very long time to wait for a network event, but in CI
@@ -37,15 +40,22 @@ namespace Unity.Netcode.RuntimeTests
 
         // Common code to initialize a UnityTransport that logs its events.
         public static void InitializeTransport(out UnityTransport transport, out List<TransportEvent> events,
-            int maxPayloadSize = UnityTransport.InitialMaxPayloadSize, int maxSendQueueSize = 0)
+            int maxPayloadSize = UnityTransport.InitialMaxPayloadSize, int maxSendQueueSize = 0, NetworkFamily family = NetworkFamily.Ipv4)
         {
             var logger = new TransportEventLogger();
             events = logger.Events;
 
             transport = new GameObject().AddComponent<UnityTransport>();
+
             transport.OnTransportEvent += logger.HandleEvent;
             transport.MaxPayloadSize = maxPayloadSize;
             transport.MaxSendQueueSize = maxSendQueueSize;
+
+            if (family == NetworkFamily.Ipv6)
+            {
+                transport.SetConnectionData("::1", 7777);
+            }
+
             transport.Initialize();
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTestHelpers.cs
@@ -8,8 +8,6 @@ using UnityEngine;
 
 namespace Unity.Netcode.RuntimeTests
 {
-    using NetworkEvent = Unity.Netcode.NetworkEvent;
-
     public static class UnityTransportTestHelpers
     {
         // Half a second might seem like a very long time to wait for a network event, but in CI

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
@@ -5,12 +5,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Unity.Netcode.Transports.UTP;
+using Unity.Networking.Transport;
 using UnityEngine;
 using UnityEngine.TestTools;
 using static Unity.Netcode.RuntimeTests.UnityTransportTestHelpers;
 
 namespace Unity.Netcode.RuntimeTests
 {
+    using NetworkEvent = Unity.Netcode.NetworkEvent;
+
     public class UnityTransportTests
     {
         // No need to test all reliable delivery methods since they all map to the same pipeline.
@@ -19,6 +22,15 @@ namespace Unity.Netcode.RuntimeTests
             NetworkDelivery.Unreliable,
             NetworkDelivery.UnreliableSequenced,
             NetworkDelivery.Reliable
+        };
+
+        private static readonly NetworkFamily[] k_NetworkFamiltyParameters =
+        {
+            NetworkFamily.Ipv4,
+#if !(UNITY_SWITCH || UNITY_PS4 || UNITY_PS5)
+            // IPv6 is not supported on Switch, PS4, and PS5.
+            NetworkFamily.Ipv6
+#endif
         };
 
         private UnityTransport m_Server, m_Client1, m_Client2;
@@ -60,10 +72,12 @@ namespace Unity.Netcode.RuntimeTests
 
         // Check if can make a simple data exchange.
         [UnityTest]
-        public IEnumerator PingPong([ValueSource("k_DeliveryParameters")] NetworkDelivery delivery)
+        public IEnumerator PingPong(
+            [ValueSource("k_DeliveryParameters")] NetworkDelivery delivery,
+            [ValueSource("k_NetworkFamiltyParameters")] NetworkFamily family)
         {
-            InitializeTransport(out m_Server, out m_ServerEvents);
-            InitializeTransport(out m_Client1, out m_Client1Events);
+            InitializeTransport(out m_Server, out m_ServerEvents, family: family);
+            InitializeTransport(out m_Client1, out m_Client1Events, family: family);
 
             m_Server.StartServer();
             m_Client1.StartClient();
@@ -89,10 +103,12 @@ namespace Unity.Netcode.RuntimeTests
 
         // Check if can make a simple data exchange (both ways at a time).
         [UnityTest]
-        public IEnumerator PingPongSimultaneous([ValueSource("k_DeliveryParameters")] NetworkDelivery delivery)
+        public IEnumerator PingPongSimultaneous(
+            [ValueSource("k_DeliveryParameters")] NetworkDelivery delivery,
+            [ValueSource("k_NetworkFamiltyParameters")] NetworkFamily family)
         {
-            InitializeTransport(out m_Server, out m_ServerEvents);
-            InitializeTransport(out m_Client1, out m_Client1Events);
+            InitializeTransport(out m_Server, out m_ServerEvents, family: family);
+            InitializeTransport(out m_Client1, out m_Client1Events, family: family);
 
             m_Server.StartServer();
             m_Client1.StartClient();
@@ -126,13 +142,15 @@ namespace Unity.Netcode.RuntimeTests
         // loopback traffic are too small for the amount of data sent in a single update here.
         [UnityTest]
         [UnityPlatform(exclude = new[] { RuntimePlatform.Switch, RuntimePlatform.PS4, RuntimePlatform.PS5 })]
-        public IEnumerator SendMaximumPayloadSize([ValueSource("k_DeliveryParameters")] NetworkDelivery delivery)
+        public IEnumerator SendMaximumPayloadSize(
+            [ValueSource("k_DeliveryParameters")] NetworkDelivery delivery,
+            [ValueSource("k_NetworkFamiltyParameters")] NetworkFamily family)
         {
             // We want something that's over the old limit of ~44KB for reliable payloads.
             var payloadSize = 64 * 1024;
 
-            InitializeTransport(out m_Server, out m_ServerEvents, payloadSize);
-            InitializeTransport(out m_Client1, out m_Client1Events, payloadSize);
+            InitializeTransport(out m_Server, out m_ServerEvents, payloadSize, family: family);
+            InitializeTransport(out m_Client1, out m_Client1Events, payloadSize, family: family);
 
             m_Server.StartServer();
             m_Client1.StartClient();
@@ -164,10 +182,12 @@ namespace Unity.Netcode.RuntimeTests
 
         // Check making multiple sends to a client in a single frame.
         [UnityTest]
-        public IEnumerator MultipleSendsSingleFrame([ValueSource("k_DeliveryParameters")] NetworkDelivery delivery)
+        public IEnumerator MultipleSendsSingleFrame(
+            [ValueSource("k_DeliveryParameters")] NetworkDelivery delivery,
+            [ValueSource("k_NetworkFamiltyParameters")] NetworkFamily family)
         {
-            InitializeTransport(out m_Server, out m_ServerEvents);
-            InitializeTransport(out m_Client1, out m_Client1Events);
+            InitializeTransport(out m_Server, out m_ServerEvents, family: family);
+            InitializeTransport(out m_Client1, out m_Client1Events, family: family);
 
             m_Server.StartServer();
             m_Client1.StartClient();
@@ -193,11 +213,13 @@ namespace Unity.Netcode.RuntimeTests
 
         // Check sending data to multiple clients.
         [UnityTest]
-        public IEnumerator SendMultipleClients([ValueSource("k_DeliveryParameters")] NetworkDelivery delivery)
+        public IEnumerator SendMultipleClients(
+            [ValueSource("k_DeliveryParameters")] NetworkDelivery delivery,
+            [ValueSource("k_NetworkFamiltyParameters")] NetworkFamily family)
         {
-            InitializeTransport(out m_Server, out m_ServerEvents);
-            InitializeTransport(out m_Client1, out m_Client1Events);
-            InitializeTransport(out m_Client2, out m_Client2Events);
+            InitializeTransport(out m_Server, out m_ServerEvents, family: family);
+            InitializeTransport(out m_Client1, out m_Client1Events, family: family);
+            InitializeTransport(out m_Client2, out m_Client2Events, family: family);
 
             m_Server.StartServer();
             m_Client1.StartClient();
@@ -234,11 +256,13 @@ namespace Unity.Netcode.RuntimeTests
 
         // Check receiving data from multiple clients.
         [UnityTest]
-        public IEnumerator ReceiveMultipleClients([ValueSource("k_DeliveryParameters")] NetworkDelivery delivery)
+        public IEnumerator ReceiveMultipleClients(
+            [ValueSource("k_DeliveryParameters")] NetworkDelivery delivery,
+            [ValueSource("k_NetworkFamiltyParameters")] NetworkFamily family)
         {
-            InitializeTransport(out m_Server, out m_ServerEvents);
-            InitializeTransport(out m_Client1, out m_Client1Events);
-            InitializeTransport(out m_Client2, out m_Client2Events);
+            InitializeTransport(out m_Server, out m_ServerEvents, family: family);
+            InitializeTransport(out m_Client1, out m_Client1Events, family: family);
+            InitializeTransport(out m_Client2, out m_Client2Events, family: family);
 
             m_Server.StartServer();
             m_Client1.StartClient();

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
@@ -12,8 +12,6 @@ using static Unity.Netcode.RuntimeTests.UnityTransportTestHelpers;
 
 namespace Unity.Netcode.RuntimeTests
 {
-    using NetworkEvent = Unity.Netcode.NetworkEvent;
-
     public class UnityTransportTests
     {
         // No need to test all reliable delivery methods since they all map to the same pipeline.


### PR DESCRIPTION
UTP fully supports IPv6, but this support was not available in the adapter because we only tried parsing user-provided IP addresses as IPv4. Supporting IPv6 was as simple as modifying the endpoint parsing code to also check for IPv6 addresses. The rest of the code changes is mostly adapting the tests to also test IPv6.

Note that when using Relay, only IPv4 is supported. AFAIK the Relay SDK only hands out IPv4 addresses so that's not really an issue for now. In any case, once I move the adapter to the new APIs provided by UTP 1.3 and 2.0 for Relay integration, IPv6 support will be taken care of transparently.

## Changelog

- Added: IPv6 is now supported for direct connections when using `UnityTransport`.

## Testing and Documentation

- Includes unit tests.
- Includes integration tests.
- No documentation changes or additions were necessary.