### PR TITLE
fix: correctly rejecting NetworkList modifications on unauthorized clients

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -39,9 +39,13 @@ namespace Unity.Netcode
             NetworkVariableWritePermission writePerm = DefaultWritePerm)
             : base(readPerm, writePerm)
         {
-            foreach (var value in values)
+            // allow null IEnumerable<T> to mean "no values"
+            if (values != null)
             {
-                m_List.Add(value);
+                foreach (var value in values)
+                {
+                    m_List.Add(value);
+                }
             }
         }
 
@@ -364,6 +368,12 @@ namespace Unity.Netcode
         /// <inheritdoc />
         public void Add(T item)
         {
+            // check write permissions
+            if (!CanClientWrite(m_NetworkBehaviour.NetworkManager.LocalClientId))
+            {
+                throw new InvalidOperationException("Client is not allowed to write to this NetworkList");
+            }
+
             m_List.Add(item);
 
             var listEvent = new NetworkListEvent<T>()
@@ -379,6 +389,12 @@ namespace Unity.Netcode
         /// <inheritdoc />
         public void Clear()
         {
+            // check write permissions
+            if (!CanClientWrite(m_NetworkBehaviour.NetworkManager.LocalClientId))
+            {
+                throw new InvalidOperationException("Client is not allowed to write to this NetworkList");
+            }
+
             m_List.Clear();
 
             var listEvent = new NetworkListEvent<T>()
@@ -399,6 +415,12 @@ namespace Unity.Netcode
         /// <inheritdoc />
         public bool Remove(T item)
         {
+            // check write permissions
+            if (!CanClientWrite(m_NetworkBehaviour.NetworkManager.LocalClientId))
+            {
+                throw new InvalidOperationException("Client is not allowed to write to this NetworkList");
+            }
+
             int index = NativeArrayExtensions.IndexOf(m_List, item);
             if (index == -1)
             {
@@ -428,6 +450,12 @@ namespace Unity.Netcode
         /// <inheritdoc />
         public void Insert(int index, T item)
         {
+            // check write permissions
+            if (!CanClientWrite(m_NetworkBehaviour.NetworkManager.LocalClientId))
+            {
+                throw new InvalidOperationException("Client is not allowed to write to this NetworkList");
+            }
+
             if (index < m_List.Length)
             {
                 m_List.InsertRangeWithBeginEnd(index, index + 1);
@@ -451,6 +479,12 @@ namespace Unity.Netcode
         /// <inheritdoc />
         public void RemoveAt(int index)
         {
+            // check write permissions
+            if (!CanClientWrite(m_NetworkBehaviour.NetworkManager.LocalClientId))
+            {
+                throw new InvalidOperationException("Client is not allowed to write to this NetworkList");
+            }
+
             m_List.RemoveAt(index);
 
             var listEvent = new NetworkListEvent<T>()
@@ -468,6 +502,12 @@ namespace Unity.Netcode
             get => m_List[index];
             set
             {
+                // check write permissions
+                if (!CanClientWrite(m_NetworkBehaviour.NetworkManager.LocalClientId))
+                {
+                    throw new InvalidOperationException("Client is not allowed to write to this NetworkList");
+                }
+
                 var previousValue = m_List[index];
                 m_List[index] = value;
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/OwnerPermissionTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/OwnerPermissionTests.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Unity.Netcode.TestHelpers.Runtime;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    public class OwnerPermissionTestComponent : NetworkBehaviour
+    {
+
+    }
+
+    public class OwnerPermissionObject : NetworkBehaviour
+    {
+        // indexed by [object, machine]
+        public static OwnerPermissionObject[,] Objects = new OwnerPermissionObject[3, 3];
+        public static int CurrentlySpawning = 0;
+
+        public static List<OwnerPermissionObject> ClientTargetedNetworkObjects = new List<OwnerPermissionObject>();
+        // a client-owned NetworkVariable
+        public NetworkVariable<int> MyNetworkVariableOwner;
+        // a server-owned NetworkVariable
+        public NetworkVariable<int> MyNetworkVariableServer;
+
+        // a client-owned NetworkVariable
+        public NetworkList<int> MyNetworkListOwner;
+        // a server-owned NetworkVariable
+        public NetworkList<int> MyNetworkListServer;
+
+        // verifies two lists are identical
+        public static void CheckLists(NetworkList<int> listA, NetworkList<int> listB)
+        {
+            Debug.Assert(listA.Count == listB.Count);
+            for (var i = 0; i < listA.Count; i++)
+            {
+                Debug.Assert(listA[i] == listB[i]);
+            }
+        }
+
+        // verifies all objects have consistent lists on all clients
+        public static void VerifyConsistency()
+        {
+            for (var objectIndex = 0; objectIndex < 3; objectIndex++)
+            {
+                CheckLists(Objects[objectIndex, 0].MyNetworkListOwner, Objects[objectIndex, 1].MyNetworkListOwner);
+                CheckLists(Objects[objectIndex, 0].MyNetworkListOwner, Objects[objectIndex, 2].MyNetworkListOwner);
+
+                CheckLists(Objects[objectIndex, 0].MyNetworkListServer, Objects[objectIndex, 1].MyNetworkListServer);
+                CheckLists(Objects[objectIndex, 0].MyNetworkListServer, Objects[objectIndex, 2].MyNetworkListServer);
+            }
+        }
+
+        public override void OnNetworkSpawn()
+        {
+            Objects[CurrentlySpawning, NetworkManager.LocalClientId] = GetComponent<OwnerPermissionObject>();
+            Debug.Log($"Object index ({CurrentlySpawning}) spawned on client {NetworkManager.LocalClientId}");
+        }
+
+        private void Awake()
+        {
+            MyNetworkVariableOwner = new NetworkVariable<int>(writePerm: NetworkVariableWritePermission.Owner);
+            MyNetworkVariableOwner.OnValueChanged += OwnerChanged;
+
+            MyNetworkVariableServer = new NetworkVariable<int>(writePerm: NetworkVariableWritePermission.Server);
+            MyNetworkVariableServer.OnValueChanged += ServerChanged;
+
+            MyNetworkListOwner = new NetworkList<int>(writePerm: NetworkVariableWritePermission.Owner);
+            MyNetworkListOwner.OnListChanged += ListOwnerChanged;
+
+            MyNetworkListServer = new NetworkList<int>(writePerm: NetworkVariableWritePermission.Server);
+            MyNetworkListServer.OnListChanged += ListServerChanged;
+        }
+
+        public void OwnerChanged(int before, int after)
+        {
+        }
+
+        public void ServerChanged(int before, int after)
+        {
+        }
+
+        public void ListOwnerChanged(NetworkListEvent<int> listEvent)
+        {
+        }
+
+        public void ListServerChanged(NetworkListEvent<int> listEvent)
+        {
+        }
+    }
+
+    public class OwnerPermissionHideTests : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 2;
+
+        private GameObject m_PrefabToSpawn;
+
+        protected override void OnCreatePlayerPrefab()
+        {
+            var networkTransform = m_PlayerPrefab.AddComponent<OwnerPermissionTestComponent>();
+        }
+
+        protected override void OnServerAndClientsCreated()
+        {
+            m_PrefabToSpawn = CreateNetworkObjectPrefab("OwnerPermissionObject");
+            m_PrefabToSpawn.AddComponent<OwnerPermissionObject>();
+        }
+
+        [UnityTest]
+        public IEnumerator OwnerPermissionTest()
+        {
+            // create 3 objects
+            for (var objectIndex = 0; objectIndex < 3; objectIndex++)
+            {
+                OwnerPermissionObject.CurrentlySpawning = objectIndex;
+
+                NetworkManager ownerManager = m_ServerNetworkManager;
+                if (objectIndex != 0)
+                {
+                    ownerManager = m_ClientNetworkManagers[objectIndex - 1];
+                }
+                SpawnObject(m_PrefabToSpawn, ownerManager);
+
+                // wait for each object to spawn on each client
+                for (var clientIndex = 0; clientIndex < 3; clientIndex++)
+                {
+                    while (OwnerPermissionObject.Objects[objectIndex, clientIndex] == null)
+                    {
+                        yield return new WaitForSeconds(0.0f);
+                    }
+                }
+            }
+
+            var nextValueToWrite = 1;
+            var serverIndex = 0;
+
+            for (var objectIndex = 0; objectIndex < 3; objectIndex++)
+            {
+                for (var clientWriting = 0; clientWriting < 3; clientWriting++)
+                {
+                    // ==== Server-writable NetworkVariable ====
+                    var gotException = false;
+                    Debug.Log($"Writing to server-write variable on object {objectIndex} on client {clientWriting}");
+
+                    try
+                    {
+                        nextValueToWrite++;
+                        OwnerPermissionObject.Objects[objectIndex, clientWriting].MyNetworkVariableServer.Value = nextValueToWrite;
+                    }
+                    catch (Exception)
+                    {
+                        gotException = true;
+                    }
+
+                    // Verify server-owned netvar can only be written by server
+                    Debug.Assert(gotException == (clientWriting != serverIndex));
+
+                    // ==== Owner-writable NetworkVariable ====
+                    gotException = false;
+                    Debug.Log($"Writing to owner-write variable on object {objectIndex} on client {clientWriting}");
+
+                    try
+                    {
+                        nextValueToWrite++;
+                        OwnerPermissionObject.Objects[objectIndex, clientWriting].MyNetworkVariableOwner.Value = nextValueToWrite;
+                    }
+                    catch (Exception)
+                    {
+                        gotException = true;
+                    }
+
+                    // Verify client-owned netvar can only be written by owner
+                    Debug.Assert(gotException == (clientWriting != objectIndex));
+
+                    // ==== Server-writable NetworkList ====
+                    gotException = false;
+                    Debug.Log($"Writing to server-write list on object {objectIndex} on client {clientWriting}");
+
+                    try
+                    {
+                        nextValueToWrite++;
+                        OwnerPermissionObject.Objects[objectIndex, clientWriting].MyNetworkListServer.Add(nextValueToWrite);
+                    }
+                    catch (Exception)
+                    {
+                        gotException = true;
+                    }
+
+                    // Verify server-owned networkList can only be written by server
+                    Debug.Assert(gotException == (clientWriting != serverIndex));
+
+                    // ==== Owner-writable NetworkList ====
+                    gotException = false;
+                    Debug.Log($"Writing to owner-write list on object {objectIndex} on client {clientWriting}");
+
+                    try
+                    {
+                        nextValueToWrite++;
+                        OwnerPermissionObject.Objects[objectIndex, clientWriting].MyNetworkListOwner.Add(nextValueToWrite);
+                    }
+                    catch (Exception)
+                    {
+                        gotException = true;
+                    }
+
+                    // Verify client-owned networkList can only be written by owner
+                    Debug.Assert(gotException == (clientWriting != objectIndex));
+
+                    yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ServerNetworkManager, 5);
+                    yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ClientNetworkManagers[0], 5);
+                    yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ClientNetworkManagers[1], 5);
+
+                    OwnerPermissionObject.VerifyConsistency();
+                }
+            }
+
+            yield return null;
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/OwnerPermissionTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/OwnerPermissionTests.cs
@@ -214,8 +214,6 @@ namespace Unity.Netcode.RuntimeTests
                     OwnerPermissionObject.VerifyConsistency();
                 }
             }
-
-            yield return null;
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/OwnerPermissionTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/OwnerPermissionTests.cs
@@ -7,11 +7,6 @@ using Unity.Netcode.TestHelpers.Runtime;
 
 namespace Unity.Netcode.RuntimeTests
 {
-    public class OwnerPermissionTestComponent : NetworkBehaviour
-    {
-
-    }
-
     public class OwnerPermissionObject : NetworkBehaviour
     {
         // indexed by [object, machine]
@@ -95,11 +90,6 @@ namespace Unity.Netcode.RuntimeTests
         protected override int NumberOfClients => 2;
 
         private GameObject m_PrefabToSpawn;
-
-        protected override void OnCreatePlayerPrefab()
-        {
-            var networkTransform = m_PlayerPrefab.AddComponent<OwnerPermissionTestComponent>();
-        }
 
         protected override void OnServerAndClientsCreated()
         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/OwnerPermissionTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/OwnerPermissionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 88c657dcbe9a2414ba551b60dab19acd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Correctly rejecting NetworkList modifications on unauthorized clients

Also: 
- Adding tests for it. 
- Allowing null IEnumerable to mean empty list in NetworkList

[MTT-4519](https://jira.unity3d.com/browse/MTT-4519)

#2156

## Testing and Documentation

- [OwnerPermissionTests.cs](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/compare/fix/networklist-permission-MTT-4519?expand=1#diff-c5565901562a77eaf775f752c970ec085f66a2180ed567817dfe1e04dfffdd8e) has been added. Tests writing to NetworkLists and NetworkVariables from all server and clients, for owner- and server-owned variables/lists.
