### PR TITLE
chore: Update to use UTP 2.0.0-exp.7 for compatibility test

### DIFF
--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -69,7 +69,7 @@ projects:
 # Package dependencies
 dependencies: 
   - name: com.unity.transport
-    version: 2.0.0-exp.6
+    version: 2.0.0-exp.7
     test_editors:
       - 2022.2
       - trunk


### PR DESCRIPTION
Update to use UTP 2.0.0-exp.7 for compatibility test

## Changelog

- None

## Testing and Documentation

- CI

