### PR TITLE
feat: Add new SetRelayServerData method to UnityTransport

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,6 +11,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
+- `UnityTransport` now provides a way to set the Relay server data directly from the `RelayServerData` structure (provided by the Unity Transport package) throuh its `SetRelayServerData` method. This allows making use of the new APIs in UTP 1.3 that simplify integration of the Relay SDK.
 - IPv6 is now supported for direct connections when using `UnityTransport`. (#2232)
 - Added WebSocket support when using UTP 2.0 with `UseWebSockets` property in the `UnityTransport` component of the `NetworkManager` allowing to pick WebSockets for communication. When building for WebGL, this selection happens automatically. (#2201)
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,7 +11,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
-- `UnityTransport` now provides a way to set the Relay server data directly from the `RelayServerData` structure (provided by the Unity Transport package) throuh its `SetRelayServerData` method. This allows making use of the new APIs in UTP 1.3 that simplify integration of the Relay SDK.
+- `UnityTransport` now provides a way to set the Relay server data directly from the `RelayServerData` structure (provided by the Unity Transport package) throuh its `SetRelayServerData` method. This allows making use of the new APIs in UTP 1.3 that simplify integration of the Relay SDK. (#2235)
 - IPv6 is now supported for direct connections when using `UnityTransport`. (#2232)
 - Added WebSocket support when using UTP 2.0 with `UseWebSockets` property in the `UnityTransport` component of the `NetworkManager` allowing to pick WebSockets for communication. When building for WebGL, this selection happens automatically. (#2201)
 

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -609,7 +609,7 @@ namespace Unity.Netcode.Transports.UTP
 
         /// <summary>Set the relay server data (using the lower-level Unity Transport data structure).</summary>
         /// <param name="serverData">Data for the Relay server to use.</param>
-        public void SetRelayServerData(ref RelayServerData serverData)
+        public void SetRelayServerData(RelayServerData serverData)
         {
             m_RelayServerData = serverData;
             SetProtocol(ProtocolType.RelayUnityTransport);

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -607,6 +607,14 @@ namespace Unity.Netcode.Transports.UTP
             SetProtocol(ProtocolType.RelayUnityTransport);
         }
 
+        /// <summary>Set the relay server data (using the lower-level Unity Transport data structure).</summary>
+        /// <param name="serverData">Data for the Relay server to use.</param>
+        public void SetRelayServerData(ref RelayServerData serverData)
+        {
+            m_RelayServerData = serverData;
+            SetProtocol(ProtocolType.RelayUnityTransport);
+        }
+
         /// <summary>Set the relay server data for the host.</summary>
         /// <param name="ipAddress">IP address of the relay server.</param>
         /// <param name="port">UDP port of the relay server.</param>


### PR DESCRIPTION
This PR adds a new API to `UnityTransport` that allows setting the Relay server data directly from the `RelayServerData` structure provided by UTP. The idea behind this change is to make it easier for NGO users to benefit from new APIs introduced in UTP 1.3. These new APIs allow creating `RelayServerData` structures directly from allocation objects from the Relay SDK.

For example, given an `allocation` object coming directly from the Relay SDK, this PR allows configuring the Relay server data in this manner:

```csharp
var serverData = new RelayServerData(allocation, "dtls");
transport.SetRelayServerData(serverData);
```

Compared to the previous ways of configuring the server data, this has many advantages:

- It's the same API for both client and host, since the `RelayServerData` constructors accept both `Allocation` and `JoinAllocation` objects.
- There's no need to deconstruct the `Allocation`/`JoinAllocation` objects in their individual fields just to pass them to NGO.
- There's no need to loop through the server endpoints in the allocation to find the one you want.
- There's no error possible where there's mismatch between the endpoint selected and the `isSecure` parameter of `SetClientRelayData` and `SetHostRelayData` (e.g. you can't select a DTLS endpoint and forget to set `isSecure` to true).
- It handles endpoints that are provided as hostnames instead of IP addresses (e.g. for secure WebSockets).
- It would transparently support IPv6 endpoints if the Relay server would start handing those out.

The previous APIs to set Relay server data remain available (and I'll get them to work with secure WebSockets in a future PR). Although if this lands I'll probably modify the Relay documentation to use the new ones.

## Changelog

- Added: `UnityTransport` now provides a way to set the Relay server data directly from the `RelayServerData` structure (provided by the Unity Transport package) throuh its `SetRelayServerData` method. This allows making use of the new APIs in UTP 1.3 that simplify integration of the Relay SDK.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary (maybe Relay documentation, but that can wait).