### PR TITLE
fix: Exclude test for rising animation state count during runtime builds

### DIFF
--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -549,6 +549,7 @@ namespace Unity.Netcode.Components
         private ClientRpcParams m_ClientRpcParams;
         private AnimationMessage m_AnimationMessage;
 
+#if UNITY_EDITOR
         /// <summary>
         /// Used for integration test to validate that the
         /// AnimationMessage.AnimationStates remains the same
@@ -558,6 +559,7 @@ namespace Unity.Netcode.Components
         {
             return m_AnimationMessage;
         }
+#endif
 
         // Only used in Cleanup
         private NetworkManager m_CachedNetworkManager;

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -549,7 +549,6 @@ namespace Unity.Netcode.Components
         private ClientRpcParams m_ClientRpcParams;
         private AnimationMessage m_AnimationMessage;
 
-#if UNITY_EDITOR
         /// <summary>
         /// Used for integration test to validate that the
         /// AnimationMessage.AnimationStates remains the same
@@ -559,7 +558,6 @@ namespace Unity.Netcode.Components
         {
             return m_AnimationMessage;
         }
-#endif
 
         // Only used in Cleanup
         private NetworkManager m_CachedNetworkManager;

--- a/testproject/Assets/Tests/Runtime/Animation/AnimatorTestHelper.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/AnimatorTestHelper.cs
@@ -29,10 +29,12 @@ namespace TestProject.RuntimeTests
             m_NetworkAnimator = GetComponent<NetworkAnimator>();
         }
 
+#if UNITY_EDITOR
         internal int GetAnimatorStateCount()
         {
             return m_NetworkAnimator.GetAnimationMessage().AnimationStates.Count;
         }
+#endif
 
         public override void OnNetworkSpawn()
         {

--- a/testproject/Assets/Tests/Runtime/Animation/AnimatorTestHelper.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/AnimatorTestHelper.cs
@@ -29,6 +29,8 @@ namespace TestProject.RuntimeTests
             m_NetworkAnimator = GetComponent<NetworkAnimator>();
         }
 
+        // Since the com.unity.netcode.components does not allow test project to access its internals
+        // during runtime, this is only used when running test runner from within the editor
 #if UNITY_EDITOR
         internal int GetAnimatorStateCount()
         {

--- a/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
@@ -256,6 +256,9 @@ namespace TestProject.RuntimeTests
             AssertOnTimeout($"Timed out waiting for the client-side instance of {GetNetworkAnimatorName(authoritativeMode)} to be spawned!");
             var animatorTestHelper = ownerShipMode == OwnerShipMode.ClientOwner ? AnimatorTestHelper.ClientSideInstances[m_ClientNetworkManagers[0].LocalClientId] : AnimatorTestHelper.ServerSideInstance;
             var layerCount = animatorTestHelper.GetAnimator().layerCount;
+
+            // Since the com.unity.netcode.components does not allow test project to access its internals
+            // during runtime, this is only used when running test runner from within the editor
 #if UNITY_EDITOR
             var animationStateCount = animatorTestHelper.GetAnimatorStateCount();
             Assert.True(layerCount == animationStateCount, $"AnimationState count {animationStateCount} does not equal the layer count {layerCount}!");
@@ -305,6 +308,8 @@ namespace TestProject.RuntimeTests
             // Verify we only entered each state once
             yield return WaitForConditionOrTimeOut(() => CheckStateEnterCount.AllStatesEnteredMatch(clientIdList));
             AssertOnTimeout($"Timed out waiting for all states entered to match!");
+            // Since the com.unity.netcode.components does not allow test project to access its internals
+            // during runtime, this is only used when running test runner from within the editor
 #if UNITY_EDITOR
             // Now, update some states for several seconds to assure the AnimationState count does not grow
             var waitForSeconds = new WaitForSeconds(0.25f);

--- a/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
@@ -256,9 +256,10 @@ namespace TestProject.RuntimeTests
             AssertOnTimeout($"Timed out waiting for the client-side instance of {GetNetworkAnimatorName(authoritativeMode)} to be spawned!");
             var animatorTestHelper = ownerShipMode == OwnerShipMode.ClientOwner ? AnimatorTestHelper.ClientSideInstances[m_ClientNetworkManagers[0].LocalClientId] : AnimatorTestHelper.ServerSideInstance;
             var layerCount = animatorTestHelper.GetAnimator().layerCount;
+#if UNITY_EDITOR
             var animationStateCount = animatorTestHelper.GetAnimatorStateCount();
-
             Assert.True(layerCount == animationStateCount, $"AnimationState count {animationStateCount} does not equal the layer count {layerCount}!");
+#endif
             if (authoritativeMode == AuthoritativeMode.ServerAuth)
             {
                 animatorTestHelper = AnimatorTestHelper.ServerSideInstance;
@@ -304,7 +305,7 @@ namespace TestProject.RuntimeTests
             // Verify we only entered each state once
             yield return WaitForConditionOrTimeOut(() => CheckStateEnterCount.AllStatesEnteredMatch(clientIdList));
             AssertOnTimeout($"Timed out waiting for all states entered to match!");
-
+#if UNITY_EDITOR
             // Now, update some states for several seconds to assure the AnimationState count does not grow
             var waitForSeconds = new WaitForSeconds(0.25f);
             bool rotateToggle = true;
@@ -317,7 +318,7 @@ namespace TestProject.RuntimeTests
                 yield return waitForSeconds;
                 rotateToggle = !rotateToggle;
             }
-
+#endif
             AnimatorTestHelper.IsTriggerTest = false;
             VerboseDebug($" ------------------ Trigger Test [{TriggerTest.Iteration}][{ownerShipMode}] Stopping ------------------ ");
         }


### PR DESCRIPTION
Since the test project does not have access to the Unity.Netcode.Components internals during runtime, this PR only does this check when the integration tests are run from within the editor.
