### PR TITLE
fix: Ensure network variable ILPP code picks up types used in NetworkList, too

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -755,7 +755,7 @@ namespace Unity.Netcode.Editor.CodeGen
                     //var type = field.FieldType;
                     if (type.IsGenericInstance)
                     {
-                        if (type.Resolve().Name == typeof(NetworkVariable<>).Name)
+                        if (type.Resolve().Name == typeof(NetworkVariable<>).Name || type.Resolve().Name == typeof(NetworkList<>).Name)
                         {
                             var genericInstanceType = (GenericInstanceType)type;
                             var wrappedType = genericInstanceType.GenericArguments[0];

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -845,8 +845,8 @@ namespace Unity.Netcode.RuntimeTests
                        m_Player1OnClient1.TheStructList[1].Value == m_Player1OnServer.TheStructList[1].Value;
             }
 
-            m_Player1OnServer.TheStructList.Add(new StructUsedOnlyInNetworkList{Value = 1});
-            m_Player1OnServer.TheStructList.Add(new StructUsedOnlyInNetworkList{Value = 2});
+            m_Player1OnServer.TheStructList.Add(new StructUsedOnlyInNetworkList { Value = 1 });
+            m_Player1OnServer.TheStructList.Add(new StructUsedOnlyInNetworkList { Value = 2 });
             m_Player1OnServer.TheStructList.SetDirty(true);
 
             // Wait for the client-side to notify it is finished initializing and spawning.

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -48,6 +48,26 @@ namespace Unity.Netcode.RuntimeTests
 
     }
 
+    public struct StructUsedOnlyInNetworkList : IEquatable<StructUsedOnlyInNetworkList>, INetworkSerializeByMemcpy
+    {
+        public int Value;
+
+        public bool Equals(StructUsedOnlyInNetworkList other)
+        {
+            return Value == other.Value;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is StructUsedOnlyInNetworkList other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return Value;
+        }
+    }
+
     [TestFixtureSource(nameof(TestDataSource))]
     public class NetworkVariablePermissionTests : NetcodeIntegrationTest
     {
@@ -433,6 +453,7 @@ namespace Unity.Netcode.RuntimeTests
         public readonly NetworkVariable<int> TheScalar = new NetworkVariable<int>();
         public readonly NetworkVariable<SomeEnum> TheEnum = new NetworkVariable<SomeEnum>();
         public readonly NetworkList<int> TheList = new NetworkList<int>();
+        public readonly NetworkList<StructUsedOnlyInNetworkList> TheStructList = new NetworkList<StructUsedOnlyInNetworkList>();
         public readonly NetworkList<FixedString128Bytes> TheLargeList = new NetworkList<FixedString128Bytes>();
 
         public readonly NetworkVariable<FixedString32Bytes> FixedString32 = new NetworkVariable<FixedString32Bytes>();
@@ -449,7 +470,6 @@ namespace Unity.Netcode.RuntimeTests
 
         public readonly NetworkVariable<TestStruct> TheStruct = new NetworkVariable<TestStruct>();
         public readonly NetworkVariable<TestClass> TheClass = new NetworkVariable<TestClass>();
-        public readonly NetworkList<TestStruct> TheListOfStructs = new NetworkList<TestStruct>();
 
         public NetworkVariable<UnmanagedTemplateNetworkSerializableType<TestStruct>> TheTemplateStruct = new NetworkVariable<UnmanagedTemplateNetworkSerializableType<TestStruct>>();
         public NetworkVariable<ManagedTemplateNetworkSerializableType<TestClass>> TheTemplateClass = new NetworkVariable<ManagedTemplateNetworkSerializableType<TestClass>>();
@@ -811,6 +831,26 @@ namespace Unity.Netcode.RuntimeTests
 
             // Wait for the client-side to notify it is finished initializing and spawning.
             yield return WaitForConditionOrTimeOut(VerifyClass);
+        }
+
+        [UnityTest]
+        public IEnumerator TestNetworkListStruct([Values(true, false)] bool useHost)
+        {
+            yield return InitializeServerAndClients(useHost);
+
+            bool VerifyList()
+            {
+                return m_Player1OnClient1.TheStructList.Count == m_Player1OnServer.TheStructList.Count &&
+                       m_Player1OnClient1.TheStructList[0].Value == m_Player1OnServer.TheStructList[0].Value &&
+                       m_Player1OnClient1.TheStructList[1].Value == m_Player1OnServer.TheStructList[1].Value;
+            }
+
+            m_Player1OnServer.TheStructList.Add(new StructUsedOnlyInNetworkList{Value = 1});
+            m_Player1OnServer.TheStructList.Add(new StructUsedOnlyInNetworkList{Value = 2});
+            m_Player1OnServer.TheStructList.SetDirty(true);
+
+            // Wait for the client-side to notify it is finished initializing and spawning.
+            yield return WaitForConditionOrTimeOut(VerifyList);
         }
 
         [UnityTest]


### PR DESCRIPTION
After the Managed Network Variable PR, I realized the ILPP code finding the list of types wasn't considering NetworkList, which also uses NetworkVariableSerialization.

NetworkVariableSerialization<T> is a public type (though it shouldn't be, but can't be changed now) but all its members are `internal` so we fortunately don't have to worry about finding any user-created NetworkVariableBase derivatives for now.

## Testing and Documentation

- Includes integration tests.
- No documentation changes or additions were necessary.
