### PR TITLE
chore: Add CI for WebGL builds [MTT-4656]

### DIFF
--- a/.yamato/_run-all.yml
+++ b/.yamato/_run-all.yml
@@ -8,6 +8,14 @@ run_all_tests:
     - .yamato/mobile-build-and-test.yml#run_{{ projects.first.name }}_tests_{{ mobile_validation_editor }}_iOS
     - .yamato/mobile-build-and-test.yml#run_{{ projects.first.name }}_tests_{{ mobile_validation_editor }}_android
     # - .yamato/_run-all.yml#all_project_tests_standalone
+{% for project in projects -%}
+{% if project.name == "testproject" -%}
+{% for editor in project.test_editors -%}
+    - .yamato/webgl-build.yml#build_{{ project.name }}_tests_{{ editor }}_webgl
+{% endfor -%}
+{% endif -%}
+{% endfor -%}
+
 {% for platform in test_platforms -%}
 {% for project in projects -%}
 {% for editor in project.test_editors -%}
@@ -137,6 +145,17 @@ all_project_tests_mobile:
 {% for editor in project.test_editors -%}
     - .yamato/mobile-build-and-test.yml#run_{{ project.name }}_tests_{{ editor }}_android
     - .yamato/mobile-build-and-test.yml#run_{{ project.name }}_tests_{{ editor }}_iOS
+{% endfor -%}
+{% endif -%}
+{% endfor -%}
+
+all_project_tests_webgl:
+  name: Build All Project Tests - WebGL
+  dependencies:
+{% for project in projects -%}
+{% if project.name == "testproject" -%}
+{% for editor in project.test_editors -%}
+    - .yamato/webgl-build.yml#build_{{ project.name }}_tests_{{ editor }}_webgl
 {% endfor -%}
 {% endif -%}
 {% endfor -%}

--- a/.yamato/webgl-build.yml
+++ b/.yamato/webgl-build.yml
@@ -1,0 +1,39 @@
+{% metadata_file .yamato/project.metafile %}
+---
+
+{% for project in projects -%}
+{% if project.name == "testproject" -%}
+{% for editor in project.test_editors -%}
+build_{{ project.name }}_tests_{{ editor }}_webgl:
+  name: Build {{ project.name }} Tests - {{ editor }} - WebGL
+  agent:
+      type: Unity::VM
+      image: dots-ci/windows10:v1.493-auto
+      flavor: b1.xlarge
+  commands:
+    - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
+    - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
+    - python .yamato/disable-burst-if-requested.py --project-path testproject --platform WebGL
+    - unity-downloader-cli -u {{ editor }} -c editor -c webgl -c il2cpp -w --fast
+    - |
+       set UTR_VERSION=0.12.0
+       utr.bat --artifacts_path=artifacts --timeout=1800 --testproject={{ project.name }} --editor-location=.Editor --suite=playmode --platform=WebGL --build-only --player-save-path=build/players --extra-editor-arg=-batchmode --extra-editor-arg=-nographics --scripting-backend=il2cpp --extra-editor-arg="-cloudEnvironment staging"
+  artifacts:
+    logs:
+      paths:
+      - '*.log'
+      - '*.xml'
+      - artifacts/**/*
+      - testproject/Logs/**
+      - testproject/Library/*.log
+      - testproject/*.log
+      - testproject/Builds/*.log
+      - build/test-results/**
+      - artifacts/**
+      - build/players/**
+  variables:
+    CI: true
+    ENABLE_BURST_COMPILATION: False
+{% endfor -%}
+{% endif -%}
+{% endfor -%}


### PR DESCRIPTION
Add CI for WebGL builds (only for building, no tests are being run). This partially addresses https://jira.unity3d.com/browse/MTT-4656
Add it to nightly.

https://unity-ci.cds.internal.unity3d.com/job/17476724/dependency-graph

Tests cannot be run "as is" on WebGL, at least when UTP 2.0 is installed. If UTP 2.0 is installed, the logic on WebGL is to use the WebSocket network interface no matter what, but this won't allow listening for new connections (can't do that in a browser). Getting the tests to run on WebGL will be addressed by the same story in the future.

## Changelog

None

## Testing and Documentation

- CI
