### PR TITLE
fix: Allow empty paths in SecretsLoaderHelper

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/SecretsLoaderHelper.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/SecretsLoaderHelper.cs
@@ -93,7 +93,7 @@ namespace Unity.Netcode.Transports.UTP
 
         [Tooltip("Client CA filepath. Useful with self-signed certificates")]
         [SerializeField]
-        private string m_ClientCAFilePath = "Assets/Secure/myGameClientCA.pem";
+        private string m_ClientCAFilePath = ""; // "Assets/Secure/myGameClientCA.pem"
 
         /// <summary>Client CA filepath. Useful with self-signed certificates</summary>
         public string ClientCAFilePath
@@ -118,7 +118,7 @@ namespace Unity.Netcode.Transports.UTP
 
         [Tooltip("Server Certificate filepath")]
         [SerializeField]
-        private string m_ServerCertificateFilePath = "Assets/Secure/myGameServerCertificate.pem";
+        private string m_ServerCertificateFilePath = ""; // "Assets/Secure/myGameServerCertificate.pem"
 
         /// <summary>Server Certificate filepath</summary>
         public string ServerCertificateFilePath
@@ -129,7 +129,7 @@ namespace Unity.Netcode.Transports.UTP
 
         [Tooltip("Server Private Key filepath")]
         [SerializeField]
-        private string m_ServerPrivateFilePath = "Assets/Secure/myGameServerPrivate.pem";
+        private string m_ServerPrivateFilePath = ""; // "Assets/Secure/myGameServerPrivate.pem"
 
         /// <summary>Server Private Key filepath</summary>
         public string ServerPrivateFilePath
@@ -174,6 +174,11 @@ namespace Unity.Netcode.Transports.UTP
 
         private static string ReadFile(string path, string label)
         {
+            if (path == null || path == "")
+            {
+                return "";
+            }
+
             var reader = new StreamReader(path);
             string fileContent = reader.ReadToEnd();
             Debug.Log((fileContent.Length > 1) ? ("Successfully loaded " + fileContent.Length + " byte(s) from " + label) : ("Could not read " + label + " file"));


### PR DESCRIPTION
If a path was not provided, it would throw an exception while loading the (non-existent) file. But this will be the normal use case in live deployments, since servers and clients will have different files to load (e.g. the client will not be loading a private key).

This PR makes it so that not providing a path will just mean an empty string is used as the contents of the file. This should be functionally equivalent to not providing these values at all.

This PR also makes the paths empty by default. The previous defaults made sense in the context of the script in the test project that generates the files, but they are unlikely to be valuable to users otherwise. Not having any defaults also means we don't seem like we're taking position as to where certificates must be stored (having defaults pointing to the assets folder could have led users to think this was good or standard practice).

## Changelog

N/A

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.