### PR TITLE
fix: Not sending ChangeOwnership messages to clients that have an object hidden

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -28,6 +28,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue caused when changing ownership of objects hidden to some clients (#2242)
 - Fixed issue where an in-scene placed NetworkObject would not invoke NetworkBehaviour.OnNetworkSpawn if the GameObject was disabled when it was despawned. (#2239)
 - Fixed issue where clients were not rebuilding the `NetworkConfig` hash value for each unique connection request. (#2226)
 - Fixed the issue where player objects were not taking the `DontDestroyWithOwner` property into consideration when a client disconnected. (#2225)

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -278,11 +278,14 @@ namespace Unity.Netcode
                 NetworkObjectId = networkObject.NetworkObjectId,
                 OwnerClientId = networkObject.OwnerClientId
             };
-            var size = NetworkManager.SendMessage(ref message, NetworkDelivery.ReliableSequenced, NetworkManager.ConnectedClientsIds);
 
-            foreach (var client in NetworkManager.ConnectedClients)
+            foreach (var client in NetworkManager.ConnectedClientsIds)
             {
-                NetworkManager.NetworkMetrics.TrackOwnershipChangeSent(client.Key, networkObject, size);
+                if (networkObject.IsNetworkVisibleTo(client))
+                {
+                    var size = NetworkManager.SendMessage(ref message, NetworkDelivery.ReliableSequenced, client);
+                    NetworkManager.NetworkMetrics.TrackOwnershipChangeSent(client, networkObject, size);
+                }
             }
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -279,12 +279,12 @@ namespace Unity.Netcode
                 OwnerClientId = networkObject.OwnerClientId
             };
 
-            foreach (var client in NetworkManager.ConnectedClientsIds)
+            foreach (var client in NetworkManager.ConnectedClients)
             {
-                if (networkObject.IsNetworkVisibleTo(client))
+                if (networkObject.IsNetworkVisibleTo(client.Value.ClientId))
                 {
-                    var size = NetworkManager.SendMessage(ref message, NetworkDelivery.ReliableSequenced, client);
-                    NetworkManager.NetworkMetrics.TrackOwnershipChangeSent(client, networkObject, size);
+                    var size = NetworkManager.SendMessage(ref message, NetworkDelivery.ReliableSequenced, client.Value.ClientId);
+                    NetworkManager.NetworkMetrics.TrackOwnershipChangeSent(client.Key, networkObject, size);
                 }
             }
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/OwnershipChangeMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/OwnershipChangeMetricsTests.cs
@@ -61,10 +61,13 @@ namespace Unity.Netcode.RuntimeTests.Metrics
             var ownershipChangeSent = metricValues.First();
             Assert.AreEqual(networkObject.NetworkObjectId, ownershipChangeSent.NetworkId.NetworkId);
             Assert.AreEqual(Server.LocalClientId, ownershipChangeSent.Connection.Id);
+            Assert.AreEqual(0, ownershipChangeSent.BytesCount);
 
             // The first metric is to the server(self), so its size is now correctly reported as 0.
             // Let's check the last one instead, to have a valid value
             ownershipChangeSent = metricValues.Last();
+            Assert.AreEqual(networkObject.NetworkObjectId, ownershipChangeSent.NetworkId.NetworkId);
+            Assert.AreEqual(Client.LocalClientId, ownershipChangeSent.Connection.Id);
             Assert.AreEqual(FastBufferWriter.GetWriteSize<ChangeOwnershipMessage>() + k_MessageHeaderSize, ownershipChangeSent.BytesCount);
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/OwnershipChangeMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/OwnershipChangeMetricsTests.cs
@@ -61,6 +61,10 @@ namespace Unity.Netcode.RuntimeTests.Metrics
             var ownershipChangeSent = metricValues.First();
             Assert.AreEqual(networkObject.NetworkObjectId, ownershipChangeSent.NetworkId.NetworkId);
             Assert.AreEqual(Server.LocalClientId, ownershipChangeSent.Connection.Id);
+
+            // The first metric is to the server(self), so its size is now correctly reported as 0.
+            // Let's check the last one instead, to have a valid value
+            ownershipChangeSent = metricValues.Last();
             Assert.AreEqual(FastBufferWriter.GetWriteSize<ChangeOwnershipMessage>() + k_MessageHeaderSize, ownershipChangeSent.BytesCount);
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
@@ -310,44 +310,41 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator NetworkHideChangeOwnership()
         {
-            m_ClientId0 = m_ClientNetworkManagers[0].LocalClientId;
             ShowHideObject.ClientTargetedNetworkObjects.Clear();
-            ShowHideObject.ClientIdToTarget = m_ClientId0;
+            ShowHideObject.ClientIdToTarget = m_ClientNetworkManagers[1].LocalClientId;
             ShowHideObject.Silent = true;
 
             var spawnedObject1 = SpawnObject(m_PrefabToSpawn, m_ServerNetworkManager);
-            var spawnedObject2 = SpawnObject(m_PrefabToSpawn, m_ServerNetworkManager);
-            var spawnedObject3 = SpawnObject(m_PrefabToSpawn, m_ServerNetworkManager);
             m_NetSpawnedObject1 = spawnedObject1.GetComponent<NetworkObject>();
-            m_NetSpawnedObject2 = spawnedObject2.GetComponent<NetworkObject>();
-            m_NetSpawnedObject3 = spawnedObject3.GetComponent<NetworkObject>();
 
             m_NetSpawnedObject1.GetComponent<ShowHideObject>().MyNetworkVariable.Value++;
             // Hide an object to a client
             m_NetSpawnedObject1.NetworkHide(m_ClientNetworkManagers[1].LocalClientId);
 
-            yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ServerNetworkManager, 5);
-            yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ClientNetworkManagers[0], 5);
-            yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ClientNetworkManagers[1], 5);
+            yield return WaitForConditionOrTimeOut(() => ShowHideObject.ClientTargetedNetworkObjects.Count == 0);
+
+            //yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ServerNetworkManager, 5);
+            //yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ClientNetworkManagers[0], 5);
+            //yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ClientNetworkManagers[1], 5);
 
             // Change ownership while the object is hidden to some
             m_NetSpawnedObject1.ChangeOwnership(m_ClientNetworkManagers[0].LocalClientId);
 
-            yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ServerNetworkManager, 5);
-            yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ClientNetworkManagers[0], 5);
-            yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ClientNetworkManagers[1], 5);
+            //yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ServerNetworkManager, 5);
+            //yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ClientNetworkManagers[0], 5);
+            //yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ClientNetworkManagers[1], 5);
 
             // The two-second wait is actually needed as there's a potential warning of unhandled message after 1 second
-            yield return new WaitForSeconds(2.0f);
+            yield return new WaitForSeconds(1.25f);
+
+            LogAssert.NoUnexpectedReceived();
 
             // Show the object again to check nothing unexpected happens
             m_NetSpawnedObject1.NetworkShow(m_ClientNetworkManagers[1].LocalClientId);
 
-            yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ServerNetworkManager, 5);
-            yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ClientNetworkManagers[0], 5);
-            yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ClientNetworkManagers[1], 5);
+            yield return WaitForConditionOrTimeOut(() => ShowHideObject.ClientTargetedNetworkObjects.Count == 1);
 
-            LogAssert.NoUnexpectedReceived();
+            Assert.True(ShowHideObject.ClientTargetedNetworkObjects[0].OwnerClientId == m_ClientNetworkManagers[0].LocalClientId);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
@@ -323,16 +323,8 @@ namespace Unity.Netcode.RuntimeTests
 
             yield return WaitForConditionOrTimeOut(() => ShowHideObject.ClientTargetedNetworkObjects.Count == 0);
 
-            //yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ServerNetworkManager, 5);
-            //yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ClientNetworkManagers[0], 5);
-            //yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ClientNetworkManagers[1], 5);
-
             // Change ownership while the object is hidden to some
             m_NetSpawnedObject1.ChangeOwnership(m_ClientNetworkManagers[0].LocalClientId);
-
-            //yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ServerNetworkManager, 5);
-            //yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ClientNetworkManagers[0], 5);
-            //yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ClientNetworkManagers[1], 5);
 
             // The two-second wait is actually needed as there's a potential warning of unhandled message after 1 second
             yield return new WaitForSeconds(1.25f);


### PR DESCRIPTION
This PR filters the ChangeOwnershipMessage to clients that have a given object hidden (not spawned). Addresses https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/2242

## Changelog

- Fixed issue caused when changing ownership of objects hidden to some clients (#2242)

## Testing and Documentation

- NetworkHideChangeOwnership test added