### PR TITLE
fix: NetworkSpawnManager.OnDespawnObject removing parent on client-side

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -625,6 +625,14 @@ namespace Unity.Netcode
         }
 
         /// <summary>
+        /// Used when despawning the parent, we want to preserve the cached WorldPositionStays value
+        /// </summary>
+        internal bool TryRemoveParentCachedWorldPositionStays()
+        {
+            return TrySetParent((NetworkObject)null, m_CachedWorldPositionStays);
+        }
+
+        /// <summary>
         /// Removes the parent of the NetworkObject's transform
         /// </summary>
         /// <remarks>

--- a/testproject/Assets/Tests/Manual/InSceneObjectParentingTests/InSceneParentChildHandler.cs
+++ b/testproject/Assets/Tests/Manual/InSceneObjectParentingTests/InSceneParentChildHandler.cs
@@ -48,6 +48,11 @@ namespace TestProject.RuntimeTests
             ClientRelativeInstances.Clear();
         }
 
+        public InSceneParentChildHandler GetChild()
+        {
+            return m_Child;
+        }
+
         private Vector3 GenerateVector3(Vector3 min, Vector3 max)
         {
             var result = Vector3.zero;


### PR DESCRIPTION
This fixes the issue where the NetworkSpawnManager.OnDespawnObject would attempt to remove a child from a parent on the client-side.

## Testing and Documentation
- Includes integration test.
