### PR TITLE
fix: Removing extra bracket in UnityTransport

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -1,4 +1,4 @@
-
+ 
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -1,4 +1,4 @@
- 
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1474,7 +1474,7 @@ namespace Unity.Netcode.Transports.UTP
                             }
                             else
                             {
-                                m_NetworkSettings.WithSecureClientParameters(m_ClientCaCertificate, m_ServerCommonName));
+                                m_NetworkSettings.WithSecureClientParameters(m_ClientCaCertificate, m_ServerCommonName);
                             }
                         }
                     }


### PR DESCRIPTION
There is an extra bracket in the else statement when we set the client security parameters.

## Changelog
None

## Testing and Documentation
- CI