### PR TITLE
fix: SceneEventProgress does not handle NetworkManager shut down during scene event

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1678,11 +1678,16 @@ namespace Unity.Netcode
             else
             {
                 float timeStarted = Time.realtimeSinceStartup;
-
-                //We yield every frame incase a pending client disconnects and someone else gets its connection id
+                //We yield every frame in case a pending client disconnects and someone else gets its connection id
                 while (IsListening && (Time.realtimeSinceStartup - timeStarted) < NetworkConfig.ClientConnectionBufferTimeout && !IsConnectedClient)
                 {
                     yield return null;
+                }
+
+                if (!IsConnectedClient && NetworkLog.CurrentLogLevel <= LogLevel.Normal)
+                {
+                    // TODO: Possibly add a callback for users to be notified of this condition here?
+                    NetworkLog.LogWarning($"[ApprovalTimeout] Client timed out! You might need to increase the {nameof(NetworkConfig.ClientConnectionBufferTimeout)} duration.  Approval Check Start: {timeStarted} | Approval Check Stopped: {Time.realtimeSinceStartup}");
                 }
 
                 if (!IsListening)


### PR DESCRIPTION
This fixes the issue with `SceneEventProgress` not gracefully handling the scenario where the `NetworkManager` shuts down during a scene event.  (regression from recent update to `SceneEventProgress`)

## Testing and Documentation
- Includes integration test.