### PR TITLE
fix: INetworkMessageILPP failing to output registration code for network messages

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/CodeGen/CodeGenHelpers.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/CodeGenHelpers.cs
@@ -407,7 +407,7 @@ namespace Unity.Netcode.Editor.CodeGen
                 {
                     continue;
                 }
-                Console.WriteLine($"{module.Name} == {DotnetModuleName}");
+
                 if (unityModule != null && netcodeModule != null)
                 {
                     return;

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/CodeGenHelpers.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/CodeGenHelpers.cs
@@ -398,7 +398,7 @@ namespace Unity.Netcode.Editor.CodeGen
             return assemblyDefinition;
         }
 
-        private static void SearchForBaseModulesRecursive(AssemblyDefinition assemblyDefinition, PostProcessorAssemblyResolver assemblyResolver, ref ModuleDefinition dotnetModule, ref ModuleDefinition unityModule, ref ModuleDefinition netcodeModule, HashSet<string> visited)
+        private static void SearchForBaseModulesRecursive(AssemblyDefinition assemblyDefinition, PostProcessorAssemblyResolver assemblyResolver, ref ModuleDefinition unityModule, ref ModuleDefinition netcodeModule, HashSet<string> visited)
         {
 
             foreach (var module in assemblyDefinition.Modules)
@@ -408,15 +408,9 @@ namespace Unity.Netcode.Editor.CodeGen
                     continue;
                 }
                 Console.WriteLine($"{module.Name} == {DotnetModuleName}");
-                if (dotnetModule != null && unityModule != null && netcodeModule != null)
+                if (unityModule != null && netcodeModule != null)
                 {
                     return;
-                }
-
-                if (dotnetModule == null && module.Name == DotnetModuleName)
-                {
-                    dotnetModule = module;
-                    continue;
                 }
 
                 if (unityModule == null && module.Name == UnityModuleName)
@@ -431,7 +425,7 @@ namespace Unity.Netcode.Editor.CodeGen
                     continue;
                 }
             }
-            if (dotnetModule != null && unityModule != null && netcodeModule != null)
+            if (unityModule != null && netcodeModule != null)
             {
                 return;
             }
@@ -454,24 +448,23 @@ namespace Unity.Netcode.Editor.CodeGen
                 {
                     continue;
                 }
-                SearchForBaseModulesRecursive(assembly, assemblyResolver, ref dotnetModule, ref unityModule, ref netcodeModule, visited);
+                SearchForBaseModulesRecursive(assembly, assemblyResolver, ref unityModule, ref netcodeModule, visited);
 
-                if (dotnetModule != null && unityModule != null && netcodeModule != null)
+                if (unityModule != null && netcodeModule != null)
                 {
                     return;
                 }
             }
         }
 
-        public static (ModuleDefinition DotnetModule, ModuleDefinition UnityModule, ModuleDefinition NetcodeModule) FindBaseModules(AssemblyDefinition assemblyDefinition, PostProcessorAssemblyResolver assemblyResolver)
+        public static (ModuleDefinition UnityModule, ModuleDefinition NetcodeModule) FindBaseModules(AssemblyDefinition assemblyDefinition, PostProcessorAssemblyResolver assemblyResolver)
         {
-            ModuleDefinition dotnetModule = null;
             ModuleDefinition unityModule = null;
             ModuleDefinition netcodeModule = null;
             var visited = new HashSet<string>();
-            SearchForBaseModulesRecursive(assemblyDefinition, assemblyResolver, ref dotnetModule, ref unityModule, ref netcodeModule, visited);
+            SearchForBaseModulesRecursive(assemblyDefinition, assemblyResolver, ref unityModule, ref netcodeModule, visited);
 
-            return (dotnetModule, unityModule, netcodeModule);
+            return (unityModule, netcodeModule);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/CodeGenHelpers.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/CodeGenHelpers.cs
@@ -406,6 +406,11 @@ namespace Unity.Netcode.Editor.CodeGen
 
             foreach (var module in assemblyDefinition.Modules)
             {
+                if (module == null)
+                {
+                    Console.WriteLine("Encountered a null module.");
+                    continue;
+                }
                 if (dotnetModule == null && module.Name == DotnetModuleName)
                 {
                     dotnetModule = module;
@@ -432,8 +437,25 @@ namespace Unity.Netcode.Editor.CodeGen
 
             foreach (var assemblyNameReference in assemblyDefinition.MainModule.AssemblyReferences)
             {
-                foreach (var module in assemblyResolver.Resolve(assemblyNameReference).Modules)
+                if (assemblyNameReference == null)
                 {
+                    Console.WriteLine("Encountered a null assembly reference.");
+                    continue;
+                }
+
+                var assembly = assemblyResolver.Resolve(assemblyNameReference);
+                if (assembly == null)
+                {
+                    Console.WriteLine("Could not resolve an assembly.");
+                    continue;
+                }
+                foreach (var module in assembly.Modules)
+                {
+                    if (module == null)
+                    {
+                        Console.WriteLine("Encountered a null module.");
+                        continue;
+                    }
                     if (dotnetModule == null && module.Name == DotnetModuleName)
                     {
                         dotnetModule = module;

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/CodeGenHelpers.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/CodeGenHelpers.cs
@@ -406,11 +406,8 @@ namespace Unity.Netcode.Editor.CodeGen
 
             foreach (var module in assemblyDefinition.Modules)
             {
-                if (module == null)
-                {
-                    Console.WriteLine("Encountered a null module.");
-                    continue;
-                }
+                Console.WriteLine($"{module.Name} == {DotnetModuleName}");
+
                 if (dotnetModule == null && module.Name == DotnetModuleName)
                 {
                     dotnetModule = module;
@@ -437,25 +434,10 @@ namespace Unity.Netcode.Editor.CodeGen
 
             foreach (var assemblyNameReference in assemblyDefinition.MainModule.AssemblyReferences)
             {
-                if (assemblyNameReference == null)
+                foreach (var module in assemblyResolver.Resolve(assemblyNameReference).Modules)
                 {
-                    Console.WriteLine("Encountered a null assembly reference.");
-                    continue;
-                }
+                    Console.WriteLine($"{module.Name} == {DotnetModuleName}");
 
-                var assembly = assemblyResolver.Resolve(assemblyNameReference);
-                if (assembly == null)
-                {
-                    Console.WriteLine("Could not resolve an assembly.");
-                    continue;
-                }
-                foreach (var module in assembly.Modules)
-                {
-                    if (module == null)
-                    {
-                        Console.WriteLine("Encountered a null module.");
-                        continue;
-                    }
                     if (dotnetModule == null && module.Name == DotnetModuleName)
                     {
                         dotnetModule = module;

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
@@ -64,7 +64,8 @@ namespace Unity.Netcode.Editor.CodeGen
 
             if (m_DotnetModule == null)
             {
-                Console.WriteLine("No .NET module");
+                var typeType = assemblyDefinition.MainModule.ImportReference(typeof(Type));
+                Console.WriteLine($"No .NET module... type module is in {typeType.Module}");
                 m_Diagnostics.AddError($"Cannot find .NET module: {CodeGenHelpers.DotnetModuleName}");
                 return null;
             }

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
@@ -64,8 +64,8 @@ namespace Unity.Netcode.Editor.CodeGen
 
             if (m_DotnetModule == null)
             {
-                var typeType = assemblyDefinition.MainModule.ImportReference(typeof(Type));
-                Console.WriteLine($"No .NET module... type module is in {typeType.Module}");
+                var listType = assemblyDefinition.MainModule.ImportReference(typeof(List<>));
+                Console.WriteLine($"No .NET module... type module is in {listType.Module}");
                 m_Diagnostics.AddError($"Cannot find .NET module: {CodeGenHelpers.DotnetModuleName}");
                 return null;
             }

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
@@ -49,8 +49,16 @@ namespace Unity.Netcode.Editor.CodeGen
 
             Console.WriteLine("Got assembly definition");
 
-            // modules
-            (m_DotnetModule, _, m_NetcodeModule) = CodeGenHelpers.FindBaseModules(assemblyDefinition, m_AssemblyResolver);
+            try
+            {
+                // modules
+                (m_DotnetModule, _, m_NetcodeModule) = CodeGenHelpers.FindBaseModules(assemblyDefinition, m_AssemblyResolver);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"Could not find base modules because {(e.ToString() + e.StackTrace).Replace("\n", "|").Replace("\r", "|")}");
+                throw;
+            }
 
             Console.WriteLine("After FindBaseModules");
 

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
@@ -16,7 +16,11 @@ namespace Unity.Netcode.Editor.CodeGen
     {
         public override ILPPInterface GetInstance() => this;
 
-        public override bool WillProcess(ICompiledAssembly compiledAssembly) => compiledAssembly.Name == CodeGenHelpers.RuntimeAssemblyName;
+        public override bool WillProcess(ICompiledAssembly compiledAssembly)
+        {
+            Console.WriteLine($"check {compiledAssembly.Name} == {CodeGenHelpers.RuntimeAssemblyName};");
+            return compiledAssembly.Name == CodeGenHelpers.RuntimeAssemblyName;
+        }
 
         private readonly List<DiagnosticMessage> m_Diagnostics = new List<DiagnosticMessage>();
 
@@ -27,6 +31,7 @@ namespace Unity.Netcode.Editor.CodeGen
                 Console.WriteLine($"Not processing {compiledAssembly.Name}");
                 return null;
             }
+            Console.WriteLine("Running...");
 
             m_Diagnostics.Clear();
 

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
@@ -24,6 +24,7 @@ namespace Unity.Netcode.Editor.CodeGen
         {
             if (!WillProcess(compiledAssembly))
             {
+                Console.WriteLine($"Not processing {compiledAssembly.Name}");
                 return null;
             }
 
@@ -64,6 +65,7 @@ namespace Unity.Netcode.Editor.CodeGen
                     // process `INetworkMessage` types
                     if (types.Count == 0)
                     {
+                        Console.WriteLine("Couldn't find any messages to process.");
                         return null;
                     }
 
@@ -296,6 +298,7 @@ namespace Unity.Netcode.Editor.CodeGen
 
                     foreach (var type in networkMessageTypes)
                     {
+                        Console.WriteLine($"Creating initializer for {type}");
                         var receiveMethod = new GenericInstanceMethod(m_MessagingSystem_ReceiveMessage_MethodRef);
                         receiveMethod.GenericArguments.Add(type);
                         CreateInstructionsToRegisterType(processor, instructions, type, receiveMethod);

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -44,7 +44,7 @@ namespace Unity.Netcode.Editor.CodeGen
             }
 
             // modules
-            (_, m_UnityModule, m_NetcodeModule) = CodeGenHelpers.FindBaseModules(assemblyDefinition, m_AssemblyResolver);
+            (m_UnityModule, m_NetcodeModule) = CodeGenHelpers.FindBaseModules(assemblyDefinition, m_AssemblyResolver);
 
             if (m_UnityModule == null)
             {


### PR DESCRIPTION
There were two issues at play here:

1. We were looking for netstandard.dll with a simple single-layer-deep assembly reference search. In our development environments, apparently our assemblies all have it as a direct reference. In some users' environments, it's not. The search was updated to be recursive.
2. Apparently in some environments, `Type` and `List<>` aren't even defined in netstandard.dll anyway... so I reverted those things back to importing using `typeof()`, which should be safe and ok for system types since they don't have any differences in structure based on conditional compilation... so netstandard.dll isn't even needed anymore, but I kept the change from part 1 because it's "more correct" anyway and will prevent us from potentially hitting any future edge cases involving assemblies that have indirect references to assemblies we need to import.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.