### PR TITLE
fix: NetworkManager property more robust on NetworkBehaviour

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -286,7 +286,18 @@ namespace Unity.Netcode
         /// Gets the NetworkManager that owns this NetworkBehaviour instance
         ///   See note around `NetworkObject` for how there is a chicken / egg problem when we are not initialized
         /// </summary>
-        public NetworkManager NetworkManager => NetworkObject.NetworkManager;
+        public NetworkManager NetworkManager
+        {
+            get
+            {
+                if (NetworkObject?.NetworkManager != null)
+                {
+                    return NetworkObject?.NetworkManager;
+                }
+
+                return NetworkManager.Singleton;
+            }
+        }
 
         /// <summary>
         /// If a NetworkObject is assigned, it will return whether or not this NetworkObject
@@ -349,9 +360,16 @@ namespace Unity.Netcode
         {
             get
             {
-                if (m_NetworkObject == null)
+                try
                 {
-                    m_NetworkObject = GetComponentInParent<NetworkObject>();
+                    if (m_NetworkObject == null)
+                    {
+                        m_NetworkObject = GetComponentInParent<NetworkObject>();
+                    }
+                }
+                catch (Exception)
+                {
+                    return null;
                 }
 
                 // ShutdownInProgress check:


### PR DESCRIPTION
Makes the NetworkManager property more robust by checking
- NetworkObject being null
- Its NetworkManager being null
- GetComponentInParent throwing an exception on null objects
- returning NetworkManager.Singleton if all else fails

Addresses https://jira.unity3d.com/browse/MTT-3376