### PR TITLE
fix: NetworkManager ApprovalTimeout should not depend upon client synchronization

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -7,6 +7,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
+## [Unreleased]
+
+### Added
+- Added `NetworkManager.IsApproved` flag that is set to `true` a client has been approved.(#2261)
+
+### Changed
+
+
+### Fixed
+
+- Fixed `NetworkManager.ApprovalTimeout` will not timeout due to slower client synchronization times as it now uses the added `NetworkManager.IsApproved` flag to determined if the client has been approved or not.(#2261)
+
+
 ## [1.1.0] - 2022-10-19
 
 ### Added

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -232,6 +232,10 @@ namespace Unity.Netcode.Components
         private void BuildTransitionStateInfoList()
         {
 #if UNITY_EDITOR
+            if (UnityEditor.EditorApplication.isUpdating)
+            {
+                return;
+            }
             TransitionStateInfoList = new List<TransitionStateinfo>();
             var animatorController = m_Animator.runtimeAnimatorController as AnimatorController;
             if (animatorController == null)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1719,8 +1719,8 @@ namespace Unity.Netcode
                 }
             }
 
-            // Exit coroutine if we are no longer listening (client or server)
-            if (!IsListening)
+            // Exit coroutine if we are no longer listening or a shutdown is in progress (client or server)
+            if (!IsListening || ShutdownInProgress)
             {
                 yield break;
             }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1681,7 +1681,7 @@ namespace Unity.Netcode
             var timeoutMarker = timeStarted + NetworkConfig.ClientConnectionBufferTimeout + latency;
             var rttIdentifier = IsServer ? clientId : ServerClientId;
 
-            while (IsListening && !timedOut && !connectionApproved)
+            while (IsListening && !ShutdownInProgress && !timedOut && !connectionApproved)
             {
                 yield return waitPeriod;
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1685,7 +1685,7 @@ namespace Unity.Netcode
             {
                 yield return waitPeriod;
 
-                // Adjust for changes in the RTT (cap the maximum value to 1 second latency to prevent DDOS/Latency based attacks)
+                // Adjust for changes in the RTT (cap the maximum value to 1 second latency to prevent latency oriented attacks)
                 var nextlatency = Mathf.Min(1.0f, 0.001f * NetworkConfig.NetworkTransport.GetCurrentRtt(rttIdentifier));
 
                 if (nextlatency > latency)

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
@@ -79,6 +79,7 @@ namespace Unity.Netcode
             networkManager.NetworkTickSystem.Reset(networkManager.NetworkTimeSystem.LocalTime, networkManager.NetworkTimeSystem.ServerTime);
 
             networkManager.LocalClient = new NetworkClient() { ClientId = networkManager.LocalClientId };
+            networkManager.IsApproved = true;
 
             // Only if scene management is disabled do we handle NetworkObject synchronization at this point
             if (!networkManager.NetworkConfig.EnableSceneManagement)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApprovalTimeoutTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApprovalTimeoutTests.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using System.Linq;
 using System.Text.RegularExpressions;
 using NUnit.Framework;
 using Unity.Netcode.TestHelpers.Runtime;
@@ -8,97 +7,95 @@ using UnityEngine.TestTools;
 
 namespace Unity.Netcode.RuntimeTests
 {
-    [TestFixture(true)]
-    [TestFixture(false)]
+    [TestFixture(ApprovalFailureTypes.ServerDoesNotRespond)]
+    [TestFixture(ApprovalFailureTypes.ClientDoesNotRequest)]
     public class ConnectionApprovalTimeoutTests : NetcodeIntegrationTest
     {
         protected override int NumberOfClients => 1;
 
-        protected override bool CanStartServerAndClients() => false;
-
-        private bool m_UseSceneManagement;
-        public ConnectionApprovalTimeoutTests(bool useSceneManagement)
+        public enum ApprovalFailureTypes
         {
-            m_UseSceneManagement = useSceneManagement;
+            ClientDoesNotRequest,
+            ServerDoesNotRespond
+        }
+
+        private ApprovalFailureTypes m_ApprovalFailureType;
+
+        public ConnectionApprovalTimeoutTests(ApprovalFailureTypes approvalFailureType)
+        {
+            m_ApprovalFailureType = approvalFailureType;
         }
 
         // Must be >= 2 since this is an int value and the test waits for timeout - 1 to try to verify it doesn't
         // time out early
-        private const int k_TestTimeoutPeriod = 2;
+        private const int k_TestTimeoutPeriod = 1;
 
-        private void Start()
+        private Regex m_ExpectedLogMessage;
+        private LogType m_LogType;
+
+
+        protected override IEnumerator OnSetup()
         {
-            m_ServerNetworkManager.NetworkConfig.EnableSceneManagement = m_UseSceneManagement;
-            m_ClientNetworkManagers[0].NetworkConfig.EnableSceneManagement = m_UseSceneManagement;
-            if (!NetcodeIntegrationTestHelpers.Start(false, m_ServerNetworkManager, m_ClientNetworkManagers))
-            {
-                Debug.LogError("Failed to start instances");
-                Assert.Fail("Failed to start instances");
-            }
+            m_BypassConnectionTimeout = true;
+            return base.OnSetup();
         }
 
-        [UnityTest]
-        public IEnumerator WhenClientDoesntRequestApproval_ServerTimesOut()
+        protected override IEnumerator OnTearDown()
         {
-            Start();
-            var hook = new MessageCatcher<ConnectionRequestMessage>(m_ServerNetworkManager);
-            m_ServerNetworkManager.MessagingSystem.Hook(hook); ;
+            m_BypassConnectionTimeout = true;
+            return base.OnTearDown();
+        }
 
+        protected override void OnServerAndClientsCreated()
+        {
             m_ServerNetworkManager.NetworkConfig.ClientConnectionBufferTimeout = k_TestTimeoutPeriod;
             m_ServerNetworkManager.LogLevel = LogLevel.Developer;
+            m_ClientNetworkManagers[0].NetworkConfig.ClientConnectionBufferTimeout = k_TestTimeoutPeriod;
             m_ClientNetworkManagers[0].LogLevel = LogLevel.Developer;
-
-            yield return new WaitForSeconds(m_ServerNetworkManager.NetworkConfig.ClientConnectionBufferTimeout - 1);
-
-            Assert.AreEqual(0, m_ServerNetworkManager.ConnectedClients.Count);
-            Assert.AreEqual(1, m_ServerNetworkManager.PendingClients.Count);
-
-            var expectedLogMessage = new Regex($"Client {m_ServerNetworkManager.PendingClients.FirstOrDefault().Key} Handshake Timed Out");
-
-            NetcodeLogAssert.LogWasNotReceived(LogType.Log, expectedLogMessage);
-
-            yield return new WaitForSeconds(2);
-
-            NetcodeLogAssert.LogWasReceived(LogType.Log, expectedLogMessage);
-
-            Assert.AreEqual(0, m_ServerNetworkManager.ConnectedClients.Count);
-            Assert.AreEqual(0, m_ServerNetworkManager.PendingClients.Count);
+            base.OnServerAndClientsCreated();
         }
 
-        [UnityTest]
-        public IEnumerator WhenServerDoesntRespondWithApproval_ClientTimesOut()
+        protected override IEnumerator OnStartedServerAndClients()
         {
-            Start();
-
-            if (m_UseSceneManagement)
+            if (m_ApprovalFailureType == ApprovalFailureTypes.ServerDoesNotRespond)
             {
-                var sceneEventHook = new MessageCatcher<SceneEventMessage>(m_ClientNetworkManagers[0]);
-                m_ClientNetworkManagers[0].MessagingSystem.Hook(sceneEventHook);
+                // We catch (don't process) the incoming approval message to simulate the server not sending the approved message in time
+                m_ClientNetworkManagers[0].MessagingSystem.Hook(new MessageCatcher<ConnectionApprovedMessage>(m_ClientNetworkManagers[0]));
+                m_ExpectedLogMessage = new Regex("Timed out waiting for the server to approve the connection request.");
+                m_LogType = LogType.Log;
             }
             else
             {
-                var approvalHook = new MessageCatcher<ConnectionApprovedMessage>(m_ClientNetworkManagers[0]);
-                m_ClientNetworkManagers[0].MessagingSystem.Hook(approvalHook);
+                // We catch (don't process) the incoming connection request message to simulate a transport connection but the client never
+                // sends (or takes too long to send) the connection request.
+                m_ServerNetworkManager.MessagingSystem.Hook(new MessageCatcher<ConnectionRequestMessage>(m_ServerNetworkManager));
+
+                // For this test, we know the timed out client will be Client-1
+                m_ExpectedLogMessage = new Regex("Server detected a transport connection from Client-1, but timed out waiting for the connection request message.");
+                m_LogType = LogType.Warning;
             }
+            yield return null;
+        }
 
-            m_ClientNetworkManagers[0].NetworkConfig.ClientConnectionBufferTimeout = k_TestTimeoutPeriod;
-            m_ServerNetworkManager.LogLevel = LogLevel.Developer;
-            m_ClientNetworkManagers[0].LogLevel = LogLevel.Developer;
+        [UnityTest]
+        public IEnumerator ValidateApprovalTimeout()
+        {
+            // Delay for half of the wait period
+            yield return new WaitForSeconds(k_TestTimeoutPeriod * 0.5f);
 
-            yield return new WaitForSeconds(m_ClientNetworkManagers[0].NetworkConfig.ClientConnectionBufferTimeout - 1);
+            // Verify we haven't received the time out message yet (we already waiting for half of the time out period in OnStartedServerAndClients)
+            NetcodeLogAssert.LogWasNotReceived(LogType.Log, m_ExpectedLogMessage);
 
-            Assert.IsFalse(m_ClientNetworkManagers[0].IsConnectedClient);
-            Assert.IsTrue(m_ClientNetworkManagers[0].IsListening);
+            // Wait for 3/4s of the time out period to pass (totally 1.25 times the wait period)
+            yield return new WaitForSeconds(k_TestTimeoutPeriod * 0.75f);
 
-            var expectedLogMessage = new Regex("Server Handshake Timed Out");
-            NetcodeLogAssert.LogWasNotReceived(LogType.Log, expectedLogMessage);
+            // We should have a test relative logged message by this time.
+            NetcodeLogAssert.LogWasReceived(m_LogType, m_ExpectedLogMessage);
 
-            yield return new WaitForSeconds(2);
-
-            NetcodeLogAssert.LogWasReceived(LogType.Log, expectedLogMessage);
-
-            Assert.IsFalse(m_ClientNetworkManagers[0].IsConnectedClient);
-            Assert.IsFalse(m_ClientNetworkManagers[0].IsListening);
+            // It should only have the host client connected
+            Assert.AreEqual(1, m_ServerNetworkManager.ConnectedClients.Count, $"Expected only one client when there were {m_ServerNetworkManager.ConnectedClients.Count} clients connected!");
+            Assert.AreEqual(0, m_ServerNetworkManager.PendingClients.Count, $"Expected no pending clients when there were {m_ServerNetworkManager.PendingClients.Count} pending clients!");
+            Assert.True(!m_ClientNetworkManagers[0].IsApproved, $"Expected the client to not have been approved, but it was!");
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApprovalTimeoutTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApprovalTimeoutTests.cs
@@ -7,21 +7,21 @@ using UnityEngine.TestTools;
 
 namespace Unity.Netcode.RuntimeTests
 {
-    [TestFixture(ApprovalFailureTypes.ServerDoesNotRespond)]
-    [TestFixture(ApprovalFailureTypes.ClientDoesNotRequest)]
+    [TestFixture(ApprovalTimedOutTypes.ServerDoesNotRespond)]
+    [TestFixture(ApprovalTimedOutTypes.ClientDoesNotRequest)]
     public class ConnectionApprovalTimeoutTests : NetcodeIntegrationTest
     {
         protected override int NumberOfClients => 1;
 
-        public enum ApprovalFailureTypes
+        public enum ApprovalTimedOutTypes
         {
             ClientDoesNotRequest,
             ServerDoesNotRespond
         }
 
-        private ApprovalFailureTypes m_ApprovalFailureType;
+        private ApprovalTimedOutTypes m_ApprovalFailureType;
 
-        public ConnectionApprovalTimeoutTests(ApprovalFailureTypes approvalFailureType)
+        public ConnectionApprovalTimeoutTests(ApprovalTimedOutTypes approvalFailureType)
         {
             m_ApprovalFailureType = approvalFailureType;
         }
@@ -57,7 +57,7 @@ namespace Unity.Netcode.RuntimeTests
 
         protected override IEnumerator OnStartedServerAndClients()
         {
-            if (m_ApprovalFailureType == ApprovalFailureTypes.ServerDoesNotRespond)
+            if (m_ApprovalFailureType == ApprovalTimedOutTypes.ServerDoesNotRespond)
             {
                 // We catch (don't process) the incoming approval message to simulate the server not sending the approved message in time
                 m_ClientNetworkManagers[0].MessagingSystem.Hook(new MessageCatcher<ConnectionApprovedMessage>(m_ClientNetworkManagers[0]));
@@ -83,13 +83,13 @@ namespace Unity.Netcode.RuntimeTests
             // Delay for half of the wait period
             yield return new WaitForSeconds(k_TestTimeoutPeriod * 0.5f);
 
-            // Verify we haven't received the time out message yet (we already waiting for half of the time out period in OnStartedServerAndClients)
+            // Verify we haven't received the time out message yet
             NetcodeLogAssert.LogWasNotReceived(LogType.Log, m_ExpectedLogMessage);
 
-            // Wait for 3/4s of the time out period to pass (totally 1.25 times the wait period)
+            // Wait for 3/4s of the time out period to pass (totaling 1.25x the wait period)
             yield return new WaitForSeconds(k_TestTimeoutPeriod * 0.75f);
 
-            // We should have a test relative logged message by this time.
+            // We should have the test relative log message by this time.
             NetcodeLogAssert.LogWasReceived(m_LogType, m_ExpectedLogMessage);
 
             // It should only have the host client connected

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApprovalTimeoutTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApprovalTimeoutTests.cs
@@ -42,7 +42,7 @@ namespace Unity.Netcode.RuntimeTests
 
         protected override IEnumerator OnTearDown()
         {
-            m_BypassConnectionTimeout = true;
+            m_BypassConnectionTimeout = false;
             return base.OnTearDown();
         }
 


### PR DESCRIPTION
This bug was discovered in a Boss Room play test where the ClientConnectionBufferTimeout was set to 1 second. The underlying issue was that the ApprovalTimeout coroutine would depend upon the NetworkManager.IsConnectedClient to be determine if the client has been approved.  This is problematic because NetworkManager.IsConnectedClient (when scene management is enabled) is set once the client has already been approved **and** has been **fully synchronized**.  If the time it takes a client to synchronize exceeds the ClientConnectionBufferTimeout then while the client was approved it would time out anyway.

**Here is how this fix addresses the issue:** 
- It adds a new internally set property NetworkManager.IsApproved which is set upon the client being approved.
- The timeout messages have been updated with more pertinent/useful information about the timeout.

[MTT-4895](https://jira.unity3d.com/browse/MTT-4895)

## Changelog
- Added: `NetworkManager.IsApproved` flag that is set to `true` a client has been approved.
- Fixed: `NetworkManager.ApprovalTimeout` will not timeout due to slower client synchronization times as it now uses the added `NetworkManager.IsApproved` flag to determined if the client has been approved or not.

## Testing and Documentation
- Includes integration test update to ConnectionApprovalTimeoutTests.
- Includes new API xml documentation for NetworkManager.IsApproved
