### PR TITLE
fix: Letting NetworkVariables be serialized even if they're not going to be sent

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
@@ -42,10 +42,6 @@ namespace Unity.Netcode
                         for (int i = 0; i < networkManager.ConnectedClientsList.Count; i++)
                         {
                             var client = networkManager.ConnectedClientsList[i];
-                            if (networkManager.IsHost && client.ClientId == networkManager.LocalClientId)
-                            {
-                                continue;
-                            }
 
                             if (dirtyObj.IsNetworkVisibleTo(client.ClientId))
                             {


### PR DESCRIPTION
This prevents NetworkList synchronization issues