### PR TITLE
fix: Don't allocate extraneous memory in FastBufferReader

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,7 +11,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Creating a `FastBufferReader` with `Allocator.None` will not result in extra memory being allocated for the buffer (since it's owned externally in that scenario).
+- Creating a `FastBufferReader` with `Allocator.None` will not result in extra memory being allocated for the buffer (since it's owned externally in that scenario). (#2265)
 
 ## [1.1.0] - 2022-10-21
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
+## [Unreleased]
+
+### Fixed
+
+- Creating a `FastBufferReader` with `Allocator.None` will not result in extra memory being allocated for the buffer (since it's owned externally in that scenario).
+
 ## [1.1.0] - 2022-10-21
 
 ### Added

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
@@ -65,7 +65,7 @@ namespace Unity.Netcode
             ReaderHandle* readerHandle = null;
             if (copyAllocator == Allocator.None)
             {
-                readerHandle = (ReaderHandle*)UnsafeUtility.Malloc(sizeof(ReaderHandle) + length, UnsafeUtility.AlignOf<byte>(), internalAllocator);
+                readerHandle = (ReaderHandle*)UnsafeUtility.Malloc(sizeof(ReaderHandle), UnsafeUtility.AlignOf<byte>(), internalAllocator);
                 readerHandle->BufferPointer = buffer;
                 readerHandle->Position = offset;
             }


### PR DESCRIPTION
Creating a `FastBufferReader` with `copyAllocator` set to `Allocator.None` means not to allocate a copy of the buffer, and to instead directly use the one provided by the user. But in that situation the code would still allocate memory for the entire buffer. That memory would go unused.

Props to user Frolo on Discord for finding this issue.

## Changelog

- Fixed: Creating a `FastBufferReader` with `Allocator.None` will not result in extra memory being allocated for the buffer (since it's owned externally in that scenario).

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.