### PR TITLE
fix: NetcodeIntegrationTest preserve player prefab 

### DIFF
--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -112,6 +112,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         }
 
         protected GameObject m_PlayerPrefab;
+        private NetworkManager m_PlayerPrefabMockNetworkManager;
         protected NetworkManager m_ServerNetworkManager;
         protected NetworkManager[] m_ClientNetworkManagers;
 
@@ -250,6 +251,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
             // Make it a prefab
             NetcodeIntegrationTestHelpers.MakeNetworkObjectTestPrefab(networkObject);
+            m_PlayerPrefabMockNetworkManager = new NetworkManager();
+            networkObject.NetworkManagerOwner = m_PlayerPrefabMockNetworkManager;
 
             OnCreatePlayerPrefab();
 
@@ -582,6 +585,12 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 {
                     Object.Destroy(m_PlayerPrefab);
                     m_PlayerPrefab = null;
+                }
+
+                if (m_PlayerPrefabMockNetworkManager != null)
+                {
+                    Object.Destroy(m_PlayerPrefabMockNetworkManager);
+                    m_PlayerPrefabMockNetworkManager = null;
                 }
             }
 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -112,6 +112,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
         }
 
         protected GameObject m_PlayerPrefab;
+        // This is used to prevent the player prefab from getting destroyed if a UnityTest
+        // shuts down the NetworkManager assigned to the NetworkManager.Singleton
         private NetworkManager m_PlayerPrefabMockNetworkManager;
         protected NetworkManager m_ServerNetworkManager;
         protected NetworkManager[] m_ClientNetworkManagers;
@@ -586,7 +588,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
                     Object.Destroy(m_PlayerPrefab);
                     m_PlayerPrefab = null;
                 }
-
+                // Destroy the mock NetworkManager
                 if (m_PlayerPrefabMockNetworkManager != null)
                 {
                     Object.Destroy(m_PlayerPrefabMockNetworkManager);

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -842,7 +842,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             var gameObject = new GameObject();
             gameObject.name = baseName;
             var networkObject = gameObject.AddComponent<NetworkObject>();
-            networkObject.NetworkManagerOwner = m_ServerNetworkManager;
+            networkObject.NetworkManagerOwner = m_PlayerPrefabMockNetworkManager;
             NetcodeIntegrationTestHelpers.MakeNetworkObjectTestPrefab(networkObject);
             var networkPrefab = new NetworkPrefab() { Prefab = gameObject };
             m_ServerNetworkManager.NetworkConfig.NetworkPrefabs.Add(networkPrefab);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/PreserveIntegrationTestPrefabs.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/PreserveIntegrationTestPrefabs.cs
@@ -1,0 +1,76 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Unity.Netcode.TestHelpers.Runtime;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    public class PreserveIntegrationTestPrefabs : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 2;
+
+        private List<GameObject> m_Prefabs = new List<GameObject>();
+
+        public PreserveIntegrationTestPrefabs(HostOrServer hostOrServer)
+        {
+            m_UseHost = hostOrServer == HostOrServer.Host;
+        }
+
+        protected override void OnServerAndClientsCreated()
+        {
+            m_Prefabs.Add(CreateNetworkObjectPrefab("TestPrefab1"));
+            m_Prefabs.Add(CreateNetworkObjectPrefab("TestPrefab2"));
+        }
+
+        private void CheckPrefabs(bool beforeShutdown = true)
+        {
+            var beforOrAfterLabel = beforeShutdown ? "Before Shutdown" : "After Shutdown";
+            Assert.True(m_ServerNetworkManager.NetworkConfig.PlayerPrefab != null, $"[{beforeShutdown}][Server] Player prefab is null!");
+            for (int i = 0; i < NumberOfClients; i++)
+            {
+                Assert.True(m_ClientNetworkManagers[i].NetworkConfig.PlayerPrefab != null, $"[{beforeShutdown}][Client NetworkManager-{i}] Player prefab is null!");
+            }
+        }
+
+        private bool ServerAndClientsShutdown()
+        {
+            if (m_ServerNetworkManager.ShutdownInProgress)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < NumberOfClients; i++)
+            {
+                if (m_ClientNetworkManagers[i].ShutdownInProgress)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        [UnityTest]
+        public IEnumerator PreservePrefabsDuringShutdown()
+        {
+            CheckPrefabs();
+            m_ServerNetworkManager.Shutdown();
+            m_ClientNetworkManagers[0].Shutdown();
+            m_ClientNetworkManagers[1].Shutdown();
+
+            yield return WaitForConditionOrTimeOut(ServerAndClientsShutdown);
+            AssertOnTimeout("Timed out waiting for the server and all clients to shutdown!");
+
+            m_ServerNetworkManager.StartHost();
+            m_ClientNetworkManagers[0].StartClient();
+            m_ClientNetworkManagers[1].StartClient();
+
+            yield return WaitForClientsConnectedOrTimeOut();
+
+            CheckPrefabs();
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/PreserveIntegrationTestPrefabs.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/PreserveIntegrationTestPrefabs.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 883bc94f69382144e96902c696ecf24b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This fixes an issue where the player prefab would get destroyed if you shutdown the `NetworkManager` assigned to the `NetworkManager.Singleton` (which is typically the server).  This would occur with any test prefab created with `NetcodeIntegrationTest.CreateNetworkObjectPrefab`.

## Testing and Documentation
- No documentation changes or additions were necessary.
- Includes Integration Test: `PreserveIntegrationTestPrefabs` 
