### PR TITLE
fix: Migrate OnClientConnectedCallback invocation into StartHost [MTT-4972]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,6 +11,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed the issue where `NetworkManager.OnClientConnectedCallback` was being invoked before in-scene placed `NetworkObject`s had been spawned when starting `NetworkManager` as a host. (#2277)
 - Creating a `FastBufferReader` with `Allocator.None` will not result in extra memory being allocated for the buffer (since it's owned externally in that scenario). (#2265)
 
 ## [1.1.0] - 2022-10-21

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1181,6 +1181,9 @@ namespace Unity.Netcode
 
             SpawnManager.ServerSpawnSceneObjectsOnStartSweep();
 
+            // This assures that any in-scene placed NetworkObject is spawned and
+            // any associated NetworkBehaviours' netcode related properties are
+            // set prior to invoking OnClientConnected.
             InvokeOnClientConnectedCallback(LocalClientId);
 
             OnServerStarted?.Invoke();

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1181,6 +1181,8 @@ namespace Unity.Netcode
 
             SpawnManager.ServerSpawnSceneObjectsOnStartSweep();
 
+            InvokeOnClientConnectedCallback(LocalClientId);
+
             OnServerStarted?.Invoke();
 
             return true;
@@ -2219,7 +2221,6 @@ namespace Unity.Netcode
                 {
                     LocalClient = client;
                     SpawnManager.UpdateObservedNetworkObjects(ownerClientId);
-                    InvokeOnClientConnectedCallback(ownerClientId);
                 }
 
                 if (!response.CreatePlayerObject || (response.PlayerPrefabHash == null && NetworkConfig.PlayerPrefab == null))

--- a/testproject/Assets/Tests/Runtime/NetworkManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkManagerTests.cs
@@ -1,17 +1,70 @@
 using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using Unity.Netcode;
 using Unity.Netcode.TestHelpers.Runtime;
-
+using System.Collections;
 
 namespace TestProject.RuntimeTests
 {
     public class NetworkManagerTests : NetcodeIntegrationTest
     {
-        protected override int NumberOfClients => 1;
+        private const string k_SceneToLoad = "InSceneNetworkObject";
+        protected override int NumberOfClients => 0;
+
+        private NetworkObject m_NetworkObject;
+        private bool m_NetworkObjectWasSpawned;
+        private bool m_NetworkBehaviourIsHostWasSet;
+        private bool m_NetworkBehaviourIsClientWasSet;
+        private bool m_NetworkBehaviourIsServerWasSet;
+        private AsyncOperation m_AsyncOperation;
+        private NetworkObjectTestComponent m_NetworkObjectTestComponent;
+
+        private void OnClientConnectedCallback(NetworkObject networkObject, bool isHost, bool isClient, bool isServer)
+        {
+            m_NetworkObject = networkObject;
+            m_NetworkObjectWasSpawned = networkObject.IsSpawned;
+            m_NetworkBehaviourIsHostWasSet = isHost;
+            m_NetworkBehaviourIsClientWasSet = isClient;
+            m_NetworkBehaviourIsServerWasSet = isServer;
+        }
+
+        private bool TestComponentFound()
+        {
+            if (!m_AsyncOperation.isDone)
+            {
+                return false;
+            }
+
+            m_NetworkObjectTestComponent = Object.FindObjectOfType<NetworkObjectTestComponent>();
+            if (m_NetworkObjectTestComponent == null)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        protected override IEnumerator OnSetup()
+        {
+            m_AsyncOperation = SceneManager.LoadSceneAsync(k_SceneToLoad, LoadSceneMode.Additive);
+            yield return WaitForConditionOrTimeOut(TestComponentFound);
+            AssertOnTimeout($"Failed to find {nameof(NetworkObjectTestComponent)} after loading test scene {k_SceneToLoad}");
+        }
+
+        protected override void OnServerAndClientsCreated()
+        {
+            m_NetworkObjectTestComponent.ConfigureClientConnected(m_ServerNetworkManager, OnClientConnectedCallback);
+            base.OnServerAndClientsCreated();
+        }
 
         [Test]
-        public void ValidateHostLocalClient()
+        public void ValidateHostSettings()
         {
             Assert.IsTrue(m_ServerNetworkManager.LocalClient != null);
+            Assert.IsTrue(m_NetworkObjectWasSpawned, $"{m_NetworkObject.name} was not spawned when OnClientConnectedCallback was invoked!");
+            Assert.IsTrue(m_NetworkBehaviourIsHostWasSet, $"IsHost was not true when OnClientConnectedCallback was invoked!");
+            Assert.IsTrue(m_NetworkBehaviourIsClientWasSet, $"IsClient was not true when OnClientConnectedCallback was invoked!");
+            Assert.IsTrue(m_NetworkBehaviourIsServerWasSet, $"IsServer was not true when OnClientConnectedCallback was invoked!");
         }
     }
 }

--- a/testproject/Assets/Tests/Runtime/NetworkManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkManagerTests.cs
@@ -7,26 +7,44 @@ using System.Collections;
 
 namespace TestProject.RuntimeTests
 {
+    [TestFixture(UseSceneManagement.SceneManagementDisabled)]
+    [TestFixture(UseSceneManagement.SceneManagementEnabled)]
     public class NetworkManagerTests : NetcodeIntegrationTest
     {
         private const string k_SceneToLoad = "InSceneNetworkObject";
         protected override int NumberOfClients => 0;
 
+        public enum UseSceneManagement
+        {
+            SceneManagementEnabled,
+            SceneManagementDisabled
+        }
+
+        private bool m_EnableSceneManagement;
         private NetworkObject m_NetworkObject;
         private bool m_NetworkObjectWasSpawned;
         private bool m_NetworkBehaviourIsHostWasSet;
         private bool m_NetworkBehaviourIsClientWasSet;
         private bool m_NetworkBehaviourIsServerWasSet;
+        private int m_NumberOfTimesInvoked;
         private AsyncOperation m_AsyncOperation;
         private NetworkObjectTestComponent m_NetworkObjectTestComponent;
 
-        private void OnClientConnectedCallback(NetworkObject networkObject, bool isHost, bool isClient, bool isServer)
+        private bool m_UseSceneManagement;
+
+        public NetworkManagerTests(UseSceneManagement useSceneManagement)
+        {
+            m_UseSceneManagement = useSceneManagement == UseSceneManagement.SceneManagementEnabled;
+        }
+
+        private void OnClientConnectedCallback(NetworkObject networkObject, int numberOfTimesInvoked, bool isHost, bool isClient, bool isServer)
         {
             m_NetworkObject = networkObject;
             m_NetworkObjectWasSpawned = networkObject.IsSpawned;
             m_NetworkBehaviourIsHostWasSet = isHost;
             m_NetworkBehaviourIsClientWasSet = isClient;
             m_NetworkBehaviourIsServerWasSet = isServer;
+            m_NumberOfTimesInvoked = numberOfTimesInvoked;
         }
 
         private bool TestComponentFound()
@@ -51,10 +69,16 @@ namespace TestProject.RuntimeTests
             AssertOnTimeout($"Failed to find {nameof(NetworkObjectTestComponent)} after loading test scene {k_SceneToLoad}");
         }
 
+        protected override IEnumerator OnTearDown()
+        {
+            SceneManager.UnloadSceneAsync(SceneManager.GetSceneByName(k_SceneToLoad));
+            yield return s_DefaultWaitForTick;
+        }
+
         protected override void OnServerAndClientsCreated()
         {
+            m_ServerNetworkManager.NetworkConfig.EnableSceneManagement = m_EnableSceneManagement;
             m_NetworkObjectTestComponent.ConfigureClientConnected(m_ServerNetworkManager, OnClientConnectedCallback);
-            base.OnServerAndClientsCreated();
         }
 
         [Test]
@@ -64,6 +88,7 @@ namespace TestProject.RuntimeTests
             Assert.IsTrue(m_NetworkObjectWasSpawned, $"{m_NetworkObject.name} was not spawned when OnClientConnectedCallback was invoked!");
             Assert.IsTrue(m_NetworkBehaviourIsHostWasSet, $"IsHost was not true when OnClientConnectedCallback was invoked!");
             Assert.IsTrue(m_NetworkBehaviourIsClientWasSet, $"IsClient was not true when OnClientConnectedCallback was invoked!");
+            Assert.IsTrue(m_NumberOfTimesInvoked == 1, $"OnClientConnectedCallback was invoked {m_NumberOfTimesInvoked} as opposed to just once!");
             Assert.IsTrue(m_NetworkBehaviourIsServerWasSet, $"IsServer was not true when OnClientConnectedCallback was invoked!");
         }
     }

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectTestComponent.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectTestComponent.cs
@@ -27,19 +27,20 @@ namespace TestProject.RuntimeTests
             DespawnedInstances.Clear();
         }
 
-        private Action<NetworkObject, bool, bool, bool> m_ActionClientConnected;
-        public void ConfigureClientConnected(NetworkManager networkManager, Action<NetworkObject, bool, bool, bool> clientConnected)
+        private Action<NetworkObject, int, bool, bool, bool> m_ActionClientConnected;
+        private int m_NumberOfTimesInvoked;
+        public void ConfigureClientConnected(NetworkManager networkManager, Action<NetworkObject, int, bool, bool, bool> clientConnected)
         {
-
             networkManager.OnClientConnectedCallback += NetworkManager_OnClientConnectedCallback;
             m_ActionClientConnected = clientConnected;
         }
 
         private void NetworkManager_OnClientConnectedCallback(ulong obj)
         {
+            m_NumberOfTimesInvoked++;
             if (m_ActionClientConnected != null)
             {
-                m_ActionClientConnected.Invoke(NetworkObject, IsHost, IsClient, IsServer);
+                m_ActionClientConnected.Invoke(NetworkObject, m_NumberOfTimesInvoked, IsHost, IsClient, IsServer);
             }
         }
 

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectTestComponent.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectTestComponent.cs
@@ -27,6 +27,22 @@ namespace TestProject.RuntimeTests
             DespawnedInstances.Clear();
         }
 
+        private Action<NetworkObject, bool, bool, bool> m_ActionClientConnected;
+        public void ConfigureClientConnected(NetworkManager networkManager, Action<NetworkObject, bool, bool, bool> clientConnected)
+        {
+
+            networkManager.OnClientConnectedCallback += NetworkManager_OnClientConnectedCallback;
+            m_ActionClientConnected = clientConnected;
+        }
+
+        private void NetworkManager_OnClientConnectedCallback(ulong obj)
+        {
+            if (m_ActionClientConnected != null)
+            {
+                m_ActionClientConnected.Invoke(NetworkObject, IsHost, IsClient, IsServer);
+            }
+        }
+
         // When disabling on spawning we only want this to happen on the initial spawn.
         // This is used to track this so the server only does it once upon spawning.
         public bool ObjectWasDisabledUponSpawn;


### PR DESCRIPTION
This assures that any NetworkBehaviour components attached to in-scene placed NetworkObjects will have their associated netcode/NetworkManager properties properly initialized when OnClientConnected is invoked.

[MTT-4972](https://jira.unity3d.com/browse/MTT-4972)

## Changelog
- Fixed: The issue where `NetworkManager.OnClientConnectedCallback` was being invoked before in-scene placed `NetworkObject`s had been spawned when starting `NetworkManager` as a host.

## Testing and Documentation
- Includes integration test (wip)
