### PR TITLE
chore: Better NetworkBehaviour index out of range message

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1051,7 +1051,7 @@ namespace Unity.Netcode
             {
                 if (NetworkLog.CurrentLogLevel <= LogLevel.Error)
                 {
-                    NetworkLog.LogError($"Behaviour index was out of bounds. Did you mess up the order of your {nameof(NetworkBehaviour)}s?");
+                    NetworkLog.LogError($"NetworkBehaviour index was out of bounds for {name}. NetworkBehaviours must be the same, and in the same order, between server and client.");
                 }
 
                 return null;

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1051,7 +1051,20 @@ namespace Unity.Netcode
             {
                 if (NetworkLog.CurrentLogLevel <= LogLevel.Error)
                 {
-                    NetworkLog.LogError($"NetworkBehaviour index was out of bounds for {name}. NetworkBehaviours must be the same, and in the same order, between server and client.");
+                    NetworkLog.LogError($"{nameof(NetworkBehaviour)} index {index} was out of bounds for {name}. NetworkBehaviours must be the same, and in the same order, between server and client.");
+                }
+
+                if (NetworkLog.CurrentLogLevel <= LogLevel.Developer)
+                {
+                    var currentKnownChildren = new System.Text.StringBuilder();
+                    currentKnownChildren.Append($"Known child {nameof(NetworkBehaviour)}s:");
+                    for(int i = 0; i < ChildNetworkBehaviours.Count; i++)
+                    {
+                        var childNetworkBehaviour = ChildNetworkBehaviours[i];
+                        currentKnownChildren.Append($" [{i}] {childNetworkBehaviour.__getTypeName()}");
+                        currentKnownChildren.Append(i < ChildNetworkBehaviours.Count - 1 ? "," : ".");
+                    }
+                    NetworkLog.LogInfo(currentKnownChildren.ToString());
                 }
 
                 return null;

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1058,7 +1058,7 @@ namespace Unity.Netcode
                 {
                     var currentKnownChildren = new System.Text.StringBuilder();
                     currentKnownChildren.Append($"Known child {nameof(NetworkBehaviour)}s:");
-                    for(int i = 0; i < ChildNetworkBehaviours.Count; i++)
+                    for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
                     {
                         var childNetworkBehaviour = ChildNetworkBehaviours[i];
                         currentKnownChildren.Append($" [{i}] {childNetworkBehaviour.__getTypeName()}");

--- a/com.unity.netcode.gameobjects/Tests/Editor/NetworkObjectTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/NetworkObjectTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -31,19 +32,17 @@ namespace Unity.Netcode.EditorTests
         }
 
         [Test]
-        public void GetBehaviourIndexNone()
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(2)]
+        public void GetBehaviourIndexNone(int index)
         {
             var gameObject = new GameObject(nameof(GetBehaviourIndexNone));
             var networkObject = gameObject.AddComponent<NetworkObject>();
 
-            // TODO: Maybe not hardcode message?
-            LogAssert.Expect(LogType.Error, $"[Netcode] Behaviour index was out of bounds. Did you mess up the order of your {nameof(NetworkBehaviour)}s?");
-            LogAssert.Expect(LogType.Error, $"[Netcode] Behaviour index was out of bounds. Did you mess up the order of your {nameof(NetworkBehaviour)}s?");
-            LogAssert.Expect(LogType.Error, $"[Netcode] Behaviour index was out of bounds. Did you mess up the order of your {nameof(NetworkBehaviour)}s?");
+            LogAssert.Expect(LogType.Error, new Regex(".*out of bounds.*"));
 
-            Assert.That(networkObject.GetNetworkBehaviourAtOrderIndex(0), Is.Null);
-            Assert.That(networkObject.GetNetworkBehaviourAtOrderIndex(1), Is.Null);
-            Assert.That(networkObject.GetNetworkBehaviourAtOrderIndex(2), Is.Null);
+            Assert.That(networkObject.GetNetworkBehaviourAtOrderIndex((ushort)index), Is.Null);
 
             // Cleanup
             Object.DestroyImmediate(gameObject);
@@ -56,13 +55,10 @@ namespace Unity.Netcode.EditorTests
             var networkObject = gameObject.AddComponent<NetworkObject>();
             var networkBehaviour = gameObject.AddComponent<EmptyNetworkBehaviour>();
 
-            // TODO: Maybe not hardcode message?
-            LogAssert.Expect(LogType.Error, $"[Netcode] Behaviour index was out of bounds. Did you mess up the order of your {nameof(NetworkBehaviour)}s?");
-            LogAssert.Expect(LogType.Error, $"[Netcode] Behaviour index was out of bounds. Did you mess up the order of your {nameof(NetworkBehaviour)}s?");
+            LogAssert.Expect(LogType.Error, new Regex(".*out of bounds.*"));
 
             Assert.That(networkObject.GetNetworkBehaviourAtOrderIndex(0), Is.EqualTo(networkBehaviour));
             Assert.That(networkObject.GetNetworkBehaviourAtOrderIndex(1), Is.Null);
-            Assert.That(networkObject.GetNetworkBehaviourAtOrderIndex(2), Is.Null);
 
             // Cleanup
             Object.DestroyImmediate(gameObject);


### PR DESCRIPTION
Changes the error message to be more easily actionable for users

## Changelog

- Changed: Provide a more actionable error message when the framework encounters a NB index out of range

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.