### PR TITLE
feat: Show public NetworkVariables in editor with a nice name

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -37,8 +37,8 @@ namespace Unity.Netcode.Editor
                 var ft = fields[i].FieldType;
                 if (ft.IsGenericType && ft.GetGenericTypeDefinition() == typeof(NetworkVariable<>) && !fields[i].IsDefined(typeof(HideInInspector), true))
                 {
-                    m_NetworkVariableNames.Add(fields[i].Name);
-                    m_NetworkVariableFields.Add(fields[i].Name, fields[i]);
+                    m_NetworkVariableNames.Add(ObjectNames.NicifyVariableName(fields[i].Name));
+                    m_NetworkVariableFields.Add(ObjectNames.NicifyVariableName(fields[i].Name), fields[i]);
                 }
             }
         }


### PR DESCRIPTION
From Slack request/suggestion:

> When having a public NetworkVariable, I am assuming the inspector field is a custom drawer. Is it not using `NicifyVariableName` or purpose? I'd expect it to use it to format the variable name like everything else in Unity, thereby not showing the m_ and replacing underscores with spaces
