### PR TITLE
fix: Fixes for Deferred Messaging Tests [MTT-5102]

### DIFF
--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/MessageHooks.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/MessageHooks.cs
@@ -44,7 +44,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
         public void OnAfterReceiveMessage(ulong senderId, Type messageType, int messageSizeBytes)
         {
-            if (!CurrentMessageHasTriggerdAHook && IsWaiting && (HandleCheck == null || HandleCheck.Invoke(messageType)))
+            if (!CurrentMessageHasTriggerdAHook && IsWaiting && ReceiptCheck != null && ReceiptCheck.Invoke(messageType))
             {
                 IsWaiting = false;
                 CurrentMessageHasTriggerdAHook = true;
@@ -92,7 +92,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
         public void OnAfterHandleMessage<T>(ref T message, ref NetworkContext context) where T : INetworkMessage
         {
-            if (!CurrentMessageHasTriggerdAHook && IsWaiting && (HandleCheck == null || HandleCheck.Invoke(message)))
+            if (!CurrentMessageHasTriggerdAHook && IsWaiting && HandleCheck != null && HandleCheck.Invoke(message))
             {
                 IsWaiting = false;
                 CurrentMessageHasTriggerdAHook = true;

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -331,6 +331,11 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
             NetcodeIntegrationTestHelpers.StartOneClient(networkManager);
 
+            if (LogAllMessages)
+            {
+                networkManager.MessagingSystem.Hook(new DebugNetworkHooks());
+            }
+
             AddRemoveNetworkManager(networkManager, true);
 
             OnNewClientStarted(networkManager);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DeferredMessagingTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DeferredMessagingTests.cs
@@ -639,6 +639,8 @@ namespace Unity.Netcode.RuntimeTests
             }
         }
 
+        protected override bool LogAllMessages => true;
+
         [UnityTest]
         public IEnumerator WhenMultipleSpawnTriggeredMessagesAreDeferred_TheyAreAllProcessedOnSpawn()
         {
@@ -658,7 +660,7 @@ namespace Unity.Netcode.RuntimeTests
 
             serverObject.GetComponent<NetworkObject>().ChangeOwnership(m_ClientNetworkManagers[0].LocalClientId);
 
-            yield return WaitForAllClientsToReceive<ChangeOwnershipMessage>();
+            yield return WaitForAllClientsToReceive<ChangeOwnershipMessage, NetworkVariableDeltaMessage>();
 
             foreach (var client in m_ClientNetworkManagers)
             {
@@ -666,9 +668,9 @@ namespace Unity.Netcode.RuntimeTests
                 Assert.IsTrue(manager.DeferMessageCalled);
                 Assert.IsFalse(manager.ProcessTriggersCalled);
 
-                Assert.AreEqual(3, manager.DeferredMessageCountTotal());
-                Assert.AreEqual(3, manager.DeferredMessageCountForType(IDeferredMessageManager.TriggerType.OnSpawn));
-                Assert.AreEqual(3, manager.DeferredMessageCountForKey(IDeferredMessageManager.TriggerType.OnSpawn, serverObject.GetComponent<NetworkObject>().NetworkObjectId));
+                Assert.AreEqual(4, manager.DeferredMessageCountTotal());
+                Assert.AreEqual(4, manager.DeferredMessageCountForType(IDeferredMessageManager.TriggerType.OnSpawn));
+                Assert.AreEqual(4, manager.DeferredMessageCountForKey(IDeferredMessageManager.TriggerType.OnSpawn, serverObject.GetComponent<NetworkObject>().NetworkObjectId));
                 Assert.AreEqual(0, manager.DeferredMessageCountForType(IDeferredMessageManager.TriggerType.OnAddPrefab));
                 AddPrefabsToClient(client);
             }
@@ -795,10 +797,6 @@ namespace Unity.Netcode.RuntimeTests
             serverObject.GetComponent<NetworkObject>().ChangeOwnership(m_ClientNetworkManagers[0].LocalClientId);
 
             yield return WaitForAllClientsToReceive<ChangeOwnershipMessage, NetworkVariableDeltaMessage>();
-
-            // wait three ticks
-            yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ServerNetworkManager, 3);
-            yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ClientNetworkManagers[0], 3);
 
             // Validate messages are deferred and pending
             foreach (var client in m_ClientNetworkManagers)


### PR DESCRIPTION
MessageHooks had a logic error that, when waiting on messages with `ReceiptType.Received`, would result in it basically ignoring the type of the message it received and just wait for n messages of any type - which resulted in a TimeSyncMessage sometimes inserting itself in between the two messages being waited on and resulting in an early end to the wait before the second message actually arrived.