### PR TITLE
fix: Allow Relay hosts/servers on WebGL

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,9 +11,12 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Added
 
 ### Changed
+
 - The default listen address of `UnityTransport` is now 0.0.0.0. (#2307)
 
 ### Fixed
+
+- Fixed an issue in `UnityTransport` where an exception would be thrown if starting a Relay host/server on WebGL. This exception should only be thrown if using direct connections (where WebGL can't act as a host/server).
 
 ## [1.2.0] - 2022-11-21
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -16,7 +16,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed an issue in `UnityTransport` where an exception would be thrown if starting a Relay host/server on WebGL. This exception should only be thrown if using direct connections (where WebGL can't act as a host/server).
+- Fixed an issue in `UnityTransport` where an exception would be thrown if starting a Relay host/server on WebGL. This exception should only be thrown if using direct connections (where WebGL can't act as a host/server). (#2321)
 
 ## [1.2.0] - 2022-11-21
 

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1471,7 +1471,7 @@ namespace Unity.Netcode.Transports.UTP
                 heartbeatTimeoutMS: transport.m_HeartbeatTimeoutMS);
 
 #if UNITY_WEBGL && !UNITY_EDITOR
-            if (NetworkManager.IsServer)
+            if (NetworkManager.IsServer && m_ProtocolType != ProtocolType.RelayUnityTransport)
             {
                 throw new Exception("WebGL as a server is not supported by Unity Transport, outside the Editor.");
             }


### PR DESCRIPTION
The check in place cast too wide a net, which resulted in an exception being thrown if starting a host on WebGL even if using the Relay service, which is a valid use case. What we want to prevent is trying to start a host/server on WebGL builds when using direct IP connections, because browsers can't act as servers. But when using Relay, the browser is not acting as a server, it's always acting as a client to the Relay server.

This PR addresses that by only throwing the exception when not using Relay.

## Changelog

- Fixed: Fixed an issue in `UnityTransport` where an exception would be thrown if starting a Relay host/server on WebGL. This exception should only be thrown if using direct connections (where WebGL can't act as a host/server).

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.