### PR TITLE
fix: OnNetworkDespawn is not called on server side when a client disconnects [MTT-5120]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -14,6 +14,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - The default listen address of `UnityTransport` is now 0.0.0.0. (#2307)
 
 ### Fixed
+- Fixed server side issue where, depending upon component ordering, some NetworkBehaviour components might not have their OnNetworkDespawn method invoked if the client side disconnected. (#2323)
 
 ## [1.2.0] - 2022-11-21
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -2082,7 +2082,7 @@ namespace Unity.Netcode
                             }
                             else
                             {
-                                Destroy(playerObject.gameObject);
+                                SpawnManager.DespawnObject(playerObject, true);
                             }
                         }
                         else

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -2082,6 +2082,11 @@ namespace Unity.Netcode
                             }
                             else
                             {
+                                // Call despawn to assure NetworkBehaviour.OnNetworkDespawn is invoked
+                                // on the server-side (when the client side disconnected).
+                                // This prevents the issue (when just destroying the GameObject) where
+                                // any NetworkBehaviour component(s) destroyed before the NetworkObject
+                                // would not have OnNetworkDespawn invoked.
                                 SpawnManager.DespawnObject(playerObject, true);
                             }
                         }

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -241,11 +241,20 @@ namespace Unity.Netcode.TestHelpers.Runtime
         {
         }
 
+        /// <summary>
+        /// Invoked immediately after the player prefab GameObject is created
+        /// prior to adding a NetworkObject component
+        /// </summary>
+        protected virtual void OnPlayerPrefabGameObjectCreated()
+        {
+        }
+
         private void CreatePlayerPrefab()
         {
             VerboseDebug($"Entering {nameof(CreatePlayerPrefab)}");
             // Create playerPrefab
             m_PlayerPrefab = new GameObject("Player");
+            OnPlayerPrefabGameObjectCreated();
             NetworkObject networkObject = m_PlayerPrefab.AddComponent<NetworkObject>();
 
             // Make it a prefab


### PR DESCRIPTION
This resolves the issue when a client player disconnects from a server and, on the server-side. if any `NetworkBehaviour` components preceded the `NetworkObject` component then those `NetworkBehaviour` components' `OnNetworkDespawn` method would not be invoked.

[MTT-5120](https://jira.unity3d.com/browse/MTT-5120)

## Changelog
- Fixed: Server side issue where, depending upon component ordering, some NetworkBehaviour components might not have their OnNetworkDespawn method invoked if the client side disconnected.

## Testing and Documentation
- Includes integration test: NetworkBehaviourGenericTests.OnNetworkDespawnInvokedWhenClientDisconnects
- No documentation changes or additions were necessary.
