### PR TITLE
fix: IsSpawnedObjectsPendingInDontDestroyOnLoad should only be set when LoadSceneMode.Single

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -34,7 +34,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Optimized bandwidth usage by encoding most integer fields using variable-length encoding. (#2276)
 
 ### Fixed
-
+- Fixed `IsSpawnedObjectsPendingInDontDestroyOnLoad` is only set to true when loading a scene using `LoadSceneMode.Singleonly`. (#2330)
 - Fixed issue where `NetworkTransform` components nested under a parent with a `NetworkObject` component  (i.e. network prefab) would not have their associated `GameObject`'s transform synchronized. (#2298)
 - Fixed issue where `NetworkObject`s that failed to instantiate could cause the entire synchronization pipeline to be disrupted/halted for a connecting client. (#2298)
 - Fixed issue where in-scene placed `NetworkObject`s nested under a `GameObject` would be added to the orphaned children list causing continual console warning log messages. (#2298)

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -862,16 +862,6 @@ namespace Unity.Netcode
 
             SceneEventProgressTracking.Add(sceneEventProgress.Guid, sceneEventProgress);
 
-            if (!isUnloading)
-            {
-                // The Condition: While a scene is asynchronously loaded in single loading scene mode, if any new NetworkObjects are spawned
-                // they need to be moved into the do not destroy temporary scene
-                // When it is set: Just before starting the asynchronous loading call
-                // When it is unset: After the scene has loaded, the PopulateScenePlacedObjects is called, and all NetworkObjects in the do
-                // not destroy temporary scene are moved into the active scene
-                IsSpawnedObjectsPendingInDontDestroyOnLoad = true;
-            }
-
             m_IsSceneEventActive = true;
 
             // Set our callback delegate handler for completion
@@ -1162,6 +1152,13 @@ namespace Unity.Netcode
 
             if (sceneEventData.LoadSceneMode == LoadSceneMode.Single)
             {
+                // The Condition: While a scene is asynchronously loaded in single loading scene mode, if any new NetworkObjects are spawned
+                // they need to be moved into the do not destroy temporary scene
+                // When it is set: Just before starting the asynchronous loading call
+                // When it is unset: After the scene has loaded, the PopulateScenePlacedObjects is called, and all NetworkObjects in the do
+                // not destroy temporary scene are moved into the active scene
+                IsSpawnedObjectsPendingInDontDestroyOnLoad = true;
+
                 // Destroy current scene objects before switching.
                 m_NetworkManager.SpawnManager.ServerDestroySpawnedSceneObjects();
 


### PR DESCRIPTION
This fix assures that `IsSpawnedObjectsPendingInDontDestroyOnLoad` is only set to true when `LoadSceneMode == LoadSceneMode.Singleonly`.

[MTT-4681](https://jira.unity3d.com/browse/MTT-4681)
#2315

## Changelog
- Fixed: `IsSpawnedObjectsPendingInDontDestroyOnLoad` is only set to true when loading a scene using `LoadSceneMode.Singleonly`.

## Testing and Documentation
- No tests have been added.
- No documentation changes or additions were necessary.
