### PR TITLE
fix: Fixed an issue where BatchedSendQueue was including the HeadIndex twice when copying data, which was causing stream corruption when the data exceeded a certain throughput. [NCCBUG-187]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -17,6 +17,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 - Fixed server side issue where, depending upon component ordering, some NetworkBehaviour components might not have their OnNetworkDespawn method invoked if the client side disconnected. (#2323)
+- Fixed a case where data corruption could occur when using UnityTransport when reaching a certain level of send throughput. (#2332)
 
 - Fixed an issue in `UnityTransport` where an exception would be thrown if starting a Relay host/server on WebGL. This exception should only be thrown if using direct connections (where WebGL can't act as a host/server). (#2321)
 

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/BatchedSendQueue.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/BatchedSendQueue.cs
@@ -226,7 +226,7 @@ namespace Unity.Netcode.Transports.UTP
                     {
                         writer.WriteInt(messageLength);
 
-                        var messageOffset = HeadIndex + reader.GetBytesRead();
+                        var messageOffset = reader.GetBytesRead();
                         WriteBytes(ref writer, (byte*)m_Data.GetUnsafePtr() + messageOffset, messageLength);
 
                         writerAvailable -= sizeof(int) + messageLength;

--- a/com.unity.netcode.gameobjects/Tests/Editor/Transports/BatchedSendQueueTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Transports/BatchedSendQueueTests.cs
@@ -229,6 +229,12 @@ namespace Unity.Netcode.EditorTests
             var writer = new DataStreamWriter(data);
             Assert.AreEqual(messageLength, q.FillWriterWithMessages(ref writer));
             AssertIsTestMessage(data);
+
+            q.Consume(messageLength);
+
+            writer = new DataStreamWriter(data);
+            Assert.AreEqual(messageLength, q.FillWriterWithMessages(ref writer));
+            AssertIsTestMessage(data);
         }
 
         [Test]


### PR DESCRIPTION
## Changelog

- Fixed: Fixed a case where data corruption could occur when using UnityTransport when reaching a certain level of send throughput.

## Testing and Documentation

- Includes unit test.
- No documentation changes or additions were necessary.
