### PR TITLE
chore: Ignore BasicBuildTest on release/1.2.0

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Editor/Build/BuildTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Build/BuildTests.cs
@@ -12,6 +12,7 @@ namespace Unity.Netcode.EditorTests
         public const string DefaultBuildScenePath = "Tests/Editor/Build/BuildTestScene.unity";
 
         [Test]
+        [Ignore("Disabling this test on release/1.2.0 branch due to Burst failures caused when running with upm ci")]
         public void BasicBuildTest()
         {
             var execAssembly = Assembly.GetExecutingAssembly();


### PR DESCRIPTION
BasicBuildTest fails when run with upm ci due to a Burst issue https://unity.slack.com/archives/CBZ9KFENR/p1670369615666939

Ignore the test on release branch only.