### PR TITLE
fix: enumerating NetworkVariables with BindingFlags.DeclaredOnly …

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -570,11 +570,11 @@ namespace Unity.Netcode
             if (list == null)
             {
                 list = new List<FieldInfo>();
-                list.AddRange(type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance));
+                list.AddRange(type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly));
             }
             else
             {
-                list.AddRange(type.GetFields(BindingFlags.NonPublic | BindingFlags.Instance));
+                list.AddRange(type.GetFields(BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly));
             }
 
             if (type.BaseType != null && type.BaseType != typeof(NetworkBehaviour))


### PR DESCRIPTION
Enumerating NetworkVariables with BindingFlags.DeclaredOnly so that derived classes with NetworkVariables don't get doubly enumerated

MTT-5197

https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/2335