### PR TITLE
fix: resetting the NetworkVariable dirty status at end of frame, …

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,9 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+- `NetworkShow()` of `NetworkObject`s are delayed until the end of the frame to ensure consistency of delta-driven variables like `NetworkList`.
+- Dirty `NetworkObject` are reset at end-of-frame and not at serialization time.
+- `NetworkHide()` of an object that was just `NetworkShow()`n produces a warning, as remote clients will _not_ get a spawn/despawn pair.
 - The default listen address of `UnityTransport` is now 0.0.0.0. (#2307)
 - Renamed the NetworkTransform.SetState parameter `shouldGhostsInterpolate` to `teleportDisabled` for better clarity of what that parameter does. (#2228)
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -210,6 +210,13 @@ namespace Unity.Netcode
                     }
                     rpcWriteSize = NetworkManager.MessagingSystem.SendMessage(ref clientRpcMessage, networkDelivery, observerEnumerator.Current);
                 }
+                foreach (var it in NetworkManager.ObjectsToShowToClient)
+                {
+                    if (it.Value.Contains(NetworkObject))
+                    {
+                        rpcWriteSize = NetworkManager.MessagingSystem.SendMessage(ref clientRpcMessage, networkDelivery, it.Key);
+                    }
+                }
             }
 
             // If we are a server/host then we just no op and send to ourself

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -210,13 +210,6 @@ namespace Unity.Netcode
                     }
                     rpcWriteSize = NetworkManager.MessagingSystem.SendMessage(ref clientRpcMessage, networkDelivery, observerEnumerator.Current);
                 }
-                foreach (var it in NetworkManager.ObjectsToShowToClient)
-                {
-                    if (it.Value.Contains(NetworkObject))
-                    {
-                        rpcWriteSize = NetworkManager.MessagingSystem.SendMessage(ref clientRpcMessage, networkDelivery, it.Key);
-                    }
-                }
             }
 
             // If we are a server/host then we just no op and send to ourself

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
@@ -72,6 +72,23 @@ namespace Unity.Netcode
                         }
                     }
                 }
+
+                foreach (var dirtyObj in m_DirtyNetworkObjects)
+                {
+                    for (int k = 0; k < dirtyObj.ChildNetworkBehaviours.Count; k++)
+                    {
+                        var behaviour = dirtyObj.ChildNetworkBehaviours[k];
+                        for (int i = 0; i < behaviour.NetworkVariableFields.Count; i++)
+                        {
+                            if (behaviour.NetworkVariableFields[i].IsDirty() &&
+                                !behaviour.NetworkVariableIndexesToResetSet.Contains(i))
+                            {
+                                behaviour.NetworkVariableIndexesToResetSet.Add(i);
+                                behaviour.NetworkVariableIndexesToReset.Add(i);
+                            }
+                        }
+                    }
+                }
                 // Now, reset all the no-longer-dirty variables
                 foreach (var dirtyobj in m_DirtyNetworkObjects)
                 {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1672,7 +1672,6 @@ namespace Unity.Netcode
                 ulong clientId = client.Key;
                 foreach (var networkObject in client.Value)
                 {
-                    networkObject.Observers.Add(clientId);
                     SpawnManager.SendSpawnCallForObject(clientId, networkObject);
                 }
             }
@@ -2381,6 +2380,8 @@ namespace Unity.Netcode
                 ObjectsToShowToClient[clientId].Remove(networkObject);
                 ret = true;
             }
+
+            networkObject.Observers.Remove(clientId);
 
             return ret;
         }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -2363,5 +2363,26 @@ namespace Unity.Netcode
             }
             ObjectsToShowToClient[clientId].Add(networkObject);
         }
+
+        // returns whether any matching objects would have become visible and were returned to hidden state
+        internal bool RemoveObjectFromShowingTo(NetworkObject networkObject, ulong clientId)
+        {
+            var ret = false;
+            if (!ObjectsToShowToClient.ContainsKey(clientId))
+            {
+                return false;
+            }
+
+            // probably overkill, but deals with multiple entries
+            while (ObjectsToShowToClient[clientId].Contains(networkObject))
+            {
+                Debug.LogWarning(
+                    "Object was shown and hidden from the same client in the same Network frame. As a result, the client will _not_ receive a NetworkSpawn");
+                ObjectsToShowToClient[clientId].Remove(networkObject);
+                ret = true;
+            }
+
+            return ret;
+        }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1667,7 +1667,7 @@ namespace Unity.Netcode
             BehaviourUpdater.NetworkBehaviourUpdate(this);
 
             // Handle NetworkObjects to show
-            foreach(var client in ObjectsToShowToClient)
+            foreach (var client in ObjectsToShowToClient)
             {
                 ulong clientId = client.Key;
                 foreach (var networkObject in client.Value)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -266,6 +266,7 @@ namespace Unity.Netcode
             }
 
             NetworkManager.MarkObjectForShowingTo(this, clientId);
+            Observers.Add(clientId);
         }
 
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -265,9 +265,7 @@ namespace Unity.Netcode
                 throw new VisibilityChangeException("The object is already visible");
             }
 
-            Observers.Add(clientId);
-
-            NetworkManager.SpawnManager.SendSpawnCallForObject(clientId, this);
+            NetworkManager.MarkObjectForShowingTo(this, clientId);
         }
 
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -349,26 +349,28 @@ namespace Unity.Netcode
                 throw new NotServerException("Only server can change visibility");
             }
 
-            if (!Observers.Contains(clientId))
-            {
-                throw new VisibilityChangeException("The object is already hidden");
-            }
-
             if (clientId == NetworkManager.ServerClientId)
             {
                 throw new VisibilityChangeException("Cannot hide an object from the server");
             }
 
-            Observers.Remove(clientId);
-
-            var message = new DestroyObjectMessage
+            if (!NetworkManager.RemoveObjectFromShowingTo(this, clientId))
             {
-                NetworkObjectId = NetworkObjectId,
-                DestroyGameObject = !IsSceneObject.Value
-            };
-            // Send destroy call
-            var size = NetworkManager.SendMessage(ref message, NetworkDelivery.ReliableSequenced, clientId);
-            NetworkManager.NetworkMetrics.TrackObjectDestroySent(clientId, this, size);
+                if (!Observers.Contains(clientId))
+                {
+                    throw new VisibilityChangeException("The object is already hidden");
+                }
+                Observers.Remove(clientId);
+
+                var message = new DestroyObjectMessage
+                {
+                    NetworkObjectId = NetworkObjectId,
+                    DestroyGameObject = !IsSceneObject.Value
+                };
+                // Send destroy call
+                var size = NetworkManager.SendMessage(ref message, NetworkDelivery.ReliableSequenced, clientId);
+                NetworkManager.NetworkMetrics.TrackObjectDestroySent(clientId, this, size);
+            }
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkVariableDeltaMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkVariableDeltaMessage.cs
@@ -96,12 +96,6 @@ namespace Unity.Netcode
                         networkVariable.WriteDelta(writer);
                     }
 
-                    if (!NetworkBehaviour.NetworkVariableIndexesToResetSet.Contains(i))
-                    {
-                        NetworkBehaviour.NetworkVariableIndexesToResetSet.Add(i);
-                        NetworkBehaviour.NetworkVariableIndexesToReset.Add(i);
-                    }
-
                     NetworkBehaviour.NetworkManager.NetworkMetrics.TrackNetworkVariableDeltaSent(
                         TargetClientId,
                         NetworkBehaviour.NetworkObject,

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkVariableDeltaMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkVariableDeltaMessage.cs
@@ -64,6 +64,16 @@ namespace Unity.Netcode
                     shouldWrite = false;
                 }
 
+                // The object containing the behaviour we're about to process is about to be shown to this client
+                // As a result, the client will get the fully serialized NetworkVariable and would be confused by
+                // an extraneous delta
+                if (NetworkBehaviour.NetworkManager.ObjectsToShowToClient.ContainsKey(TargetClientId) &&
+                    NetworkBehaviour.NetworkManager.ObjectsToShowToClient[TargetClientId]
+                    .Contains(NetworkBehaviour.NetworkObject))
+                {
+                    shouldWrite = false;
+                }
+
                 if (NetworkBehaviour.NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
                 {
                     if (!shouldWrite)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
@@ -440,6 +440,30 @@ namespace Unity.Netcode.RuntimeTests
             Debug.Assert(list1.Count == list2.Count);
         }
 
+        private IEnumerator HideThenShowAndHideThenModifyAndShow()
+        {
+            Debug.Log("Hiding");
+            // hide
+            m_NetSpawnedObject1.NetworkHide(1);
+            yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ServerNetworkManager, 3);
+            yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ClientNetworkManagers[0], 3);
+
+            Debug.Log("Showing and Hiding");
+            // show and hide
+            m_NetSpawnedObject1.NetworkShow(1);
+            m_NetSpawnedObject1.NetworkHide(1);
+            yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ServerNetworkManager, 3);
+            yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ClientNetworkManagers[0], 3);
+
+            Debug.Log("Modifying and Showing");
+            // modify and show
+            m_NetSpawnedObject1.GetComponent<ShowHideObject>().MyList.Add(5);
+            m_NetSpawnedObject1.NetworkShow(1);
+            yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ServerNetworkManager, 3);
+            yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ClientNetworkManagers[0], 3);
+        }
+
+
         private IEnumerator HideThenModifyAndShow()
         {
             // hide
@@ -485,7 +509,7 @@ namespace Unity.Netcode.RuntimeTests
                 yield return new WaitForSeconds(0.0f);
             }
 
-            for (int i = 0; i < 2; i++)
+            for (int i = 0; i < 3; i++)
             {
                 // wait for three ticks
                 yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ServerNetworkManager, 3);
@@ -493,12 +517,19 @@ namespace Unity.Netcode.RuntimeTests
 
                 switch (i)
                 {
-                    case 1:
+                    case 0:
+                        Debug.Log("Running HideThenModifyAndShow");
                         yield return HideThenModifyAndShow();
                         break;
-                    case 2:
+                    case 1:
+                        Debug.Log("Running HideThenShowAndModify");
                         yield return HideThenShowAndModify();
                         break;
+                    case 2:
+                        Debug.Log("Running HideThenShowAndHideThenModifyAndShow");
+                        yield return HideThenShowAndHideThenModifyAndShow();
+                        break;
+
 
                 }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
@@ -406,7 +406,7 @@ namespace Unity.Netcode.RuntimeTests
             Assert.True(ShowHideObject.ValueAfterOwnershipChange == 1);
         }
 
-        string Display(NetworkList<int> list)
+        private string Display(NetworkList<int> list)
         {
             string message = "";
             foreach (var i in list)
@@ -417,7 +417,7 @@ namespace Unity.Netcode.RuntimeTests
             return message;
         }
 
-        void Compare(NetworkList<int> list1, NetworkList<int> list2)
+        private void Compare(NetworkList<int> list1, NetworkList<int> list2)
         {
             if (list1.Count != list2.Count)
             {
@@ -485,7 +485,7 @@ namespace Unity.Netcode.RuntimeTests
                 yield return new WaitForSeconds(0.0f);
             }
 
-            for(int i = 0; i < 2; i++)
+            for (int i = 0; i < 2; i++)
             {
                 // wait for three ticks
                 yield return NetcodeIntegrationTestHelpers.WaitForTicks(m_ServerNetworkManager, 3);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
@@ -83,7 +83,6 @@ namespace Unity.Netcode.RuntimeTests
 
             MyListSetOnSpawn = new NetworkList<int>();
             MyList = new NetworkList<int>();
-            ClientIdsRpcCalledOn = new List<ulong>();
 
             MyOwnerReadNetworkVariable = new NetworkVariable<int>(readPerm: NetworkVariableReadPermission.Owner);
             MyOwnerReadNetworkVariable.OnValueChanged += OwnerReadChanged;
@@ -115,7 +114,10 @@ namespace Unity.Netcode.RuntimeTests
         public void SomeRandomClientRPC()
         {
             Debug.Log($"RPC called {NetworkManager.LocalClientId}");
-            ClientIdsRpcCalledOn.Add(NetworkManager.LocalClientId);
+            if (ClientIdsRpcCalledOn != null)
+            {
+                ClientIdsRpcCalledOn.Add(NetworkManager.LocalClientId);
+            }
         }
 
         public void TriggerRpc()
@@ -557,6 +559,7 @@ namespace Unity.Netcode.RuntimeTests
                         break;
                     case 3:
                         Debug.Log("Running HideThenShowAndRPC");
+                        ShowHideObject.ClientIdsRpcCalledOn = new List<ulong>();
                         yield return HideThenShowAndRPC();
                         Debug.Assert(ShowHideObject.ClientIdsRpcCalledOn.Count == NumberOfClients + 1);
                         break;


### PR DESCRIPTION
… even if a given NetworkVariable is not sent to any client

Also queueing NetworkShow to be done at end-of-frame, to address modified-after-shown objects.

Also changing NetworkHide so that hiding objects that would be shown at end of frame does nothing, but emit a warning.

[MTT-5121](https://jira.unity3d.com/browse/MTT-5121)
https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/2306

Changelog:

- `NetworkShow()` of `NetworkObject`s are delayed until the end of the frame to ensure consistency of delta-driven variables like `NetworkList`.
- Dirty `NetworkObject` are reset at end-of-frame and not at serialization time.
- `NetworkHide()` of an object that was just `NetworkShow()`n produces a warning, as remote clients will _not_ get a spawn/despawn pair.