### PR TITLE
fix: NetcodeSettingsProvider Exception [MTT-5217]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -19,9 +19,9 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Renamed the NetworkTransform.SetState parameter `shouldGhostsInterpolate` to `teleportDisabled` for better clarity of what that parameter does. (#2228)
 
 ### Fixed
+- Fixed issue where `NetcodeSettingsProvider` would throw an exception in Unity 2020.3.x versions. (#2345)
 - Fixed server side issue where, depending upon component ordering, some NetworkBehaviour components might not have their OnNetworkDespawn method invoked if the client side disconnected. (#2323)
 - Fixed a case where data corruption could occur when using UnityTransport when reaching a certain level of send throughput. (#2332)
-
 - Fixed an issue in `UnityTransport` where an exception would be thrown if starting a Relay host/server on WebGL. This exception should only be thrown if using direct connections (where WebGL can't act as a host/server). (#2321)
 
 ## [1.2.0] - 2022-11-21

--- a/com.unity.netcode.gameobjects/Editor/Configuration/NetcodeSettingsProvider.cs
+++ b/com.unity.netcode.gameobjects/Editor/Configuration/NetcodeSettingsProvider.cs
@@ -1,9 +1,10 @@
+#if UNITY_EDITOR
 using UnityEditor;
 using UnityEngine;
 
 namespace Unity.Netcode.Editor.Configuration
 {
-    internal static class NetcodeSettingsProvider
+    public static class NetcodeSettingsProvider
     {
         [SettingsProvider]
         public static SettingsProvider CreateNetcodeSettingsProvider()
@@ -20,14 +21,44 @@ namespace Unity.Netcode.Editor.Configuration
             return provider;
         }
 
-        internal static NetcodeSettingsLabel NetworkObjectsSectionLabel = new NetcodeSettingsLabel("NetworkObject Helper Settings", 20);
-        internal static NetcodeSettingsToggle AutoAddNetworkObjectToggle = new NetcodeSettingsToggle("Auto-Add NetworkObjects", "When enabled, NetworkObjects are automatically added to GameObjects when NetworkBehaviours are added first.", 20);
-        internal static NetcodeSettingsLabel MultiplayerToolsLabel = new NetcodeSettingsLabel("Multiplayer Tools", 20);
-        internal static NetcodeSettingsToggle MultiplayerToolTipStatusToggle = new NetcodeSettingsToggle("Multiplayer Tools Install Reminder", "When enabled, the NetworkManager will display " +
-            "the notification to install the multiplayer tools package.", 20);
+        internal static NetcodeSettingsLabel NetworkObjectsSectionLabel;
+        internal static NetcodeSettingsToggle AutoAddNetworkObjectToggle;
+        internal static NetcodeSettingsLabel MultiplayerToolsLabel;
+        internal static NetcodeSettingsToggle MultiplayerToolTipStatusToggle;
+
+        /// <summary>
+        /// Creates an instance of the settings UI Elements if they don't already exist.
+        /// </summary>
+        /// <remarks>
+        /// We have to construct any NetcodeGUISettings derived classes here because in
+        /// version 2020.x.x EditorStyles.label does not exist yet (higher versions it does)
+        /// </remarks>
+        private static void CheckForInitialize()
+        {
+            if (NetworkObjectsSectionLabel == null)
+            {
+                NetworkObjectsSectionLabel = new NetcodeSettingsLabel("NetworkObject Helper Settings", 20);
+            }
+
+            if (AutoAddNetworkObjectToggle == null)
+            {
+                AutoAddNetworkObjectToggle = new NetcodeSettingsToggle("Auto-Add NetworkObjects", "When enabled, NetworkObjects are automatically added to GameObjects when NetworkBehaviours are added first.", 20);
+            }
+
+            if (MultiplayerToolsLabel == null)
+            {
+                MultiplayerToolsLabel = new NetcodeSettingsLabel("Multiplayer Tools", 20);
+            }
+
+            if (MultiplayerToolTipStatusToggle == null)
+            {
+                MultiplayerToolTipStatusToggle = new NetcodeSettingsToggle("Multiplayer Tools Install Reminder", "When enabled, the NetworkManager will display the notification to install the multiplayer tools package.", 20);
+            }
+        }
 
         private static void OnGuiHandler(string obj)
         {
+            CheckForInitialize();
             var autoAddNetworkObjectSetting = NetcodeForGameObjectsSettings.GetAutoAddNetworkObjectSetting();
             var multiplayerToolsTipStatus = NetcodeForGameObjectsSettings.GetNetcodeInstallMultiplayerToolTips() == 0;
             EditorGUI.BeginChangeCheck();
@@ -56,7 +87,7 @@ namespace Unity.Netcode.Editor.Configuration
         public NetcodeSettingsLabel(string labelText, float layoutOffset = 0.0f)
         {
             m_LabelContent = labelText;
-            AdjustLableSize(labelText, layoutOffset);
+            AdjustLabelSize(labelText, layoutOffset);
         }
     }
 
@@ -72,7 +103,7 @@ namespace Unity.Netcode.Editor.Configuration
 
         public NetcodeSettingsToggle(string labelText, string toolTip, float layoutOffset)
         {
-            AdjustLableSize(labelText, layoutOffset);
+            AdjustLabelSize(labelText, layoutOffset);
             m_ToggleContent = new GUIContent(labelText, toolTip);
         }
     }
@@ -84,11 +115,12 @@ namespace Unity.Netcode.Editor.Configuration
 
         protected GUILayoutOption m_LayoutWidth { get; private set; }
 
-        protected void AdjustLableSize(string labelText, float offset = 0.0f)
+        protected void AdjustLabelSize(string labelText, float offset = 0.0f)
         {
             m_LabelSize = Mathf.Min(k_MaxLabelWidth, EditorStyles.label.CalcSize(new GUIContent(labelText)).x);
             m_LayoutWidth = GUILayout.Width(m_LabelSize + offset);
         }
     }
-
 }
+#endif
+

--- a/com.unity.netcode.gameobjects/Editor/Configuration/NetcodeSettingsProvider.cs
+++ b/com.unity.netcode.gameobjects/Editor/Configuration/NetcodeSettingsProvider.cs
@@ -58,7 +58,9 @@ namespace Unity.Netcode.Editor.Configuration
 
         private static void OnGuiHandler(string obj)
         {
+            // Make sure all NetcodeGUISettings derived classes are instantiated first
             CheckForInitialize();
+
             var autoAddNetworkObjectSetting = NetcodeForGameObjectsSettings.GetAutoAddNetworkObjectSetting();
             var multiplayerToolsTipStatus = NetcodeForGameObjectsSettings.GetNetcodeInstallMultiplayerToolTips() == 0;
             EditorGUI.BeginChangeCheck();

--- a/com.unity.netcode.gameobjects/Editor/Configuration/NetcodeSettingsProvider.cs
+++ b/com.unity.netcode.gameobjects/Editor/Configuration/NetcodeSettingsProvider.cs
@@ -1,10 +1,9 @@
-#if UNITY_EDITOR
 using UnityEditor;
 using UnityEngine;
 
 namespace Unity.Netcode.Editor.Configuration
 {
-    public static class NetcodeSettingsProvider
+    internal static class NetcodeSettingsProvider
     {
         [SettingsProvider]
         public static SettingsProvider CreateNetcodeSettingsProvider()
@@ -124,5 +123,3 @@ namespace Unity.Netcode.Editor.Configuration
         }
     }
 }
-#endif
-


### PR DESCRIPTION
Since UI Element helper classes were being instantiated when they were declared,  when entering into play mode, in unity 2020.3.x versions, the `EditorStyles.label` was not yet assigned and would throw an exception (in 2021 and later versions `EditorStyles.label` is assigned at that point in time).  This PR resolves the issue by instantiating the helper classes when `OnGuiHandler` is invoked.

[MTT-5217](https://jira.unity3d.com/browse/MTT-5217)

## Changelog
- Fixed: Issue where `NetcodeSettingsProvider` would throw an exception in Unity 2020.3.x versions.

## Testing and Documentation
- No tests have been added.
- No documentation changes or additions were necessary.
