### PR TITLE
fix: fix UnityTransport_RestartSucceedsAfterFailure test

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -23,6 +23,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed server side issue where, depending upon component ordering, some NetworkBehaviour components might not have their OnNetworkDespawn method invoked if the client side disconnected. (#2323)
 - Fixed a case where data corruption could occur when using UnityTransport when reaching a certain level of send throughput. (#2332)
 - Fixed an issue in `UnityTransport` where an exception would be thrown if starting a Relay host/server on WebGL. This exception should only be thrown if using direct connections (where WebGL can't act as a host/server). (#2321)
+- Fixed a UTP test that was failing when you install Unity Transport package 2.0.0 or newer. (#2321)
 
 ## [1.2.0] - 2022-11-21
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -23,7 +23,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed server side issue where, depending upon component ordering, some NetworkBehaviour components might not have their OnNetworkDespawn method invoked if the client side disconnected. (#2323)
 - Fixed a case where data corruption could occur when using UnityTransport when reaching a certain level of send throughput. (#2332)
 - Fixed an issue in `UnityTransport` where an exception would be thrown if starting a Relay host/server on WebGL. This exception should only be thrown if using direct connections (where WebGL can't act as a host/server). (#2321)
-- Fixed a UTP test that was failing when you install Unity Transport package 2.0.0 or newer. (#2321)
+- Fixed a UTP test that was failing when you install Unity Transport package 2.0.0 or newer. (#2347)
 
 ## [1.2.0] - 2022-11-21
 

--- a/com.unity.netcode.gameobjects/Tests/Editor/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Transports/UnityTransportTests.cs
@@ -119,6 +119,9 @@ namespace Unity.Netcode.EditorTests
             Assert.False(transport.StartServer());
 
             LogAssert.Expect(LogType.Error, "Invalid network endpoint: 127.0.0.:4242.");
+#if UTP_TRANSPORT_2_0_ABOVE
+            LogAssert.Expect(LogType.Error, "Socket creation failed (error Unity.Baselib.LowLevel.Binding+Baselib_ErrorState: Invalid argument (0x01000003) <argument name stripped>");
+#endif
             LogAssert.Expect(LogType.Error, "Server failed to bind. This is usually caused by another process being bound to the same port.");
 
             transport.SetConnectionData("127.0.0.1", 4242, "127.0.0.1");


### PR DESCRIPTION
Fixing a UnityTransport_RestartSucceedsAfterFailure test that was failing when you install NGO package with UTP 2.0.0.

## Changelog
- Fixed: Fixed a UTP test that was failing when you install Unity Transport package 2.0.0 or newer.

## Testing and Documentation
Ran the test locally and automated CI run
