### PR TITLE
fix: fix UnityTransport_RestartSucceedsAfterFailure test for release 1.2.0

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Editor/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Transports/UnityTransportTests.cs
@@ -119,6 +119,9 @@ namespace Unity.Netcode.EditorTests
             Assert.False(transport.StartServer());
 
             LogAssert.Expect(LogType.Error, "Invalid network endpoint: 127.0.0.:4242.");
+#if UTP_TRANSPORT_2_0_ABOVE
+            LogAssert.Expect(LogType.Error, "Socket creation failed (error Unity.Baselib.LowLevel.Binding+Baselib_ErrorState: Invalid argument (0x01000003) <argument name stripped>");
+#endif
             LogAssert.Expect(LogType.Error, "Server failed to bind");
 
             transport.SetConnectionData("127.0.0.1", 4242);


### PR DESCRIPTION
Fixing a UnityTransport_RestartSucceedsAfterFailure test that was failing when you install NGO release/1.2.0 package with UTP 2.0.0.

## Changelog
 No changelog needed for release 1.2 since the release is done and that branch is now obsolete. 

## Testing and Documentation
Ran the test locally and automated CI run