### PR TITLE
fix: Showing the NetworkLists too in the inspector, not just the NetworkVariables

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -20,6 +20,7 @@ namespace Unity.Netcode.Editor
         private readonly Dictionary<string, object> m_NetworkVariableObjects = new Dictionary<string, object>();
 
         private GUIContent m_NetworkVariableLabelGuiContent;
+        private GUIContent m_NetworkListLabelGuiContent;
 
         private void Init(MonoScript script)
         {
@@ -30,6 +31,7 @@ namespace Unity.Netcode.Editor
             m_NetworkVariableObjects.Clear();
 
             m_NetworkVariableLabelGuiContent = new GUIContent("NetworkVariable", "This variable is a NetworkVariable. It can not be serialized and can only be changed during runtime.");
+            m_NetworkListLabelGuiContent = new GUIContent("NetworkList", "This variable is a NetworkList. It is rendered, but you can't serialize or change it.");
 
             var fields = script.GetClass().GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
             for (int i = 0; i < fields.Length; i++)
@@ -39,6 +41,13 @@ namespace Unity.Netcode.Editor
                 {
                     m_NetworkVariableNames.Add(ObjectNames.NicifyVariableName(fields[i].Name));
                     m_NetworkVariableFields.Add(ObjectNames.NicifyVariableName(fields[i].Name), fields[i]);
+                    Debug.Log($"Adding NetworkVariable {fields[i].Name}");
+                }
+                if (ft.IsGenericType && ft.GetGenericTypeDefinition() == typeof(NetworkList<>) && !fields[i].IsDefined(typeof(HideInInspector), true))
+                {
+                    m_NetworkVariableNames.Add(ObjectNames.NicifyVariableName(fields[i].Name));
+                    m_NetworkVariableFields.Add(ObjectNames.NicifyVariableName(fields[i].Name), fields[i]);
+                    Debug.Log($"Adding NetworkList {fields[i].Name}");
                 }
             }
         }
@@ -72,25 +81,48 @@ namespace Unity.Netcode.Editor
             EditorGUILayout.BeginHorizontal();
             if (genericType.IsValueType)
             {
-                var method = typeof(NetworkBehaviourEditor).GetMethod("RenderNetworkVariableValueType", BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy | BindingFlags.NonPublic);
+                var method = typeof(NetworkBehaviourEditor).GetMethod("RenderNetworkContainerValueType", BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy | BindingFlags.NonPublic);
                 var genericMethod = method.MakeGenericMethod(genericType);
                 genericMethod.Invoke(this, new[] { (object)index });
             }
             else
             {
                 EditorGUILayout.LabelField("Type not renderable");
+
+                GUILayout.Label(m_NetworkVariableLabelGuiContent, EditorStyles.miniLabel, GUILayout.Width(EditorStyles.miniLabel.CalcSize(m_NetworkVariableLabelGuiContent).x));
+                EditorGUILayout.EndHorizontal();
+            }
+        }
+
+        private void RenderNetworkContainerValueType<T>(int index) where T : unmanaged, IEquatable<T>
+        {
+            try
+            {
+                var networkVariable = (NetworkVariable<T>)m_NetworkVariableFields[m_NetworkVariableNames[index]].GetValue(target);
+                RenderNetworkVariableValueType(index, networkVariable);
+            }
+            catch (Exception)
+            {
+                try
+                {
+                    var networkList = (NetworkList<T>)m_NetworkVariableFields[m_NetworkVariableNames[index]].GetValue(target);
+                    RenderNetworkListValueType(index, networkList);
+                }
+                catch (Exception e)
+                {
+                    Debug.Log(e);
+                    throw;
+                }
             }
 
-            GUILayout.Label(m_NetworkVariableLabelGuiContent, EditorStyles.miniLabel, GUILayout.Width(EditorStyles.miniLabel.CalcSize(m_NetworkVariableLabelGuiContent).x));
             EditorGUILayout.EndHorizontal();
         }
 
-        private void RenderNetworkVariableValueType<T>(int index) where T : unmanaged
+        private void RenderNetworkVariableValueType<T>(int index, NetworkVariable<T> networkVariable) where T : unmanaged
         {
-            var networkVariable = (NetworkVariable<T>)m_NetworkVariableFields[m_NetworkVariableNames[index]].GetValue(target);
             var type = typeof(T);
             object val = networkVariable.Value;
-            string name = m_NetworkVariableNames[index];
+            string variableName = m_NetworkVariableNames[index];
 
             var behaviour = (NetworkBehaviour)target;
 
@@ -99,47 +131,47 @@ namespace Unity.Netcode.Editor
             {
                 if (type == typeof(int))
                 {
-                    val = EditorGUILayout.IntField(name, (int)val);
+                    val = EditorGUILayout.IntField(variableName, (int)val);
                 }
                 else if (type == typeof(uint))
                 {
-                    val = (uint)EditorGUILayout.LongField(name, (long)((uint)val));
+                    val = (uint)EditorGUILayout.LongField(variableName, (long)((uint)val));
                 }
                 else if (type == typeof(short))
                 {
-                    val = (short)EditorGUILayout.IntField(name, (int)((short)val));
+                    val = (short)EditorGUILayout.IntField(variableName, (int)((short)val));
                 }
                 else if (type == typeof(ushort))
                 {
-                    val = (ushort)EditorGUILayout.IntField(name, (int)((ushort)val));
+                    val = (ushort)EditorGUILayout.IntField(variableName, (int)((ushort)val));
                 }
                 else if (type == typeof(sbyte))
                 {
-                    val = (sbyte)EditorGUILayout.IntField(name, (int)((sbyte)val));
+                    val = (sbyte)EditorGUILayout.IntField(variableName, (int)((sbyte)val));
                 }
                 else if (type == typeof(byte))
                 {
-                    val = (byte)EditorGUILayout.IntField(name, (int)((byte)val));
+                    val = (byte)EditorGUILayout.IntField(variableName, (int)((byte)val));
                 }
                 else if (type == typeof(long))
                 {
-                    val = EditorGUILayout.LongField(name, (long)val);
+                    val = EditorGUILayout.LongField(variableName, (long)val);
                 }
                 else if (type == typeof(ulong))
                 {
-                    val = (ulong)EditorGUILayout.LongField(name, (long)((ulong)val));
+                    val = (ulong)EditorGUILayout.LongField(variableName, (long)((ulong)val));
                 }
                 else if (type == typeof(bool))
                 {
-                    val = EditorGUILayout.Toggle(name, (bool)val);
+                    val = EditorGUILayout.Toggle(variableName, (bool)val);
                 }
                 else if (type == typeof(string))
                 {
-                    val = EditorGUILayout.TextField(name, (string)val);
+                    val = EditorGUILayout.TextField(variableName, (string)val);
                 }
                 else if (type.IsEnum)
                 {
-                    val = EditorGUILayout.EnumPopup(name, (Enum)val);
+                    val = EditorGUILayout.EnumPopup(variableName, (Enum)val);
                 }
                 else
                 {
@@ -150,11 +182,31 @@ namespace Unity.Netcode.Editor
             }
             else
             {
-                EditorGUILayout.LabelField(name, EditorStyles.wordWrappedLabel);
+                EditorGUILayout.LabelField(variableName, EditorStyles.wordWrappedLabel);
                 EditorGUILayout.SelectableLabel(val.ToString(), EditorStyles.wordWrappedLabel);
             }
+            GUILayout.Label(m_NetworkVariableLabelGuiContent, EditorStyles.miniLabel, GUILayout.Width(EditorStyles.miniLabel.CalcSize(m_NetworkVariableLabelGuiContent).x));
         }
 
+        private void RenderNetworkListValueType<T>(int index, NetworkList<T> networkList)
+            where T : unmanaged, IEquatable<T>
+        {
+            string variableName = m_NetworkVariableNames[index];
+
+            string value = "";
+            bool addComma = false;
+            foreach (var v in networkList)
+            {
+                if (addComma)
+                {
+                    value += ", ";
+                }
+                value += v.ToString();
+                addComma = true;
+            }
+            EditorGUILayout.LabelField(variableName, value);
+            GUILayout.Label(m_NetworkListLabelGuiContent, EditorStyles.miniLabel, GUILayout.Width(EditorStyles.miniLabel.CalcSize(m_NetworkListLabelGuiContent).x));
+        }
 
         /// <inheritdoc/>
         public override void OnInspectorGUI()


### PR DESCRIPTION
Showing the NetworkList too in the inspector, not just the NetworkVariables

#2356 

