### PR TITLE
chore: Update UTP to 1.3.1 (and improve performance)

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+- Updated `UnityTransport` dependency on `com.unity.transport` to 1.3.1.
 - `NetworkShow()` of `NetworkObject`s are delayed until the end of the frame to ensure consistency of delta-driven variables like `NetworkList`.
 - Dirty `NetworkObject` are reset at end-of-frame and not at serialization time.
 - `NetworkHide()` of an object that was just `NetworkShow()`n produces a warning, as remote clients will _not_ get a spawn/despawn pair.

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -6,6 +6,6 @@
     "unity": "2020.3",
     "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",
-        "com.unity.transport": "1.3.0"
+        "com.unity.transport": "1.3.1"
     }
 }

--- a/minimalproject/Packages/packages-lock.json
+++ b/minimalproject/Packages/packages-lock.json
@@ -39,7 +39,7 @@
       "source": "local",
       "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",
-        "com.unity.transport": "1.3.0"
+        "com.unity.transport": "1.3.1"
       }
     },
     "com.unity.nuget.mono-cecil": {
@@ -61,7 +61,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.transport": {
-      "version": "1.3.0",
+      "version": "1.3.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/testproject-tools-integration/Packages/packages-lock.json
+++ b/testproject-tools-integration/Packages/packages-lock.json
@@ -61,7 +61,7 @@
       "source": "local",
       "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",
-        "com.unity.transport": "1.3.0"
+        "com.unity.transport": "1.3.1"
       }
     },
     "com.unity.nuget.mono-cecil": {
@@ -107,7 +107,7 @@
       "url": "https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-candidates"
     },
     "com.unity.transport": {
-      "version": "1.3.0",
+      "version": "1.3.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/testproject/Packages/packages-lock.json
+++ b/testproject/Packages/packages-lock.json
@@ -87,7 +87,7 @@
       "source": "local",
       "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",
-        "com.unity.transport": "1.3.0"
+        "com.unity.transport": "1.3.1"
       }
     },
     "com.unity.nuget.mono-cecil": {
@@ -202,7 +202,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.transport": {
-      "version": "1.3.0",
+      "version": "1.3.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
This PR updates the UTP dependency to version 1.3.1. This version comes with a welcome change for NGO: it's possible to increase the reliable window size to 64. That is, it's now possible for a connection to have 64 reliable packets in flight, compared to 32 previously. Considering that NGO makes heavy use of reliable delivery, that should be a nice performance improvement (especially for larger scenes). Otherwise 1.3.1 only brings bug fixes.

## Changelog

- Changed: Updated `UnityTransport` dependency on `com.unity.transport` to 1.3.1.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.