### PR TITLE
fix: NetworkSceneManager clearing scene placed NetworkObjects list when ClientSynchronizationMode is additive

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -22,6 +22,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 - Fixed issue when the ClientSynchronizationMode is additive and the server changes the currently active scene prior to a client connecting then upon a client connecting and being synchronized the NetworkSceneManager would clear its internal ScenePlacedObjects list that could already be populated. (#2383)
+    - This removes the need to resync the whole scene when players disconnect and reconnect while still being in the same scene.
 - Fixed a UTP test that was failing when you install Unity Transport package 2.0.0 or newer. (#2347)
 - Fixed issue where `NetcodeSettingsProvider` would throw an exception in Unity 2020.3.x versions. (#2345)
 - Fixed server side issue where, depending upon component ordering, some NetworkBehaviour components might not have their OnNetworkDespawn method invoked if the client side disconnected. (#2323)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -20,6 +20,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed registry of public `NetworkVariable`s in derived `NetworkBehaviour`s (#2423)
 - Fixed issue when the `NetworkSceneManager.ClientSynchronizationMode` is `LoadSceneMode.Additive` and the server changes the currently active scene prior to a client connecting then upon a client connecting and being synchronized the NetworkSceneManager would clear its internal ScenePlacedObjects list that could already be populated. (#2383)
 - Fixed issue where a client would load duplicate scenes of already preloaded scenes during the initial client synchronization and `NetworkSceneManager.ClientSynchronizationMode` was set to `LoadSceneMode.Additive`. (#2383)
 
@@ -37,7 +38,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed registry of public `NetworkVariable`s in derived `NetworkBehaviour`s (#2423)
 - Fixed issue where changes to a layer's weight would not synchronize unless a state transition was occurring.(#2399)
 - Fixed issue where `NetworkManager.LocalClientId` was returning the `NetworkTransport.ServerClientId` as opposed to the `NetworkManager.m_LocalClientId`. (#2398)
 - Fixed issue where a dynamically spawned `NetworkObject` parented under an in-scene placed `NetworkObject` would have its `InScenePlaced` value changed to `true`. This would result in a soft synchronization error for late joining clients. (#2396)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -5,21 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
-## [Unreleased - Post v1.3.0]
+## [Unreleased]
+
 ### Added
-- Added `NetworkSceneManager.ActiveSceneSynchronizationEnabled` property, disabled by default, that will synchronize clients when the active scene is changed on the server side. (#2383)
+
+- Added `NetworkSceneManager.ActiveSceneSynchronizationEnabled` property, disabled by default, that enables client synchronization of server-side active scene changes. (#2383)
 - Added `NetworkObject.ActiveSceneSynchronization`, disabled by default, that will automatically migrate a `NetworkObject` to a newly assigned active scene. (#2383)
 - Added `NetworkObject.SceneMigrationSynchronization`, enabled by default, that will synchronize client(s) when a `NetworkObject` is migrated into a new scene on the server side via `SceneManager.MoveGameObjectToScene`. (#2383)
 
 ### Changed
+
 - Updated `NetworkSceneManager` to migrate dynamically spawned `NetworkObject`s with `DestroyWithScene` set to false into the active scene if their current scene is unloaded. (#2383)
 - Updated the server to synchronize its local `NetworkSceneManager.ClientSynchronizationMode` during the initial client synchronization. (#2383)
 
-### Fixed:
+### Fixed
+
 - Fixed issue when the `NetworkSceneManager.ClientSynchronizationMode` is `LoadSceneMode.Additive` and the server changes the currently active scene prior to a client connecting then upon a client connecting and being synchronized the NetworkSceneManager would clear its internal ScenePlacedObjects list that could already be populated. (#2383)
 - Fixed issue where a client would load duplicate scenes of already preloaded scenes during the initial client synchronization and `NetworkSceneManager.ClientSynchronizationMode` was set to `LoadSceneMode.Additive`. (#2383)
 
-## [Unreleased]
+## [1.3.0]
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -5,10 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
+## [Unreleased - Post v1.3.0]
+### Added
+- Added `NetworkSceneManager.ActiveSceneSynchronizationEnabled` property, disabled by default, that will synchronize clients when the active scene is changed on the server side via `SceneManager.MoveGameObjectToScene`. (#2383)
+- Added `NetworkObject.ActiveSceneSynchronization`, disabled by default, that will automatically migrate a `NetworkObject` to a newly assigned active scene. (#2383)
+- Added `NetworkObject.SceneMigrationSynchronization`, enabled by default, that will synchronize client(s) when a `NetworkObject` is migrated into a new scene. (#2383)
+
+### Changed
+- Updated `NetworkSceneManager` to migrate dynamically spawned `NetworkObject`s with `DestroyWithScene` set to false into the active scene if their current scene is unloaded. (#2383)
+- Updated the server to synchronize its local `NetworkSceneManager.ClientSynchronizationMode` during the initial client synchronization. (#2383)
+
+### Fixed:
+- Fixed issue when the `NetworkSceneManager.ClientSynchronizationMode` is `LoadSceneMode.Additive` and the server changes the currently active scene prior to a client connecting then upon a client connecting and being synchronized the NetworkSceneManager would clear its internal ScenePlacedObjects list that could already be populated. (#2383)
+- Fixed issue where a client would load duplicate scenes of already preloaded scenes during the initial client synchronization and `NetworkSceneManager.ClientSynchronizationMode` was set to `LoadSceneMode.Additive`. (#2383)
 
 ## [Unreleased]
-
-### Added
 
 ### Changed
 
@@ -25,8 +36,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed issue where changes to a layer's weight would not synchronize unless a state transition was occurring.(#2399)
 - Fixed issue where `NetworkManager.LocalClientId` was returning the `NetworkTransport.ServerClientId` as opposed to the `NetworkManager.m_LocalClientId`. (#2398)
 - Fixed issue where a dynamically spawned `NetworkObject` parented under an in-scene placed `NetworkObject` would have its `InScenePlaced` value changed to `true`. This would result in a soft synchronization error for late joining clients. (#2396)
-- Fixed issue when the ClientSynchronizationMode is additive and the server changes the currently active scene prior to a client connecting then upon a client connecting and being synchronized the NetworkSceneManager would clear its internal ScenePlacedObjects list that could already be populated. (#2383)
-    - This removes the need to resync the whole scene when players disconnect and reconnect while still being in the same scene.
 - Fixed a UTP test that was failing when you install Unity Transport package 2.0.0 or newer. (#2347)
 - Fixed issue where `NetcodeSettingsProvider` would throw an exception in Unity 2020.3.x versions. (#2345)
 - Fixed server side issue where, depending upon component ordering, some NetworkBehaviour components might not have their OnNetworkDespawn method invoked if the client side disconnected. (#2323)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -21,6 +21,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Network prefabs are now stored in a ScriptableObject that can be shared between NetworkManagers, and have been exposed for public access. By default, a Default Prefabs List is created that contains all NetworkObject prefabs in the project, and new NetworkManagers will default to using that unless that option is turned off in the Netcode for GameObjects settings. Existing NetworkManagers will maintain their existing lists, which can be migrated to the new format via a button in their inspector. (#2322)
 
 ### Fixed
+- Fixed issue when the ClientSynchronizationMode is additive and the server changes the currently active scene prior to a client connecting then upon a client connecting and being synchronized the NetworkSceneManager would clear its internal ScenePlacedObjects list that could already be populated. (#2383)
 - Fixed a UTP test that was failing when you install Unity Transport package 2.0.0 or newer. (#2347)
 - Fixed issue where `NetcodeSettingsProvider` would throw an exception in Unity 2020.3.x versions. (#2345)
 - Fixed server side issue where, depending upon component ordering, some NetworkBehaviour components might not have their OnNetworkDespawn method invoked if the client side disconnected. (#2323)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -7,9 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 ## [Unreleased - Post v1.3.0]
 ### Added
-- Added `NetworkSceneManager.ActiveSceneSynchronizationEnabled` property, disabled by default, that will synchronize clients when the active scene is changed on the server side via `SceneManager.MoveGameObjectToScene`. (#2383)
+- Added `NetworkSceneManager.ActiveSceneSynchronizationEnabled` property, disabled by default, that will synchronize clients when the active scene is changed on the server side. (#2383)
 - Added `NetworkObject.ActiveSceneSynchronization`, disabled by default, that will automatically migrate a `NetworkObject` to a newly assigned active scene. (#2383)
-- Added `NetworkObject.SceneMigrationSynchronization`, enabled by default, that will synchronize client(s) when a `NetworkObject` is migrated into a new scene. (#2383)
+- Added `NetworkObject.SceneMigrationSynchronization`, enabled by default, that will synchronize client(s) when a `NetworkObject` is migrated into a new scene on the server side via `SceneManager.MoveGameObjectToScene`. (#2383)
 
 ### Changed
 - Updated `NetworkSceneManager` to migrate dynamically spawned `NetworkObject`s with `DestroyWithScene` set to false into the active scene if their current scene is unloaded. (#2383)

--- a/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkPrefabs.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkPrefabs.cs
@@ -53,11 +53,22 @@ namespace Unity.Netcode
 
         ~NetworkPrefabs()
         {
+            Shutdown();
+        }
+
+        /// <summary>
+        /// Deregister from add and remove events
+        /// Clear the list
+        /// </summary>
+        internal void Shutdown()
+        {
             foreach (var list in NetworkPrefabsLists)
             {
                 list.OnAdd -= AddTriggeredByNetworkPrefabList;
                 list.OnRemove -= RemoveTriggeredByNetworkPrefabList;
             }
+
+            NetworkPrefabsLists.Clear();
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1277,6 +1277,8 @@ namespace Unity.Netcode
             m_StopProcessingMessages = false;
 
             ClearClients();
+            // This cleans up the internal prefabs list
+            NetworkConfig?.Prefabs.Shutdown();
         }
 
         /// <inheritdoc />

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1976,6 +1976,9 @@ namespace Unity.Netcode
                     var playerPrefabHash = response.PlayerPrefabHash ?? NetworkConfig.PlayerPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash;
 
                     // Generate a SceneObject for the player object to spawn
+                    // Note: This is only to create the local NetworkObject,
+                    // many of the serialized properties of the player prefab
+                    // will be set when instantiated.
                     var sceneObject = new NetworkObject.SceneObject
                     {
                         OwnerClientId = ownerClientId,

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1397,6 +1397,10 @@ namespace Unity.Netcode
 
             if (!m_ShuttingDown || !m_StopProcessingMessages)
             {
+                // This should be invoked just prior to the MessagingSystem
+                // processes its outbound queue.
+                SceneManager.CheckForAndSendNetworkObjectSceneChanged();
+
                 MessagingSystem.ProcessSendQueues();
                 NetworkMetrics.UpdateNetworkObjectsCount(SpawnManager.SpawnedObjects.Count);
                 NetworkMetrics.UpdateConnectionsCount((IsServer) ? ConnectedClients.Count : 1);

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1178,7 +1178,6 @@ namespace Unity.Netcode
 
                 var writeSize = 0;
                 writeSize += HasTransform ? FastBufferWriter.GetWriteSize<TransformData>() : 0;
-                //writeSize += IsSceneObject ? FastBufferWriter.GetWriteSize<int>() : 0;
                 writeSize += FastBufferWriter.GetWriteSize<int>();
 
                 if (!writer.TryBeginWrite(writeSize))
@@ -1191,14 +1190,8 @@ namespace Unity.Netcode
                     writer.WriteValue(Transform);
                 }
 
-                // In-Scene NetworkObjects are uniquely identified NetworkPrefabs defined by their
-                // NetworkSceneHandle and GlobalObjectIdHash. Client-side NetworkSceneManagers use
-                // this to locate their local instance of the in-scene placed NetworkObject instance.
-                // Only written for in-scene placed NetworkObjects.
-                //if (IsSceneObject)
-                //{
-                //    writer.WriteValue(OwnerObject.GetSceneOriginHandle());
-                //}
+                // The NetworkSceneHandle is the server-side relative
+                // scene handle that the NetworkObject resides in.
                 writer.WriteValue(OwnerObject.GetSceneOriginHandle());
 
                 // Synchronize NetworkVariables and NetworkBehaviours
@@ -1225,7 +1218,6 @@ namespace Unity.Netcode
 
                 var readSize = 0;
                 readSize += HasTransform ? FastBufferWriter.GetWriteSize<TransformData>() : 0;
-                //readSize += IsSceneObject ? FastBufferWriter.GetWriteSize<int>() : 0;
                 readSize += FastBufferWriter.GetWriteSize<int>();
 
                 // Try to begin reading the remaining bytes
@@ -1239,14 +1231,8 @@ namespace Unity.Netcode
                     reader.ReadValue(out Transform);
                 }
 
-                // In-Scene NetworkObjects are uniquely identified NetworkPrefabs defined by their
-                // NetworkSceneHandle and GlobalObjectIdHash. Client-side NetworkSceneManagers use
-                // this to locate their local instance of the in-scene placed NetworkObject instance.
-                // Only read for in-scene placed NetworkObjects
-                //if (IsSceneObject)
-                //{
-                //    reader.ReadValue(out NetworkSceneHandle);
-                //}
+                // The NetworkSceneHandle is the server-side relative
+                // scene handle that the NetworkObject resides in.
                 reader.ReadValue(out NetworkSceneHandle);
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -110,6 +110,9 @@ namespace Unity.Netcode
         /// </summary>
         public bool AutoSynchActiveScene;
 
+        /// <summary>
+        /// Notifies when a NetworkObject is migrated into a new scene
+        /// </summary>
         public Action MigratedToNewScene;
 
         /// <summary>
@@ -1130,6 +1133,12 @@ namespace Unity.Netcode
                 set => ByteUtility.SetBit(ref m_BitField, 5, value);
             }
 
+            /// <summary>
+            /// Even though the server sends notifications for NetworkObjects that get
+            /// destroyed when a scene is unloaded, we want to synchronize this so
+            /// the client side can use it as part of a filter for automatically migrating
+            /// to the current active scene when its scene is unloaded. (only for dynamically spawned)
+            /// </summary>
             public bool DestroyWithScene
             {
                 get => ByteUtility.GetBit(m_BitField, 6);

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -103,7 +103,7 @@ namespace Unity.Netcode
         /// <summary>
         /// Gets whether or not the object should be automatically removed when the scene is unloaded.
         /// </summary>
-        public bool DestroyWithScene = true;
+        public bool DestroyWithScene { get; set; }
 
         /// <summary>
         /// When set to true, this will automatically migrate the NetworkObject to a newly assigned active scene

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1492,7 +1492,7 @@ namespace Unity.Netcode
             networkObject.SynchronizeNetworkBehaviours(ref bufferSerializer, networkManager.LocalClientId);
 
             // Spawn the NetworkObject
-            networkManager.SpawnManager.SpawnNetworkObjectLocally(networkObject, sceneObject, false);
+            networkManager.SpawnManager.SpawnNetworkObjectLocally(networkObject, sceneObject, sceneObject.DestroyWithScene);
 
             return networkObject;
         }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/DefaultSceneManagerHandler.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/DefaultSceneManagerHandler.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+
+namespace Unity.Netcode
+{
+    /// <summary>
+    ///  The default SceneManagerHandler that interfaces between the SceneManager and NetworkSceneManager
+    /// </summary>
+    internal class DefaultSceneManagerHandler : ISceneManagerHandler
+    {
+        private Scene m_InvalidScene = new Scene();
+
+        internal struct SceneEntry
+        {
+            public bool IsAssigned;
+            public Scene Scene;
+        }
+
+        internal Dictionary<string, Dictionary<int, SceneEntry>> SceneNameToSceneHandles = new Dictionary<string, Dictionary<int, SceneEntry>>();
+
+        public AsyncOperation LoadSceneAsync(string sceneName, LoadSceneMode loadSceneMode, SceneEventProgress sceneEventProgress)
+        {
+            var operation = SceneManager.LoadSceneAsync(sceneName, loadSceneMode);
+            sceneEventProgress.SetAsyncOperation(operation);
+            return operation;
+        }
+
+        public AsyncOperation UnloadSceneAsync(Scene scene, SceneEventProgress sceneEventProgress)
+        {
+            var operation = SceneManager.UnloadSceneAsync(scene);
+            sceneEventProgress.SetAsyncOperation(operation);
+            return operation;
+        }
+
+        /// <summary>
+        /// Resets scene tracking
+        /// </summary>
+        public void ClearSceneTracking(NetworkManager networkManager)
+        {
+            SceneNameToSceneHandles.Clear();
+        }
+
+        /// <summary>
+        /// Stops tracking a specific scene
+        /// </summary>
+        public void StopTrackingScene(int handle, string name, NetworkManager networkManager)
+        {
+            if (SceneNameToSceneHandles.ContainsKey(name))
+            {
+                if (SceneNameToSceneHandles[name].ContainsKey(handle))
+                {
+                    SceneNameToSceneHandles[name].Remove(handle);
+                    if (SceneNameToSceneHandles[name].Count == 0)
+                    {
+                        SceneNameToSceneHandles.Remove(name);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Starts tracking a specific scene
+        /// </summary>
+        public void StartTrackingScene(Scene scene, bool assigned, NetworkManager networkManager)
+        {
+            if (!SceneNameToSceneHandles.ContainsKey(scene.name))
+            {
+                SceneNameToSceneHandles.Add(scene.name, new Dictionary<int, SceneEntry>());
+            }
+
+            if (!SceneNameToSceneHandles[scene.name].ContainsKey(scene.handle))
+            {
+                var sceneEntry = new SceneEntry()
+                {
+                    IsAssigned = true,
+                    Scene = scene
+                };
+                SceneNameToSceneHandles[scene.name].Add(scene.handle, sceneEntry);
+            }
+            else
+            {
+                throw new Exception($"[Duplicate Handle] Scene {scene.name} already has scene handle {scene.handle} registered!");
+            }
+        }
+
+        /// <summary>
+        /// Determines if there is an existing scene loaded that matches the scene name but has not been assigned
+        /// </summary>
+        public bool DoesSceneHaveUnassignedEntry(string sceneName, NetworkManager networkManager)
+        {
+            if (SceneNameToSceneHandles.ContainsKey(sceneName))
+            {
+                foreach (var sceneHandleEntry in SceneNameToSceneHandles[sceneName])
+                {
+                    if (!sceneHandleEntry.Value.IsAssigned)
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// This will find any scene entry that hasn't been used/assigned, set the entry to assigned, and
+        /// return the associated scene. If none are found it returns an invalid scene.
+        /// </summary>
+        public Scene GetSceneFromLoadedScenes(string sceneName, NetworkManager networkManager)
+        {
+            if (SceneNameToSceneHandles.ContainsKey(sceneName))
+            {
+                foreach (var sceneHandleEntry in SceneNameToSceneHandles[sceneName])
+                {
+                    if (!sceneHandleEntry.Value.IsAssigned)
+                    {
+                        var sceneEntry = sceneHandleEntry.Value;
+                        sceneEntry.IsAssigned = true;
+                        SceneNameToSceneHandles[sceneName][sceneHandleEntry.Key] = sceneEntry;
+                        return sceneEntry.Scene;
+                    }
+                }
+            }
+            // If we found nothing return an invalid scene
+            return m_InvalidScene;
+        }
+
+        /// <summary>
+        /// Only invoked is client synchronization is additive, this will generate the scene tracking table
+        /// in order to re-use the same scenes the server is synchronizing instead of having to unload the
+        /// scenes and reload them when synchronizing (i.e. client disconnects due to external reason, the
+        /// same application instance is still running, the same scenes are still loaded on the client, and
+        /// upon reconnecting the client doesn't have to unload the scenes and then reload them)
+        /// </summary>
+        public void PopulateLoadedScenes(ref Dictionary<int, Scene> scenesLoaded, NetworkManager networkManager)
+        {
+            SceneNameToSceneHandles.Clear();
+            var sceneCount = SceneManager.sceneCount;
+            for (int i = 0; i < sceneCount; i++)
+            {
+                var scene = SceneManager.GetSceneAt(i);
+                if (!SceneNameToSceneHandles.ContainsKey(scene.name))
+                {
+                    SceneNameToSceneHandles.Add(scene.name, new Dictionary<int, SceneEntry>());
+                }
+
+                if (!SceneNameToSceneHandles[scene.name].ContainsKey(scene.handle))
+                {
+                    var sceneEntry = new SceneEntry()
+                    {
+                        IsAssigned = false,
+                        Scene = scene
+                    };
+                    SceneNameToSceneHandles[scene.name].Add(scene.handle, sceneEntry);
+                    if (!scenesLoaded.ContainsKey(scene.handle))
+                    {
+                        scenesLoaded.Add(scene.handle, scene);
+                    }
+                }
+                else
+                {
+                    throw new Exception($"[Duplicate Handle] Scene {scene.name} already has scene handle {scene.handle} registered!");
+                }
+            }
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/DefaultSceneManagerHandler.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/DefaultSceneManagerHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c18076bb9734cf4ea7297f85b7729be
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs
@@ -26,5 +26,7 @@ namespace Unity.Netcode
         void ClearSceneTracking(NetworkManager networkManager = null);
 
         void UnloadUnassignedScenes(NetworkManager networkManager = null);
+
+        void MoveObjectsFromSceneToDontDestroyOnLoad(ref NetworkManager networkManager, Scene scene);
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs
@@ -24,5 +24,7 @@ namespace Unity.Netcode
         void StartTrackingScene(Scene scene, bool assigned, NetworkManager networkManager = null);
 
         void ClearSceneTracking(NetworkManager networkManager = null);
+
+        void UnloadUnassignedScenes(NetworkManager networkManager = null);
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs
@@ -28,5 +28,7 @@ namespace Unity.Netcode
         void UnloadUnassignedScenes(NetworkManager networkManager = null);
 
         void MoveObjectsFromSceneToDontDestroyOnLoad(ref NetworkManager networkManager, Scene scene);
+
+        void SetClientSynchronizationMode(ref NetworkManager networkManager, LoadSceneMode mode);
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs
@@ -30,5 +30,7 @@ namespace Unity.Netcode
         void MoveObjectsFromSceneToDontDestroyOnLoad(ref NetworkManager networkManager, Scene scene);
 
         void SetClientSynchronizationMode(ref NetworkManager networkManager, LoadSceneMode mode);
+
+        bool ClientShouldPassThrough(string sceneName, bool isPrimaryScene, LoadSceneMode clientSynchronizationMode, NetworkManager networkManager);
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -12,5 +13,16 @@ namespace Unity.Netcode
         AsyncOperation LoadSceneAsync(string sceneName, LoadSceneMode loadSceneMode, SceneEventProgress sceneEventProgress);
 
         AsyncOperation UnloadSceneAsync(Scene scene, SceneEventProgress sceneEventProgress);
+
+        void PopulateLoadedScenes(ref Dictionary<int, Scene> scenesLoaded, NetworkManager networkManager = null);
+        Scene GetSceneFromLoadedScenes(string sceneName, NetworkManager networkManager = null);
+
+        bool DoesSceneHaveUnassignedEntry(string sceneName, NetworkManager networkManager = null);
+
+        void StopTrackingScene(int handle, string name, NetworkManager networkManager = null);
+
+        void StartTrackingScene(Scene scene, bool assigned, NetworkManager networkManager = null);
+
+        void ClearSceneTracking(NetworkManager networkManager = null);
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -345,11 +345,11 @@ namespace Unity.Netcode
                     m_ActiveSceneSynchronizationEnabled = value;
                     if (m_ActiveSceneSynchronizationEnabled)
                     {
-                        SceneManager.activeSceneChanged += SceneManager_activeSceneChanged;
+                        SceneManager.activeSceneChanged += SceneManager_ActiveSceneChanged;
                     }
                     else
                     {
-                        SceneManager.activeSceneChanged -= SceneManager_activeSceneChanged;
+                        SceneManager.activeSceneChanged -= SceneManager_ActiveSceneChanged;
                     }
                 }
             }
@@ -690,7 +690,7 @@ namespace Unity.Netcode
         /// <summary>
         /// Synchronizes clients when the currently active scene is changed
         /// </summary>
-        private void SceneManager_activeSceneChanged(Scene current, Scene next)
+        private void SceneManager_ActiveSceneChanged(Scene current, Scene next)
         {
             // If no clients are connected, then don't worry about notifications
             if (!(m_NetworkManager.ConnectedClientsIds.Count > (m_NetworkManager.IsHost ? 1 : 0)))

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -518,8 +518,9 @@ namespace Unity.Netcode
         /// </summary>
         public void Dispose()
         {
+            // Always assure we no longer listen to scene changes when disposed.
+            SceneManager.activeSceneChanged -= SceneManager_ActiveSceneChanged;
             SceneUnloadEventHandler.Shutdown();
-
             foreach (var keypair in SceneEventDataStore)
             {
                 if (NetworkLog.CurrentLogLevel == LogLevel.Developer)

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1778,6 +1778,8 @@ namespace Unity.Netcode
 
                             OnSynchronizeComplete?.Invoke(m_NetworkManager.LocalClientId);
 
+                            SceneManagerHandler.UnloadUnassignedScenes(m_NetworkManager);
+
                             EndSceneEvent(sceneEventId);
                         }
                         break;

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1865,14 +1865,14 @@ namespace Unity.Netcode
             HandleClientSceneEvent(sceneEventId);
         }
 
-        private void MigrateNetworkObjectsToTheirProperScenes()
+        private void MigrateNetworkObjectsToAssignedScene()
         {
             foreach (var networkObject in m_NetworkManager.SpawnManager.SpawnedObjectsList)
             {
                 // This is only done for dynamically spawned NetworkObjects
                 // Theoretically, a server could have NetworkObjects in a server-side only scene, if the client doesn't have that scene loaded
                 // then skip it.
-                if (networkObject.IsSceneObject != false && ServerSceneHandleToClientSceneHandle.ContainsKey(networkObject.NetworkSceneHandle))
+                if (networkObject.IsSceneObject.Value == false && ServerSceneHandleToClientSceneHandle.ContainsKey(networkObject.NetworkSceneHandle))
                 {
                     networkObject.SceneOriginHandle = ServerSceneHandleToClientSceneHandle[networkObject.NetworkSceneHandle];
 
@@ -1882,16 +1882,6 @@ namespace Unity.Netcode
                     {
                         var scene = HandleToScene[networkObject.SceneOriginHandle];
                         SceneManager.MoveGameObjectToScene(networkObject.gameObject, scene);
-
-                        //for (int i = 0; i < SceneManager.sceneCount; i++)
-                        //{
-                        //    var scene = SceneManager.GetSceneAt(i);
-                        //    if (networkObject.SceneOriginHandle == scene.handle)
-                        //    {
-                        //        SceneManager.MoveGameObjectToScene(networkObject.gameObject, scene);
-                        //        break;
-                        //    }
-                        //}
                     }
                 }
             }
@@ -1953,7 +1943,7 @@ namespace Unity.Netcode
                             }
 
                             // Now migrate any dynamically spawned NetworkObjects that are not in the same scene as on the server side
-                            MigrateNetworkObjectsToTheirProperScenes();
+                            MigrateNetworkObjectsToAssignedScene();
 
                             sceneEventData.SceneEventType = SceneEventType.SynchronizeComplete;
                             SendSceneEventData(sceneEventId, new ulong[] { NetworkManager.ServerClientId });

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1622,7 +1622,12 @@ namespace Unity.Netcode
                 OnSynchronize?.Invoke(m_NetworkManager.LocalClientId);
 
                 // Clear the in-scene placed NetworkObjects when we load the first scene in our synchronization process
-                ScenePlacedObjects.Clear();
+                // But only clear the in-scene placed NetworkObjects if we are loading in Single mode, otherwise we could
+                // already have scene placed objects populated
+                if (loadSceneMode == LoadSceneMode.Single)
+                {
+                    ScenePlacedObjects.Clear();
+                }
             }
 
             // Always check to see if the scene needs to be validated

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -2205,13 +2205,13 @@ namespace Unity.Netcode
             var localSpawnedObjectsHashSet = new HashSet<NetworkObject>(m_NetworkManager.SpawnManager.SpawnedObjectsList);
             foreach (var networkObject in localSpawnedObjectsHashSet)
             {
-                if (networkObject == null)
+                if (networkObject == null || (networkObject != null && networkObject.gameObject.scene == DontDestroyOnLoadScene))
                 {
                     continue;
                 }
 
-                // Only NetworkObjects marked to not be destroyed with the scene and are not already in the DDOL
-                if (!networkObject.DestroyWithScene && networkObject.gameObject.scene != DontDestroyOnLoadScene)
+                // Only NetworkObjects marked to not be destroyed with the scene
+                if (!networkObject.DestroyWithScene)
                 {
                     // Only move dynamically spawned NetworkObjects with no parent as the children will follow
                     if (networkObject.gameObject.transform.parent == null && networkObject.IsSceneObject != null && !networkObject.IsSceneObject.Value)

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
@@ -139,6 +139,8 @@ namespace Unity.Netcode
         internal Queue<uint> ScenesToSynchronize;
         internal Queue<uint> SceneHandlesToSynchronize;
 
+        internal LoadSceneMode ClientSynchronizationMode;
+
 
         /// <summary>
         /// Server Side:
@@ -392,6 +394,10 @@ namespace Unity.Netcode
             {
                 writer.WriteValueSafe(SceneEventProgressId);
             }
+            else
+            {
+                writer.WriteValueSafe(ClientSynchronizationMode);
+            }
 
             // Write the scene index and handle
             writer.WriteValueSafe(SceneHash);
@@ -542,6 +548,10 @@ namespace Unity.Netcode
             if (SceneEventType != SceneEventType.Synchronize)
             {
                 reader.ReadValueSafe(out SceneEventProgressId);
+            }
+            else
+            {
+                reader.ReadValueSafe(out ClientSynchronizationMode);
             }
 
             reader.ReadValueSafe(out SceneHash);

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -408,26 +408,6 @@ namespace Unity.Netcode
                 networkObject.DestroyWithScene = sceneObject.DestroyWithScene;
                 networkObject.NetworkSceneHandle = sceneObject.NetworkSceneHandle;
 
-                // For dynamically spawned NetworkObjects, check to make sure it is in the right scene and if not migrate it to the right scene
-                if (!sceneObject.IsSceneObject && NetworkManager.SceneManager.ServerSceneHandleToClientSceneHandle.ContainsKey(networkObject.NetworkSceneHandle))
-                {
-                    networkObject.SceneOriginHandle = NetworkManager.SceneManager.ServerSceneHandleToClientSceneHandle[networkObject.NetworkSceneHandle];
-
-                    // If the NetworkObject is not in the scene it should be in, then find the right scene and migrate it to that scene
-                    if (networkObject.gameObject.scene.handle != networkObject.SceneOriginHandle && networkObject.transform.parent == null)
-                    {
-                        for (int i = 0; i < UnityEngine.SceneManagement.SceneManager.sceneCount; i++)
-                        {
-                            var scene = UnityEngine.SceneManagement.SceneManager.GetSceneAt(i);
-                            if (networkObject.SceneOriginHandle == scene.handle)
-                            {
-                                UnityEngine.SceneManagement.SceneManager.MoveGameObjectToScene(networkObject.gameObject, scene);
-                                break;
-                            }
-                        }
-                    }
-                }
-
                 // SPECIAL CASE FOR IN-SCENE PLACED:  (only when the parent has a NetworkObject)
                 // This is a special case scenario where a late joining client has joined and loaded one or
                 // more scenes that contain nested in-scene placed NetworkObject children yet the server's

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
@@ -427,13 +427,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 };
                 SceneNameToSceneHandles[networkManager][scene.name].Add(scene.handle, sceneEntry);
             }
-            //else
-            //{
-            //    if (exceptionOnExisting)
-            //    {
-            //        throw new Exception($"[{networkManager.LocalClient.PlayerObject.name}][Duplicate Handle] Scene {scene.name} already has scene handle {scene.handle} registered!");
-            //    }
-            //}
         }
 
         private bool DoesANetworkManagerHoldThisScene(Scene scene)

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -692,6 +692,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         [UnityTearDown]
         public IEnumerator TearDown()
         {
+            IntegrationTestSceneHandler.SceneNameToSceneHandles.Clear();
             VerboseDebug($"Entering {nameof(TearDown)}");
             yield return OnTearDown();
 

--- a/testproject/Assets/Scripts/ConnectionModeScript.cs
+++ b/testproject/Assets/Scripts/ConnectionModeScript.cs
@@ -154,7 +154,7 @@ public class ConnectionModeScript : MonoBehaviour
         NetworkManager.Singleton.StartServer();
         NetworkManager.Singleton.SceneManager.SetClientSynchronizationMode(m_ClientSynchronizationMode);
         OnNotifyConnectionEventServer?.Invoke();
-        m_ConnectionModeButtons.SetActive(false);
+        m_ConnectionModeButtons?.SetActive(false);
     }
 
 
@@ -240,7 +240,10 @@ public class ConnectionModeScript : MonoBehaviour
         NetworkManager.Singleton.StartClient();
         OnNotifyConnectionEventClient?.Invoke();
         m_ConnectionModeButtons.SetActive(false);
-        m_DisconnectClientButton.SetActive(true);
+        if (m_DisconnectClientButton != null)
+        {
+            m_DisconnectClientButton.SetActive(true);
+        }
     }
 
     public void DisconnectClient()

--- a/testproject/Assets/Tests/Manual/IntegrationTestScenes/EmptyScene1.unity
+++ b/testproject/Assets/Tests/Manual/IntegrationTestScenes/EmptyScene1.unity
@@ -1,0 +1,125 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.37311953, g: 0.38074014, b: 0.3587274, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}

--- a/testproject/Assets/Tests/Manual/IntegrationTestScenes/EmptyScene1.unity.meta
+++ b/testproject/Assets/Tests/Manual/IntegrationTestScenes/EmptyScene1.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 057ba2cc37faa0b43aa7051d9f555caa
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/testproject/Assets/Tests/Manual/IntegrationTestScenes/EmptyScene2.unity
+++ b/testproject/Assets/Tests/Manual/IntegrationTestScenes/EmptyScene2.unity
@@ -1,0 +1,125 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.37311953, g: 0.38074014, b: 0.3587274, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}

--- a/testproject/Assets/Tests/Manual/IntegrationTestScenes/EmptyScene2.unity.meta
+++ b/testproject/Assets/Tests/Manual/IntegrationTestScenes/EmptyScene2.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 17b92153f7381d34fa48c4d5c0393d13
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/testproject/Assets/Tests/Manual/IntegrationTestScenes/EmptyScene3.unity
+++ b/testproject/Assets/Tests/Manual/IntegrationTestScenes/EmptyScene3.unity
@@ -1,0 +1,125 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.37311953, g: 0.38074014, b: 0.3587274, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}

--- a/testproject/Assets/Tests/Manual/IntegrationTestScenes/EmptyScene3.unity.meta
+++ b/testproject/Assets/Tests/Manual/IntegrationTestScenes/EmptyScene3.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: abd4c8b51c445d54faa16c67ac973f1b
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/testproject/Assets/Tests/Manual/SceneTransitioning/SceneTransitioningTest.unity
+++ b/testproject/Assets/Tests/Manual/SceneTransitioning/SceneTransitioningTest.unity
@@ -178,7 +178,7 @@ MonoBehaviour:
   m_SceneToSwitchTo: SecondSceneToLoad
   m_EnableAutoSwitch: 1
   m_AutoSwitchTimeOut: 300
-  DisconnectClientUponLoadScene: 1
+  DisconnectClientUponLoadScene: 0
 --- !u!114 &34066668
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -193,6 +193,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   GlobalObjectIdHash: 3270232563
   AlwaysReplicateAsRoot: 0
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 1
   DontDestroyWithOwner: 0
   AutoObjectParentSync: 1
 --- !u!1 &37242881
@@ -984,6 +986,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   GlobalObjectIdHash: 2831848344
   AlwaysReplicateAsRoot: 0
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 1
   DontDestroyWithOwner: 0
   AutoObjectParentSync: 1
 --- !u!4 &797949416
@@ -1102,7 +1106,24 @@ MonoBehaviour:
     NetworkTransport: {fileID: 1024114719}
     PlayerPrefab: {fileID: 4079352819444256614, guid: c16f03336b6104576a565ef79ad643c0,
       type: 3}
-    NetworkPrefabs:
+    Prefabs:
+      NetworkPrefabsLists: []
+    TickRate: 30
+    ClientConnectionBufferTimeout: 10
+    ConnectionApproval: 0
+    ConnectionData: 
+    EnableTimeResync: 0
+    TimeResyncInterval: 30
+    EnsureNetworkVariableLengthSafety: 0
+    EnableSceneManagement: 1
+    ForceSamePrefabs: 1
+    RecycleNetworkIds: 1
+    NetworkIdRecycleDelay: 120
+    RpcHashSize: 0
+    LoadSceneTimeOut: 120
+    SpawnTimeout: 1
+    EnableNetworkLogs: 1
+    OldPrefabList:
     - Override: 1
       Prefab: {fileID: 771575417923360811, guid: c0a45bdb516f341498d933b7a7ed4fc1,
         type: 3}
@@ -1129,21 +1150,6 @@ MonoBehaviour:
       SourcePrefabToOverride: {fileID: 0}
       SourceHashToOverride: 0
       OverridingTargetPrefab: {fileID: 0}
-    TickRate: 30
-    ClientConnectionBufferTimeout: 10
-    ConnectionApproval: 0
-    ConnectionData: 
-    EnableTimeResync: 0
-    TimeResyncInterval: 30
-    EnsureNetworkVariableLengthSafety: 0
-    EnableSceneManagement: 1
-    ForceSamePrefabs: 1
-    RecycleNetworkIds: 1
-    NetworkIdRecycleDelay: 120
-    RpcHashSize: 0
-    LoadSceneTimeOut: 120
-    SpawnTimeout: 1
-    EnableNetworkLogs: 1
 --- !u!114 &1024114719
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1277,6 +1283,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   GlobalObjectIdHash: 2782806529
   AlwaysReplicateAsRoot: 0
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 1
   DontDestroyWithOwner: 0
   AutoObjectParentSync: 1
 --- !u!1 &1332123091
@@ -1979,6 +1987,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
   m_HorizontalAxis: Horizontal
   m_VerticalAxis: Vertical
   m_SubmitButton: Submit
@@ -2679,7 +2688,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_ClientServerToggle: {fileID: 1588117327}
   m_TrackSceneEvents: 1
-  m_LogSceneEventsToConsole: 1
 --- !u!114 &2107482023
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2694,6 +2702,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   GlobalObjectIdHash: 2267100048
   AlwaysReplicateAsRoot: 0
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 1
   DontDestroyWithOwner: 0
   AutoObjectParentSync: 1
 --- !u!1001 &2848221156282925290

--- a/testproject/Assets/Tests/Manual/SceneTransitioning/SecondSceneToLoad.unity
+++ b/testproject/Assets/Tests/Manual/SceneTransitioning/SecondSceneToLoad.unity
@@ -1031,6 +1031,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   GlobalObjectIdHash: 2807568818
   AlwaysReplicateAsRoot: 0
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 1
   DontDestroyWithOwner: 0
   AutoObjectParentSync: 1
 --- !u!1 &1332123091
@@ -1465,6 +1467,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
   m_HorizontalAxis: Horizontal
   m_VerticalAxis: Vertical
   m_SubmitButton: Submit
@@ -1950,6 +1953,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2051885573}
   - component: {fileID: 2051885574}
+  - component: {fileID: 2051885575}
   m_Layer: 5
   m_Name: SwitchSceneParent
   m_TagString: Untagged
@@ -1995,6 +1999,24 @@ MonoBehaviour:
   m_EnableAutoSwitch: 1
   m_AutoSwitchTimeOut: 300
   DisconnectClientUponLoadScene: 0
+--- !u!114 &2051885575
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2051885572}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 3071296511
+  AlwaysReplicateAsRoot: 0
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 1
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1
 --- !u!1 &2058276875
 GameObject:
   m_ObjectHideFlags: 0
@@ -2146,7 +2168,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_ClientServerToggle: {fileID: 2126410740}
   m_TrackSceneEvents: 1
-  m_LogSceneEventsToConsole: 0
 --- !u!114 &2107482023
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2161,6 +2182,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   GlobalObjectIdHash: 4086995543
   AlwaysReplicateAsRoot: 0
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 1
   DontDestroyWithOwner: 0
   AutoObjectParentSync: 1
 --- !u!1 &2126410740

--- a/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/SceneTransitioningBase1.unity
+++ b/testproject/Assets/Tests/Manual/SceneTransitioningAdditive/SceneTransitioningBase1.unity
@@ -186,6 +186,7 @@ GameObject:
   m_Component:
   - component: {fileID: 34066665}
   - component: {fileID: 34066667}
+  - component: {fileID: 34066668}
   m_Layer: 5
   m_Name: SwitchSceneParent
   m_TagString: Untagged
@@ -231,6 +232,22 @@ MonoBehaviour:
   m_EnableAutoSwitch: 0
   m_AutoSwitchTimeOut: 60
   DisconnectClientUponLoadScene: 0
+--- !u!114 &34066668
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 34066664}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 412081913
+  AlwaysReplicateAsRoot: 0
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1
 --- !u!1 &37242881
 GameObject:
   m_ObjectHideFlags: 0
@@ -638,6 +655,43 @@ MonoBehaviour:
   m_ActivateOnLoad: 0
   m_SceneToLoad: AdditiveSceneMultiInstance
   m_SceneAsset: {fileID: 102900000, guid: 0ae94f636016d3b40bfbecad57d99553, type: 3}
+--- !u!1 &97319464
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 97319465}
+  m_Layer: 5
+  m_Name: DisconnectClientRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &97319465
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 97319464}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1259474592}
+  m_Father: {fileID: 167044834}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 300, y: 51}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &125866602
 GameObject:
   m_ObjectHideFlags: 0
@@ -843,12 +897,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
+  m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
+  m_ReferenceResolution: {x: 1024, y: 768}
   m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
+  m_MatchWidthOrHeight: 0.5
   m_PhysicalUnit: 3
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
@@ -888,6 +942,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1865409449}
+  - {fileID: 97319465}
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1510,6 +1565,86 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 432733928}
+  m_CullTransparentMesh: 1
+--- !u!1 &462643752
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 462643753}
+  - component: {fileID: 462643755}
+  - component: {fileID: 462643754}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &462643753
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 462643752}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1259474592}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &462643754
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 462643752}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.5058824, b: 0.003921569, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Disconnect Client
+--- !u!222 &462643755
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 462643752}
   m_CullTransparentMesh: 1
 --- !u!1 &562991978
 GameObject:
@@ -2349,7 +2484,24 @@ MonoBehaviour:
     NetworkTransport: {fileID: 1024114723}
     PlayerPrefab: {fileID: 4079352819444256614, guid: c16f03336b6104576a565ef79ad643c0,
       type: 3}
-    NetworkPrefabs:
+    Prefabs:
+      NetworkPrefabsLists: []
+    TickRate: 32
+    ClientConnectionBufferTimeout: 10
+    ConnectionApproval: 0
+    ConnectionData: 
+    EnableTimeResync: 0
+    TimeResyncInterval: 30
+    EnsureNetworkVariableLengthSafety: 0
+    EnableSceneManagement: 1
+    ForceSamePrefabs: 1
+    RecycleNetworkIds: 0
+    NetworkIdRecycleDelay: 120
+    RpcHashSize: 0
+    LoadSceneTimeOut: 120
+    SpawnTimeout: 1
+    EnableNetworkLogs: 1
+    OldPrefabList:
     - Override: 0
       Prefab: {fileID: 771575417923360811, guid: c0a45bdb516f341498d933b7a7ed4fc1,
         type: 3}
@@ -2400,21 +2552,6 @@ MonoBehaviour:
       SourcePrefabToOverride: {fileID: 0}
       SourceHashToOverride: 0
       OverridingTargetPrefab: {fileID: 0}
-    TickRate: 32
-    ClientConnectionBufferTimeout: 10
-    ConnectionApproval: 0
-    ConnectionData: 
-    EnableTimeResync: 0
-    TimeResyncInterval: 30
-    EnsureNetworkVariableLengthSafety: 0
-    EnableSceneManagement: 1
-    ForceSamePrefabs: 1
-    RecycleNetworkIds: 0
-    NetworkIdRecycleDelay: 120
-    RpcHashSize: 0
-    LoadSceneTimeOut: 120
-    SpawnTimeout: 1
-    EnableNetworkLogs: 1
 --- !u!4 &1024114720
 Transform:
   m_ObjectHideFlags: 0
@@ -2690,6 +2827,140 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1210784441}
+  m_CullTransparentMesh: 1
+--- !u!1 &1259474591
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1259474592}
+  - component: {fileID: 1259474595}
+  - component: {fileID: 1259474594}
+  - component: {fileID: 1259474593}
+  m_Layer: 5
+  m_Name: DisconnectClient
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1259474592
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1259474591}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 462643753}
+  m_Father: {fileID: 97319465}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1259474593
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1259474591}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1259474594}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1865409450}
+        m_TargetAssemblyTypeName: ConnectionModeScript, TestProject
+        m_MethodName: DisconnectClient
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1259474594
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1259474591}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.1981132, g: 0.1981132, b: 0.1981132, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1259474595
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1259474591}
   m_CullTransparentMesh: 1
 --- !u!1 &1290928582
 GameObject:
@@ -4234,6 +4505,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
   m_HorizontalAxis: Horizontal
   m_VerticalAxis: Vertical
   m_SubmitButton: Submit
@@ -4455,6 +4727,16 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 167044834}
     m_Modifications:
+    - target: {fileID: 4850072633501053442, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_DisconnectClientButton
+      value: 
+      objectReference: {fileID: 97319464}
+    - target: {fileID: 4850072633501053442, guid: d725b5588e1b956458798319e6541d84,
+        type: 3}
+      propertyPath: m_ClientSynchronizationMode
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6633621479308595792, guid: d725b5588e1b956458798319e6541d84,
         type: 3}
       propertyPath: m_Pivot.x
@@ -4573,6 +4855,18 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1865409448}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1865409450 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4850072633501053442, guid: d725b5588e1b956458798319e6541d84,
+    type: 3}
+  m_PrefabInstance: {fileID: 1865409448}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 50623966c8d88ab40982cc2b0e4c2d2e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1889006546
 GameObject:
   m_ObjectHideFlags: 0

--- a/testproject/Assets/Tests/Manual/Scripts/NetworkPrefabPool.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/NetworkPrefabPool.cs
@@ -56,9 +56,12 @@ namespace TestProject.ManualTests
                 if (s_Instance != null && s_Instance != this)
                 {
                     var instancePool = s_Instance.GetComponent<NetworkPrefabPool>();
-                    instancePool.MoveBackToCurrentlyActiveScene();
-                    m_ObjectPool = new List<GameObject>(instancePool.m_ObjectPool);
-                    instancePool.m_ObjectPool.Clear();
+                    if (instancePool.m_ObjectPool != null)
+                    {
+                        instancePool.MoveBackToCurrentlyActiveScene();
+                        instancePool.m_ObjectPool.Clear();
+                        m_ObjectPool = new List<GameObject>(instancePool.m_ObjectPool);
+                    }
                     Destroy(s_Instance);
                     s_Instance = null;
                 }

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/ClientSynchronizationModeTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/ClientSynchronizationModeTests.cs
@@ -1,0 +1,283 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+using Unity.Netcode;
+using Unity.Netcode.TestHelpers.Runtime;
+
+namespace TestProject.RuntimeTests
+{
+    /// <summary>
+    /// Validates that <see cref="NetworkSceneManager.ClientSynchronizationMode"/> set to <see cref="LoadSceneMode.Additive"/>
+    /// Will synchronize clients properly when scenes are preloaded and when the server changes the currently active scene
+    /// prior to a client joining.
+    /// </summary>
+    /// <remarks>
+    /// Note: If a client does not preload a scene prior to the server setting it as the active scene then the client(s) and the
+    /// server will end up sharing the same scene. More info: <see cref="IntegrationTestSceneHandler.GetSceneFromLoadedScenes"/>
+    /// </remarks>
+    [TestFixture(ServerPreloadStates.NoPreloadOnServer)]
+    [TestFixture(ServerPreloadStates.PreloadOnServer)]
+    public class ClientSynchronizationModeTests : NetcodeIntegrationTest
+    {
+        // Two scenes with different in-scene placed NetworkObjects and one empty scene used to test active scene switching and client synchronization.
+        private List<string> m_TestScenes = new List<string>() { "InSceneNetworkObject", "GenericInScenePlacedObject", "EmptyScene1" };
+
+        protected override int NumberOfClients => 0;
+
+        public enum ServerPreloadStates
+        {
+            PreloadOnServer,
+            NoPreloadOnServer
+        }
+
+        public enum ClientPreloadStates
+        {
+            PreloadOnClient,
+            NoPreloadOnClient
+        }
+
+        public enum ActiveSceneStates
+        {
+            DefaultActiveScene,
+            SwitchActiveScene,
+        }
+
+        private ServerPreloadStates m_ServerPreloadState;
+        private List<Scene> m_ServerLoadedScenes = new List<Scene>();
+        private List<Scene> m_TempClientPreLoadedScenes = new List<Scene>();
+
+        private Dictionary<ulong, List<Scene>> m_ClientScenesLoaded = new Dictionary<ulong, List<Scene>>();
+
+
+        public ClientSynchronizationModeTests(ServerPreloadStates serverPreloadStates)
+        {
+            m_ServerPreloadState = serverPreloadStates;
+        }
+
+        protected override IEnumerator OnSetup()
+        {
+            m_TempClientPreLoadedScenes.Clear();
+            m_ServerLoadedScenes.Clear();
+            if (m_ServerPreloadState == ServerPreloadStates.PreloadOnServer)
+            {
+                SceneManager.sceneLoaded += SceneManager_sceneLoaded;
+                yield return LoadScenesOnServer();
+            }
+            yield return base.OnSetup();
+        }
+
+        private IEnumerator LoadScenesOnServer()
+        {
+            if (m_ServerPreloadState == ServerPreloadStates.PreloadOnServer)
+            {
+                foreach (var sceneToLoad in m_TestScenes)
+                {
+                    SceneManager.LoadSceneAsync(sceneToLoad, LoadSceneMode.Additive);
+                }
+                yield return WaitForConditionOrTimeOut(AllScenesLoadedOnServer);
+                SceneManager.sceneLoaded -= SceneManager_sceneLoaded;
+                AssertOnTimeout($"[{m_ServerPreloadState}] Timed out waiting for all server-side scenes to be loaded!");
+            }
+            else
+            {
+                foreach (var sceneToLoad in m_TestScenes)
+                {
+                    m_ServerNetworkManager.SceneManager.LoadScene(sceneToLoad, LoadSceneMode.Additive);
+                    yield return WaitForConditionOrTimeOut(() => SceneLoadedOnServer(sceneToLoad));
+                    AssertOnTimeout($"[{m_ServerPreloadState}] Timed out waiting for scene {sceneToLoad} to be loaded!");
+                }
+            }
+        }
+
+        private bool SceneLoadedOnServer(string sceneName)
+        {
+            foreach (var scene in m_ServerLoadedScenes)
+            {
+                if (scene.name == sceneName)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private bool AllScenesLoadedOnServer()
+        {
+            if (m_ServerLoadedScenes.Count == m_TestScenes.Count)
+            {
+                foreach (var loadedScene in m_ServerLoadedScenes)
+                {
+                    if (!m_TestScenes.Contains(loadedScene.name))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
+        }
+
+        private bool AllScenesPreloadedForClient()
+        {
+            if (m_TempClientPreLoadedScenes.Count == m_TestScenes.Count)
+            {
+                foreach (var loadedScene in m_TempClientPreLoadedScenes)
+                {
+                    if (!m_TestScenes.Contains(loadedScene.name))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
+        }
+
+        private bool AllScenesLoadedOnClients()
+        {
+            foreach (var clientNetworkManager in m_ClientNetworkManagers)
+            {
+                if (!m_ClientScenesLoaded.ContainsKey(clientNetworkManager.LocalClientId))
+                {
+                    return false;
+                }
+
+                if (m_ClientScenesLoaded[clientNetworkManager.LocalClientId].Count != m_TestScenes.Count)
+                {
+                    return false;
+                }
+                foreach (var loadedScene in m_ClientScenesLoaded[clientNetworkManager.LocalClientId])
+                {
+                    if (!m_TestScenes.Contains(loadedScene.name))
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        private void SceneManager_sceneLoaded(Scene scene, LoadSceneMode loadSceneMode)
+        {
+            m_ServerLoadedScenes.Add(scene);
+        }
+
+
+        protected override IEnumerator OnStartedServerAndClients()
+        {
+            m_ServerNetworkManager.SceneManager.SetClientSynchronizationMode(LoadSceneMode.Additive);
+            return base.OnStartedServerAndClients();
+        }
+
+        protected override void OnNewClientStarted(NetworkManager networkManager)
+        {
+            networkManager.SceneManager.OnSceneEvent += ClientSide_OnSceneEvent;
+            base.OnNewClientStarted(networkManager);
+        }
+
+        /// <summary>
+        /// Verifies that both clients and the server will utilize preloaded scenes and that
+        /// in-scene placed NetworkObjects synchronize properly if the active scene changes
+        /// prior to a client connecting.
+        /// </summary>
+        /// <remarks>
+        /// Notes:
+        /// ClientPreloadStates.NoPreloadOnClient: verifies that if no scene that needs to
+        /// be synchronized is preloaded the client will load the scene to be synchronized.
+        ///
+        /// ClientPreloadStates.PreloadOnClient: verifies that if a client has scenes that
+        /// will be synchronized preloaded the client will use those scenes as opposed to
+        /// loading duplicates.
+        /// </remarks>
+        [UnityTest]
+        public IEnumerator PreloadedScenesTest([Values] ClientPreloadStates clientPreloadStates, [Values] ActiveSceneStates activeSceneState)
+        {
+            // If we didn't preload the scenes, then load the scenes via NetworkSceneManager
+            if (m_ServerPreloadState == ServerPreloadStates.NoPreloadOnServer)
+            {
+                m_ServerNetworkManager.SceneManager.OnSceneEvent += ServerSide_OnSceneEvent;
+                yield return LoadScenesOnServer();
+            }
+
+            // This tests that a change in the active scene will not impact in-scene placed
+            // NetworkObject synchronization (if it does then the clients would get a soft
+            // synchronization error).
+            if (activeSceneState == ActiveSceneStates.SwitchActiveScene)
+            {
+                SceneManager.SetActiveScene(m_ServerLoadedScenes[2]);
+            }
+
+            // Late join some clients
+            for (int i = 0; i < 1; i++)
+            {
+                // This tests that clients can have scenes preloaded prior to
+                // connecting and will use those scenes for synchronization
+                if (clientPreloadStates == ClientPreloadStates.PreloadOnClient)
+                {
+                    m_TempClientPreLoadedScenes.Clear();
+                    SceneManager.sceneLoaded += PreLoadClient_SceneLoaded;
+                    foreach (var sceneToLoad in m_TestScenes)
+                    {
+                        SceneManager.LoadSceneAsync(sceneToLoad, LoadSceneMode.Additive);
+                    }
+                    yield return WaitForConditionOrTimeOut(AllScenesPreloadedForClient);
+                    SceneManager.sceneLoaded -= PreLoadClient_SceneLoaded;
+                    AssertOnTimeout($"[{clientPreloadStates}] Timed out waiting for client-side scenes to be preloaded!");
+                }
+                yield return CreateAndStartNewClient();
+                AssertOnTimeout($"[Client Instance {i + 1}] Timed out waiting for client to start and connect!");
+
+                yield return WaitForConditionOrTimeOut(AllScenesLoadedOnClients);
+                AssertOnTimeout($"[Client-{m_ClientNetworkManagers[i].LocalClientId}] Timed out waiting for all scenes to be synchronized for new client!");
+            }
+        }
+
+        private void PreLoadClient_SceneLoaded(Scene scene, LoadSceneMode loadSceneMode)
+        {
+            m_TempClientPreLoadedScenes.Add(scene);
+        }
+
+        private void ClientSide_OnSceneEvent(SceneEvent sceneEvent)
+        {
+            switch (sceneEvent.SceneEventType)
+            {
+                case SceneEventType.LoadComplete:
+                    {
+                        if (!m_ClientScenesLoaded.ContainsKey(sceneEvent.ClientId))
+                        {
+                            m_ClientScenesLoaded.Add(sceneEvent.ClientId, new List<Scene>());
+                        }
+                        m_ClientScenesLoaded[sceneEvent.ClientId].Add(sceneEvent.Scene);
+                        break;
+                    }
+            }
+        }
+        private void ServerSide_OnSceneEvent(SceneEvent sceneEvent)
+        {
+            // Filter for server-side only scene events
+            if (sceneEvent.ClientId != m_ServerNetworkManager.LocalClientId)
+            {
+                return;
+            }
+
+            switch (sceneEvent.SceneEventType)
+            {
+                case SceneEventType.LoadComplete:
+                    {
+                        m_ServerLoadedScenes.Add(sceneEvent.Scene);
+                        break;
+                    }
+            }
+        }
+
+        protected override IEnumerator OnTearDown()
+        {
+            SceneManager.sceneLoaded -= SceneManager_sceneLoaded;
+            m_TempClientPreLoadedScenes.Clear();
+            m_ClientScenesLoaded.Clear();
+            return base.OnTearDown();
+        }
+    }
+}

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/ClientSynchronizationModeTests.cs.meta
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/ClientSynchronizationModeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 26618a817fc595d4dbc1ad91cc89e53d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectSceneMigrationTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectSceneMigrationTests.cs
@@ -499,9 +499,12 @@ namespace TestProject.RuntimeTests
 
         public override void OnDestroy()
         {
-            if (NetworkManager.LocalClientId == NetworkManager.ServerClientId)
+            if (NetworkManager != null)
             {
-                NetworkObjectDestroyed?.Invoke(NetworkObject);
+                if (NetworkManager.LocalClientId == NetworkManager.ServerClientId)
+                {
+                    NetworkObjectDestroyed?.Invoke(NetworkObject);
+                }
             }
             base.OnDestroy();
         }

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectSceneMigrationTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectSceneMigrationTests.cs
@@ -1,0 +1,182 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+using Unity.Netcode;
+using Unity.Netcode.TestHelpers.Runtime;
+
+namespace TestProject.RuntimeTests
+{
+    public class NetworkObjectSceneMigrationTests : NetcodeIntegrationTest
+    {
+        private List<string> m_TestScenes = new List<string>() { "EmptyScene1", "EmptyScene2", "EmptyScene3" };
+        protected override int NumberOfClients => 2;
+        private GameObject m_TestPrefab;
+
+        protected override void OnServerAndClientsCreated()
+        {
+            m_TestPrefab = CreateNetworkObjectPrefab("TestObject");
+            base.OnServerAndClientsCreated();
+        }
+
+        protected override void OnNewClientCreated(NetworkManager networkManager)
+        {
+            foreach (var networkPrfab in m_ServerNetworkManager.NetworkConfig.Prefabs.Prefabs)
+            {
+                networkManager.NetworkConfig.Prefabs.Add(networkPrfab);
+            }
+            base.OnNewClientCreated(networkManager);
+        }
+
+        private bool VerifyAllClientsSpawnedInstances()
+        {
+            foreach (var serverObject in m_ServerSpawnedPrefabInstances)
+            {
+                foreach (var networkManager in m_ClientNetworkManagers)
+                {
+                    if (!s_GlobalNetworkObjects.ContainsKey(networkManager.LocalClientId))
+                    {
+                        return false;
+                    }
+                    var clientNetworkObjects = s_GlobalNetworkObjects[networkManager.LocalClientId];
+                    if (!clientNetworkObjects.ContainsKey(serverObject.NetworkObjectId))
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        private bool VerifySpawnedObjectsMigrated()
+        {
+            foreach (var serverObject in m_ServerSpawnedPrefabInstances)
+            {
+                foreach (var networkManager in m_ClientNetworkManagers)
+                {
+                    var clientNetworkObjects = s_GlobalNetworkObjects[networkManager.LocalClientId];
+                    if (clientNetworkObjects[serverObject.NetworkObjectId].gameObject.scene.name != serverObject.gameObject.scene.name)
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        private bool m_ClientsLoadedScene;
+        private Scene m_SceneLoaded;
+        private List<NetworkObject> m_ServerSpawnedPrefabInstances = new List<NetworkObject>();
+        private List<Scene> m_ScenesLoaded = new List<Scene>();
+        private string m_CurrentSceneLoading;
+
+        /// <summary>
+        /// Integration test to verify that migrating NetworkObjects
+        /// into different scenes (in the same frame) is synchronized
+        /// with connected clients and synchronizes with late joining
+        /// clients.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator MigrateIntoNewSceneTest()
+        {
+            // Spawn 10 NetworkObject instances
+            for (int i = 0; i < 9; i++)
+            {
+                var serverInstance = Object.Instantiate(m_TestPrefab);
+                var serverNetworkObject = serverInstance.GetComponent<NetworkObject>();
+                serverNetworkObject.Spawn();
+                m_ServerSpawnedPrefabInstances.Add(serverNetworkObject);
+            }
+            yield return WaitForConditionOrTimeOut(VerifyAllClientsSpawnedInstances);
+            AssertOnTimeout($"Timed out waiting for all clients to spawn {nameof(NetworkObject)}s!");
+
+            // Now load three scenes to migrate the newly spawned NetworkObjects into
+            m_ServerNetworkManager.SceneManager.OnSceneEvent += SceneManager_OnSceneEvent;
+            for (int i = 0; i < 3; i++)
+            {
+                m_ClientsLoadedScene = false;
+                m_CurrentSceneLoading = m_TestScenes[i];
+                var status = m_ServerNetworkManager.SceneManager.LoadScene(m_TestScenes[i], LoadSceneMode.Additive);
+                Assert.True(status == SceneEventProgressStatus.Started, $"Failed to start loading scene {m_CurrentSceneLoading}! Return status: {status}");
+                yield return WaitForConditionOrTimeOut(() => m_ClientsLoadedScene);
+                AssertOnTimeout($"Timed out waiting for all clients to load scene {m_CurrentSceneLoading}!");
+            }
+
+            var objectCount = 0;
+            // Migrate each networkObject into one of the three scenes.
+            // There will be 3 networkObjects per newly loaded scenes when done.
+            foreach (var scene in m_ScenesLoaded)
+            {
+                // Now migrate the NetworkObject
+                SceneManager.MoveGameObjectToScene(m_ServerSpawnedPrefabInstances[objectCount].gameObject, scene);
+                SceneManager.MoveGameObjectToScene(m_ServerSpawnedPrefabInstances[objectCount + 1].gameObject, scene);
+                SceneManager.MoveGameObjectToScene(m_ServerSpawnedPrefabInstances[objectCount + 2].gameObject, scene);
+                objectCount += 3;
+            }
+
+            yield return WaitForConditionOrTimeOut(VerifySpawnedObjectsMigrated);
+            AssertOnTimeout($"Timed out waiting for all clients to migrate all NetworkObjects into the appropriate scenes!");
+
+            // Verify that a late joining client synchronizes properly
+            yield return CreateAndStartNewClient();
+            yield return WaitForConditionOrTimeOut(VerifySpawnedObjectsMigrated);
+            AssertOnTimeout($"[Late Joined Client] Timed out waiting for all clients to migrate all NetworkObjects into the appropriate scenes!");
+        }
+
+        /// <summary>
+        /// Integration test to verify changing the currently active scene
+        /// will migrate NetworkObjects with ActiveSceneSynchronization set
+        /// to true.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ActiveSceneSynchronizationTest()
+        {
+            // WIP
+            yield return null;
+        }
+
+        public enum MigrateUnloadType
+        {
+            ActiveSynch,
+            DestroyWithScene
+        }
+
+        /// <summary>
+        /// Integration test to verify that unloading a scene that a NetworkObject
+        /// with ActiveSceneSynchronization (true) and DestroyWithScene (false) will
+        /// migrate the NetworkObject into the next active scene when their current
+        /// one is unloaded.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator MigrateOnUnloadSceneTest([Values] MigrateUnloadType migrateUnloadType)
+        {
+            // WIP
+            yield return null;
+        }
+
+
+        private void SceneManager_OnSceneEvent(SceneEvent sceneEvent)
+        {
+            switch (sceneEvent.SceneEventType)
+            {
+                case SceneEventType.LoadComplete:
+                    {
+                        if (sceneEvent.ClientId == m_ServerNetworkManager.LocalClientId)
+                        {
+                            m_SceneLoaded = sceneEvent.Scene;
+                            m_ScenesLoaded.Add(sceneEvent.Scene);
+                        }
+                        break;
+                    }
+                case SceneEventType.LoadEventCompleted:
+                    {
+                        Assert.IsTrue(sceneEvent.ClientsThatTimedOut.Count == 0, $"{sceneEvent.ClientsThatTimedOut.Count} clients timed out while trying to load scene {m_CurrentSceneLoading}!");
+                        m_ClientsLoadedScene = true;
+                        break;
+                    }
+            }
+        }
+    }
+}

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectSceneMigrationTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectSceneMigrationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework;
@@ -6,18 +7,55 @@ using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 using Unity.Netcode;
 using Unity.Netcode.TestHelpers.Runtime;
+using Object = UnityEngine.Object;
 
 namespace TestProject.RuntimeTests
 {
+    /// <summary>
+    /// NetworkObject Scene Migration Integration Tests
+    /// <see cref="MigrateIntoNewSceneTest"/>
+    /// <see cref="ActiveSceneSynchronizationTest"/>
+    /// </summary>
     public class NetworkObjectSceneMigrationTests : NetcodeIntegrationTest
     {
         private List<string> m_TestScenes = new List<string>() { "EmptyScene1", "EmptyScene2", "EmptyScene3" };
         protected override int NumberOfClients => 2;
         private GameObject m_TestPrefab;
+        private GameObject m_TestPrefabAutoSynchActiveScene;
+        private GameObject m_TestPrefabDestroyWithScene;
+        private Scene m_OriginalActiveScene;
+
+        private bool m_ClientsLoadedScene;
+        private bool m_ClientsUnloadedScene;
+        private Scene m_SceneLoaded;
+        private List<NetworkObject> m_ServerSpawnedPrefabInstances = new List<NetworkObject>();
+        private List<NetworkObject> m_ServerSpawnedDestroyWithSceneInstances = new List<NetworkObject>();
+        private List<Scene> m_ScenesLoaded = new List<Scene>();
+        private string m_CurrentSceneLoading;
+        private string m_CurrentSceneUnloading;
+
+
+        protected override IEnumerator OnSetup()
+        {
+            m_OriginalActiveScene = SceneManager.GetActiveScene();
+            return base.OnSetup();
+        }
 
         protected override void OnServerAndClientsCreated()
         {
+            // Synchronize Scene Changes (default) Test Network Prefab
             m_TestPrefab = CreateNetworkObjectPrefab("TestObject");
+
+            // Auto Synchronize Active Scene Changes Test Network Prefab
+            m_TestPrefabAutoSynchActiveScene = CreateNetworkObjectPrefab("ASASObject");
+            m_TestPrefabAutoSynchActiveScene.GetComponent<NetworkObject>().ActiveSceneSynchronization = true;
+
+            // Destroy With Scene Test Network Prefab
+            m_TestPrefabDestroyWithScene = CreateNetworkObjectPrefab("DWSObject");
+            m_TestPrefabDestroyWithScene.AddComponent<DestroyWithSceneInstancesTestHelper>();
+
+            DestroyWithSceneInstancesTestHelper.ShouldNeverSpawn = m_TestPrefabDestroyWithScene;
+
             base.OnServerAndClientsCreated();
         }
 
@@ -25,26 +63,74 @@ namespace TestProject.RuntimeTests
         {
             foreach (var networkPrfab in m_ServerNetworkManager.NetworkConfig.Prefabs.Prefabs)
             {
+                if (networkPrfab.Prefab == null)
+                {
+                    continue;
+                }
                 networkManager.NetworkConfig.Prefabs.Add(networkPrfab);
             }
             base.OnNewClientCreated(networkManager);
+        }
+
+        private bool DidClientsSpawnInstance(NetworkObject serverObject, bool checkDestroyWithScene = false)
+        {
+            foreach (var networkManager in m_ClientNetworkManagers)
+            {
+                if (!s_GlobalNetworkObjects.ContainsKey(networkManager.LocalClientId))
+                {
+                    return false;
+                }
+                var clientNetworkObjects = s_GlobalNetworkObjects[networkManager.LocalClientId];
+                if (!clientNetworkObjects.ContainsKey(serverObject.NetworkObjectId))
+                {
+                    return false;
+                }
+
+                if (checkDestroyWithScene)
+                {
+                    if (serverObject.DestroyWithScene != clientNetworkObjects[serverObject.NetworkObjectId])
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
         }
 
         private bool VerifyAllClientsSpawnedInstances()
         {
             foreach (var serverObject in m_ServerSpawnedPrefabInstances)
             {
-                foreach (var networkManager in m_ClientNetworkManagers)
+                if (!DidClientsSpawnInstance(serverObject))
                 {
-                    if (!s_GlobalNetworkObjects.ContainsKey(networkManager.LocalClientId))
-                    {
-                        return false;
-                    }
-                    var clientNetworkObjects = s_GlobalNetworkObjects[networkManager.LocalClientId];
-                    if (!clientNetworkObjects.ContainsKey(serverObject.NetworkObjectId))
-                    {
-                        return false;
-                    }
+                    return false;
+                }
+            }
+
+            foreach (var serverObject in m_ServerSpawnedDestroyWithSceneInstances)
+            {
+                if (!DidClientsSpawnInstance(serverObject, true))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private bool AreClientInstancesInTheRightScene(NetworkObject serverObject)
+        {
+            foreach (var networkManager in m_ClientNetworkManagers)
+            {
+                var clientNetworkObjects = s_GlobalNetworkObjects[networkManager.LocalClientId];
+                if (clientNetworkObjects == null)
+                {
+                    continue;
+                }
+                // If a networkObject is null then it was destroyed
+                if (clientNetworkObjects[serverObject.NetworkObjectId].gameObject.scene.name != serverObject.gameObject.scene.name)
+                {
+                    return false;
                 }
             }
             return true;
@@ -54,23 +140,22 @@ namespace TestProject.RuntimeTests
         {
             foreach (var serverObject in m_ServerSpawnedPrefabInstances)
             {
-                foreach (var networkManager in m_ClientNetworkManagers)
+                if (!AreClientInstancesInTheRightScene(serverObject))
                 {
-                    var clientNetworkObjects = s_GlobalNetworkObjects[networkManager.LocalClientId];
-                    if (clientNetworkObjects[serverObject.NetworkObjectId].gameObject.scene.name != serverObject.gameObject.scene.name)
-                    {
-                        return false;
-                    }
+                    return false;
                 }
             }
+
+            foreach (var serverObject in m_ServerSpawnedDestroyWithSceneInstances)
+            {
+                if (!AreClientInstancesInTheRightScene(serverObject))
+                {
+                    return false;
+                }
+            }
+
             return true;
         }
-
-        private bool m_ClientsLoadedScene;
-        private Scene m_SceneLoaded;
-        private List<NetworkObject> m_ServerSpawnedPrefabInstances = new List<NetworkObject>();
-        private List<Scene> m_ScenesLoaded = new List<Scene>();
-        private string m_CurrentSceneLoading;
 
         /// <summary>
         /// Integration test to verify that migrating NetworkObjects
@@ -81,7 +166,7 @@ namespace TestProject.RuntimeTests
         [UnityTest]
         public IEnumerator MigrateIntoNewSceneTest()
         {
-            // Spawn 10 NetworkObject instances
+            // Spawn 9 NetworkObject instances
             for (int i = 0; i < 9; i++)
             {
                 var serverInstance = Object.Instantiate(m_TestPrefab);
@@ -133,29 +218,202 @@ namespace TestProject.RuntimeTests
         [UnityTest]
         public IEnumerator ActiveSceneSynchronizationTest()
         {
-            // WIP
-            yield return null;
-        }
+            // Disable resynchronization for this test to avoid issues with trying
+            // to synchronize them.
+            NetworkSceneManager.DisableReSynchronization = true;
 
-        public enum MigrateUnloadType
-        {
-            ActiveSynch,
-            DestroyWithScene
+            // Spawn 3 NetworkObject instances that auto synchronize to active scene changes
+            for (int i = 0; i < 3; i++)
+            {
+                var serverInstance = Object.Instantiate(m_TestPrefabAutoSynchActiveScene);
+                var serverNetworkObject = serverInstance.GetComponent<NetworkObject>();
+                // We are also testing that objects marked to synchronize with changes to
+                // the active scene and marked to destroy with scene =are destroyed= if
+                // the scene being unloaded is currently the active scene and the scene that
+                // the NetworkObjects reside within.
+                serverNetworkObject.Spawn(true);
+                m_ServerSpawnedPrefabInstances.Add(serverNetworkObject);
+            }
+
+            // Spawn 3 NetworkObject instances that do not auto synchronize to active scene changes
+            // and ==should not be== destroyed with the scene (these should be the only remaining
+            // instances)
+            for (int i = 0; i < 3; i++)
+            {
+                var serverInstance = Object.Instantiate(m_TestPrefab);
+                var serverNetworkObject = serverInstance.GetComponent<NetworkObject>();
+                // This set of NetworkObjects will be used to verify that NetworkObjets
+                // spawned with DestroyWithScene set to false will migrate into the current
+                // active scene if the scene they currently reside within is destroyed and
+                // is not the currently active scene.
+                serverNetworkObject.Spawn();
+                m_ServerSpawnedPrefabInstances.Add(serverNetworkObject);
+            }
+
+            // Spawn 3 NetworkObject instances that do not auto synchronize to active scene changes
+            // and ==should be== destroyed with the scene when it is unloaded
+            for (int i = 0; i < 3; i++)
+            {
+                var serverInstance = Object.Instantiate(m_TestPrefabDestroyWithScene);
+                var serverNetworkObject = serverInstance.GetComponent<NetworkObject>();
+                // This set of NetworkObjects will be used to verify that NetworkObjets
+                // spawned with DestroyWithScene == true will get destroyed when the scene
+                // is unloaded
+                serverNetworkObject.Spawn(true);
+                m_ServerSpawnedDestroyWithSceneInstances.Add(serverNetworkObject);
+            }
+
+            yield return WaitForConditionOrTimeOut(VerifyAllClientsSpawnedInstances);
+            AssertOnTimeout($"Timed out waiting for all clients to spawn {nameof(NetworkObject)}s!");
+
+            // Now load three scenes
+            m_ServerNetworkManager.SceneManager.OnSceneEvent += SceneManager_OnSceneEvent;
+            for (int i = 0; i < 3; i++)
+            {
+                m_ClientsLoadedScene = false;
+                m_CurrentSceneLoading = m_TestScenes[i];
+                var loadStatus = m_ServerNetworkManager.SceneManager.LoadScene(m_TestScenes[i], LoadSceneMode.Additive);
+                Assert.True(loadStatus == SceneEventProgressStatus.Started, $"Failed to start loading scene {m_CurrentSceneLoading}! Return status: {loadStatus}");
+                yield return WaitForConditionOrTimeOut(() => m_ClientsLoadedScene);
+                AssertOnTimeout($"Timed out waiting for all clients to load scene {m_CurrentSceneLoading}!");
+            }
+
+            // Migrate the instances that don't synchronize with active scene changes into the 3rd loaded scene
+            // (We are making sure these stay in the same scene they are migrated into)
+            for (int i = 3; i < m_ServerSpawnedPrefabInstances.Count; i++)
+            {
+                SceneManager.MoveGameObjectToScene(m_ServerSpawnedPrefabInstances[i].gameObject, m_ScenesLoaded[2]);
+            }
+
+            // Migrate the instances that don't synchronize with active scene changes and are destroyed with the
+            // scene unloading into the 3rd loaded scene
+            // (We are making sure these get destroyed when the scene is unloaded)
+            for (int i = 0; i < m_ServerSpawnedDestroyWithSceneInstances.Count; i++)
+            {
+                SceneManager.MoveGameObjectToScene(m_ServerSpawnedDestroyWithSceneInstances[i].gameObject, m_ScenesLoaded[2]);
+            }
+
+            // Make sure they migrated to the proper scene
+            yield return WaitForConditionOrTimeOut(VerifySpawnedObjectsMigrated);
+            AssertOnTimeout($"Timed out waiting for all clients to migrate all NetworkObjects into the appropriate scenes!");
+
+            // Now change the active scene
+            SceneManager.SetActiveScene(m_ScenesLoaded[1]);
+            // We have to do this
+            Object.DontDestroyOnLoad(m_TestPrefabAutoSynchActiveScene);
+
+            // First, make sure server-side scenes and client side scenes match
+            yield return WaitForConditionOrTimeOut(VerifySpawnedObjectsMigrated);
+            AssertOnTimeout($"Timed out waiting for all clients to migrate all NetworkObjects into the appropriate scenes!");
+
+            // Verify that the auto-active-scene synchronization NetworkObjects migrated to the newly
+            // assigned active scene
+            for (int i = 0; i < 3; i++)
+            {
+                Assert.True(m_ServerSpawnedPrefabInstances[i].gameObject.scene == m_ScenesLoaded[1],
+                    $"{m_ServerSpawnedPrefabInstances[i].gameObject.name} did not migrate into scene {m_ScenesLoaded[1].name}!");
+            }
+
+            // Verify that the other NetworkObjects that don't synchronize with active scene changes did
+            // not migrate into the active scene.
+            for (int i = 3; i < m_ServerSpawnedPrefabInstances.Count; i++)
+            {
+                Assert.False(m_ServerSpawnedPrefabInstances[i].gameObject.scene == m_ScenesLoaded[1],
+                    $"{m_ServerSpawnedPrefabInstances[i].gameObject.name} migrated into scene {m_ScenesLoaded[1].name}!");
+            }
+
+            for (int i = 0; i < 3; i++)
+            {
+                Assert.False(m_ServerSpawnedDestroyWithSceneInstances[i].gameObject.scene == m_ScenesLoaded[1],
+                    $"{m_ServerSpawnedDestroyWithSceneInstances[i].gameObject.name} migrated into scene {m_ScenesLoaded[1].name}!");
+            }
+
+            // Verify that a late joining client synchronizes properly and destroys the appropriate NetworkObjects
+            yield return CreateAndStartNewClient();
+            yield return WaitForConditionOrTimeOut(VerifySpawnedObjectsMigrated);
+            AssertOnTimeout($"[Late Joined Client #1] Timed out waiting for all clients to migrate all NetworkObjects into the appropriate scenes!");
+
+            // Now, unload the scene containing the NetworkObjects that don't synchronize with active scene changes
+            DestroyWithSceneInstancesTestHelper.NetworkObjectDestroyed += OnNonActiveSynchDestroyWithSceneNetworkObjectDestroyed;
+            m_ClientsUnloadedScene = false;
+            m_CurrentSceneUnloading = m_ScenesLoaded[2].name;
+            var status = m_ServerNetworkManager.SceneManager.UnloadScene(m_ScenesLoaded[2]);
+            Assert.True(status == SceneEventProgressStatus.Started, $"Failed to start unloading scene {m_ScenesLoaded[2].name} with status {status}!");
+            yield return WaitForConditionOrTimeOut(() => m_ClientsUnloadedScene);
+
+            // Clean up any destroyed NetworkObjects
+            for (int i = m_ServerSpawnedPrefabInstances.Count - 1; i >= 0; i--)
+            {
+                if (m_ServerSpawnedPrefabInstances[i] == null)
+                {
+                    m_ServerSpawnedPrefabInstances.RemoveAt(i);
+                }
+            }
+
+            AssertOnTimeout($"Timed out waiting for all clients to unload scene {m_CurrentSceneUnloading}!");
+            yield return WaitForConditionOrTimeOut(VerifySpawnedObjectsMigrated);
+            AssertOnTimeout($"Timed out waiting for all clients to migrate all NetworkObjects into the appropriate scenes!");
+
+            // Verify that the NetworkObjects that don't synchronize with active scene changes but marked to not
+            // destroy with the scene are migrated into the current active scene
+            for (int i = 3; i < m_ServerSpawnedPrefabInstances.Count; i++)
+            {
+                Assert.True(m_ServerSpawnedPrefabInstances[i].gameObject.scene == m_ScenesLoaded[1],
+                    $"{m_ServerSpawnedPrefabInstances[i].gameObject.name} did not migrate into scene {m_ScenesLoaded[1].name} but are in scene {m_ServerSpawnedPrefabInstances[i].gameObject.scene.name}!");
+            }
+
+            // Verify all NetworkObjects that should have been destroyed with the scene unloaded were destroyed
+            yield return WaitForConditionOrTimeOut(() => DestroyWithSceneInstancesTestHelper.ObjectRelativeInstances.Count == 0);
+            DestroyWithSceneInstancesTestHelper.NetworkObjectDestroyed -= OnNonActiveSynchDestroyWithSceneNetworkObjectDestroyed;
+            AssertOnTimeout($"Timed out waiting for all client instances marked to destroy when the scene unloaded to be despawned and destroyed.");
+
+            // Now unload the active scene to verify all remaining NetworkObjects are migrated into the SceneManager
+            // assigned active scene
+            m_ClientsUnloadedScene = false;
+            m_CurrentSceneUnloading = m_ScenesLoaded[1].name;
+            m_ServerNetworkManager.SceneManager.UnloadScene(m_ScenesLoaded[1]);
+            yield return WaitForConditionOrTimeOut(() => m_ClientsUnloadedScene);
+            AssertOnTimeout($"Timed out waiting for all clients to unload scene {m_CurrentSceneUnloading}!");
+
+            // Clean up any destroyed NetworkObjects
+            for (int i = m_ServerSpawnedPrefabInstances.Count - 1; i >= 0; i--)
+            {
+                if (m_ServerSpawnedPrefabInstances[i] == null)
+                {
+                    m_ServerSpawnedPrefabInstances.RemoveAt(i);
+                }
+            }
+
+            // Verify a late joining client will synchronize properly with the end result
+            yield return CreateAndStartNewClient();
+
+            // Verify the late joining client spawns all instances
+            yield return WaitForConditionOrTimeOut(VerifyAllClientsSpawnedInstances);
+            AssertOnTimeout($"Timed out waiting for all clients to spawn {nameof(NetworkObject)}s!");
+
+            // Verify the instances are in the correct scenes
+            yield return WaitForConditionOrTimeOut(VerifySpawnedObjectsMigrated);
+            AssertOnTimeout($"[Late Joined Client #2] Timed out waiting for all clients to migrate all NetworkObjects into the appropriate scenes!");
+
+            // All but 3 instances should be destroyed
+            Assert.True(m_ServerSpawnedPrefabInstances.Count == 3, $"{nameof(m_ServerSpawnedPrefabInstances)} still has a count of {m_ServerSpawnedPrefabInstances.Count} " +
+                $"NetworkObject instances!");
+            Assert.True(m_ServerSpawnedDestroyWithSceneInstances.Count == 0, $"{nameof(m_ServerSpawnedDestroyWithSceneInstances)} still has a count of " +
+                $"{m_ServerSpawnedDestroyWithSceneInstances.Count} NetworkObject instances!");
+            for (int i = 0; i < 3; i++)
+            {
+                Assert.True(m_ServerSpawnedPrefabInstances[i].gameObject.name.Contains(m_TestPrefab.gameObject.name), $"Expected {m_ServerSpawnedPrefabInstances[i].gameObject.name} to contain {m_TestPrefab.gameObject.name}!");
+            }
         }
 
         /// <summary>
-        /// Integration test to verify that unloading a scene that a NetworkObject
-        /// with ActiveSceneSynchronization (true) and DestroyWithScene (false) will
-        /// migrate the NetworkObject into the next active scene when their current
-        /// one is unloaded.
+        /// Callback invoked when a test prefab, with the <see cref="DestroyWithSceneInstancesTestHelper"/>
+        /// component attached, is destroyed.
         /// </summary>
-        [UnityTest]
-        public IEnumerator MigrateOnUnloadSceneTest([Values] MigrateUnloadType migrateUnloadType)
+        private void OnNonActiveSynchDestroyWithSceneNetworkObjectDestroyed(NetworkObject networkObject)
         {
-            // WIP
-            yield return null;
+            m_ServerSpawnedDestroyWithSceneInstances.Remove(networkObject);
         }
-
 
         private void SceneManager_OnSceneEvent(SceneEvent sceneEvent)
         {
@@ -176,7 +434,77 @@ namespace TestProject.RuntimeTests
                         m_ClientsLoadedScene = true;
                         break;
                     }
+                case SceneEventType.UnloadEventCompleted:
+                    {
+                        if (sceneEvent.SceneName == m_CurrentSceneUnloading)
+                        {
+                            m_ClientsUnloadedScene = true;
+                        }
+                        break;
+                    }
             }
         }
+
+        protected override IEnumerator OnTearDown()
+        {
+            m_TestPrefab = null;
+            m_TestPrefabAutoSynchActiveScene = null;
+            m_TestPrefabDestroyWithScene = null;
+            SceneManager.SetActiveScene(m_OriginalActiveScene);
+            m_ServerSpawnedDestroyWithSceneInstances.Clear();
+            m_ServerSpawnedPrefabInstances.Clear();
+            m_ScenesLoaded.Clear();
+            yield return base.OnTearDown();
+        }
     }
+
+    /// <summary>
+    /// Helper NetworkBehaviour Component
+    /// For test: <see cref="NetworkObjectSceneMigrationTests.ActiveSceneSynchronizationTest"/>
+    /// </summary>
+    internal class DestroyWithSceneInstancesTestHelper : NetworkBehaviour
+    {
+        public static GameObject ShouldNeverSpawn;
+
+        public static Dictionary<ulong, Dictionary<ulong, NetworkObject>> ObjectRelativeInstances = new Dictionary<ulong, Dictionary<ulong, NetworkObject>>();
+
+        public static Action<NetworkObject> NetworkObjectDestroyed;
+
+        /// <summary>
+        /// Called when destroyed
+        /// Passes the client ID and the NetworkObject instance
+        /// </summary>
+        public Action<ulong, NetworkObject> ObjectDestroyed;
+
+        public override void OnNetworkSpawn()
+        {
+            if (!ObjectRelativeInstances.ContainsKey(NetworkManager.LocalClientId))
+            {
+                ObjectRelativeInstances.Add(NetworkManager.LocalClientId, new Dictionary<ulong, NetworkObject>());
+            }
+
+            ObjectRelativeInstances[NetworkManager.LocalClientId].Add(NetworkObjectId, NetworkObject);
+            base.OnNetworkSpawn();
+        }
+
+        public override void OnNetworkDespawn()
+        {
+            ObjectRelativeInstances[NetworkManager.LocalClientId].Remove(NetworkObjectId);
+            if (ObjectRelativeInstances[NetworkManager.LocalClientId].Count == 0)
+            {
+                ObjectRelativeInstances.Remove(NetworkManager.LocalClientId);
+            }
+            base.OnNetworkDespawn();
+        }
+
+        public override void OnDestroy()
+        {
+            if (NetworkManager.LocalClientId == NetworkManager.ServerClientId)
+            {
+                NetworkObjectDestroyed?.Invoke(NetworkObject);
+            }
+            base.OnDestroy();
+        }
+    }
+
 }

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectSceneMigrationTests.cs.meta
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectSceneMigrationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7915a6a8062bc414ab4ff730f3f778f5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventNotifications.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventNotifications.cs
@@ -89,7 +89,7 @@ namespace TestProject.RuntimeTests
                     {
                         var matchedClient = m_ClientNetworkManagers.Where(c => c.LocalClientId == sceneEvent.ClientId);
                         Assert.True(matchedClient.Count() > 0, $"Found no client {nameof(NetworkManager)}s that had a {nameof(NetworkManager.LocalClientId)} of {sceneEvent.ClientId}");
-                        Assert.AreEqual(matchedClient.First().SceneManager.ClientSynchronizationMode, m_LoadSceneMode);
+                        Assert.AreEqual(matchedClient.First().SceneManager.ClientSynchronizationMode, m_ServerNetworkManager.SceneManager.ClientSynchronizationMode);
                         break;
                     }
             }

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerSeneVerification.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerSeneVerification.cs
@@ -161,10 +161,8 @@ namespace TestProject.RuntimeTests
             m_ScenesLoaded.Clear();
             foreach (var manager in m_ClientNetworkManagers)
             {
-
                 m_ShouldWaitList.Add(new SceneTestInfo() { ClientId = manager.LocalClientId, ShouldWait = false });
                 manager.SceneManager.VerifySceneBeforeLoading = m_ClientVerificationAction;
-                manager.SceneManager.SetClientSynchronizationMode(clientSynchronizationMode);
             }
         }
 
@@ -255,11 +253,20 @@ namespace TestProject.RuntimeTests
 
         private bool ServerVerifySceneBeforeLoading(int sceneIndex, string sceneName, LoadSceneMode loadSceneMode)
         {
-            Assert.IsTrue(m_ExpectedSceneIndex == sceneIndex);
-            Assert.IsTrue(m_ExpectedSceneName == sceneName);
-            Assert.IsTrue(m_ExpectedLoadMode == loadSceneMode);
+            if (m_ExpectedSceneIndex != 0 && m_ExpectedSceneName != null)
+            {
+                // Ignore the test runner test scene.
+                if (sceneIndex != m_ExpectedSceneIndex && sceneName.Contains("InitTestScene"))
+                {
+                    return false;
+                }
 
-            return m_ServerVerifyScene;
+                Assert.IsTrue(m_ExpectedSceneIndex == sceneIndex);
+                Assert.IsTrue(m_ExpectedSceneName == sceneName);
+                Assert.IsTrue(m_ExpectedLoadMode == loadSceneMode);
+                return m_ServerVerifyScene;
+            }
+            return false;
         }
 
         private bool ClientVerifySceneBeforeLoading(int sceneIndex, string sceneName, LoadSceneMode loadSceneMode)

--- a/testproject/Assets/Tests/Runtime/ObjectParenting/NetworkObjectParentingTests.cs
+++ b/testproject/Assets/Tests/Runtime/ObjectParenting/NetworkObjectParentingTests.cs
@@ -38,6 +38,11 @@ namespace TestProject.RuntimeTests
             }
         }
 
+        private void InvokeBeforeClientsStart()
+        {
+            m_ServerNetworkManager.SceneManager.ClientSynchronizationMode = LoadSceneMode.Additive;
+        }
+
         [UnitySetUp]
         public IEnumerator Setup()
         {
@@ -83,7 +88,7 @@ namespace TestProject.RuntimeTests
             }
 
             // Start server and client NetworkManager instances
-            Assert.That(NetcodeIntegrationTestHelpers.Start(true, m_ServerNetworkManager, m_ClientNetworkManagers));
+            Assert.That(NetcodeIntegrationTestHelpers.Start(true, m_ServerNetworkManager, m_ClientNetworkManagers, InvokeBeforeClientsStart));
 
             // Wait for connection on client side
             yield return NetcodeIntegrationTestHelpers.WaitForClientsConnected(m_ClientNetworkManagers);

--- a/testproject/Assets/Tests/Runtime/ObjectParenting/ParentDynamicUnderInScenePlaced.cs
+++ b/testproject/Assets/Tests/Runtime/ObjectParenting/ParentDynamicUnderInScenePlaced.cs
@@ -40,13 +40,6 @@ namespace TestProject.RuntimeTests
             base.OnServerAndClientsCreated();
         }
 
-        protected override IEnumerator OnStartedServerAndClients()
-        {
-            m_ServerNetworkManager.SceneManager.DisableValidationWarnings(true);
-            m_ServerNetworkManager.SceneManager.ClientSynchronizationMode = LoadSceneMode.Additive;
-            return base.OnStartedServerAndClients();
-        }
-
         protected override void OnNewClientCreated(NetworkManager networkManager)
         {
             foreach (var networkPrefab in m_ServerNetworkManager.NetworkConfig.Prefabs.Prefabs)
@@ -65,7 +58,7 @@ namespace TestProject.RuntimeTests
         private NetworkObject m_FailedValidation;
         private bool TestParentedAndNotInScenePlaced()
         {
-            var serverPlayer = m_ServerNetworkManager.LocalClient.PlayerObject;
+            var serverPlayer = m_FailedValidation = m_ServerNetworkManager.LocalClient.PlayerObject;
             if (serverPlayer.transform.parent == null || serverPlayer.IsSceneObject.Value == true)
             {
                 m_FailedValidation = serverPlayer;
@@ -111,9 +104,11 @@ namespace TestProject.RuntimeTests
             m_ServerNetworkManager.SceneManager.LoadScene(k_SceneToLoad, LoadSceneMode.Additive);
             // Wait for the scene with the in-scene placed NetworkObject to be loaded
             yield return WaitForConditionOrTimeOut(() => m_SceneIsLoaded == true);
+            AssertOnTimeout($"Timed out waiting for the scene {k_SceneToLoad} to load!");
 
             // Wait for the host-server's player to be parented under the in-scene placed NetworkObject
             yield return WaitForConditionOrTimeOut(TestParentedAndNotInScenePlaced);
+            AssertOnTimeout($"[{m_FailedValidation.name}] Failed validation! InScenePlaced ({m_FailedValidation.IsSceneObject.Value}) | Was Parented ({m_FailedValidation.transform.position != null})");
 
             // Now dynamically spawn a NetworkObject to also test dynamically spawned NetworkObjects being parented
             // under in-scene placed NetworkObjects

--- a/testproject/Assets/Tests/Runtime/ObjectParenting/ParentDynamicUnderInScenePlaced.cs
+++ b/testproject/Assets/Tests/Runtime/ObjectParenting/ParentDynamicUnderInScenePlaced.cs
@@ -40,6 +40,12 @@ namespace TestProject.RuntimeTests
             base.OnServerAndClientsCreated();
         }
 
+        protected override IEnumerator OnStartedServerAndClients()
+        {
+            m_ServerNetworkManager.SceneManager.SetClientSynchronizationMode(LoadSceneMode.Additive);
+            return base.OnStartedServerAndClients();
+        }
+
         protected override void OnNewClientCreated(NetworkManager networkManager)
         {
             foreach (var networkPrefab in m_ServerNetworkManager.NetworkConfig.Prefabs.Prefabs)

--- a/testproject/Assets/Tests/Runtime/ObjectParenting/ParentingInSceneObjectsTests.cs
+++ b/testproject/Assets/Tests/Runtime/ObjectParenting/ParentingInSceneObjectsTests.cs
@@ -328,7 +328,7 @@ namespace TestProject.RuntimeTests
             SceneManager.LoadScene(k_BaseSceneToLoad, LoadSceneMode.Additive);
             m_InitialClientsLoadedScene = false;
             m_ServerNetworkManager.SceneManager.OnSceneEvent += SceneManager_OnSceneEvent;
-
+            m_ServerNetworkManager.SceneManager.ClientSynchronizationMode = LoadSceneMode.Additive;
             var sceneEventStartedStatus = m_ServerNetworkManager.SceneManager.LoadScene(k_TestSceneToLoad, LoadSceneMode.Additive);
             Assert.True(sceneEventStartedStatus == SceneEventProgressStatus.Started, $"Failed to load scene {k_TestSceneToLoad} with a return status of {sceneEventStartedStatus}.");
             yield return WaitForConditionOrTimeOut(() => m_InitialClientsLoadedScene);

--- a/testproject/ProjectSettings/EditorBuildSettings.asset
+++ b/testproject/ProjectSettings/EditorBuildSettings.asset
@@ -122,6 +122,15 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Tests/Manual/IntegrationTestScenes/GenericInScenePlacedObject.unity
     guid: 43c36dc1d38660e4d9879e84e580e22f
+  - enabled: 1
+    path: Assets/Tests/Manual/IntegrationTestScenes/EmptyScene1.unity
+    guid: 057ba2cc37faa0b43aa7051d9f555caa
+  - enabled: 1
+    path: Assets/Tests/Manual/IntegrationTestScenes/EmptyScene2.unity
+    guid: 17b92153f7381d34fa48c4d5c0393d13
+  - enabled: 1
+    path: Assets/Tests/Manual/IntegrationTestScenes/EmptyScene3.unity
+    guid: abd4c8b51c445d54faa16c67ac973f1b
   m_configObjects:
     com.unity.addressableassets: {fileID: 11400000, guid: 5a3d5c53c25349c48912726ae850f3b0,
       type: 2}


### PR DESCRIPTION
When the `NetworkSceneManager.ClientSynchronizationMode` is set to `LoadSceneMode.Additive` and the client is being synchronized, `NetworkSceneManager` should not clear its scene placed objects list as there might already be in-scene `NetworkObject`s populated. This can happen if the default active scene is already loaded on the host and client(s) side and before one or more client(s) connect the active scene gets changed on the server side.
Pertains to #2377

[MTT-3363](https://jira.unity3d.com/browse/MTT-3363)
[MTT-5356](https://jira.unity3d.com/browse/MTT-5356)

This also resolves issues related to seamless scene transitions and scene streaming related issues when the `NetworkSceneManager.ClientSynchronizationMode` is set to `LoadSceneMode.Additive`.

This also includes added `NetworkObject` scene migration synchronization capabilities that will synchronize clients when a `NetworkObject` is migrated to a different scene as well as synchronizes late joining clients.  
This also includes the ability to synchronize clients when the currently active scene is changed on the server side along with the ability to set a `NetworkObject` to auto-synchronize itself with the change (i.e. automatically migrates to the new active scene).

[Internal Companion Project](https://github.cds.internal.unity3d.com/noel-stephens/Additive-ClientSynchronizationMode): This project demonstrates the various fixes and additions related to this PR.


## Changelog
### Added
- Added: `NetworkSceneManager.ActiveSceneSynchronizationEnabled` property, disabled by default, that enables client synchronization of server-side active scene changes.
- Added: `NetworkObject.ActiveSceneSynchronization`, disabled by default, that will automatically migrate a `NetworkObject` to a newly assigned active scene.
- Added: `NetworkObject.SceneMigrationSynchronization`, enabled by default, that will synchronize client(s) when a `NetworkObject` is migrated into a new scene on the server side via `SceneManager.MoveGameObjectToScene`.

### Changed
- Updated: `NetworkSceneManager` to migrate dynamically spawned `NetworkObject`s with `DestroyWithScene` set to false into the active scene if their current scene is unloaded.
- Updated: the server to synchronize its local `NetworkSceneManager.ClientSynchronizationMode` during the initial client synchronization.

### Fixed:
- Fixed: issue when the `NetworkSceneManager.ClientSynchronizationMode` is `LoadSceneMode.Additive` and the server changes the currently active scene prior to a client connecting then upon a client connecting and being synchronized the NetworkSceneManager would clear its internal ScenePlacedObjects list that could already be populated.
- Fixed: issue where a client would load duplicate scenes of already preloaded scenes during the initial client synchronization and `NetworkSceneManager.ClientSynchronizationMode` was set to `LoadSceneMode.Additive`.

## Testing and Documentation
- Includes integration test additions and updates:
  - ClientSynchronizationModeTests (added for additive client synchronization mode tests)
  - NetworkObjectSceneMigrationTests (added for `NetworkObject` scene migration tests)
  - ParentDynamicUnderInScenePlacedHelper (updated to test Client Synch Additive + Parenting)
  - ParentingInSceneObjectsTests (updated to test Client Synch Additive + Parenting In-Scene Placed)
