### PR TITLE
refactor: reorganize `InternalsVisibleTo` directives in `AssemblyInfo.cs` files

### DIFF
--- a/com.unity.netcode.gameobjects/Components/AssemblyInfo.cs
+++ b/com.unity.netcode.gameobjects/Components/AssemblyInfo.cs
@@ -1,15 +1,15 @@
 using System.Runtime.CompilerServices;
 
 #if UNITY_EDITOR
-[assembly: InternalsVisibleTo("Unity.Netcode.Editor.CodeGen")]
 [assembly: InternalsVisibleTo("Unity.Netcode.Editor")]
-#endif
+[assembly: InternalsVisibleTo("Unity.Netcode.Editor.CodeGen")]
+#endif // UNITY_EDITOR
 
 #if UNITY_INCLUDE_TESTS
+[assembly: InternalsVisibleTo("Unity.Netcode.RuntimeTests")]
+[assembly: InternalsVisibleTo("TestProject.RuntimeTests")]
 #if UNITY_EDITOR
 [assembly: InternalsVisibleTo("Unity.Netcode.EditorTests")]
 [assembly: InternalsVisibleTo("TestProject.EditorTests")]
-#endif
-[assembly: InternalsVisibleTo("TestProject.RuntimeTests")]
-[assembly: InternalsVisibleTo("Unity.Netcode.RuntimeTests")]
-#endif
+#endif // UNITY_EDITOR
+#endif // UNITY_INCLUDE_TESTS

--- a/com.unity.netcode.gameobjects/Editor/AssemblyInfo.cs
+++ b/com.unity.netcode.gameobjects/Editor/AssemblyInfo.cs
@@ -1,3 +1,7 @@
 using System.Runtime.CompilerServices;
 
+#if UNITY_INCLUDE_TESTS
+#if UNITY_EDITOR
 [assembly: InternalsVisibleTo("Unity.Netcode.EditorTests")]
+#endif // UNITY_EDITOR
+#endif // UNITY_INCLUDE_TESTS

--- a/com.unity.netcode.gameobjects/Runtime/AssemblyInfo.cs
+++ b/com.unity.netcode.gameobjects/Runtime/AssemblyInfo.cs
@@ -1,15 +1,25 @@
 using System.Runtime.CompilerServices;
 
 #if UNITY_EDITOR
-[assembly: InternalsVisibleTo("Unity.Netcode.EditorTests")]
-[assembly: InternalsVisibleTo("Unity.Netcode.Editor.CodeGen")]
 [assembly: InternalsVisibleTo("Unity.Netcode.Editor")]
-[assembly: InternalsVisibleTo("TestProject.EditorTests")]
 [assembly: InternalsVisibleTo("Unity.Netcode.Editor.CodeGen")]
-#endif
-[assembly: InternalsVisibleTo("TestProject.ToolsIntegration.RuntimeTests")]
-[assembly: InternalsVisibleTo("TestProject.RuntimeTests")]
+#endif // UNITY_EDITOR
+#if MULTIPLAYER_TOOLS
+[assembly: InternalsVisibleTo("Unity.Multiplayer.Tools.Adapters.Ngo1WithUtp2")]
+#endif // MULTIPLAYER_TOOLS
+#if COM_UNITY_NETCODE_ADAPTER_UTP
+[assembly: InternalsVisibleTo("Unity.Netcode.Adapter.UTP")]
+#endif // COM_UNITY_NETCODE_ADAPTER_UTP
+
+#if UNITY_INCLUDE_TESTS
 [assembly: InternalsVisibleTo("Unity.Netcode.RuntimeTests")]
 [assembly: InternalsVisibleTo("Unity.Netcode.TestHelpers.Runtime")]
-[assembly: InternalsVisibleTo("Unity.Netcode.Adapter.UTP")]
-[assembly: InternalsVisibleTo("Unity.Multiplayer.Tools.Adapters.Ngo1WithUtp2")]
+[assembly: InternalsVisibleTo("TestProject.RuntimeTests")]
+#if UNITY_EDITOR
+[assembly: InternalsVisibleTo("Unity.Netcode.EditorTests")]
+[assembly: InternalsVisibleTo("TestProject.EditorTests")]
+#endif // UNITY_EDITOR
+#if MULTIPLAYER_TOOLS
+[assembly: InternalsVisibleTo("TestProject.ToolsIntegration.RuntimeTests")]
+#endif // MULTIPLAYER_TOOLS
+#endif // UNITY_INCLUDE_TESTS

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/AssemblyInfo.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/AssemblyInfo.cs
@@ -1,6 +1,12 @@
 using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("TestProject.EditorTests")]
-[assembly: InternalsVisibleTo("TestProject.RuntimeTests")]
-[assembly: InternalsVisibleTo("TestProject.ToolsIntegration.RuntimeTests")]
+#if UNITY_INCLUDE_TESTS
 [assembly: InternalsVisibleTo("Unity.Netcode.RuntimeTests")]
+[assembly: InternalsVisibleTo("TestProject.RuntimeTests")]
+#if UNITY_EDITOR
+[assembly: InternalsVisibleTo("TestProject.EditorTests")]
+#endif // UNITY_EDITOR
+#if MULTIPLAYER_TOOLS
+[assembly: InternalsVisibleTo("TestProject.ToolsIntegration.RuntimeTests")]
+#endif // MULTIPLAYER_TOOLS
+#endif // UNITY_INCLUDE_TESTS

--- a/com.unity.netcode.gameobjects/Tests/Runtime/AssemblyInfo.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/AssemblyInfo.cs
@@ -1,5 +1,11 @@
 using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("TestProject.EditorTests")]
+#if UNITY_INCLUDE_TESTS
 [assembly: InternalsVisibleTo("TestProject.RuntimeTests")]
+#if UNITY_EDITOR
+[assembly: InternalsVisibleTo("TestProject.EditorTests")]
+#endif // UNITY_EDITOR
+#if MULTIPLAYER_TOOLS
 [assembly: InternalsVisibleTo("TestProject.ToolsIntegration.RuntimeTests")]
+#endif // MULTIPLAYER_TOOLS
+#endif // UNITY_INCLUDE_TESTS


### PR DESCRIPTION
By using `UNITY_INCLUDE_TESTS`, `UNITY_EDITOR`, `MULTIPLAYER_TOOLS` and other macros, we're exposing internals of asmdefs more carefully with much more limited scope/exposure.