### PR TITLE
fix: NetworkAnimator not synchronizing changes to layer weights

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -21,6 +21,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Network prefabs are now stored in a ScriptableObject that can be shared between NetworkManagers, and have been exposed for public access. By default, a Default Prefabs List is created that contains all NetworkObject prefabs in the project, and new NetworkManagers will default to using that unless that option is turned off in the Netcode for GameObjects settings. Existing NetworkManagers will maintain their existing lists, which can be migrated to the new format via a button in their inspector. (#2322)
 
 ### Fixed
+- Fixed issue where changes to a layer's weight would not synchronize unless a state transition was occurring.(#2399)
 - Fixed issue where `NetworkManager.LocalClientId` was returning the `NetworkTransport.ServerClientId` as opposed to the `NetworkManager.m_LocalClientId`. (#2398)
 - Fixed a UTP test that was failing when you install Unity Transport package 2.0.0 or newer. (#2347)
 - Fixed issue where `NetcodeSettingsProvider` would throw an exception in Unity 2020.3.x versions. (#2345)

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -1100,6 +1100,16 @@ namespace Unity.Netcode.Components
         /// </summary>
         internal void UpdateAnimationState(AnimationState animationState)
         {
+            // Handle updating layer weights first.
+            if (animationState.Layer < m_LayerWeights.Length)
+            {
+                if (m_LayerWeights[animationState.Layer] != animationState.Weight)
+                {
+                    m_Animator.SetLayerWeight(animationState.Layer, animationState.Weight);
+                }
+            }
+
+            // If there is no state transition then return
             if (animationState.StateHash == 0)
             {
                 return;
@@ -1147,7 +1157,6 @@ namespace Unity.Netcode.Components
                     m_Animator.Play(animationState.StateHash, animationState.Layer, animationState.NormalizedTime);
                 }
             }
-            m_Animator.SetLayerWeight(animationState.Layer, animationState.Weight);
         }
 
         /// <summary>

--- a/testproject/Assets/Tests/Manual/NetworkAnimatorTests/AnimatedCubeController.cs
+++ b/testproject/Assets/Tests/Manual/NetworkAnimatorTests/AnimatedCubeController.cs
@@ -179,6 +179,16 @@ namespace Tests.Manual.NetworkAnimatorTests
             m_NetworkAnimator.SetTrigger("Attack");
         }
 
+        private void SetLayerWeight(int layer, float weight)
+        {
+            m_Animator.SetLayerWeight(layer, weight);
+        }
+
+        private float GetLayerWeight(int layer)
+        {
+            return m_Animator.GetLayerWeight(layer);
+        }
+
         private void LateUpdate()
         {
 
@@ -186,6 +196,10 @@ namespace Tests.Manual.NetworkAnimatorTests
             {
                 if (!IsOwner && IsSpawned)
                 {
+                    if (Input.GetKeyDown(KeyCode.Alpha4))
+                    {
+                        Debug.Log($"Layer 1 weight: {GetLayerWeight(1)}");
+                    }
                     DisplayTestIntValueIfChanged();
                     return;
                 }
@@ -229,6 +243,10 @@ namespace Tests.Manual.NetworkAnimatorTests
                 BeginAttack(2);
             }
 
+            if (Input.GetKeyDown(KeyCode.Alpha3))
+            {
+                SetLayerWeight(1, 0.75f);
+            }
         }
     }
 }

--- a/testproject/Assets/Tests/Runtime/Animation/AnimatorTestHelper.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/AnimatorTestHelper.cs
@@ -153,5 +153,15 @@ namespace TestProject.RuntimeTests
         {
             return m_NetworkAnimator;
         }
+
+        public void SetLayerWeight(int layer, float weight)
+        {
+            m_Animator.SetLayerWeight(layer, weight);
+        }
+
+        public float GetLayerWeight(int layer)
+        {
+            return m_Animator.GetLayerWeight(layer);
+        }
     }
 }

--- a/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
@@ -190,7 +190,6 @@ namespace TestProject.RuntimeTests
 
         private bool AllTriggersDetected(OwnerShipMode ownerShipMode)
         {
-            var serverParameters = AnimatorTestHelper.ServerSideInstance.GetParameterValues();
             if (ownerShipMode == OwnerShipMode.ClientOwner)
             {
                 if (!TriggerTest.ClientsThatTriggered.Contains(m_ServerNetworkManager.LocalClientId))
@@ -206,6 +205,31 @@ namespace TestProject.RuntimeTests
                     continue;
                 }
                 if (!TriggerTest.ClientsThatTriggered.Contains(animatorTestHelper.Value.NetworkManager.LocalClientId))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private bool AllInstancesSameLayerWeight(OwnerShipMode ownerShipMode, int layer, float targetWeight)
+        {
+
+            if (ownerShipMode == OwnerShipMode.ClientOwner)
+            {
+                if (AnimatorTestHelper.ServerSideInstance.GetLayerWeight(layer) != targetWeight)
+                {
+                    return false;
+                }
+            }
+
+            foreach (var animatorTestHelper in AnimatorTestHelper.ClientSideInstances)
+            {
+                if (ownerShipMode == OwnerShipMode.ClientOwner && animatorTestHelper.Value.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId)
+                {
+                    continue;
+                }
+                if (animatorTestHelper.Value.GetLayerWeight(layer) != targetWeight)
                 {
                     return false;
                 }
@@ -365,6 +389,55 @@ namespace TestProject.RuntimeTests
             networkManager.NetworkConfig.Prefabs.Add(networkPrefab);
             networkPrefab = new NetworkPrefab() { Prefab = m_AnimationOwnerTestPrefab };
             networkManager.NetworkConfig.Prefabs.Add(networkPrefab);
+        }
+
+        /// <summary>
+        /// Verifies that triggers are synchronized with currently connected clients
+        /// </summary>
+        /// <param name="authoritativeMode">Server or Owner authoritative</param>
+        [UnityTest]
+        public IEnumerator WeightUpdateTests([Values] OwnerShipMode ownerShipMode, [Values] AuthoritativeMode authoritativeMode)
+        {
+            CheckStateEnterCount.ResetTest();
+            TriggerTest.ResetTest();
+            VerboseDebug($" ++++++++++++++++++ Weight Test [{ownerShipMode}] Starting ++++++++++++++++++ ");
+            TriggerTest.IsVerboseDebug = m_EnableVerboseDebug;
+            AnimatorTestHelper.IsTriggerTest = m_EnableVerboseDebug;
+
+            // Spawn our test animator object
+            var objectInstance = SpawnPrefab(ownerShipMode == OwnerShipMode.ClientOwner, authoritativeMode);
+
+            // Wait for it to spawn server-side
+            yield return WaitForConditionOrTimeOut(() => AnimatorTestHelper.ServerSideInstance != null);
+            AssertOnTimeout($"Timed out waiting for the server-side instance of {GetNetworkAnimatorName(authoritativeMode)} to be spawned!");
+
+            // Wait for it to spawn client-side
+            yield return WaitForConditionOrTimeOut(WaitForClientsToInitialize);
+            AssertOnTimeout($"Timed out waiting for the client-side instance of {GetNetworkAnimatorName(authoritativeMode)} to be spawned!");
+            var animatorTestHelper = ownerShipMode == OwnerShipMode.ClientOwner ? AnimatorTestHelper.ClientSideInstances[m_ClientNetworkManagers[0].LocalClientId] : AnimatorTestHelper.ServerSideInstance;
+            var layerCount = animatorTestHelper.GetAnimator().layerCount;
+
+            var animationStateCount = animatorTestHelper.GetAnimatorStateCount();
+            Assert.True(layerCount == animationStateCount, $"AnimationState count {animationStateCount} does not equal the layer count {layerCount}!");
+
+            if (authoritativeMode == AuthoritativeMode.ServerAuth)
+            {
+                animatorTestHelper = AnimatorTestHelper.ServerSideInstance;
+            }
+
+            animatorTestHelper.SetLayerWeight(1, 0.75f);
+            // Wait for all instances to update their weight value for layer 1
+            yield return WaitForConditionOrTimeOut(() => AllInstancesSameLayerWeight(ownerShipMode, 1, 0.75f));
+            AssertOnTimeout($"Timed out waiting for all instances to match weight 0.75 on layer 1!");
+
+            // Now late join a client
+            yield return CreateAndStartNewClient();
+
+            // Verify the late joined client is synchronized to the changed weight
+            yield return WaitForConditionOrTimeOut(() => AllInstancesSameLayerWeight(ownerShipMode, 1, 0.75f));
+
+            AnimatorTestHelper.IsTriggerTest = false;
+            VerboseDebug($" ------------------ Weight Test [{ownerShipMode}] Stopping ------------------ ");
         }
 
         /// <summary>

--- a/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
@@ -435,6 +435,7 @@ namespace TestProject.RuntimeTests
 
             // Verify the late joined client is synchronized to the changed weight
             yield return WaitForConditionOrTimeOut(() => AllInstancesSameLayerWeight(ownerShipMode, 1, 0.75f));
+            AssertOnTimeout($"[Late-Join] Timed out waiting for all instances to match weight 0.75 on layer 1!");
 
             AnimatorTestHelper.IsTriggerTest = false;
             VerboseDebug($" ------------------ Weight Test [{ownerShipMode}] Stopping ------------------ ");


### PR DESCRIPTION
This resolves the issue where layer weights were not being updated unless a state transition was occurring.
[MTT-5389](https://jira.unity3d.com/browse/MTT-5389)

## Changelog
- Fixed: Issue where changes to a layer's weight would not synchronize unless a state transition was occurring.

## Testing and Documentation
- Includes integration tests additions.
