### PR TITLE
misc: Don't use 0.0.0.0 as the default listen address and warn if using a loopback

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+- `UnityTransport` will now emit a warning if binding to a loopback address with an empty 'Server Listen Address' setting. The warning can be silenced by entering a valid IP address (127.0.0.1 is recommended for local development, 0.0.0.0 if accepting remote connections is required).
 - Updated `UnityTransport` dependency on `com.unity.transport` to 1.3.1.
 - `NetworkShow()` of `NetworkObject`s are delayed until the end of the frame to ensure consistency of delta-driven variables like `NetworkList`.
 - Dirty `NetworkObject` are reset at end-of-frame and not at serialization time.

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -16,7 +16,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - `NetworkShow()` of `NetworkObject`s are delayed until the end of the frame to ensure consistency of delta-driven variables like `NetworkList`.
 - Dirty `NetworkObject` are reset at end-of-frame and not at serialization time.
 - `NetworkHide()` of an object that was just `NetworkShow()`n produces a warning, as remote clients will _not_ get a spawn/despawn pair.
-- The default listen address of `UnityTransport` is now 0.0.0.0. (#2307)
 - Renamed the NetworkTransform.SetState parameter `shouldGhostsInterpolate` to `teleportDisabled` for better clarity of what that parameter does. (#2228)
 - Network prefabs are now stored in a ScriptableObject that can be shared between NetworkManagers, and have been exposed for public access. By default, a Default Prefabs List is created that contains all NetworkObject prefabs in the project, and new NetworkManagers will default to using that unless that option is turned off in the Netcode for GameObjects settings. Existing NetworkManagers will maintain their existing lists, which can be migrated to the new format via a button in their inspector. (#2322)
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,7 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
-- `UnityTransport` will now emit a warning if binding to a loopback address with an empty 'Server Listen Address' setting. The warning can be silenced by entering a valid IP address (127.0.0.1 is recommended for local development, 0.0.0.0 if accepting remote connections is required).
+- `UnityTransport` will now emit a warning if binding to a loopback address with an empty 'Server Listen Address' setting. The warning can be silenced by entering a valid IP address (127.0.0.1 is recommended for local development, 0.0.0.0 if accepting remote connections is required). (#2406)
 - Updated `UnityTransport` dependency on `com.unity.transport` to 1.3.1.
 - `NetworkShow()` of `NetworkObject`s are delayed until the end of the frame to ensure consistency of delta-driven variables like `NetworkList`.
 - Dirty `NetworkObject` are reset at end-of-frame and not at serialization time.

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -303,9 +303,9 @@ namespace Unity.Netcode.Transports.UTP
             public ushort Port;
 
             /// <summary>
-            /// IP address the server will listen on. If not provided, will use 0.0.0.0.
+            /// IP address the server will listen on. If not provided, will use 'Address'.
             /// </summary>
-            [Tooltip("IP address the server will listen on. If not provided, will use 0.0.0.0.")]
+            [Tooltip("IP address the server will listen on. If not provided, will use 'Address'.")]
             [SerializeField]
             public string ServerListenAddress;
 
@@ -330,29 +330,7 @@ namespace Unity.Netcode.Transports.UTP
             /// <summary>
             /// Endpoint (IP address and port) server will listen/bind on.
             /// </summary>
-            public NetworkEndpoint ListenEndPoint
-            {
-                get
-                {
-                    if (string.IsNullOrEmpty(ServerListenAddress))
-                    {
-                        var ep = NetworkEndpoint.AnyIpv4;
-
-                        // If an address was entered and it's IPv6, switch to using :: as the
-                        // default listen address. (Otherwise we always assume IPv4.)
-                        if (!string.IsNullOrEmpty(Address) && ServerEndPoint.Family == NetworkFamily.Ipv6)
-                        {
-                            ep = NetworkEndpoint.AnyIpv6;
-                        }
-
-                        return ep.WithPort(Port);
-                    }
-                    else
-                    {
-                        return ParseNetworkEndpoint(ServerListenAddress, Port);
-                    }
-                }
-            }
+            public NetworkEndpoint ListenEndPoint => ParseNetworkEndpoint((ServerListenAddress?.Length == 0) ? Address : ServerListenAddress, Port);
         }
 
         /// <summary>
@@ -551,14 +529,14 @@ namespace Unity.Netcode.Transports.UTP
             int result = m_Driver.Bind(endPoint);
             if (result != 0)
             {
-                Debug.LogError("Server failed to bind. This is usually caused by another process being bound to the same port.");
+                Debug.LogError("Server failed to bind");
                 return false;
             }
 
             result = m_Driver.Listen();
             if (result != 0)
             {
-                Debug.LogError("Server failed to listen.");
+                Debug.LogError("Server failed to listen");
                 return false;
             }
 
@@ -1498,7 +1476,7 @@ namespace Unity.Netcode.Transports.UTP
                 {
                     if (NetworkManager.IsServer)
                     {
-                        if (string.IsNullOrEmpty(m_ServerCertificate) || string.IsNullOrEmpty(m_ServerPrivateKey))
+                        if (String.IsNullOrEmpty(m_ServerCertificate) || String.IsNullOrEmpty(m_ServerPrivateKey))
                         {
                             throw new Exception("In order to use encrypted communications, when hosting, you must set the server certificate and key.");
                         }
@@ -1507,11 +1485,11 @@ namespace Unity.Netcode.Transports.UTP
                     }
                     else
                     {
-                        if (string.IsNullOrEmpty(m_ServerCommonName))
+                        if (String.IsNullOrEmpty(m_ServerCommonName))
                         {
                             throw new Exception("In order to use encrypted communications, clients must set the server common name.");
                         }
-                        else if (string.IsNullOrEmpty(m_ClientCaCertificate))
+                        else if (String.IsNullOrEmpty(m_ClientCaCertificate))
                         {
                             m_NetworkSettings.WithSecureClientParameters(m_ServerCommonName);
                         }

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -529,7 +529,7 @@ namespace Unity.Netcode.Transports.UTP
             int result = m_Driver.Bind(endPoint);
             if (result != 0)
             {
-                Debug.LogError("Server failed to bind");
+                Debug.LogError("Server failed to bind. This is usually caused by another process being bound to the same port.");
                 return false;
             }
 
@@ -1476,7 +1476,7 @@ namespace Unity.Netcode.Transports.UTP
                 {
                     if (NetworkManager.IsServer)
                     {
-                        if (String.IsNullOrEmpty(m_ServerCertificate) || String.IsNullOrEmpty(m_ServerPrivateKey))
+                        if (string.IsNullOrEmpty(m_ServerCertificate) || string.IsNullOrEmpty(m_ServerPrivateKey))
                         {
                             throw new Exception("In order to use encrypted communications, when hosting, you must set the server certificate and key.");
                         }
@@ -1485,11 +1485,11 @@ namespace Unity.Netcode.Transports.UTP
                     }
                     else
                     {
-                        if (String.IsNullOrEmpty(m_ServerCommonName))
+                        if (string.IsNullOrEmpty(m_ServerCommonName))
                         {
                             throw new Exception("In order to use encrypted communications, clients must set the server common name.");
                         }
-                        else if (String.IsNullOrEmpty(m_ClientCaCertificate))
+                        else if (string.IsNullOrEmpty(m_ClientCaCertificate))
                         {
                             m_NetworkSettings.WithSecureClientParameters(m_ServerCommonName);
                         }

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -559,7 +559,7 @@ namespace Unity.Netcode.Transports.UTP
             result = m_Driver.Listen();
             if (result != 0)
             {
-                Debug.LogError("Server failed to listen");
+                Debug.LogError("Server failed to listen.");
                 return false;
             }
 

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -330,7 +330,30 @@ namespace Unity.Netcode.Transports.UTP
             /// <summary>
             /// Endpoint (IP address and port) server will listen/bind on.
             /// </summary>
-            public NetworkEndpoint ListenEndPoint => ParseNetworkEndpoint((ServerListenAddress?.Length == 0) ? Address : ServerListenAddress, Port);
+            public NetworkEndpoint ListenEndPoint
+            {
+                get
+                {
+                    if (string.IsNullOrEmpty(ServerListenAddress))
+                    {
+                        var ep = ParseNetworkEndpoint(Address, Port);
+
+                        if (ep.IsLoopback)
+                        {
+                            Debug.LogWarning("Server/host will only listen for local connections. To allow connections " +
+                                "from remote devices, set the 'Server Listen Address' setting of the 'Unity Transport' " +
+                                "component to 0.0.0.0. To preserve the current behavior and silence this warning, set " +
+                                "it to 127.0.0.1 instead.");
+                        }
+
+                        return ep;
+                    }
+                    else
+                    {
+                        return ParseNetworkEndpoint(ServerListenAddress, Port);
+                    }
+                }
+            }
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
@@ -181,6 +181,9 @@ namespace Unity.Netcode.TestHelpers.Runtime
             unityTransport.MaxConnectAttempts = 4;
             unityTransport.ConnectTimeoutMS = 500;
 
+            // Prevent the warning about binding to localhost.
+            unityTransport.SetConnectionData("127.0.0.1", 7777, "127.0.0.1");
+
             // Set the NetworkConfig
             networkManager.NetworkConfig ??= new NetworkConfig();
             networkManager.NetworkConfig.NetworkTransport = unityTransport;

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetworkManagerHelper.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetworkManagerHelper.cs
@@ -69,6 +69,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 Debug.Log($"{nameof(NetworkManager)} Instantiated.");
 
                 var unityTransport = NetworkManagerGameObject.AddComponent<UnityTransport>();
+                unityTransport.SetConnectionData("127.0.0.1", 7777, "127.0.0.1");
                 if (networkConfig == null)
                 {
                     networkConfig = new NetworkConfig

--- a/com.unity.netcode.gameobjects/Tests/Editor/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Transports/UnityTransportTests.cs
@@ -115,7 +115,7 @@ namespace Unity.Netcode.EditorTests
             UnityTransport transport = new GameObject().AddComponent<UnityTransport>();
             transport.Initialize();
 
-            transport.SetConnectionData("127.0.0.", 4242, "127.0.0.");
+            transport.SetConnectionData("127.0.0.", 4242);
             Assert.False(transport.StartServer());
 
             LogAssert.Expect(LogType.Error, "Invalid network endpoint: 127.0.0.:4242.");
@@ -124,20 +124,7 @@ namespace Unity.Netcode.EditorTests
 #endif
             LogAssert.Expect(LogType.Error, "Server failed to bind. This is usually caused by another process being bound to the same port.");
 
-            transport.SetConnectionData("127.0.0.1", 4242, "127.0.0.1");
-            Assert.True(transport.StartServer());
-
-            transport.Shutdown();
-        }
-
-        // Check that leaving all addresses empty is valid.
-        [Test]
-        public void UnityTransport_StartServerWithoutAddresses()
-        {
-            UnityTransport transport = new GameObject().AddComponent<UnityTransport>();
-            transport.Initialize();
-
-            transport.SetConnectionData(string.Empty, 4242);
+            transport.SetConnectionData("127.0.0.1", 4242);
             Assert.True(transport.StartServer());
 
             transport.Shutdown();

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTestHelpers.cs
@@ -51,7 +51,11 @@ namespace Unity.Netcode.RuntimeTests
 
             if (family == NetworkFamily.Ipv6)
             {
-                transport.SetConnectionData("::1", 7777);
+                transport.SetConnectionData("::1", 7777, "::1");
+            }
+            else
+            {
+                transport.SetConnectionData("127.0.0.1", 7777, "127.0.0.1");
             }
 
             transport.Initialize();


### PR DESCRIPTION
This PR reverts the changes introduced with PR #2307 and instead opts to emit a warning if the default address that would be used as the listen address is a loopback. The warning can be silenced by inputting any valid local address as the listen address (even if it's a loopback like 127.0.0.1).

Since the warning will be emitted with the default configuration of the transport, the PR also modifies a few test helpers to avoid it for tests using those helpers.

## Changelog

- Changed: `UnityTransport` will now emit a warning if binding to a loopback address with an empty 'Server Listen Address' setting. The warning can be silenced by entering a valid IP address (127.0.0.1 is recommended for local development, 0.0.0.0 if accepting remote connections is required).

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.