### PR TITLE
misc: revert default bind ip to use loopback and update UI to be more user-friendly

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,11 +12,11 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+- The UTP component UI has been updated to be more user-friendly for new users by adding a simple toggle to switch between local-only (127.0.0.1) and remote (0.0.0.0) binding modes, using the toggle "Allow Remote Connections" (#2408)
 - Updated `UnityTransport` dependency on `com.unity.transport` to 1.3.1.
 - `NetworkShow()` of `NetworkObject`s are delayed until the end of the frame to ensure consistency of delta-driven variables like `NetworkList`.
 - Dirty `NetworkObject` are reset at end-of-frame and not at serialization time.
 - `NetworkHide()` of an object that was just `NetworkShow()`n produces a warning, as remote clients will _not_ get a spawn/despawn pair.
-- The default listen address of `UnityTransport` is now 0.0.0.0. (#2307)
 - Renamed the NetworkTransform.SetState parameter `shouldGhostsInterpolate` to `teleportDisabled` for better clarity of what that parameter does. (#2228)
 - Network prefabs are now stored in a ScriptableObject that can be shared between NetworkManagers, and have been exposed for public access. By default, a Default Prefabs List is created that contains all NetworkObject prefabs in the project, and new NetworkManagers will default to using that unless that option is turned off in the Netcode for GameObjects settings. Existing NetworkManagers will maintain their existing lists, which can be migrated to the new format via a button in their inspector. (#2322)
 

--- a/com.unity.netcode.gameobjects/Editor/HiddenScriptEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/HiddenScriptEditor.cs
@@ -4,6 +4,7 @@ using Unity.Netcode.Transports.UNET;
 #endif
 using Unity.Netcode.Transports.UTP;
 using UnityEditor;
+using UnityEngine;
 
 namespace Unity.Netcode.Editor
 {
@@ -43,7 +44,109 @@ namespace Unity.Netcode.Editor
     [CustomEditor(typeof(UnityTransport), true)]
     public class UnityTransportEditor : HiddenScriptEditor
     {
+        private static readonly string[] k_HiddenFields = { "m_Script", "ConnectionData" };
 
+        private bool m_AllowIncomingConnections;
+        private bool m_Initialized;
+
+        private UnityTransport m_UnityTransport;
+
+        private SerializedProperty m_ServerAddressProperty;
+        private SerializedProperty m_ServerPortProperty;
+        private SerializedProperty m_OverrideBindIpProperty;
+
+        private const string k_LoopbackIpv4 = "127.0.0.1";
+        private const string k_LoopbackIpv6 = "::1";
+        private const string k_AnyIpv4 = "0.0.0.0";
+        private const string k_AnyIpv6 = "::";
+
+
+        private void Initialize()
+        {
+            if (m_Initialized)
+            {
+                return;
+            }
+            m_Initialized = true;
+            m_UnityTransport = (UnityTransport)target;
+
+            var connectionDataProperty = serializedObject.FindProperty(nameof(UnityTransport.ConnectionData));
+
+            m_ServerAddressProperty = connectionDataProperty.FindPropertyRelative(nameof(UnityTransport.ConnectionAddressData.Address));
+            m_ServerPortProperty = connectionDataProperty.FindPropertyRelative(nameof(UnityTransport.ConnectionAddressData.Port));
+            m_OverrideBindIpProperty = connectionDataProperty.FindPropertyRelative(nameof(UnityTransport.ConnectionAddressData.ServerListenAddress));
+        }
+
+        /// <summary>
+        /// Draws inspector properties without the script field.
+        /// </summary>
+        public override void OnInspectorGUI()
+        {
+            Initialize();
+            EditorGUI.BeginChangeCheck();
+            serializedObject.UpdateIfRequiredOrScript();
+            DrawPropertiesExcluding(serializedObject, k_HiddenFields);
+            serializedObject.ApplyModifiedProperties();
+            EditorGUI.EndChangeCheck();
+
+            EditorGUILayout.PropertyField(m_ServerAddressProperty);
+            EditorGUILayout.PropertyField(m_ServerPortProperty);
+
+            serializedObject.ApplyModifiedProperties();
+
+            EditorGUILayout.HelpBox("It's recommended to leave this disabled for local testing to avoid exposing ports on your device.", MessageType.Info);
+            bool allowIncomingConnections = m_UnityTransport.ConnectionData.ServerListenAddress != k_LoopbackIpv4 && m_UnityTransport.ConnectionData.ServerListenAddress != k_LoopbackIpv6 && !string.IsNullOrEmpty(m_UnityTransport.ConnectionData.ServerListenAddress);
+            allowIncomingConnections = EditorGUILayout.Toggle(new GUIContent("Allow Incoming Connections", $"Bind IP: {m_UnityTransport.ConnectionData.ServerListenAddress}"), allowIncomingConnections);
+
+            bool isIpV6 = m_UnityTransport.ConnectionData.IsIpv6;
+
+            if (!allowIncomingConnections)
+            {
+                if (m_UnityTransport.ConnectionData.ServerListenAddress != k_LoopbackIpv4 && m_UnityTransport.ConnectionData.ServerListenAddress != k_LoopbackIpv6)
+                {
+                    if (isIpV6)
+                    {
+                        m_UnityTransport.ConnectionData.ServerListenAddress = k_LoopbackIpv6;
+                    }
+                    else
+                    {
+                        m_UnityTransport.ConnectionData.ServerListenAddress = k_LoopbackIpv4;
+                    }
+                    EditorUtility.SetDirty(m_UnityTransport);
+                }
+            }
+
+            using (new EditorGUI.DisabledScope(!allowIncomingConnections))
+            {
+                string overrideIp = m_UnityTransport.ConnectionData.ServerListenAddress;
+                if (overrideIp == k_AnyIpv4 || overrideIp == k_AnyIpv6 || overrideIp == k_LoopbackIpv4 || overrideIp == k_LoopbackIpv6)
+                {
+                    overrideIp = "";
+                }
+
+                overrideIp = EditorGUILayout.TextField("Override Bind IP (optional)", overrideIp);
+                if (allowIncomingConnections)
+                {
+                    if (overrideIp == "")
+                    {
+                        if (isIpV6)
+                        {
+                            overrideIp = k_AnyIpv6;
+                        }
+                        else
+                        {
+                            overrideIp = k_AnyIpv4;
+                        }
+                    }
+
+                    if (m_UnityTransport.ConnectionData.ServerListenAddress != overrideIp)
+                    {
+                        m_UnityTransport.ConnectionData.ServerListenAddress = overrideIp;
+                        EditorUtility.SetDirty(m_UnityTransport);
+                    }
+                }
+            }
+        }
     }
 
 #if COM_UNITY_MODULES_ANIMATION

--- a/com.unity.netcode.gameobjects/Editor/HiddenScriptEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/HiddenScriptEditor.cs
@@ -94,13 +94,13 @@ namespace Unity.Netcode.Editor
 
             serializedObject.ApplyModifiedProperties();
 
-            EditorGUILayout.HelpBox("It's recommended to leave this disabled for local testing to avoid exposing ports on your device.", MessageType.Info);
-            bool allowIncomingConnections = m_UnityTransport.ConnectionData.ServerListenAddress != k_LoopbackIpv4 && m_UnityTransport.ConnectionData.ServerListenAddress != k_LoopbackIpv6 && !string.IsNullOrEmpty(m_UnityTransport.ConnectionData.ServerListenAddress);
-            allowIncomingConnections = EditorGUILayout.Toggle(new GUIContent("Allow Incoming Connections", $"Bind IP: {m_UnityTransport.ConnectionData.ServerListenAddress}"), allowIncomingConnections);
+            EditorGUILayout.HelpBox("It's recommended to leave remote connections disabled for local testing to avoid exposing ports on your device.", MessageType.Info);
+            bool allowRemoteConnections = m_UnityTransport.ConnectionData.ServerListenAddress != k_LoopbackIpv4 && m_UnityTransport.ConnectionData.ServerListenAddress != k_LoopbackIpv6 && !string.IsNullOrEmpty(m_UnityTransport.ConnectionData.ServerListenAddress);
+            allowRemoteConnections = EditorGUILayout.Toggle(new GUIContent("Allow Remote Connections?", $"Bind IP: {m_UnityTransport.ConnectionData.ServerListenAddress}"), allowRemoteConnections);
 
             bool isIpV6 = m_UnityTransport.ConnectionData.IsIpv6;
 
-            if (!allowIncomingConnections)
+            if (!allowRemoteConnections)
             {
                 if (m_UnityTransport.ConnectionData.ServerListenAddress != k_LoopbackIpv4 && m_UnityTransport.ConnectionData.ServerListenAddress != k_LoopbackIpv6)
                 {
@@ -116,7 +116,7 @@ namespace Unity.Netcode.Editor
                 }
             }
 
-            using (new EditorGUI.DisabledScope(!allowIncomingConnections))
+            using (new EditorGUI.DisabledScope(!allowRemoteConnections))
             {
                 string overrideIp = m_UnityTransport.ConnectionData.ServerListenAddress;
                 if (overrideIp == k_AnyIpv4 || overrideIp == k_AnyIpv6 || overrideIp == k_LoopbackIpv4 || overrideIp == k_LoopbackIpv6)
@@ -125,7 +125,7 @@ namespace Unity.Netcode.Editor
                 }
 
                 overrideIp = EditorGUILayout.TextField("Override Bind IP (optional)", overrideIp);
-                if (allowIncomingConnections)
+                if (allowRemoteConnections)
                 {
                     if (overrideIp == "")
                     {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/284434/218224115-7d46e0ca-59bc-4453-b70e-c152cbd87358.png)

## Changelog

- Changed: The UTP component UI has been updated to be more user-friendly for new users by adding a simple toggle to switch between local-only (127.0.0.1) and remote (0.0.0.0) binding modes, using the toggle "Allow Remote Connections"

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.
