### PR TITLE
fix: Network Prefabs List wasn't persisting changes made in the editor. [MTT-5458]

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/Configuration/NetworkPrefabsEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/Configuration/NetworkPrefabsEditor.cs
@@ -90,6 +90,8 @@ namespace Unity.Netcode.Editor
             }
 
             m_NetworkPrefabsList.DoLayoutList();
+
+            serializedObject.ApplyModifiedProperties();
         }
     }
 }


### PR DESCRIPTION

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.
