### PR TITLE
fix: NetworkAnimator generating AnimationCurve warnings

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,16 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+### Fixed
+- Fixed issue where runtime association of `Animator` properties to `AnimationCurve`s would cause `NetworkAnimator` to attempt to update those changes.
+- Fixed issue where `NetworkAnimator` would not check if its associated `Animator` was valid during serialization and would spam exceptions in the editor console.
+
+## [1.3.0]
+
+### Added
+
+### Changed
+
 - The UTP component UI has been updated to be more user-friendly for new users by adding a simple toggle to switch between local-only (127.0.0.1) and remote (0.0.0.0) binding modes, using the toggle "Allow Remote Connections" (#2408)
 - Updated `UnityTransport` dependency on `com.unity.transport` to 1.3.1.
 - `NetworkShow()` of `NetworkObject`s are delayed until the end of the frame to ensure consistency of delta-driven variables like `NetworkList`.

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -13,6 +13,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Changed
 
 ### Fixed
+
+- Fixed registry of public `NetworkVariable`s in derived `NetworkBehaviour`s (#2423)
 - Fixed issue where runtime association of `Animator` properties to `AnimationCurve`s would cause `NetworkAnimator` to attempt to update those changes. (#2416)
 - Fixed issue where `NetworkAnimator` would not check if its associated `Animator` was valid during serialization and would spam exceptions in the editor console. (#2416)
 
@@ -32,7 +34,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed registry of public `NetworkVariable`s in derived `NetworkBehaviour`s (#2423)
 - Fixed issue where changes to a layer's weight would not synchronize unless a state transition was occurring.(#2399)
 - Fixed issue where `NetworkManager.LocalClientId` was returning the `NetworkTransport.ServerClientId` as opposed to the `NetworkManager.m_LocalClientId`. (#2398)
 - Fixed issue where a dynamically spawned `NetworkObject` parented under an in-scene placed `NetworkObject` would have its `InScenePlaced` value changed to `true`. This would result in a soft synchronization error for late joining clients. (#2396)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -13,8 +13,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Changed
 
 ### Fixed
-- Fixed issue where runtime association of `Animator` properties to `AnimationCurve`s would cause `NetworkAnimator` to attempt to update those changes.
-- Fixed issue where `NetworkAnimator` would not check if its associated `Animator` was valid during serialization and would spam exceptions in the editor console.
+- Fixed issue where runtime association of `Animator` properties to `AnimationCurve`s would cause `NetworkAnimator` to attempt to update those changes. (#2416)
+- Fixed issue where `NetworkAnimator` would not check if its associated `Animator` was valid during serialization and would spam exceptions in the editor console. (#2416)
 
 ## [1.3.0]
 

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -279,6 +279,11 @@ namespace Unity.Netcode.Components
             {
                 return;
             }
+            if (m_Animator == null)
+            {
+                return;
+            }
+
             TransitionStateInfoList = new List<TransitionStateinfo>();
             var animatorController = m_Animator.runtimeAnimatorController as AnimatorController;
             if (animatorController == null)
@@ -906,6 +911,10 @@ namespace Unity.Netcode.Components
             for (int i = 0; i < m_CachedAnimatorParameters.Length; i++)
             {
                 ref var cacheValue = ref UnsafeUtility.ArrayElementAsRef<AnimatorParamCache>(m_CachedAnimatorParameters.GetUnsafePtr(), i);
+                if (m_Animator.IsParameterControlledByCurve(cacheValue.Hash))
+                {
+                    continue;
+                }
                 var hash = cacheValue.Hash;
                 if (cacheValue.Type == AnimationParamEnumWrapper.AnimatorControllerParameterInt)
                 {


### PR DESCRIPTION
This PR resolves an issue where `NetworkAnimator` was building a delta check list for any parameter not controlled by `AnimationCurve` during initialization which could change during runtime.  This update generates a delta check list for all parameters and culls out any parameter controlled by an `AnimationCurve` when checking for parameter deltas.  This includes an additional minor fix to an issue that could occur where if the associated `Animator` (assigned to `NetworkAnimator`) was disabled in the editor it would spam exceptions to the console log.

[MTT-5491](https://jira.unity3d.com/browse/MTT-5491)
Related Github Issue:
#2391

## Changelog

- Fixed: issue where runtime association of `Animator` properties to `AnimationCurve`s would cause `NetworkAnimator` to attempt to update those changes.
- Fixed: issue where `NetworkAnimator` would not check if its associated `Animator` was valid during serialization and would spam exceptions in the editor console.indicate where the entry should go.

## Testing and Documentation

- No tests have been added or modified.
