### PR TITLE
fix: NetworkBehaviours with inheritance are failing to sync public NetworkVariables

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -574,7 +574,7 @@ namespace Unity.Netcode
             }
             else
             {
-                list.AddRange(type.GetFields(BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly));
+                list.AddRange(type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly));
             }
 
             if (type.BaseType != null && type.BaseType != typeof(NetworkBehaviour))


### PR DESCRIPTION
If you have a class

```
class A : NetworkBehaviour
{
    private NetworkVariable<int> TestA = new();
    public NetworkVariable<int> TestB = new();
}
```

and a subclass
```
class B : A
{
    public NetworkVariable<int> TestC = new();
}
```

When a NetworkObject with B attached is spawned, Only the private fields on the parent class A will be initialized correctly and sent across the network. TestA and TestC will send fine. TestB will not get its NetworkBehaviour set and wont send.

## Testing and Documentation

- No tests have been added. But we might be able to add a test to validate this situation?
