### PR TITLE
fix: Detection and graceful handling of corrupt packets

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,6 +10,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
+- Added detection and graceful handling of corrupt packets for additional safety. (#2419)
+
 ### Changed
 
 - The UTP component UI has been updated to be more user-friendly for new users by adding a simple toggle to switch between local-only (127.0.0.1) and remote (0.0.0.0) binding modes, using the toggle "Allow Remote Connections" (#2408)

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/BatchHeader.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/BatchHeader.cs
@@ -5,7 +5,7 @@ namespace Unity.Netcode
     /// </summary>
     internal struct BatchHeader : INetworkSerializeByMemcpy
     {
-        internal const ushort k_MagicValue = 0x1160;
+        internal const ushort MagicValue = 0x1160;
         /// <summary>
         /// A magic number to detect corrupt messages.
         /// Always set to k_MagicValue

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/BatchHeader.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/BatchHeader.cs
@@ -5,9 +5,26 @@ namespace Unity.Netcode
     /// </summary>
     internal struct BatchHeader : INetworkSerializeByMemcpy
     {
+        internal const ushort k_MagicValue = 0x1160;
+        /// <summary>
+        /// A magic number to detect corrupt messages.
+        /// Always set to k_MagicValue
+        /// </summary>
+        public ushort Magic;
+
+        /// <summary>
+        /// Total number of bytes in the batch.
+        /// </summary>
+        public int BatchSize;
+
+        /// <summary>
+        /// Hash of the message to detect corrupt messages.
+        /// </summary>
+        public ulong BatchHash;
+
         /// <summary>
         /// Total number of messages in the batch.
         /// </summary>
-        public ushort BatchSize;
+        public ushort BatchCount;
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
@@ -42,7 +42,7 @@ namespace Unity.Netcode
             {
                 Writer = new FastBufferWriter(writerSize, writerAllocator, maxWriterSize);
                 NetworkDelivery = delivery;
-                BatchHeader = new BatchHeader { Magic = BatchHeader.k_MagicValue };
+                BatchHeader = new BatchHeader { Magic = BatchHeader.MagicValue };
             }
         }
 
@@ -232,7 +232,7 @@ namespace Unity.Netcode
 
                     batchReader.ReadValue(out BatchHeader batchHeader);
 
-                    if (batchHeader.Magic != BatchHeader.k_MagicValue)
+                    if (batchHeader.Magic != BatchHeader.MagicValue)
                     {
                         NetworkLog.LogError($"Received a packet with an invalid Magic Value. Please report this to the Netcode for GameObjects team at https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues and include the following data: Offset: {data.Offset}, Size: {data.Count}, Full receive array: {ByteArrayToString(data.Array, 0, data.Array.Length)}");
                         return;

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/MessagingSystem.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Text;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
@@ -41,7 +42,7 @@ namespace Unity.Netcode
             {
                 Writer = new FastBufferWriter(writerSize, writerAllocator, maxWriterSize);
                 NetworkDelivery = delivery;
-                BatchHeader = default;
+                BatchHeader = new BatchHeader { Magic = BatchHeader.k_MagicValue };
             }
         }
 
@@ -204,6 +205,17 @@ namespace Unity.Netcode
             return m_LocalVersions[messageType];
         }
 
+        internal static string ByteArrayToString(byte[] ba, int offset, int count)
+        {
+            var hex = new StringBuilder(ba.Length * 2);
+            for (int i = offset; i < offset + count; ++i)
+            {
+                hex.AppendFormat("{0:x2} ", ba[i]);
+            }
+
+            return hex.ToString();
+        }
+
         internal void HandleIncomingData(ulong clientId, ArraySegment<byte> data, float receiveTime)
         {
             unsafe
@@ -214,18 +226,38 @@ namespace Unity.Netcode
                         new FastBufferReader(nativeData + data.Offset, Allocator.None, data.Count);
                     if (!batchReader.TryBeginRead(sizeof(BatchHeader)))
                     {
-                        NetworkLog.LogWarning("Received a packet too small to contain a BatchHeader. Ignoring it.");
+                        NetworkLog.LogError("Received a packet too small to contain a BatchHeader. Ignoring it.");
                         return;
                     }
 
                     batchReader.ReadValue(out BatchHeader batchHeader);
 
-                    for (var hookIdx = 0; hookIdx < m_Hooks.Count; ++hookIdx)
+                    if (batchHeader.Magic != BatchHeader.k_MagicValue)
                     {
-                        m_Hooks[hookIdx].OnBeforeReceiveBatch(clientId, batchHeader.BatchSize, batchReader.Length);
+                        NetworkLog.LogError($"Received a packet with an invalid Magic Value. Please report this to the Netcode for GameObjects team at https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues and include the following data: Offset: {data.Offset}, Size: {data.Count}, Full receive array: {ByteArrayToString(data.Array, 0, data.Array.Length)}");
+                        return;
                     }
 
-                    for (var messageIdx = 0; messageIdx < batchHeader.BatchSize; ++messageIdx)
+                    if (batchHeader.BatchSize != data.Count)
+                    {
+                        NetworkLog.LogError($"Received a packet with an invalid Batch Size Value. Please report this to the Netcode for GameObjects team at https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues and include the following data: Offset: {data.Offset}, Size: {data.Count}, Expected Size: {batchHeader.BatchSize}, Full receive array: {ByteArrayToString(data.Array, 0, data.Array.Length)}");
+                        return;
+                    }
+
+                    var hash = XXHash.Hash64(batchReader.GetUnsafePtrAtCurrentPosition(), batchReader.Length - batchReader.Position);
+
+                    if (hash != batchHeader.BatchHash)
+                    {
+                        NetworkLog.LogError($"Received a packet with an invalid Hash Value. Please report this to the Netcode for GameObjects team at https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues and include the following data: Received Hash: {batchHeader.BatchHash}, Calculated Hash: {hash}, Offset: {data.Offset}, Size: {data.Count}, Full receive array: {ByteArrayToString(data.Array, 0, data.Array.Length)}");
+                        return;
+                    }
+
+                    for (var hookIdx = 0; hookIdx < m_Hooks.Count; ++hookIdx)
+                    {
+                        m_Hooks[hookIdx].OnBeforeReceiveBatch(clientId, batchHeader.BatchCount, batchReader.Length);
+                    }
+
+                    for (var messageIdx = 0; messageIdx < batchHeader.BatchCount; ++messageIdx)
                     {
 
                         var messageHeader = new MessageHeader();
@@ -237,7 +269,7 @@ namespace Unity.Netcode
                         }
                         catch (OverflowException)
                         {
-                            NetworkLog.LogWarning("Received a batch that didn't have enough data for all of its batches, ending early!");
+                            NetworkLog.LogError("Received a batch that didn't have enough data for all of its batches, ending early!");
                             throw;
                         }
 
@@ -245,7 +277,7 @@ namespace Unity.Netcode
 
                         if (!batchReader.TryBeginRead((int)messageHeader.MessageSize))
                         {
-                            NetworkLog.LogWarning("Received a message that claimed a size larger than the packet, ending early!");
+                            NetworkLog.LogError("Received a message that claimed a size larger than the packet, ending early!");
                             return;
                         }
                         m_IncomingMessageQueue.Add(new ReceiveQueueItem
@@ -263,7 +295,7 @@ namespace Unity.Netcode
                     }
                     for (var hookIdx = 0; hookIdx < m_Hooks.Count; ++hookIdx)
                     {
-                        m_Hooks[hookIdx].OnAfterReceiveBatch(clientId, batchHeader.BatchSize, batchReader.Length);
+                        m_Hooks[hookIdx].OnAfterReceiveBatch(clientId, batchHeader.BatchCount, batchReader.Length);
                     }
                 }
             }
@@ -650,7 +682,7 @@ namespace Unity.Netcode
 
                 writeQueueItem.Writer.WriteBytes(headerSerializer.GetUnsafePtr(), headerSerializer.Length);
                 writeQueueItem.Writer.WriteBytes(tmpSerializer.GetUnsafePtr(), tmpSerializer.Length);
-                writeQueueItem.BatchHeader.BatchSize++;
+                writeQueueItem.BatchHeader.BatchCount++;
                 for (var hookIdx = 0; hookIdx < m_Hooks.Count; ++hookIdx)
                 {
                     m_Hooks[hookIdx].OnAfterSendMessage(clientId, ref message, delivery, tmpSerializer.Length + headerSerializer.Length);
@@ -745,7 +777,7 @@ namespace Unity.Netcode
                 for (var i = 0; i < sendQueueItem.Length; ++i)
                 {
                     ref var queueItem = ref sendQueueItem.ElementAt(i);
-                    if (queueItem.BatchHeader.BatchSize == 0)
+                    if (queueItem.BatchHeader.BatchCount == 0)
                     {
                         queueItem.Writer.Dispose();
                         continue;
@@ -753,15 +785,20 @@ namespace Unity.Netcode
 
                     for (var hookIdx = 0; hookIdx < m_Hooks.Count; ++hookIdx)
                     {
-                        m_Hooks[hookIdx].OnBeforeSendBatch(clientId, queueItem.BatchHeader.BatchSize, queueItem.Writer.Length, queueItem.NetworkDelivery);
+                        m_Hooks[hookIdx].OnBeforeSendBatch(clientId, queueItem.BatchHeader.BatchCount, queueItem.Writer.Length, queueItem.NetworkDelivery);
                     }
 
                     queueItem.Writer.Seek(0);
 #if UNITY_EDITOR || DEVELOPMENT_BUILD
                     // Skipping the Verify and sneaking the write mark in because we know it's fine.
-                    queueItem.Writer.Handle->AllowedWriteMark = 2;
+                    queueItem.Writer.Handle->AllowedWriteMark = sizeof(BatchHeader);
 #endif
+                    queueItem.BatchHeader.BatchHash = XXHash.Hash64(queueItem.Writer.GetUnsafePtr() + sizeof(BatchHeader), queueItem.Writer.Length - sizeof(BatchHeader));
+
+                    queueItem.BatchHeader.BatchSize = queueItem.Writer.Length;
+
                     queueItem.Writer.WriteValue(queueItem.BatchHeader);
+
 
                     try
                     {
@@ -769,7 +806,7 @@ namespace Unity.Netcode
 
                         for (var hookIdx = 0; hookIdx < m_Hooks.Count; ++hookIdx)
                         {
-                            m_Hooks[hookIdx].OnAfterSendBatch(clientId, queueItem.BatchHeader.BatchSize, queueItem.Writer.Length, queueItem.NetworkDelivery);
+                            m_Hooks[hookIdx].OnAfterSendBatch(clientId, queueItem.BatchHeader.BatchCount, queueItem.Writer.Length, queueItem.NetworkDelivery);
                         }
                     }
                     finally

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageCorruptionTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageCorruptionTests.cs
@@ -184,7 +184,7 @@ namespace Unity.Netcode.EditorTests
                 writer.Seek(0);
                 batchHeader = new BatchHeader
                 {
-                    Magic = BatchHeader.k_MagicValue,
+                    Magic = BatchHeader.MagicValue,
                     BatchSize = writer.Length,
                     BatchHash = XXHash.Hash64(writer.GetUnsafePtr() + sizeof(BatchHeader), writer.Length - sizeof(BatchHeader)),
                     BatchCount = 1

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageCorruptionTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageCorruptionTests.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.EditorTests
+{
+    public class MessageCorruptionTests
+    {
+
+        private struct TestMessage : INetworkMessage, INetworkSerializeByMemcpy
+        {
+            public ForceNetworkSerializeByMemcpy<Guid> Value;
+            public static bool Handled;
+            public static bool Deserialized;
+
+            public void Serialize(FastBufferWriter writer, int targetVersion)
+            {
+                writer.WriteValueSafe(Value);
+            }
+
+            public bool Deserialize(FastBufferReader reader, ref NetworkContext context, int receivedMessageVersion)
+            {
+                Deserialized = true;
+                reader.ReadValueSafe(out Value);
+                return true;
+            }
+
+            public void Handle(ref NetworkContext context)
+            {
+                Handled = true;
+            }
+
+            public int Version => 0;
+        }
+
+        private class TestMessageProvider : IMessageProvider
+        {
+            public List<MessagingSystem.MessageWithHandler> GetMessages()
+            {
+                return new List<MessagingSystem.MessageWithHandler>
+                {
+                    new MessagingSystem.MessageWithHandler
+                    {
+                        MessageType = typeof(TestMessage),
+                        Handler = MessagingSystem.ReceiveMessage<TestMessage>,
+                        GetVersion = MessagingSystem.CreateMessageAndGetVersion<TestMessage>
+                    }
+                };
+            }
+        }
+
+        public enum TypeOfCorruption
+        {
+            OffsetPlus,
+            OffsetMinus,
+            CorruptBytes,
+            Truncated,
+            AdditionalGarbageData,
+        }
+
+        private class TestMessageSender : IMessageSender
+        {
+
+            public TypeOfCorruption Corruption;
+            public List<byte[]> MessageQueue = new List<byte[]>();
+
+            public unsafe void Send(ulong clientId, NetworkDelivery delivery, FastBufferWriter batchData)
+            {
+                switch (Corruption)
+                {
+                    case TypeOfCorruption.OffsetPlus:
+                        {
+                            using var subWriter = new FastBufferWriter(batchData.Length + 1, Allocator.Temp);
+                            subWriter.WriteByteSafe(0);
+                            subWriter.WriteBytesSafe(batchData.GetUnsafePtr(), batchData.Length);
+                            MessageQueue.Add(subWriter.ToArray());
+                            break;
+                        }
+                    case TypeOfCorruption.OffsetMinus:
+                        {
+                            using var subWriter = new FastBufferWriter(batchData.Length - 1, Allocator.Temp);
+                            subWriter.WriteBytesSafe(batchData.GetUnsafePtr() + 1, batchData.Length - 1);
+                            MessageQueue.Add(subWriter.ToArray());
+                            break;
+                        }
+                    case TypeOfCorruption.CorruptBytes:
+                        batchData.Seek(batchData.Length - 2);
+                        var currentByte = batchData.GetUnsafePtr()[0];
+                        batchData.WriteByteSafe((byte)(currentByte == 0 ? 1 : 0));
+                        MessageQueue.Add(batchData.ToArray());
+                        break;
+                    case TypeOfCorruption.Truncated:
+                        batchData.Truncate(batchData.Length - 1);
+                        MessageQueue.Add(batchData.ToArray());
+                        break;
+                    case TypeOfCorruption.AdditionalGarbageData:
+                        batchData.Seek(batchData.Length);
+                        batchData.WriteByteSafe(0);
+                        MessageQueue.Add(batchData.ToArray());
+                        break;
+                }
+            }
+        }
+
+        private MessagingSystem m_MessagingSystem;
+        private TestMessageSender m_MessageSender;
+
+        [SetUp]
+        public void SetUp()
+        {
+            TestMessage.Handled = false;
+            TestMessage.Deserialized = false;
+            m_MessageSender = new TestMessageSender();
+
+            m_MessagingSystem = new MessagingSystem(m_MessageSender, this, new TestMessageProvider());
+
+            m_MessagingSystem.ClientConnected(0);
+            m_MessagingSystem.SetVersion(0, XXHash.Hash32(typeof(TestMessage).FullName), 0);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            m_MessagingSystem.Dispose();
+        }
+
+        private TestMessage GetMessage()
+        {
+            return new TestMessage
+            {
+                Value = Guid.NewGuid()
+            };
+        }
+
+        [Test]
+        public unsafe void WhenPacketsAreCorrupted_TheyDontGetProcessed([Values] TypeOfCorruption typeOfCorruption)
+        {
+            m_MessageSender.Corruption = typeOfCorruption;
+
+            switch (typeOfCorruption)
+            {
+                case TypeOfCorruption.OffsetMinus:
+                case TypeOfCorruption.OffsetPlus:
+                    LogAssert.Expect(LogType.Error, new Regex("Received a packet with an invalid Magic Value\\."));
+                    break;
+                case TypeOfCorruption.Truncated:
+                case TypeOfCorruption.AdditionalGarbageData:
+                    LogAssert.Expect(LogType.Error, new Regex("Received a packet with an invalid Batch Size Value\\."));
+                    break;
+                case TypeOfCorruption.CorruptBytes:
+                    LogAssert.Expect(LogType.Error, new Regex("Received a packet with an invalid Hash Value\\."));
+                    break;
+            }
+
+            // Dummy batch header
+            var batchHeader = new BatchHeader
+            {
+                BatchCount = 1
+            };
+            var messageHeader = new MessageHeader
+            {
+                MessageSize = (ushort)UnsafeUtility.SizeOf<TestMessage>(),
+                MessageType = m_MessagingSystem.GetMessageType(typeof(TestMessage)),
+            };
+            var message = GetMessage();
+
+            var writer = new FastBufferWriter(1300, Allocator.Temp);
+            using (writer)
+            {
+                writer.TryBeginWrite(FastBufferWriter.GetWriteSize(batchHeader) +
+                                     FastBufferWriter.GetWriteSize(messageHeader) +
+                                     FastBufferWriter.GetWriteSize(message));
+                writer.WriteValue(batchHeader);
+                writer.WriteValue(messageHeader);
+                writer.WriteValue(message);
+
+                // Fill out the rest of the batch header
+                writer.Seek(0);
+                batchHeader = new BatchHeader
+                {
+                    Magic = BatchHeader.k_MagicValue,
+                    BatchSize = writer.Length,
+                    BatchHash = XXHash.Hash64(writer.GetUnsafePtr() + sizeof(BatchHeader), writer.Length - sizeof(BatchHeader)),
+                    BatchCount = 1
+                };
+                writer.WriteValue(batchHeader);
+                m_MessageSender.Send(0, NetworkDelivery.Reliable, writer);
+
+                var receivedMessage = m_MessageSender.MessageQueue[0];
+                m_MessageSender.MessageQueue.Clear();
+                m_MessagingSystem.HandleIncomingData(0, new ArraySegment<byte>(receivedMessage), 0);
+                Assert.IsFalse(TestMessage.Deserialized);
+                Assert.IsFalse(TestMessage.Handled);
+            }
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageCorruptionTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageCorruptionTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d3c01a0b5a0e478ebc5182fe339bde04
+timeCreated: 1676997550

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageReceivingTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageReceivingTests.cs
@@ -141,7 +141,7 @@ namespace Unity.Netcode.EditorTests
                 writer.Seek(0);
                 batchHeader = new BatchHeader
                 {
-                    Magic = BatchHeader.k_MagicValue,
+                    Magic = BatchHeader.MagicValue,
                     BatchSize = writer.Length,
                     BatchHash = XXHash.Hash64(writer.GetUnsafePtr() + sizeof(BatchHeader), writer.Length - sizeof(BatchHeader)),
                     BatchCount = 1
@@ -185,7 +185,7 @@ namespace Unity.Netcode.EditorTests
                 writer.Seek(0);
                 batchHeader = new BatchHeader
                 {
-                    Magic = BatchHeader.k_MagicValue,
+                    Magic = BatchHeader.MagicValue,
                     BatchSize = writer.Length,
                     BatchHash = XXHash.Hash64(writer.GetUnsafePtr() + sizeof(BatchHeader), writer.Length - sizeof(BatchHeader)),
                     BatchCount = 1
@@ -235,7 +235,7 @@ namespace Unity.Netcode.EditorTests
                 writer.Seek(0);
                 batchHeader = new BatchHeader
                 {
-                    Magic = BatchHeader.k_MagicValue,
+                    Magic = BatchHeader.MagicValue,
                     BatchSize = writer.Length,
                     BatchHash = XXHash.Hash64(writer.GetUnsafePtr() + sizeof(BatchHeader), writer.Length - sizeof(BatchHeader)),
                     BatchCount = 2

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageReceivingTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageReceivingTests.cs
@@ -114,11 +114,11 @@ namespace Unity.Netcode.EditorTests
         }
 
         [Test]
-        public void WhenHandlingIncomingData_ReceiveIsNotCalledBeforeProcessingIncomingMessageQueue()
+        public unsafe void WhenHandlingIncomingData_ReceiveIsNotCalledBeforeProcessingIncomingMessageQueue()
         {
             var batchHeader = new BatchHeader
             {
-                BatchSize = 1
+                BatchCount = 1
             };
             var messageHeader = new MessageHeader
             {
@@ -137,6 +137,17 @@ namespace Unity.Netcode.EditorTests
                 writer.WriteValue(messageHeader);
                 writer.WriteValue(message);
 
+                // Fill out the rest of the batch header
+                writer.Seek(0);
+                batchHeader = new BatchHeader
+                {
+                    Magic = BatchHeader.k_MagicValue,
+                    BatchSize = writer.Length,
+                    BatchHash = XXHash.Hash64(writer.GetUnsafePtr() + sizeof(BatchHeader), writer.Length - sizeof(BatchHeader)),
+                    BatchCount = 1
+                };
+                writer.WriteValue(batchHeader);
+
                 var reader = new FastBufferReader(writer, Allocator.Temp);
                 using (reader)
                 {
@@ -149,11 +160,11 @@ namespace Unity.Netcode.EditorTests
         }
 
         [Test]
-        public void WhenReceivingAMessageAndProcessingMessageQueue_ReceiveMethodIsCalled()
+        public unsafe void WhenReceivingAMessageAndProcessingMessageQueue_ReceiveMethodIsCalled()
         {
             var batchHeader = new BatchHeader
             {
-                BatchSize = 1
+                BatchCount = 1
             };
             var messageHeader = new MessageHeader
             {
@@ -170,6 +181,17 @@ namespace Unity.Netcode.EditorTests
                 BytePacker.WriteValueBitPacked(writer, messageHeader.MessageSize);
                 writer.WriteValueSafe(message);
 
+                // Fill out the rest of the batch header
+                writer.Seek(0);
+                batchHeader = new BatchHeader
+                {
+                    Magic = BatchHeader.k_MagicValue,
+                    BatchSize = writer.Length,
+                    BatchHash = XXHash.Hash64(writer.GetUnsafePtr() + sizeof(BatchHeader), writer.Length - sizeof(BatchHeader)),
+                    BatchCount = 1
+                };
+                writer.WriteValue(batchHeader);
+
                 var reader = new FastBufferReader(writer, Allocator.Temp);
                 using (reader)
                 {
@@ -184,11 +206,11 @@ namespace Unity.Netcode.EditorTests
         }
 
         [Test]
-        public void WhenReceivingMultipleMessagesAndProcessingMessageQueue_ReceiveMethodIsCalledMultipleTimes()
+        public unsafe void WhenReceivingMultipleMessagesAndProcessingMessageQueue_ReceiveMethodIsCalledMultipleTimes()
         {
             var batchHeader = new BatchHeader
             {
-                BatchSize = 2
+                BatchCount = 2
             };
             var messageHeader = new MessageHeader
             {
@@ -208,6 +230,17 @@ namespace Unity.Netcode.EditorTests
                 BytePacker.WriteValueBitPacked(writer, messageHeader.MessageType);
                 BytePacker.WriteValueBitPacked(writer, messageHeader.MessageSize);
                 writer.WriteValueSafe(message2);
+
+                // Fill out the rest of the batch header
+                writer.Seek(0);
+                batchHeader = new BatchHeader
+                {
+                    Magic = BatchHeader.k_MagicValue,
+                    BatchSize = writer.Length,
+                    BatchHash = XXHash.Hash64(writer.GetUnsafePtr() + sizeof(BatchHeader), writer.Length - sizeof(BatchHeader)),
+                    BatchCount = 2
+                };
+                writer.WriteValue(batchHeader);
 
                 var reader = new FastBufferReader(writer, Allocator.Temp);
                 using (reader)

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageSendingTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageSendingTests.cs
@@ -155,7 +155,7 @@ namespace Unity.Netcode.EditorTests
         {
             var message = GetMessage();
             var size = UnsafeUtility.SizeOf<TestMessage>() + 2; // MessageHeader packed with this message will be 2 bytes
-            for (var i = 0; i < 1300 / size; ++i)
+            for (var i = 0; i < (1300 - UnsafeUtility.SizeOf<BatchHeader>()) / size; ++i)
             {
                 m_MessagingSystem.SendMessage(ref message, NetworkDelivery.Reliable, m_Clients);
             }
@@ -169,7 +169,7 @@ namespace Unity.Netcode.EditorTests
         {
             var message = GetMessage();
             var size = UnsafeUtility.SizeOf<TestMessage>() + 2; // MessageHeader packed with this message will be 2 bytes
-            for (var i = 0; i < (1300 / size) + 1; ++i)
+            for (var i = 0; i < ((1300 - UnsafeUtility.SizeOf<BatchHeader>()) / size) + 1; ++i)
             {
                 m_MessagingSystem.SendMessage(ref message, NetworkDelivery.Reliable, m_Clients);
             }
@@ -183,7 +183,7 @@ namespace Unity.Netcode.EditorTests
         {
             var message = GetMessage();
             var size = UnsafeUtility.SizeOf<TestMessage>() + 2; // MessageHeader packed with this message will be 2 bytes
-            for (var i = 0; i < (1300 / size) + 1; ++i)
+            for (var i = 0; i < ((1300 - UnsafeUtility.SizeOf<BatchHeader>()) / size) + 1; ++i)
             {
                 m_MessagingSystem.SendMessage(ref message, NetworkDelivery.ReliableFragmentedSequenced, m_Clients);
             }
@@ -229,7 +229,7 @@ namespace Unity.Netcode.EditorTests
             using (reader)
             {
                 reader.ReadValueSafe(out BatchHeader header);
-                Assert.AreEqual(2, header.BatchSize);
+                Assert.AreEqual(2, header.BatchCount);
 
                 MessageHeader messageHeader;
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/InvalidConnectionEventsTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/InvalidConnectionEventsTest.cs
@@ -84,9 +84,12 @@ namespace Unity.Netcode.RuntimeTests
 
             // Unnamed message is something to wait for. When this one is received,
             // we know the above one has also reached its destination.
-            using var writer = new FastBufferWriter(1, Allocator.Temp);
-            writer.WriteByteSafe(0);
-            m_ServerNetworkManager.CustomMessagingManager.SendUnnamedMessage(m_ClientNetworkManagers[0].LocalClientId, writer);
+            var writer = new FastBufferWriter(1, Allocator.Temp);
+            using (writer)
+            {
+                writer.WriteByteSafe(0);
+                m_ServerNetworkManager.CustomMessagingManager.SendUnnamedMessage(m_ClientNetworkManagers[0].LocalClientId, writer);
+            }
 
             m_ClientNetworkManagers[0].MessagingSystem.Hook(new Hooks<ConnectionApprovedMessage>());
 
@@ -103,9 +106,12 @@ namespace Unity.Netcode.RuntimeTests
 
             // Unnamed message is something to wait for. When this one is received,
             // we know the above one has also reached its destination.
-            using var writer = new FastBufferWriter(1, Allocator.Temp);
-            writer.WriteByteSafe(0);
-            m_ServerNetworkManager.CustomMessagingManager.SendUnnamedMessage(m_ClientNetworkManagers[0].LocalClientId, writer);
+            var writer = new FastBufferWriter(1, Allocator.Temp);
+            using (writer)
+            {
+                writer.WriteByteSafe(0);
+                m_ServerNetworkManager.CustomMessagingManager.SendUnnamedMessage(m_ClientNetworkManagers[0].LocalClientId, writer);
+            }
 
             m_ClientNetworkManagers[0].MessagingSystem.Hook(new Hooks<ConnectionRequestMessage>());
 
@@ -122,9 +128,12 @@ namespace Unity.Netcode.RuntimeTests
 
             // Unnamed message is something to wait for. When this one is received,
             // we know the above one has also reached its destination.
-            using var writer = new FastBufferWriter(1, Allocator.Temp);
-            writer.WriteByteSafe(0);
-            m_ClientNetworkManagers[0].CustomMessagingManager.SendUnnamedMessage(m_ServerNetworkManager.LocalClientId, writer);
+            var writer = new FastBufferWriter(1, Allocator.Temp);
+            using (writer)
+            {
+                writer.WriteByteSafe(0);
+                m_ClientNetworkManagers[0].CustomMessagingManager.SendUnnamedMessage(m_ServerNetworkManager.LocalClientId, writer);
+            }
 
             m_ServerNetworkManager.MessagingSystem.Hook(new Hooks<ConnectionRequestMessage>());
 
@@ -141,9 +150,12 @@ namespace Unity.Netcode.RuntimeTests
 
             // Unnamed message is something to wait for. When this one is received,
             // we know the above one has also reached its destination.
-            using var writer = new FastBufferWriter(1, Allocator.Temp);
-            writer.WriteByteSafe(0);
-            m_ClientNetworkManagers[0].CustomMessagingManager.SendUnnamedMessage(m_ServerNetworkManager.LocalClientId, writer);
+            var writer = new FastBufferWriter(1, Allocator.Temp);
+            using (writer)
+            {
+                writer.WriteByteSafe(0);
+                m_ClientNetworkManagers[0].CustomMessagingManager.SendUnnamedMessage(m_ServerNetworkManager.LocalClientId, writer);
+            }
 
             m_ServerNetworkManager.MessagingSystem.Hook(new Hooks<ConnectionApprovedMessage>());
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/InvalidConnectionEventsTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/InvalidConnectionEventsTest.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using Unity.Collections;
+using UnityEngine.TestTools;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine;
+using Debug = UnityEngine.Debug;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    public class InvalidConnectionEventsTest : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 1;
+
+        public InvalidConnectionEventsTest() : base(HostOrServer.Server) { }
+
+        private class Hooks<TCatchType> : INetworkHooks
+        {
+            public void OnBeforeSendMessage<T>(ulong clientId, ref T message, NetworkDelivery delivery) where T : INetworkMessage
+            {
+            }
+
+            public void OnAfterSendMessage<T>(ulong clientId, ref T message, NetworkDelivery delivery, int messageSizeBytes) where T : INetworkMessage
+            {
+            }
+
+            public void OnBeforeReceiveMessage(ulong senderId, Type messageType, int messageSizeBytes)
+            {
+            }
+
+            public void OnAfterReceiveMessage(ulong senderId, Type messageType, int messageSizeBytes)
+            {
+            }
+
+            public void OnBeforeSendBatch(ulong clientId, int messageCount, int batchSizeInBytes, NetworkDelivery delivery)
+            {
+            }
+
+            public void OnAfterSendBatch(ulong clientId, int messageCount, int batchSizeInBytes, NetworkDelivery delivery)
+            {
+            }
+
+            public void OnBeforeReceiveBatch(ulong senderId, int messageCount, int batchSizeInBytes)
+            {
+            }
+
+            public void OnAfterReceiveBatch(ulong senderId, int messageCount, int batchSizeInBytes)
+            {
+            }
+
+            public bool OnVerifyCanSend(ulong destinationId, Type messageType, NetworkDelivery delivery)
+            {
+                return true;
+            }
+
+            public bool OnVerifyCanReceive(ulong senderId, Type messageType, FastBufferReader messageContent, ref NetworkContext context)
+            {
+                return true;
+            }
+
+            public void OnBeforeHandleMessage<T>(ref T message, ref NetworkContext context) where T : INetworkMessage
+            {
+                if (typeof(T) == typeof(TCatchType))
+                {
+                    Debug.Log("Woompa");
+                    Assert.Fail($"{typeof(T).Name} was received when it should not have been.");
+                }
+            }
+
+            public void OnAfterHandleMessage<T>(ref T message, ref NetworkContext context) where T : INetworkMessage
+            {
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator WhenSendingConnectionApprovedToAlreadyConnectedClient_ConnectionApprovedMessageIsRejected()
+        {
+            var message = new ConnectionApprovedMessage();
+            m_ServerNetworkManager.SendMessage(ref message, NetworkDelivery.Reliable, m_ClientNetworkManagers[0].LocalClientId);
+
+            // Unnamed message is something to wait for. When this one is received,
+            // we know the above one has also reached its destination.
+            using var writer = new FastBufferWriter(1, Allocator.Temp);
+            writer.WriteByteSafe(0);
+            m_ServerNetworkManager.CustomMessagingManager.SendUnnamedMessage(m_ClientNetworkManagers[0].LocalClientId, writer);
+
+            m_ClientNetworkManagers[0].MessagingSystem.Hook(new Hooks<ConnectionApprovedMessage>());
+
+            LogAssert.Expect(LogType.Error, new Regex($"A {nameof(ConnectionApprovedMessage)} was received from the server when the connection has already been established\\. This should not happen\\."));
+
+            yield return WaitForMessageReceived<UnnamedMessage>(m_ClientNetworkManagers.ToList());
+        }
+
+        [UnityTest]
+        public IEnumerator WhenSendingConnectionRequestToAnyClient_ConnectionRequestMessageIsRejected()
+        {
+            var message = new ConnectionRequestMessage();
+            m_ServerNetworkManager.SendMessage(ref message, NetworkDelivery.Reliable, m_ClientNetworkManagers[0].LocalClientId);
+
+            // Unnamed message is something to wait for. When this one is received,
+            // we know the above one has also reached its destination.
+            using var writer = new FastBufferWriter(1, Allocator.Temp);
+            writer.WriteByteSafe(0);
+            m_ServerNetworkManager.CustomMessagingManager.SendUnnamedMessage(m_ClientNetworkManagers[0].LocalClientId, writer);
+
+            m_ClientNetworkManagers[0].MessagingSystem.Hook(new Hooks<ConnectionRequestMessage>());
+
+            LogAssert.Expect(LogType.Error, new Regex($"A {nameof(ConnectionRequestMessage)} was received from the server on the client side\\. This should not happen\\."));
+
+            yield return WaitForMessageReceived<UnnamedMessage>(m_ClientNetworkManagers.ToList());
+        }
+
+        [UnityTest]
+        public IEnumerator WhenSendingConnectionRequestFromAlreadyConnectedClient_ConnectionRequestMessageIsRejected()
+        {
+            var message = new ConnectionRequestMessage();
+            m_ClientNetworkManagers[0].SendMessage(ref message, NetworkDelivery.Reliable, m_ServerNetworkManager.LocalClientId);
+
+            // Unnamed message is something to wait for. When this one is received,
+            // we know the above one has also reached its destination.
+            using var writer = new FastBufferWriter(1, Allocator.Temp);
+            writer.WriteByteSafe(0);
+            m_ClientNetworkManagers[0].CustomMessagingManager.SendUnnamedMessage(m_ServerNetworkManager.LocalClientId, writer);
+
+            m_ServerNetworkManager.MessagingSystem.Hook(new Hooks<ConnectionRequestMessage>());
+
+            LogAssert.Expect(LogType.Error, new Regex($"A {nameof(ConnectionRequestMessage)} was received from a client when the connection has already been established\\. This should not happen\\."));
+
+            yield return WaitForMessageReceived<UnnamedMessage>(new List<NetworkManager> { m_ServerNetworkManager });
+        }
+
+        [UnityTest]
+        public IEnumerator WhenSendingConnectionApprovedFromAnyClient_ConnectionApprovedMessageIsRejected()
+        {
+            var message = new ConnectionApprovedMessage();
+            m_ClientNetworkManagers[0].SendMessage(ref message, NetworkDelivery.Reliable, m_ServerNetworkManager.LocalClientId);
+
+            // Unnamed message is something to wait for. When this one is received,
+            // we know the above one has also reached its destination.
+            using var writer = new FastBufferWriter(1, Allocator.Temp);
+            writer.WriteByteSafe(0);
+            m_ClientNetworkManagers[0].CustomMessagingManager.SendUnnamedMessage(m_ServerNetworkManager.LocalClientId, writer);
+
+            m_ServerNetworkManager.MessagingSystem.Hook(new Hooks<ConnectionApprovedMessage>());
+
+            LogAssert.Expect(LogType.Error, new Regex($"A {nameof(ConnectionApprovedMessage)} was received from a client on the server side\\. This should not happen\\."));
+
+            yield return WaitForMessageReceived<UnnamedMessage>(new List<NetworkManager> { m_ServerNetworkManager });
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/InvalidConnectionEventsTest.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/InvalidConnectionEventsTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c30dd8c697274dd195f0fa8b86a4cf9d
+timeCreated: 1677003739


### PR DESCRIPTION
Adds multiple ways to detect and handle corrupt packets that could otherwise cause issues and put the game into a bad state, or potentially cause crashes:

- A "magic" value at the start of each packet helps when looking at packet dumps to see where potential start-of-packet is if the data gets offset (as was seen in the recent BatchSendQueue corruption bug)
- A "size in bytes" value helps us detect if the packet has been truncated or if garbage has been added to the end
- A "hash" value helps to detect when the other values are correct but one or more bytes within the packet have been corrupted

Additionally, code has been added to refuse to process ConnectionRequestMessage or ConnectionAcceptedMessage on an alredy-established connection, or either of those being received by the wrong side, as those could otherwise be used as a vector for attack by a malicious actor and render the framework completely broken.

In all cases, if these issues occur, the log requests the user to file an issue with us with the full hex dump of the packet that was received.

## Changelog

- Added: Added detection and graceful handling of corrupt packets for additional safety.

## Testing and Documentation

- Includes unit tests.
- Includes integration tests.
- No documentation changes or additions were necessary.
