### PR TITLE
fix: NetworkVariable subclasses not generating serialization code

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -837,6 +837,58 @@ namespace Unity.Netcode.Editor.CodeGen
             GetAllFieldsAndResolveGenerics(resolved, ref fieldTypes, genericParams);
         }
 
+        private void GetAllBaseTypesAndResolveGenerics(TypeDefinition type, ref List<TypeReference> baseTypes, Dictionary<string, TypeReference> genericParameters)
+        {
+
+            if (type.BaseType == null || type.BaseType.Name == "Object")
+            {
+                return;
+            }
+
+            var baseType = type.BaseType;
+
+            var genericParams = new Dictionary<string, TypeReference>();
+
+            if (baseType.IsGenericInstance)
+            {
+                var genericType = (GenericInstanceType)baseType;
+                var newGenericType = new GenericInstanceType(baseType.Resolve());
+                for (var i = 0; i < genericType.GenericArguments.Count; ++i)
+                {
+                    var argument = genericType.GenericArguments[i];
+
+                    if (genericParameters != null && genericParameters.ContainsKey(argument.Name))
+                    {
+                        newGenericType.GenericArguments.Add(genericParameters[argument.Name]);
+                        genericParams[baseType.Resolve().GenericParameters[newGenericType.GenericArguments.Count - 1].Name] = genericParameters[argument.Name];
+                    }
+                    else
+                    {
+                        newGenericType.GenericArguments.Add(argument);
+                    }
+                }
+                baseTypes.Add(newGenericType);
+            }
+            else
+            {
+                baseTypes.Add(baseType);
+            }
+
+            var resolved = type.BaseType.Resolve();
+            if (type.BaseType.IsGenericInstance)
+            {
+                var genericType = (GenericInstanceType)type.BaseType;
+                for (var i = 0; i < genericType.GenericArguments.Count; ++i)
+                {
+                    if (!genericParams.ContainsKey(resolved.GenericParameters[i].Name))
+                    {
+                        genericParams[resolved.GenericParameters[i].Name] = genericType.GenericArguments[i];
+                    }
+                }
+            }
+            GetAllBaseTypesAndResolveGenerics(resolved, ref baseTypes, genericParams);
+        }
+
         private void ProcessNetworkBehaviour(TypeDefinition typeDefinition, string[] assemblyDefines)
         {
             var rpcHandlers = new List<(uint RpcMethodId, MethodDefinition RpcHandler)>();
@@ -895,6 +947,34 @@ namespace Unity.Netcode.Editor.CodeGen
                             if (!m_WrappedNetworkVariableTypes.Contains(wrappedType))
                             {
                                 m_WrappedNetworkVariableTypes.Add(wrappedType);
+                            }
+                        }
+                    }
+                    {
+                        var baseTypes = new List<TypeReference>();
+
+                        var genericParams = new Dictionary<string, TypeReference>();
+                        var resolved = type.Resolve();
+                        if (type.IsGenericInstance)
+                        {
+                            var genericType = (GenericInstanceType)type;
+                            for (var i = 0; i < genericType.GenericArguments.Count; ++i)
+                            {
+                                genericParams[resolved.GenericParameters[i].Name] = genericType.GenericArguments[i];
+                            }
+                        }
+
+                        GetAllBaseTypesAndResolveGenerics(type.Resolve(), ref baseTypes, genericParams);
+                        foreach (var baseType in baseTypes)
+                        {
+                            if (baseType.Resolve().Name == typeof(NetworkVariable<>).Name || baseType.Resolve().Name == typeof(NetworkList<>).Name)
+                            {
+                                var genericInstanceType = (GenericInstanceType)baseType;
+                                var wrappedType = genericInstanceType.GenericArguments[0];
+                                if (!m_WrappedNetworkVariableTypes.Contains(wrappedType))
+                                {
+                                    m_WrappedNetworkVariableTypes.Add(wrappedType);
+                                }
                             }
                         }
                     }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -17,6 +17,22 @@ namespace Unity.Netcode.RuntimeTests
         public NetworkVariable<Vector3> OwnerReadWrite_Position = new NetworkVariable<Vector3>(Vector3.one, NetworkVariableReadPermission.Owner, NetworkVariableWritePermission.Owner);
     }
 
+    public class NetworkVariableMiddleclass<TMiddleclassName> : NetworkVariable<TMiddleclassName>
+    {
+
+    }
+
+    public class NetworkVariableSubclass<TSubclassName> : NetworkVariableMiddleclass<TSubclassName>
+    {
+
+    }
+
+    public struct TemplatedValueOnlyReferencedByNetworkVariableSubclass<T> : INetworkSerializeByMemcpy
+        where T : unmanaged
+    {
+        public T Value;
+    }
+
     // The ILPP code for NetworkVariables to determine how to serialize them relies on them existing as fields of a NetworkBehaviour to find them.
     // Some of the tests below create NetworkVariables on the stack, so this class is here just to make sure the relevant types are all accounted for.
     public class NetVarILPPClassForTests : NetworkBehaviour
@@ -25,6 +41,7 @@ namespace Unity.Netcode.RuntimeTests
         public NetworkVariable<ManagedNetworkSerializableType> ManagedNetworkSerializableTypeVar;
         public NetworkVariable<string> StringVar;
         public NetworkVariable<Guid> GuidVar;
+        public NetworkVariableSubclass<TemplatedValueOnlyReferencedByNetworkVariableSubclass<int>> SubclassVar;
     }
 
     public class TemplateNetworkBehaviourType<T> : NetworkBehaviour
@@ -1094,6 +1111,21 @@ namespace Unity.Netcode.RuntimeTests
             {
                 variable.ReadField(reader);
             });
+        }
+
+        [Test]
+        public void TestTypesReferencedInSubclassSerializeSuccessfully()
+        {
+            var variable = new NetworkVariableSubclass<TemplatedValueOnlyReferencedByNetworkVariableSubclass<int>>();
+            using var writer = new FastBufferWriter(1024, Allocator.Temp);
+            var value = new TemplatedValueOnlyReferencedByNetworkVariableSubclass<int> { Value = 12345 };
+            variable.Value = value;
+            variable.WriteField(writer);
+            variable.Value = new TemplatedValueOnlyReferencedByNetworkVariableSubclass<int> { Value = 54321 };
+
+            using var reader = new FastBufferReader(writer, Allocator.None);
+            variable.ReadField(reader);
+            Assert.AreEqual(value.Value, variable.Value.Value);
         }
 
         [Test]


### PR DESCRIPTION
ILPP didn't know how to identify subclasses when looking for the list of wrapped types to generate serialization code for.

fixes #2385 

[MTT-5503](https://jira.unity3d.com/browse/MTT-5503)

## Changelog

- Fixed: Fixed subclasses of `NetworkVariable` failing to generate serialization code unless a normal `NetworkVariable` of the same wrapped type existed somewhere else in the code.

## Testing and Documentation

- Includes unit tests.
- No documentation changes or additions were necessary.

