### PR TITLE
fix: Metrics: Exception when tracking Named Messages [MTT-5380]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -36,6 +36,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed `NetworkAnimator` issue with using pooled objects and when specific properties are cleaned during despawn and destroy.(#2309)
 - Fixed issue where `NetworkAnimator` was checking for animation changes when the associated `NetworkObject` was not spawned.(#2309)
 - Corrected an issue with the documentation for BufferSerializer (#2401)
+- Fixed an issue where Named Message Handlers could remove themselves causing an exception when the metrics tried to access the name of the message.(#2394)
 
 ## [1.2.0] - 2022-11-21
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -14,6 +14,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed an issue where Named Message Handlers could remove themselves causing an exception when the metrics tried to access the name of the message.(#2426)
 - Fixed registry of public `NetworkVariable`s in derived `NetworkBehaviour`s (#2423)
 - Fixed issue where runtime association of `Animator` properties to `AnimationCurve`s would cause `NetworkAnimator` to attempt to update those changes. (#2416)
 - Fixed issue where `NetworkAnimator` would not check if its associated `Animator` was valid during serialization and would spam exceptions in the editor console. (#2416)
@@ -49,7 +50,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed `NetworkAnimator` issue with using pooled objects and when specific properties are cleaned during despawn and destroy.(#2309)
 - Fixed issue where `NetworkAnimator` was checking for animation changes when the associated `NetworkObject` was not spawned.(#2309)
 - Corrected an issue with the documentation for BufferSerializer (#2401)
-- Fixed an issue where Named Message Handlers could remove themselves causing an exception when the metrics tried to access the name of the message.(#2394)
 
 ## [1.2.0] - 2022-11-21
 

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/CustomMessageManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/CustomMessageManager.cs
@@ -151,14 +151,18 @@ namespace Unity.Netcode
                 // We dont know what size to use. Try every (more collision prone)
                 if (m_NamedMessageHandlers32.TryGetValue(hash, out HandleNamedMessageDelegate messageHandler32))
                 {
+                    // handler can remove itself, cache the name for metrics
+                    string messageName = m_MessageHandlerNameLookup32[hash];
                     messageHandler32(sender, reader);
-                    m_NetworkManager.NetworkMetrics.TrackNamedMessageReceived(sender, m_MessageHandlerNameLookup32[hash], bytesCount);
+                    m_NetworkManager.NetworkMetrics.TrackNamedMessageReceived(sender, messageName, bytesCount);
                 }
 
                 if (m_NamedMessageHandlers64.TryGetValue(hash, out HandleNamedMessageDelegate messageHandler64))
                 {
+                    // handler can remove itself, cache the name for metrics
+                    string messageName = m_MessageHandlerNameLookup64[hash];
                     messageHandler64(sender, reader);
-                    m_NetworkManager.NetworkMetrics.TrackNamedMessageReceived(sender, m_MessageHandlerNameLookup64[hash], bytesCount);
+                    m_NetworkManager.NetworkMetrics.TrackNamedMessageReceived(sender, messageName, bytesCount);
                 }
             }
             else
@@ -169,15 +173,19 @@ namespace Unity.Netcode
                     case HashSize.VarIntFourBytes:
                         if (m_NamedMessageHandlers32.TryGetValue(hash, out HandleNamedMessageDelegate messageHandler32))
                         {
+                            // handler can remove itself, cache the name for metrics
+                            string messageName = m_MessageHandlerNameLookup32[hash];
                             messageHandler32(sender, reader);
-                            m_NetworkManager.NetworkMetrics.TrackNamedMessageReceived(sender, m_MessageHandlerNameLookup32[hash], bytesCount);
+                            m_NetworkManager.NetworkMetrics.TrackNamedMessageReceived(sender, messageName, bytesCount);
                         }
                         break;
                     case HashSize.VarIntEightBytes:
                         if (m_NamedMessageHandlers64.TryGetValue(hash, out HandleNamedMessageDelegate messageHandler64))
                         {
+                            // handler can remove itself, cache the name for metrics
+                            string messageName = m_MessageHandlerNameLookup64[hash];
                             messageHandler64(sender, reader);
-                            m_NetworkManager.NetworkMetrics.TrackNamedMessageReceived(sender, m_MessageHandlerNameLookup64[hash], bytesCount);
+                            m_NetworkManager.NetworkMetrics.TrackNamedMessageReceived(sender, messageName, bytesCount);
                         }
                         break;
                 }


### PR DESCRIPTION
This PR fixes an issue where Named Message Handlers could remove themselves causing an exception when the metrics tried to access the name of the message.  

Metrics: Exception when tracking Named Messages in NGO [MTT-5380]
Github Issue: [#2394](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/2394)

<!-- Add RFC link here if applicable. -->

## Changelog

- Fixed: An issue where Named Message Handlers could remove themselves causing an exception when the metrics tried to access the name of the message
