### PR TITLE
fix: Prevent duplicate prefab entries when reimporting

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -24,7 +24,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where reimporting a prefab would result in a duplicate entry in the default prefab list.
+- Fixed issue where reimporting a prefab would result in a duplicate entry in the default prefab list. (#2430)
 - Fixed issue where changes to a layer's weight would not synchronize unless a state transition was occurring.(#2399)
 - Fixed issue where `NetworkManager.LocalClientId` was returning the `NetworkTransport.ServerClientId` as opposed to the `NetworkManager.m_LocalClientId`. (#2398)
 - Fixed issue where a dynamically spawned `NetworkObject` parented under an in-scene placed `NetworkObject` would have its `InScenePlaced` value changed to `true`. This would result in a soft synchronization error for late joining clients. (#2396)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -24,7 +24,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where reimporting a prefab would result in a duplicate entry in the default prefab list. (#2430)
+- Fixed issue where reimporting a prefab would result in a duplicate entry in the default prefab list.
 - Fixed issue where changes to a layer's weight would not synchronize unless a state transition was occurring.(#2399)
 - Fixed issue where `NetworkManager.LocalClientId` was returning the `NetworkTransport.ServerClientId` as opposed to the `NetworkManager.m_LocalClientId`. (#2398)
 - Fixed issue where a dynamically spawned `NetworkObject` parented under an in-scene placed `NetworkObject` would have its `InScenePlaced` value changed to `true`. This would result in a soft synchronization error for late joining clients. (#2396)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -24,6 +24,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where reimporting a prefab would result in a duplicate entry in the default prefab list.
 - Fixed issue where changes to a layer's weight would not synchronize unless a state transition was occurring.(#2399)
 - Fixed issue where `NetworkManager.LocalClientId` was returning the `NetworkTransport.ServerClientId` as opposed to the `NetworkManager.m_LocalClientId`. (#2398)
 - Fixed issue where a dynamically spawned `NetworkObject` parented under an in-scene placed `NetworkObject` would have its `InScenePlaced` value changed to `true`. This would result in a soft synchronization error for late joining clients. (#2396)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -24,7 +24,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where reimporting a prefab would result in a duplicate entry in the default prefab list.
 - Fixed issue where changes to a layer's weight would not synchronize unless a state transition was occurring.(#2399)
 - Fixed issue where `NetworkManager.LocalClientId` was returning the `NetworkTransport.ServerClientId` as opposed to the `NetworkManager.m_LocalClientId`. (#2398)
 - Fixed issue where a dynamically spawned `NetworkObject` parented under an in-scene placed `NetworkObject` would have its `InScenePlaced` value changed to `true`. This would result in a soft synchronization error for late joining clients. (#2396)

--- a/com.unity.netcode.gameobjects/Editor/Configuration/NetworkPrefabProcessor.cs
+++ b/com.unity.netcode.gameobjects/Editor/Configuration/NetworkPrefabProcessor.cs
@@ -53,7 +53,7 @@ namespace Unity.Netcode.Editor.Configuration
                         if (s_PrefabsListPath.ContainsKey(assetPath))
                         {
                             // Is the imported asset different from the one we already have in the list?
-                            if(s_PrefabsListPath[assetPath].Prefab.GetHashCode() != go.GetHashCode())
+                            if (s_PrefabsListPath[assetPath].Prefab.GetHashCode() != go.GetHashCode())
                             {
                                 // If so remove the one in the list and continue on to add the imported one
                                 s_PrefabsList.List.Remove(s_PrefabsListPath[assetPath]);
@@ -123,7 +123,7 @@ namespace Unity.Netcode.Editor.Configuration
             s_PrefabsListPath.Clear();
 
             // Create our asst path to prefab table
-            foreach(var prefabEntry in s_PrefabsList.List)
+            foreach (var prefabEntry in s_PrefabsList.List)
             {
                 if (!s_PrefabsListPath.ContainsKey(AssetDatabase.GetAssetPath(prefabEntry.Prefab)))
                 {

--- a/com.unity.netcode.gameobjects/Editor/Configuration/NetworkPrefabProcessor.cs
+++ b/com.unity.netcode.gameobjects/Editor/Configuration/NetworkPrefabProcessor.cs
@@ -24,6 +24,7 @@ namespace Unity.Netcode.Editor.Configuration
             }
         }
         private static NetworkPrefabsList s_PrefabsList;
+        private static Dictionary<string, NetworkPrefab> s_PrefabsListPath = new Dictionary<string, NetworkPrefab>();
 
         private static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)
         {
@@ -48,6 +49,21 @@ namespace Unity.Netcode.Editor.Configuration
                     var go = AssetDatabase.LoadAssetAtPath<GameObject>(assetPath);
                     if (go.TryGetComponent<NetworkObject>(out _))
                     {
+                        // Make sure we are not duplicating an already existing entry
+                        if (s_PrefabsListPath.ContainsKey(assetPath))
+                        {
+                            // Is the imported asset different from the one we already have in the list?
+                            if(s_PrefabsListPath[assetPath].Prefab.GetHashCode() != go.GetHashCode())
+                            {
+                                // If so remove the one in the list and continue on to add the imported one
+                                s_PrefabsList.List.Remove(s_PrefabsListPath[assetPath]);
+                            }
+                            else // If they are identical, then just ignore the import
+                            {
+                                continue;
+                            }
+                        }
+
                         s_PrefabsList.List.Add(new NetworkPrefab { Prefab = go });
                         dirty = true;
                     }
@@ -103,7 +119,19 @@ namespace Unity.Netcode.Editor.Configuration
                     return;
                 }
             }
+            // Clear our asset path to prefab table each time
+            s_PrefabsListPath.Clear();
 
+            // Create our asst path to prefab table
+            foreach(var prefabEntry in s_PrefabsList.List)
+            {
+                if (!s_PrefabsListPath.ContainsKey(AssetDatabase.GetAssetPath(prefabEntry.Prefab)))
+                {
+                    s_PrefabsListPath.Add(AssetDatabase.GetAssetPath(prefabEntry.Prefab), prefabEntry);
+                }
+            }
+
+            // Process the imported and deleted assets
             var markDirty = ProcessImportedAssets(importedAssets);
             markDirty &= ProcessDeletedAssets(deletedAssets);
 


### PR DESCRIPTION
Fixes an issue with duplicate prefab entries in the default prefab list when reimporting.

[MTT-5541](https://jira.unity3d.com/browse/MTT-5541)
Relates to #2424

## Changelog

- Fixed issue where reimporting a prefab would result in a duplicate entry in the default prefab list.

## Testing and Documentation
- No tests have been added.
- No documentation changes or additions were necessary.
