### PR TITLE
fix: Infinite NetworkManager.ShutdownInternal on NetworkTransport.DisconnectLocalClient Exception [MTT-5551]

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1200,7 +1200,16 @@ namespace Unity.Netcode
             if (IsClient && IsListening)
             {
                 // Client only, send disconnect to server
-                NetworkConfig.NetworkTransport.DisconnectLocalClient();
+                // If transport throws and exception, log the exception and
+                // continue the shutdown sequence (or forever be shutting down)
+                try
+                {
+                    NetworkConfig.NetworkTransport.DisconnectLocalClient();
+                }
+                catch(Exception ex)
+                {
+                    Debug.LogException(ex);
+                }
             }
 
             IsConnectedClient = false;

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1206,7 +1206,7 @@ namespace Unity.Netcode
                 {
                     NetworkConfig.NetworkTransport.DisconnectLocalClient();
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
                     Debug.LogException(ex);
                 }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1197,6 +1197,9 @@ namespace Unity.Netcode
                 }
             }
 
+            // Unregister network updates before trying to disconnect the client
+            this.UnregisterAllNetworkUpdates();
+
             if (IsClient && IsListening)
             {
                 // Client only, send disconnect to server
@@ -1229,8 +1232,6 @@ namespace Unity.Netcode
 
             IsServer = false;
             IsClient = false;
-
-            this.UnregisterAllNetworkUpdates();
 
             if (NetworkTickSystem != null)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1097,7 +1097,7 @@ namespace Unity.Netcode.Transports.UTP
                     }
                 }
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Debug.Log(ex);
             }
@@ -1110,7 +1110,6 @@ namespace Unity.Netcode.Transports.UTP
         {
             if (m_State == State.Connected)
             {
-
                 FlushSendQueuesForClientId(m_ServerClientId);
 
                 if (m_Driver.Disconnect(ParseClientId(m_ServerClientId)) == 0)

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1089,8 +1089,6 @@ namespace Unity.Netcode.Transports.UTP
 
         private void FlushSendQueuesForClientId(ulong clientId)
         {
-            // In the event this throws and exception, log it
-            // and allow the invoking method to continue.
             foreach (var kvp in m_SendQueue)
             {
                 if (kvp.Key.ClientId == clientId)

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1085,12 +1085,21 @@ namespace Unity.Netcode.Transports.UTP
 
         private void FlushSendQueuesForClientId(ulong clientId)
         {
-            foreach (var kvp in m_SendQueue)
+            // In the event this throws and exception, log it
+            // and allow the invoking method to continue.
+            try
             {
-                if (kvp.Key.ClientId == clientId)
+                foreach (var kvp in m_SendQueue)
                 {
-                    SendBatchedMessages(kvp.Key, kvp.Value);
+                    if (kvp.Key.ClientId == clientId)
+                    {
+                        SendBatchedMessages(kvp.Key, kvp.Value);
+                    }
                 }
+            }
+            catch(Exception ex)
+            {
+                Debug.Log(ex);
             }
         }
 
@@ -1101,6 +1110,7 @@ namespace Unity.Netcode.Transports.UTP
         {
             if (m_State == State.Connected)
             {
+
                 FlushSendQueuesForClientId(m_ServerClientId);
 
                 if (m_Driver.Disconnect(ParseClientId(m_ServerClientId)) == 0)

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -763,6 +763,10 @@ namespace Unity.Netcode.Transports.UTP
         // Send as many batched messages from the queue as possible.
         private void SendBatchedMessages(SendTarget sendTarget, BatchedSendQueue queue)
         {
+            if (!m_Driver.IsCreated)
+            {
+                return;
+            }
             new SendBatchedMessagesJob
             {
                 Driver = m_Driver.ToConcurrent(),
@@ -1087,19 +1091,12 @@ namespace Unity.Netcode.Transports.UTP
         {
             // In the event this throws and exception, log it
             // and allow the invoking method to continue.
-            try
+            foreach (var kvp in m_SendQueue)
             {
-                foreach (var kvp in m_SendQueue)
+                if (kvp.Key.ClientId == clientId)
                 {
-                    if (kvp.Key.ClientId == clientId)
-                    {
-                        SendBatchedMessages(kvp.Key, kvp.Value);
-                    }
+                    SendBatchedMessages(kvp.Key, kvp.Value);
                 }
-            }
-            catch (Exception ex)
-            {
-                Debug.Log(ex);
             }
         }
 


### PR DESCRIPTION
This PR just adds two try catch wrappers to handle two scenarios that could disrupt the shutdown/disconnect sequence.
NetworkManager: The try catch wrapper assures that it will continue to process the remainder of the ShutdownInternal code if NetworkTransport.DisconnectLocalClient throws and exception (_otherwise it will end up in an infinite shutdown sequence_).

UnityTransport: The try catch wrapper assures the invoking methods will continue to process if FlushSendQueuesForClientId throws an exception.

[MTT-5551](https://jira.unity3d.com/browse/MTT-5551)

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.
