### PR TITLE
fix: Fixed NetworkVariable<float> not rendering properly in inspector

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -27,6 +27,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed issue where `NetworkAnimator` would not check if its associated `Animator` was valid during serialization and would spam exceptions in the editor console. (#2416)
 - Fixed issue when the `NetworkSceneManager.ClientSynchronizationMode` is `LoadSceneMode.Additive` and the server changes the currently active scene prior to a client connecting then upon a client connecting and being synchronized the NetworkSceneManager would clear its internal ScenePlacedObjects list that could already be populated. (#2383)
 - Fixed issue where a client would load duplicate scenes of already preloaded scenes during the initial client synchronization and `NetworkSceneManager.ClientSynchronizationMode` was set to `LoadSceneMode.Additive`. (#2383)
+- Fixed float NetworkVariables not being rendered properly in the inspector of NetworkObjects.
 
 ## [1.3.0]
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -27,7 +27,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed issue where `NetworkAnimator` would not check if its associated `Animator` was valid during serialization and would spam exceptions in the editor console. (#2416)
 - Fixed issue when the `NetworkSceneManager.ClientSynchronizationMode` is `LoadSceneMode.Additive` and the server changes the currently active scene prior to a client connecting then upon a client connecting and being synchronized the NetworkSceneManager would clear its internal ScenePlacedObjects list that could already be populated. (#2383)
 - Fixed issue where a client would load duplicate scenes of already preloaded scenes during the initial client synchronization and `NetworkSceneManager.ClientSynchronizationMode` was set to `LoadSceneMode.Additive`. (#2383)
-- Fixed float NetworkVariables not being rendered properly in the inspector of NetworkObjects.
+- Fixed float NetworkVariables not being rendered properly in the inspector of NetworkObjects. (#2441)
 
 ## [1.3.0]
 

--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -161,6 +161,10 @@ namespace Unity.Netcode.Editor
                 {
                     val = (ulong)EditorGUILayout.LongField(variableName, (long)((ulong)val));
                 }
+                else if (type == typeof(float))
+                {
+                    val = (float)EditorGUILayout.FloatField(variableName, (float)((float)val));
+                }
                 else if (type == typeof(bool))
                 {
                     val = EditorGUILayout.Toggle(variableName, (bool)val);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/27730963/224091741-41349c15-0662-403d-b531-569726305753.png)

The issue is that the [NetworkBehaviourEditor](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/blob/ce1869fbe208019d1fd257a993ef03dca9e025ca/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs#L146) treated `float` as an unsupported type

## Changelog

- Fixed float NetworkVariables not being rendered properly in the inspector of NetworkObjects.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.