### PR TITLE
fix: NetworkAnimator not detecting and synchronizing cross fade initiated transitions

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -41,6 +41,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where `NetworkAnimator` was not properly detecting and synchronizing cross fade initiated transitions. (#2481)
+- Fixed issue where `NetworkAnimator` was not properly synchronizing animation state updates. (#2481)
 - Fixed an issue where Named Message Handlers could remove themselves causing an exception when the metrics tried to access the name of the message.(#2426)
 - Fixed registry of public `NetworkVariable`s in derived `NetworkBehaviour`s (#2423)
 - Fixed issue where runtime association of `Animator` properties to `AnimationCurve`s would cause `NetworkAnimator` to attempt to update those changes. (#2416)

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -1235,14 +1235,7 @@ namespace Unity.Netcode.Components
             var isServerAuthoritative = IsServerAuthoritative();
             if (!isServerAuthoritative && !IsOwner || isServerAuthoritative)
             {
-                if (isServerAuthoritative)
-                {
-                    m_NetworkAnimatorStateChangeHandler.ProcessParameterUpdate(parametersUpdate);
-                }
-                else
-                {
-                    m_NetworkAnimatorStateChangeHandler.ProcessParameterUpdate(parametersUpdate);
-                }
+                m_NetworkAnimatorStateChangeHandler.ProcessParameterUpdate(parametersUpdate);
             }
         }
 

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -345,8 +345,7 @@ namespace Unity.Netcode.Components
 
             public void NetworkSerialize<T>(BufferSerializer<T> serializer) where T : IReaderWriter
             {
-                var isWriter = serializer.IsWriter;
-                if (isWriter)
+                if (serializer.IsWriter)
                 {
                     var writer = serializer.GetFastBufferWriter();
                     m_StateFlags = 0x00;

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
@@ -941,7 +941,11 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 }
             }
             QueuedSceneJobs.Clear();
-            Object.Destroy(CoroutineRunner.gameObject);
+            if (CoroutineRunner != null && CoroutineRunner.gameObject != null)
+            {
+                Object.Destroy(CoroutineRunner.gameObject);
+            }
+
         }
     }
 }

--- a/testproject/Assets/Tests/Manual/NetworkAnimatorTests/AnimatedCubeController.cs
+++ b/testproject/Assets/Tests/Manual/NetworkAnimatorTests/AnimatedCubeController.cs
@@ -189,6 +189,24 @@ namespace Tests.Manual.NetworkAnimatorTests
             return m_Animator.GetLayerWeight(layer);
         }
 
+        [ServerRpc]
+        private void TestCrossFadeServerRpc()
+        {
+            m_Animator.CrossFade("CrossFadeState", 0.25f, 0);
+        }
+
+        private void TestCrossFade()
+        {
+            if (!IsServer && m_IsServerAuthoritative)
+            {
+                TestCrossFadeServerRpc();
+            }
+            else
+            {
+                m_Animator.CrossFade("CrossFadeState", 0.25f, 0);
+            }
+        }
+
         private void LateUpdate()
         {
 
@@ -208,6 +226,11 @@ namespace Tests.Manual.NetworkAnimatorTests
             }
 
             DisplayTestIntValueIfChanged();
+
+            if (Input.GetKeyDown(KeyCode.G))
+            {
+                TestCrossFade();
+            }
 
             // Rotates the cube
             if (Input.GetKeyDown(KeyCode.C))

--- a/testproject/Assets/Tests/Manual/NetworkAnimatorTests/CrossFadeTransitionDetect.cs
+++ b/testproject/Assets/Tests/Manual/NetworkAnimatorTests/CrossFadeTransitionDetect.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using Unity.Netcode;
+using UnityEngine;
+
+/// <summary>
+/// This StateMachineBehaviour is used to detect an <see cref="Animator.CrossFade"/> initiated transition
+/// for integration test purposes.
+/// </summary>
+public class CrossFadeTransitionDetect : StateMachineBehaviour
+{
+    public static Dictionary<ulong, Dictionary<int, AnimatorStateInfo>> StatesEntered = new Dictionary<ulong, Dictionary<int, AnimatorStateInfo>>();
+    public static bool IsVerboseDebug;
+
+    public static string CurrentTargetStateName { get; private set; }
+    public static int CurrentTargetStateHash { get; private set; }
+
+    public static List<ulong> ClientIds = new List<ulong>();
+
+    public static void ResetTest()
+    {
+        ClientIds.Clear();
+        StatesEntered.Clear();
+        IsVerboseDebug = false;
+    }
+
+    private void Log(string logMessage)
+    {
+        if (!IsVerboseDebug)
+        {
+            return;
+        }
+        Debug.Log($"[CrossFadeDetect] {logMessage}");
+    }
+
+    public static bool AllClientsTransitioned()
+    {
+        foreach (var clientId in ClientIds)
+        {
+            if (!StatesEntered.ContainsKey(clientId))
+            {
+                return false;
+            }
+
+            if (!StatesEntered[clientId].ContainsKey(CurrentTargetStateHash))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static void SetTargetAnimationState(string animationStateName)
+    {
+        CurrentTargetStateName = animationStateName;
+        CurrentTargetStateHash = Animator.StringToHash(animationStateName);
+    }
+
+    public override void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    {
+        if (stateInfo.shortNameHash != CurrentTargetStateHash)
+        {
+            Log($"[Ignoring State][Layer-{layerIndex}] Incoming: ({stateInfo.fullPathHash}) | Targeting: ({CurrentTargetStateHash})");
+            return;
+        }
+
+        var networkObject = animator.GetComponent<NetworkObject>();
+        if (networkObject == null || networkObject.NetworkManager == null || !networkObject.IsSpawned)
+        {
+            return;
+        }
+
+        var clientId = networkObject.NetworkManager.LocalClientId;
+        if (!StatesEntered.ContainsKey(clientId))
+        {
+            StatesEntered.Add(clientId, new Dictionary<int, AnimatorStateInfo>());
+        }
+
+        if (!StatesEntered[clientId].ContainsKey(stateInfo.shortNameHash))
+        {
+            StatesEntered[clientId].Add(stateInfo.shortNameHash, stateInfo);
+        }
+        else
+        {
+            StatesEntered[clientId][stateInfo.shortNameHash] = stateInfo;
+        }
+
+        Log($"[{layerIndex}][STATE-ENTER][{clientId}] {networkObject.NetworkManager.name} entered state {stateInfo.shortNameHash}!");
+    }
+}

--- a/testproject/Assets/Tests/Manual/NetworkAnimatorTests/CrossFadeTransitionDetect.cs.meta
+++ b/testproject/Assets/Tests/Manual/NetworkAnimatorTests/CrossFadeTransitionDetect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 53314cafa8e073c40b0b35dd25485c42
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/testproject/Assets/Tests/Manual/NetworkAnimatorTests/CubeAnimatorController.controller
+++ b/testproject/Assets/Tests/Manual/NetworkAnimatorTests/CubeAnimatorController.controller
@@ -200,7 +200,9 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -5899436739107315318}
-  m_StateMachineBehaviours: []
+  m_StateMachineBehaviours:
+  - {fileID: 541327199996806903}
+  - {fileID: -4599709113985687942}
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
@@ -314,6 +316,18 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!114 &-4599709113985687942
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dec8cf4a19a8ef745ae0440ec04911ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1101 &-4455521266437619866
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -843,6 +857,18 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!114 &541327199996806903
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: beb3702bd4c8d274e9dffe0c6467eafb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1101 &1138737138882309440
 AnimatorStateTransition:
   m_ObjectHideFlags: 1

--- a/testproject/Assets/Tests/Manual/NetworkAnimatorTests/CubeAnimatorController.controller
+++ b/testproject/Assets/Tests/Manual/NetworkAnimatorTests/CubeAnimatorController.controller
@@ -188,6 +188,33 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1102 &-7324519211837832008
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: CrossFadeState
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -5899436739107315318}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: bd13c1363af7aaf4db0ffb085ac89d77, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1101 &-6396453490711135124
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -226,6 +253,28 @@ AnimatorStateTransition:
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -338501773749300249}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &-5899436739107315318
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -1676030328622575462}
   m_Solo: 0
   m_Mute: 0
   m_IsExit: 0
@@ -629,6 +678,9 @@ AnimatorStateMachine:
   - serializedVersion: 1
     m_State: {fileID: -1603678049383302394}
     m_Position: {x: 440, y: 190, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -7324519211837832008}
+    m_Position: {x: 570, y: -140, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []

--- a/testproject/Assets/Tests/Manual/NetworkAnimatorTests/CubeAnimatorController.controller
+++ b/testproject/Assets/Tests/Manual/NetworkAnimatorTests/CubeAnimatorController.controller
@@ -201,8 +201,7 @@ AnimatorState:
   m_Transitions:
   - {fileID: -5899436739107315318}
   m_StateMachineBehaviours:
-  - {fileID: 541327199996806903}
-  - {fileID: -4599709113985687942}
+  - {fileID: 8360333217518347423}
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
@@ -316,18 +315,6 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
---- !u!114 &-4599709113985687942
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dec8cf4a19a8ef745ae0440ec04911ae, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1101 &-4455521266437619866
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -857,18 +844,6 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
---- !u!114 &541327199996806903
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: beb3702bd4c8d274e9dffe0c6467eafb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1101 &1138737138882309440
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -1344,3 +1319,15 @@ AnimatorStateMachine:
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: 5205197960406981613}
+--- !u!114 &8360333217518347423
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 53314cafa8e073c40b0b35dd25485c42, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/testproject/Assets/Tests/Runtime/Animation/AnimatorTestHelper.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/AnimatorTestHelper.cs
@@ -121,9 +121,12 @@ namespace TestProject.RuntimeTests
                 StartCoroutine(TriggerMonitor(name));
             }
         }
+
+        public const string TargetCrossFadeState = "CrossFadeState";
+
         public void TestCrossFade()
         {
-            m_Animator.CrossFade("CrossFadeState", 0.25f, 0);
+            m_Animator.CrossFade(TargetCrossFadeState, 0.25f, 0);
         }
 
         public void SetBool(string name, bool valueToSet)

--- a/testproject/Assets/Tests/Runtime/Animation/AnimatorTestHelper.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/AnimatorTestHelper.cs
@@ -121,6 +121,10 @@ namespace TestProject.RuntimeTests
                 StartCoroutine(TriggerMonitor(name));
             }
         }
+        public void TestCrossFade()
+        {
+            m_Animator.CrossFade("CrossFadeState", 0.25f, 0);
+        }
 
         public void SetBool(string name, bool valueToSet)
         {


### PR DESCRIPTION
This PR resolves the issue where `NetworkAnimator` was not properly detecting and synchronizing cross fade initiated transitions and not properly synchronizing changes to animation states.
It also reduces the cost of each animation state update by packing eligible properties.

## Changelog

- Fixed: Issue where `NetworkAnimator` was not properly detecting and synchronizing cross fade initiated transitions.
- Fixed: Issue where `NetworkAnimator` was not properly synchronizing animation state updates.

## Testing and Documentation

- Includes integration test.
- Includes updates to manual test.
- No documentation changes or additions were necessary.
