### PR TITLE
fix: Error when a client is disconnected as a result of attempting to send to it [MTT-4607]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -8,6 +8,12 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed some errors that could occur if a connection is lost and the loss is detected when attempting to write to the socket. (#2495)
+
+## [1.4.0]
+
 ### Added
 
 - Added a way to access the GlobalObjectIdHash via PrefabIdHash for use in the Connection Approval Callback. (#2437)

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/DisconnectOnSendTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/DisconnectOnSendTests.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Unity.Netcode.EditorTests
+{
+    public class DisconnectOnSendTests
+    {
+        private struct TestMessage : INetworkMessage, INetworkSerializeByMemcpy
+        {
+            public void Serialize(FastBufferWriter writer, int targetVersion)
+            {
+            }
+
+            public bool Deserialize(FastBufferReader reader, ref NetworkContext context, int receivedMessageVersion)
+            {
+                return true;
+            }
+
+            public void Handle(ref NetworkContext context)
+            {
+            }
+
+            public int Version => 0;
+        }
+
+        private class DisconnectOnSendMessageSender : IMessageSender
+        {
+            public MessagingSystem MessagingSystem;
+
+            public void Send(ulong clientId, NetworkDelivery delivery, FastBufferWriter batchData)
+            {
+                MessagingSystem.ClientDisconnected(clientId);
+            }
+        }
+        private class TestMessageProvider : IMessageProvider
+        {
+            // Keep track of what we sent
+            private List<MessagingSystem.MessageWithHandler> m_MessageList = new List<MessagingSystem.MessageWithHandler>{
+                new MessagingSystem.MessageWithHandler
+                {
+                    MessageType = typeof(TestMessage),
+                    Handler = MessagingSystem.ReceiveMessage<TestMessage>,
+                    GetVersion = MessagingSystem.CreateMessageAndGetVersion<TestMessage>
+                }
+            };
+
+            public List<MessagingSystem.MessageWithHandler> GetMessages()
+            {
+                return m_MessageList;
+            }
+        }
+
+        private TestMessageProvider m_TestMessageProvider;
+        private DisconnectOnSendMessageSender m_MessageSender;
+        private MessagingSystem m_MessagingSystem;
+        private ulong[] m_Clients = { 0 };
+
+        [SetUp]
+        public void SetUp()
+        {
+            m_MessageSender = new DisconnectOnSendMessageSender();
+            m_TestMessageProvider = new TestMessageProvider();
+            m_MessagingSystem = new MessagingSystem(m_MessageSender, this, m_TestMessageProvider);
+            m_MessageSender.MessagingSystem = m_MessagingSystem;
+            m_MessagingSystem.ClientConnected(0);
+            m_MessagingSystem.SetVersion(0, XXHash.Hash32(typeof(TestMessage).FullName), 0);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            m_MessagingSystem.Dispose();
+        }
+
+        private TestMessage GetMessage()
+        {
+            return new TestMessage();
+        }
+
+        [Test]
+        public void WhenDisconnectIsCalledDuringSend_NoErrorsOccur()
+        {
+            var message = GetMessage();
+            m_MessagingSystem.SendMessage(ref message, NetworkDelivery.Reliable, m_Clients);
+
+            // This is where an exception would be thrown and logged.
+            m_MessagingSystem.ProcessSendQueues();
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/DisconnectOnSendTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/DisconnectOnSendTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7984df99de5c4b85a1b8567582d00c64
+timeCreated: 1680888331


### PR DESCRIPTION
This can happen in the case that the socket is detected to be closed in the send operation (i.e., EPIPE). The disconnect removed items from m_SendQueue while it was being iterated, and also resulted in a double-dispose on the FastBufferWriter being used for it. 

fixes #2168 
[MTT-4607](https://jira.unity3d.com/browse/MTT-4607)

## Changelog

- Fixed: Fixed some errors that could occur if a connection is lost and the loss is detected when attempting to write to the socket.

## Testing and Documentation

- Includes unit tests.
- No documentation changes or additions were necessary.

