### PR TITLE
fix: NGO UnityTransport not detecting invalid endpoint [MTT-3937]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -8,9 +8,14 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ## [Unreleased]
 
+### Added
+
 ### Fixed
 
+- Fixed issue where invalid endpoint addresses were not being detected and returning false from NGO UnityTransport.
 - Fixed some errors that could occur if a connection is lost and the loss is detected when attempting to write to the socket. (#2495)
+
+## Changed
 
 ## [1.4.0]
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,7 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where invalid endpoint addresses were not being detected and returning false from NGO UnityTransport.
+- Fixed issue where invalid endpoint addresses were not being detected and returning false from NGO UnityTransport. (#2496)
 - Fixed some errors that could occur if a connection is lost and the loss is detected when attempting to write to the socket. (#2495)
 
 ## Changed

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -536,6 +536,13 @@ namespace Unity.Netcode.Transports.UTP
                 serverEndpoint = ConnectionData.ServerEndPoint;
             }
 
+            // Verify the endpoint is valid before proceeding
+            if (serverEndpoint.Family == NetworkFamily.Invalid)
+            {
+                Debug.LogError($"Target server network address ({ConnectionData.Address}) is {nameof(NetworkFamily.Invalid)}!");
+                return false;
+            }
+
             InitDriver();
 
             var bindEndpoint = serverEndpoint.Family == NetworkFamily.Ipv6 ? NetworkEndpoint.AnyIpv6 : NetworkEndpoint.AnyIpv4;
@@ -554,6 +561,13 @@ namespace Unity.Netcode.Transports.UTP
 
         private bool ServerBindAndListen(NetworkEndpoint endPoint)
         {
+            // Verify the endpoint is valid before proceeding
+            if (endPoint.Family == NetworkFamily.Invalid)
+            {
+                Debug.LogError($"Network listen address ({ConnectionData.Address}) is {nameof(NetworkFamily.Invalid)}!");
+                return false;
+            }
+
             InitDriver();
 
             int result = m_Driver.Bind(endPoint);

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeLogAssert.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeLogAssert.cs
@@ -3,10 +3,11 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace Unity.Netcode.RuntimeTests
 {
-    public class NetcodeLogAssert
+    public class NetcodeLogAssert : IDisposable
     {
         private struct LogData
         {
@@ -20,8 +21,11 @@ namespace Unity.Netcode.RuntimeTests
 
         private List<LogData> AllLogs { get; }
 
-        public NetcodeLogAssert()
+        private bool m_ResetIgnoreFailingMessagesOnTearDown;
+        public NetcodeLogAssert(bool ignorFailingMessages = false, bool resetOnTearDown = true)
         {
+            LogAssert.ignoreFailingMessages = ignorFailingMessages;
+            m_ResetIgnoreFailingMessagesOnTearDown = resetOnTearDown;
             AllLogs = new List<LogData>();
             Activate();
         }
@@ -51,6 +55,16 @@ namespace Unity.Netcode.RuntimeTests
             }
         }
 
+        [UnityTearDown]
+        public void OnTearDown()
+        {
+            // Defaults to true and will reset LogAssert.ignoreFailingMessages during tear down
+            if (m_ResetIgnoreFailingMessagesOnTearDown)
+            {
+                LogAssert.ignoreFailingMessages = false;
+            }
+        }
+
         public void Dispose()
         {
             Dispose(true);
@@ -59,6 +73,8 @@ namespace Unity.Netcode.RuntimeTests
 
         private void Dispose(bool disposing)
         {
+            // Always reset when disposing
+            LogAssert.ignoreFailingMessages = false;
             if (m_Disposed)
             {
                 return;

--- a/com.unity.netcode.gameobjects/Tests/Editor/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Transports/UnityTransportTests.cs
@@ -116,14 +116,14 @@ namespace Unity.Netcode.EditorTests
             transport.Initialize();
 
             transport.SetConnectionData("127.0.0.", 4242, "127.0.0.");
+
             Assert.False(transport.StartServer());
 
             LogAssert.Expect(LogType.Error, "Invalid network endpoint: 127.0.0.:4242.");
+            LogAssert.Expect(LogType.Error, $"Network listen address (127.0.0.) is Invalid!");
 #if UTP_TRANSPORT_2_0_ABOVE
             LogAssert.Expect(LogType.Error, "Socket creation failed (error Unity.Baselib.LowLevel.Binding+Baselib_ErrorState: Invalid argument (0x01000003) <argument name stripped>");
 #endif
-            LogAssert.Expect(LogType.Error, "Server failed to bind. This is usually caused by another process being bound to the same port.");
-
             transport.SetConnectionData("127.0.0.1", 4242, "127.0.0.1");
             Assert.True(transport.StartServer());
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportConnectionTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportConnectionTests.cs
@@ -45,6 +45,23 @@ namespace Unity.Netcode.RuntimeTests
             yield return null;
         }
 
+        // Check that invalid endpoint addresses are detected and return false if detected
+        [Test]
+        public void DetectInvalidEndpoint()
+        {
+            InitializeTransport(out m_Server, out m_ServerEvents);
+            InitializeTransport(out m_Clients[0], out m_ClientsEvents[0]);
+            m_Server.ConnectionData.Address = "Fubar";
+            m_Server.ConnectionData.ServerListenAddress = "Fubar";
+            m_Clients[0].ConnectionData.Address = "MoreFubar";
+            LogAssert.Expect(LogType.Error, $"Invalid network endpoint: {m_Server.ConnectionData.Address}:{m_Server.ConnectionData.Port}.");
+            LogAssert.Expect(LogType.Error, $"Network listen address ({m_Server.ConnectionData.Address}) is Invalid!");
+            LogAssert.Expect(LogType.Error, $"Invalid network endpoint: {m_Clients[0].ConnectionData.Address}:{m_Clients[0].ConnectionData.Port}.");
+            LogAssert.Expect(LogType.Error, $"Target server network address ({m_Clients[0].ConnectionData.Address}) is Invalid!");
+            Assert.False(m_Server.StartServer(), "Server failed to detect invalid endpoint!");
+            Assert.False(m_Clients[0].StartClient(), "Client failed to detect invalid endpoint!");
+        }
+
         // Check connection with a single client.
         [UnityTest]
         public IEnumerator ConnectSingleClient()

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportConnectionTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportConnectionTests.cs
@@ -49,17 +49,16 @@ namespace Unity.Netcode.RuntimeTests
         [Test]
         public void DetectInvalidEndpoint()
         {
+            using var netcodeLogAssert = new NetcodeLogAssert(true);
             InitializeTransport(out m_Server, out m_ServerEvents);
             InitializeTransport(out m_Clients[0], out m_ClientsEvents[0]);
             m_Server.ConnectionData.Address = "Fubar";
             m_Server.ConnectionData.ServerListenAddress = "Fubar";
             m_Clients[0].ConnectionData.Address = "MoreFubar";
-            LogAssert.Expect(LogType.Error, $"Invalid network endpoint: {m_Server.ConnectionData.Address}:{m_Server.ConnectionData.Port}.");
-            LogAssert.Expect(LogType.Error, $"Network listen address ({m_Server.ConnectionData.Address}) is Invalid!");
-            LogAssert.Expect(LogType.Error, $"Invalid network endpoint: {m_Clients[0].ConnectionData.Address}:{m_Clients[0].ConnectionData.Port}.");
-            LogAssert.Expect(LogType.Error, $"Target server network address ({m_Clients[0].ConnectionData.Address}) is Invalid!");
             Assert.False(m_Server.StartServer(), "Server failed to detect invalid endpoint!");
             Assert.False(m_Clients[0].StartClient(), "Client failed to detect invalid endpoint!");
+            netcodeLogAssert.LogWasReceived(LogType.Error, $"Network listen address ({m_Server.ConnectionData.Address}) is Invalid!");
+            netcodeLogAssert.LogWasReceived(LogType.Error, $"Target server network address ({m_Clients[0].ConnectionData.Address}) is Invalid!");
         }
 
         // Check connection with a single client.


### PR DESCRIPTION
This resolves the issue where the NGO UnityTransport class was not detecting an invalid endpoint address and would always return true (even with an invalid endpoint address).

[MTT-3937](https://jira.unity3d.com/browse/MTT-3937)
Also pertains to issue #2525

## Changelog

- Fixed: Issue where invalid endpoint addresses were not being detected and returning false from NGO UnityTransport.

## Testing and Documentation

- Includes unit test.
- No documentation changes or additions were necessary.
