### PR TITLE
fix: defer ObjectSceneChanged events to occur after client has finished synchronizing

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -41,6 +41,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where during client synchronization the synchronizing client could receive a ObjectSceneChanged message before the client-side NetworkObject instance had been instantiated and spawned. (#2502)
 - Fixed issue where `NetworkAnimator` was building client RPC parameters to exclude the host from sending itself messages but was not including it in the ClientRpc parameters. (#2492)
 - Fixed issue where `NetworkAnimator` was not properly detecting and synchronizing cross fade initiated transitions. (#2481)
 - Fixed issue where `NetworkAnimator` was not properly synchronizing animation state updates. (#2481)

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -2436,7 +2436,7 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Invoked by clients when processing a <see cref="SceneEventType.ObjectSceneChanged"/> event
-        /// or invoked by SceneEventData.ProcessDeferredObjectsMovedEvents when a client finishes
+        /// or invoked by <see cref="SceneEventData.ProcessDeferredObjectSceneChangedEvents"/> when a client finishes
         /// synchronization.
         /// </summary>
         internal void MigrateNetworkObjectsIntoScenes()

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -2048,11 +2048,6 @@ namespace Unity.Netcode
                             // All scenes are synchronized, let the server know we are done synchronizing
                             m_NetworkManager.IsConnectedClient = true;
 
-                            // Process any SceneEventType.ObjectSceneChanged messages that
-                            // were deferred while synchronizing and migrate the associated
-                            // NetworkObjects to their newly assigned scenes.
-                            sceneEventData.ProcessDeferredObjectsMovedEvents();
-
                             // Client is now synchronized and fully "connected".  This also means the client can send "RPCs" at this time
                             m_NetworkManager.InvokeOnClientConnectedCallback(m_NetworkManager.LocalClientId);
 
@@ -2062,6 +2057,11 @@ namespace Unity.Netcode
                                 SceneEventType = sceneEventData.SceneEventType,
                                 ClientId = m_NetworkManager.LocalClientId, // Client sent this to the server
                             });
+
+                            // Process any SceneEventType.ObjectSceneChanged messages that
+                            // were deferred while synchronizing and migrate the associated
+                            // NetworkObjects to their newly assigned scenes.
+                            sceneEventData.ProcessDeferredObjectSceneChangedEvents();
 
                             // Only if PostSynchronizationSceneUnloading is set and we are running in client synchronization
                             // mode additive do we unload any remaining scene that was not synchronized (otherwise any loaded

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -2068,6 +2068,11 @@ namespace Unity.Netcode
 
                             OnSynchronizeComplete?.Invoke(m_NetworkManager.LocalClientId);
 
+                            // Process any SceneEventType.ObjectSceneChanged messages that
+                            // were deferred while synchronizing and migrate the associated
+                            // NetworkObjects to their newly assigned scenes.
+                            sceneEventData.ProcessDeferredObjectsMovedEvents();
+
                             EndSceneEvent(sceneEventId);
                         }
                         break;
@@ -2430,8 +2435,10 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Invoked by clients when processing a <see cref="SceneEventType.ObjectSceneChanged"/> event
+        /// or invoked by SceneEventData.ProcessDeferredObjectsMovedEvents when a client finishes
+        /// synchronization.
         /// </summary>
-        private void MigrateNetworkObjectsIntoScenes()
+        internal void MigrateNetworkObjectsIntoScenes()
         {
             try
             {

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
@@ -1090,7 +1090,7 @@ namespace Unity.Netcode
             sceneManager.DeferredObjectsMovedEvents.Add(deferredObjectsMovedEvent);
         }
 
-        internal void ProcessDeferredObjectsMovedEvents()
+        internal void ProcessDeferredObjectSceneChangedEvents()
         {
             var sceneManager = m_NetworkManager.SceneManager;
             var spawnManager = m_NetworkManager.SpawnManager;

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
@@ -1054,12 +1054,6 @@ namespace Unity.Netcode
             }
         }
 
-        private struct DeferredObjectsMovedEvent
-        {
-            internal Dictionary<int, List<ulong>> ObjectsMigratedTable;
-        }
-
-        private List<DeferredObjectsMovedEvent> m_DeferredObjectsMovedEvents = new List<DeferredObjectsMovedEvent>();
 
         /// <summary>
         /// While a client is synchronizing ObjectSceneChanged messages could be received.
@@ -1076,7 +1070,7 @@ namespace Unity.Netcode
             var objectCount = 0;
             var networkObjectId = (ulong)0;
 
-            var deferredObjectsMovedEvent = new DeferredObjectsMovedEvent()
+            var deferredObjectsMovedEvent = new NetworkSceneManager.DeferredObjectsMovedEvent()
             {
                 ObjectsMigratedTable = new Dictionary<int, List<ulong>>()
             };
@@ -1093,18 +1087,18 @@ namespace Unity.Netcode
                     deferredObjectsMovedEvent.ObjectsMigratedTable[sceneHandle].Add(networkObjectId);
                 }
             }
-            m_DeferredObjectsMovedEvents.Add(deferredObjectsMovedEvent);
+            sceneManager.DeferredObjectsMovedEvents.Add(deferredObjectsMovedEvent);
         }
 
         internal void ProcessDeferredObjectsMovedEvents()
         {
             var sceneManager = m_NetworkManager.SceneManager;
             var spawnManager = m_NetworkManager.SpawnManager;
-            if (m_DeferredObjectsMovedEvents.Count == 0)
+            if (sceneManager.DeferredObjectsMovedEvents.Count == 0)
             {
                 return;
             }
-            foreach (var objectsMovedEvent in m_DeferredObjectsMovedEvents)
+            foreach (var objectsMovedEvent in sceneManager.DeferredObjectsMovedEvents)
             {
                 foreach (var keyEntry in objectsMovedEvent.ObjectsMigratedTable)
                 {
@@ -1129,7 +1123,7 @@ namespace Unity.Netcode
                 objectsMovedEvent.ObjectsMigratedTable.Clear();
             }
 
-            m_DeferredObjectsMovedEvents.Clear();
+            sceneManager.DeferredObjectsMovedEvents.Clear();
 
             // If there are any pending objects to migrate, then migrate them
             if (sceneManager.ObjectsMigratedIntoNewScene.Count > 0)

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectSceneMigrationTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectSceneMigrationTests.cs
@@ -157,6 +157,7 @@ namespace TestProject.RuntimeTests
             return true;
         }
 
+        private const int k_MaxObjectsToSpawn = 9;
         /// <summary>
         /// Integration test to verify that migrating NetworkObjects
         /// into different scenes (in the same frame) is synchronized
@@ -167,7 +168,7 @@ namespace TestProject.RuntimeTests
         public IEnumerator MigrateIntoNewSceneTest()
         {
             // Spawn 9 NetworkObject instances
-            for (int i = 0; i < 9; i++)
+            for (int i = 0; i < k_MaxObjectsToSpawn; i++)
             {
                 var serverInstance = Object.Instantiate(m_TestPrefab);
                 var serverNetworkObject = serverInstance.GetComponent<NetworkObject>();
@@ -204,10 +205,34 @@ namespace TestProject.RuntimeTests
             yield return WaitForConditionOrTimeOut(VerifySpawnedObjectsMigrated);
             AssertOnTimeout($"Timed out waiting for all clients to migrate all NetworkObjects into the appropriate scenes!");
 
-            // Verify that a late joining client synchronizes properly
+            // Register for the server-side client synchronization so we can send an object scene migration event at the same time
+            // the new client begins to synchronize
+            m_ServerNetworkManager.SceneManager.OnSynchronize += SceneManager_OnSynchronize;
+
+            // Verify that a late joining client synchronizes properly even while new scene migrations occur
+            // during its synchronization
             yield return CreateAndStartNewClient();
             yield return WaitForConditionOrTimeOut(VerifySpawnedObjectsMigrated);
+
             AssertOnTimeout($"[Late Joined Client] Timed out waiting for all clients to migrate all NetworkObjects into the appropriate scenes!");
+        }
+
+        /// <summary>
+        /// Migrate objects into other scenes when a client begins synchronization
+        /// </summary>
+        /// <param name="clientId"></param>
+        private void SceneManager_OnSynchronize(ulong clientId)
+        {
+            var objectCount = k_MaxObjectsToSpawn - 1;
+
+            // Migrate the NetworkObjects into different scenes than they originally were migrated into
+            foreach (var scene in m_ScenesLoaded)
+            {
+                SceneManager.MoveGameObjectToScene(m_ServerSpawnedPrefabInstances[objectCount].gameObject, scene);
+                SceneManager.MoveGameObjectToScene(m_ServerSpawnedPrefabInstances[objectCount - 1].gameObject, scene);
+                SceneManager.MoveGameObjectToScene(m_ServerSpawnedPrefabInstances[objectCount - 2].gameObject, scene);
+                objectCount -= 3;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes the issue where a client could receive a SceneEventType.ObjectSceneChanged message while in the middle of synchronization which could cause an exception to be thrown due to a NetworkObject not yet being instantiated and spawned.

[MTT-6188](https://jira.unity3d.com/browse/MTT-6188)

## Changelog
- Fixed: Issue where during client synchronization the synchronizing client could receive a ObjectSceneChanged message before the client-side NetworkObject instance had been instantiated and spawned.

## Testing and Documentation
- Includes integration test updates to NetworkObjectSceneMigrationTests.MigrateIntoNewSceneTest
- No documentation changes or additions were necessary.
