### PR TITLE
fix: ArgumentException: Set Method not found for 'Name'

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
@@ -1,5 +1,6 @@
 using System;
 using UnityEngine;
+using UnityEngine.Scripting;
 
 namespace Unity.Netcode
 {
@@ -66,6 +67,7 @@ namespace Unity.Netcode
         /// Gets or sets the name of the network variable's instance
         /// (MemberInfo) where it was declared.
         /// </summary>
+        [Preserve]
         public string Name { get; internal set; }
 
         /// <summary>


### PR DESCRIPTION
## Purpose of this PR
This PR fixes the `ArgumentException: Set Method not found for 'Name' ` error when the Managed Stripping level is set to medium or higher.

Full Stack trace:
```
ArgumentException: Set Method not found for 'Name'
  at System.Reflection.RuntimePropertyInfo.SetValue (System.Object obj, System.Object value, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] index, System.Globalization.CultureInfo culture) [0x00026] in <d687c034f8db48899938ae6429c6bbeb>:0 
  at System.Reflection.PropertyInfo.SetValue (System.Object obj, System.Object value, System.Object[] index) [0x00000] in <d687c034f8db48899938ae6429c6bbeb>:0 
  at System.Reflection.PropertyInfo.SetValue (System.Object obj, System.Object value) [0x00000] in <d687c034f8db48899938ae6429c6bbeb>:0 
  at Unity.Netcode.NetworkBehaviour.InitializeVariables () [0x000c9] in C:\Development\RNSM-NetworkTransform\Library\PackageCache\com.unity.netcode.gameobjects@0e02dc7c81\Runtime\Core\NetworkBehaviour.cs:605 
  at Unity.Netcode.NetworkObject.SetNetworkVariableData (Unity.Netcode.FastBufferReader reader, System.UInt64 clientId) [0x00013] in C:\Development\RNSM-NetworkTransform\Library\PackageCache\com.unity.netcode.gameobjects@0e02dc7c81\Runtime\Core\NetworkObject.cs:1133 
  at Unity.Netcode.NetworkObject.SynchronizeNetworkBehaviours[T] (Unity.Netcode.BufferSerializer`1[T]& serializer, System.UInt64 targetClientId) [0x0013a] in C:\Development\RNSM-NetworkTransform\Library\PackageCache\com.unity.netcode.gameobjects@0e02dc7c81\Runtime\Core\NetworkObject.cs:1409 
  at Unity.Netcode.NetworkObject.AddSceneObject (Unity.Netcode.NetworkObject+SceneObject& sceneObject, Unity.Netcode.FastBufferReader reader, Unity.Netcode.NetworkManager networkManager) [0x000a9] in C:\Development\RNSM-NetworkTransform\Library\PackageCache\com.unity.netcode.gameobjects@0e02dc7c81\Runtime\Core\NetworkObject.cs:1550 
  at Unity.Netcode.SceneEventData.SynchronizeSceneNetworkObjects (Unity.Netcode.NetworkManager networkManager) [0x0005d] in C:\Development\RNSM-NetworkTransform\Library\PackageCache\com.unity.netcode.gameobjects@0e02dc7c81\Runtime\SceneManagement\SceneEventData.cs:925 
  at Unity.Netcode.NetworkSceneManager.HandleClientSceneEvent (System.UInt32 sceneEventId) [0x000f1] in C:\Development\RNSM-NetworkTransform\Library\PackageCache\com.unity.netcode.gameobjects@0e02dc7c81\Runtime\SceneManagement\NetworkSceneManager.cs:2030 
  at Unity.Netcode.NetworkSceneManager.ClientLoadedSynchronization (System.UInt32 sceneEventId) [0x001d0] in C:\Development\RNSM-NetworkTransform\Library\PackageCache\com.unity.netcode.gameobjects@0e02dc7c81\Runtime\SceneManagement\NetworkSceneManager.cs:1937 
  at Unity.Netcode.NetworkSceneManager.OnClientBeginSync (System.UInt32 sceneEventId) [0x001d0] in C:\Development\RNSM-NetworkTransform\Library\PackageCache\com.unity.netcode.gameobjects@0e02dc7c81\Runtime\SceneManagement\NetworkSceneManager.cs:1865 
  at Unity.Netcode.NetworkSceneManager.HandleClientSceneEvent (System.UInt32 sceneEventId) [0x000d4] in C:\Development\RNSM-NetworkTransform\Library\PackageCache\com.unity.netcode.gameobjects@0e02dc7c81\Runtime\SceneManagement\NetworkSceneManager.cs:2023 
  at Unity.Netcode.NetworkSceneManager.HandleSceneEvent (System.UInt64 clientId, Unity.Netcode.FastBufferReader reader) [0x000ac] in C:\Development\RNSM-NetworkTransform\Library\PackageCache\com.unity.netcode.gameobjects@0e02dc7c81\Runtime\SceneManagement\NetworkSceneManager.cs:2251 
  at Unity.Netcode.SceneEventMessage.Handle (Unity.Netcode.NetworkContext& context) [0x00001] in C:\Development\RNSM-NetworkTransform\Library\PackageCache\com.unity.netcode.gameobjects@0e02dc7c81\Runtime\Messaging\Messages\SceneEventMessage.cs:26 
  at Unity.Netcode.MessagingSystem.ReceiveMessage[T] (Unity.Netcode.FastBufferReader reader, Unity.Netcode.NetworkContext& context, Unity.Netcode.MessagingSystem system) [0x000d9] in C:\Development\RNSM-NetworkTransform\Library\PackageCache\com.unity.netcode.gameobjects@0e02dc7c81\Runtime\Messaging\MessagingSystem.cs:554 
  at (wrapper delegate-invoke) <Module>.invoke_void_FastBufferReader_NetworkContext&_MessagingSystem(Unity.Netcode.FastBufferReader,Unity.Netcode.NetworkContext&,Unity.Netcode.MessagingSystem)
  at Unity.Netcode.MessagingSystem.HandleMessage (Unity.Netcode.MessageHeader& header, Unity.Netcode.FastBufferReader reader, System.UInt64 senderId, System.Single timestamp, System.Int32 serializedHeaderSize) [0x00128] in C:\Development\RNSM-NetworkTransform\Library\PackageCache\com.unity.netcode.gameobjects@0e02dc7c81\Runtime\Messaging\MessagingSystem.cs:427 
```

## Jira ticket
https://jira.unity3d.com/browse/MTT-6162

## Changelog

- Fixed: Prevent `NetworkVariable.Name` property from being stripped out when Managed Stripping level is set to High. 

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.