### PR TITLE
fix: teleport half precision not resetting interpolator

### DIFF
--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -2003,7 +2003,7 @@ namespace Unity.Netcode.Components
 
                     if (Interpolate)
                     {
-                        UpdatePositionInterpolator(currentPosition, sentTime);
+                        UpdatePositionInterpolator(currentPosition, sentTime, true);
                     }
 
                 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -930,7 +930,8 @@ namespace Unity.Netcode.RuntimeTests
             var success = WaitForConditionOrTimeOutWithTimeTravel(() => m_AuthoritativeTransform.StatePushed && m_NonAuthoritativeTransform.StateUpdated);
             Assert.True(success, $"[Teleport] Timed out waiting for state to be pushed ({m_AuthoritativeTransform.StatePushed}) or state to be updated ({m_NonAuthoritativeTransform.StateUpdated})!");
 
-            success = WaitForConditionOrTimeOutWithTimeTravel(() => TeleportPositionMatches(nonAuthPosition));
+            // Only try once for teleporting since state was pushed and updated
+            success = WaitForConditionOrTimeOutWithTimeTravel(() => TeleportPositionMatches(nonAuthPosition), 1);
             Assert.True(success, $"[Timed-Out][Teleport] Timed out waiting for NonAuthoritative position ({m_NonAuthoritativeTransform.GetSpaceRelativePosition()}) to teleport to position {teleportDestination}!");
             var targetDistance = 0.0f;
             if (!Approximately(m_DetectedPotentialInterpolatedTeleport, 0.0f))

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -930,9 +930,9 @@ namespace Unity.Netcode.RuntimeTests
             var success = WaitForConditionOrTimeOutWithTimeTravel(() => m_AuthoritativeTransform.StatePushed && m_NonAuthoritativeTransform.StateUpdated);
             Assert.True(success, $"[Teleport] Timed out waiting for state to be pushed ({m_AuthoritativeTransform.StatePushed}) or state to be updated ({m_NonAuthoritativeTransform.StateUpdated})!");
 
-            // Only try once for teleporting since state was pushed and updated
-            success = WaitForConditionOrTimeOutWithTimeTravel(() => TeleportPositionMatches(nonAuthPosition), 1);
-            Assert.True(success, $"[Timed-Out][Teleport] Timed out waiting for NonAuthoritative position ({m_NonAuthoritativeTransform.GetSpaceRelativePosition()}) to teleport to position {teleportDestination}!");
+            SimulateOneFrame();
+            Assert.True(TeleportPositionMatches(nonAuthPosition), $"[Timed-Out][Teleport] Timed out waiting for NonAuthoritative position ({m_NonAuthoritativeTransform.GetSpaceRelativePosition()}) to teleport to position {teleportDestination}!");
+
             var targetDistance = 0.0f;
             if (!Approximately(m_DetectedPotentialInterpolatedTeleport, 0.0f))
             {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -931,7 +931,7 @@ namespace Unity.Netcode.RuntimeTests
             Assert.True(success, $"[Teleport] Timed out waiting for state to be pushed ({m_AuthoritativeTransform.StatePushed}) or state to be updated ({m_NonAuthoritativeTransform.StateUpdated})!");
 
             SimulateOneFrame();
-            Assert.True(TeleportPositionMatches(nonAuthPosition), $"[Timed-Out][Teleport] Timed out waiting for NonAuthoritative position ({m_NonAuthoritativeTransform.GetSpaceRelativePosition()}) to teleport to position {teleportDestination}!");
+            Assert.True(TeleportPositionMatches(nonAuthPosition), $"NonAuthoritative position ({m_NonAuthoritativeTransform.GetSpaceRelativePosition()}) is not the same as the destination position {teleportDestination}!");
 
             var targetDistance = 0.0f;
             if (!Approximately(m_DetectedPotentialInterpolatedTeleport, 0.0f))


### PR DESCRIPTION
Fixes the issue where half float precision mode was not reset the position interpolator when teleporting.

## Testing and Documentation
- Includes integration test modification


