### PR TITLE
fix: client throws a not server exception when destroying a NetworkObject while shutting down [MTT-6210]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where a client could throw an exception if abruptly disconnected from a network session with one or more spawned `NetworkObject`(s). (#2510)
 - Fixed issue where invalid endpoint addresses were not being detected and returning false from NGO UnityTransport. (#2496)
 - Fixed some errors that could occur if a connection is lost and the loss is detected when attempting to write to the socket. (#2495)
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -545,7 +545,8 @@ namespace Unity.Netcode
                 {
                     if (NetworkManager.LogLevel <= LogLevel.Normal)
                     {
-                        NetworkLog.LogError($"Destroy a spawned {nameof(NetworkObject)} on a non-host client is not valid. Call {nameof(Destroy)} or {nameof(Despawn)} on the server/host instead.");
+                        // We still have a session connection, log locally and on the server to inform user of this issue.
+                        NetworkLog.LogErrorServer($"Destroy a spawned {nameof(NetworkObject)} on a non-host client is not valid. Call {nameof(Destroy)} or {nameof(Despawn)} on the server/host instead.");
                     }
                     return;
                 }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -532,12 +532,12 @@ namespace Unity.Netcode
         private void OnDestroy()
         {
             // If no NetworkManager is assigned, then just exit early
-            if (NetworkManager == null)
+            if (!NetworkManager)
             {
                 return;
             }
 
-            if (NetworkManager.IsListening && NetworkManager.IsServer == false && IsSpawned &&
+            if (NetworkManager.IsListening && !NetworkManager.IsServer && IsSpawned &&
                 (IsSceneObject == null || (IsSceneObject.Value != true)))
             {
                 // Clients should not despawn NetworkObjects while connected to a session, but we don't want to destroy the current call stack

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -540,17 +540,18 @@ namespace Unity.Netcode
             if (NetworkManager.IsListening && NetworkManager.IsServer == false && IsSpawned &&
                 (IsSceneObject == null || (IsSceneObject.Value != true)))
             {
-                // Clients are not allowed to despawn NetworkObjects while connected to a session
+                // Clients should not despawn NetworkObjects while connected to a session, but we should not throw an exception but rather inform the user
+                // that this will cause issues.
                 if (!NetworkManager.ShutdownInProgress)
                 {
-                    if (NetworkManager.LogLevel <= LogLevel.Normal)
+                    // Since we still have a session connection, log locally and on the server to inform user of this issue.
+                    if (NetworkManager.LogLevel <= LogLevel.Error)
                     {
-                        // We still have a session connection, log locally and on the server to inform user of this issue.
                         NetworkLog.LogErrorServer($"Destroy a spawned {nameof(NetworkObject)} on a non-host client is not valid. Call {nameof(Destroy)} or {nameof(Despawn)} on the server/host instead.");
                     }
                     return;
                 }
-                // Otherwise, clients are allowed to despawn NetworkObjects while shutting down.
+                // Otherwise, clients can despawn NetworkObjects while shutting down and should not generate any messages when this happens
             }
 
             if (NetworkManager.SpawnManager != null && NetworkManager.SpawnManager.SpawnedObjects.TryGetValue(NetworkObjectId, out var networkObject))

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -540,8 +540,8 @@ namespace Unity.Netcode
             if (NetworkManager.IsListening && NetworkManager.IsServer == false && IsSpawned &&
                 (IsSceneObject == null || (IsSceneObject.Value != true)))
             {
-                // Clients should not despawn NetworkObjects while connected to a session, but we should not throw an exception but rather inform the user
-                // that this will cause issues.
+                // Clients should not despawn NetworkObjects while connected to a session, but we don't want to destroy the current call stack
+                // if this happens. Instead, we should just generate a network log error and exit early (as long as we are not shutting down).
                 if (!NetworkManager.ShutdownInProgress)
                 {
                     // Since we still have a session connection, log locally and on the server to inform user of this issue.

--- a/com.unity.netcode.gameobjects/Runtime/Logging/NetworkLog.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Logging/NetworkLog.cs
@@ -55,10 +55,10 @@ namespace Unity.Netcode
 
         private static void LogServer(string message, LogType logType)
         {
-            var networkManager = NetworkManagerOverride != null ? NetworkManagerOverride : NetworkManager.Singleton;
+            var networkManager = NetworkManagerOverride ??= NetworkManager.Singleton;
             // Get the sender of the local log
-            ulong localId = networkManager != null ? networkManager.LocalClientId : 0;
-            bool isServer = networkManager != null ? networkManager.IsServer : true;
+            ulong localId = networkManager?.LocalClientId ?? 0;
+            bool isServer = networkManager?.IsServer ?? true;
             switch (logType)
             {
                 case LogType.Info:

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeLogAssert.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeLogAssert.cs
@@ -147,6 +147,7 @@ namespace Unity.Netcode.RuntimeTests
                     if (logEvent.LogType == type && messageRegex.IsMatch(logEvent.Message))
                     {
                         found = true;
+                        break;
                     }
                 }
 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeLogAssert.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeLogAssert.cs
@@ -157,6 +157,23 @@ namespace Unity.Netcode.RuntimeTests
             }
         }
 
+        public bool HasLogBeenReceived(LogType type, string message)
+        {
+            var found = false;
+            lock (m_Lock)
+            {
+                foreach (var logEvent in AllLogs)
+                {
+                    if (logEvent.LogType == type && message.Equals(logEvent.Message))
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+            }
+            return found;
+        }
+
         public void Reset()
         {
             lock (m_Lock)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/ServerLogsMetricTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/ServerLogsMetricTests.cs
@@ -37,6 +37,8 @@ namespace Unity.Netcode.RuntimeTests.Metrics
         [UnityTest]
         public IEnumerator TrackServerLogSentMetric()
         {
+            // Set the client NetworkManager to assure the log is sent
+            NetworkLog.NetworkManagerOverride = Client;
             var waitForSentMetric = new WaitForEventMetricValues<ServerLogEvent>(ClientMetrics.Dispatcher, NetworkMetricTypes.ServerLogSent);
 
             var message = Guid.NewGuid().ToString();
@@ -81,6 +83,12 @@ namespace Unity.Netcode.RuntimeTests.Metrics
 
             var serializedLength = GetWriteSizeForLog(NetworkLog.LogType.Warning, message);
             Assert.AreEqual(serializedLength, receivedMetric.BytesCount);
+        }
+
+        protected override IEnumerator OnTearDown()
+        {
+            NetworkLog.NetworkManagerOverride = null;
+            return base.OnTearDown();
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectDestroyTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectDestroyTests.cs
@@ -65,7 +65,6 @@ namespace Unity.Netcode.RuntimeTests
         public IEnumerator TestNetworkObjectClientDestroy([Values] ClientDestroyObject clientDestroyObject)
         {
             var isShuttingDown = clientDestroyObject == ClientDestroyObject.ShuttingDown;
-            // This is the *CLIENT VERSION* of the *CLIENT PLAYER*
             var clientPlayer = m_ClientNetworkManagers[0].LocalClient.PlayerObject;
             var clientId = clientPlayer.OwnerClientId;
 
@@ -73,7 +72,7 @@ namespace Unity.Netcode.RuntimeTests
             if (!isShuttingDown)
             {
                 NetworkLog.NetworkManagerOverride = m_ClientNetworkManagers[0];
-                // Since NetworkLog uses singleton, we set the server header (normally it would be Netcode-Client Sender=<clientId>)
+                // Expect a client-side error message and server-side error message
                 LogAssert.Expect(LogType.Error, "[Netcode] Destroy a spawned NetworkObject on a non-host client is not valid. Call Destroy or Despawn on the server/host instead.");
                 LogAssert.Expect(LogType.Error, $"[Netcode-Server Sender={clientId}] Destroy a spawned NetworkObject on a non-host client is not valid. Call Destroy or Despawn on the server/host instead.");
             }


### PR DESCRIPTION
This fixes the edge case scenarios where a client could abruptly shutdown (host drops connection or the like) while NetworkObjects are still spawned. Under these conditions, the client-side would throw an exception if it was in the middle of the shutdown process which would disrupt the shutdown sequence.

This includes a minor modification to the NetworkLog server logging where a client generating any type of server log would get the standard [Netcode] message header/prefix and on the server-side it would generate the typical [Netcode-Server Sender=#] header/prefix. It additionally provides a means to test and validate server NetworkLog messages.

[MTT-6210](https://jira.unity3d.com/browse/MTT-6210)
Pertains to #2480 


## Changelog
- Fixed: issue where a client could throw an exception if abruptly disconnected from a network session with one or more spawned `NetworkObject`(s).

## Testing and Documentation
- Includes integration test updates to NetworkObjectDestroyTests.TestNetworkObjectClientDestroy.
- No documentation changes or additions were necessary.
