### PR TITLE
fix: Memory leak in UnityTransport after StartClient failure

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,7 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed a memory leak in `UnityTransport` that occurred if `StartClient` failed.
+- Fixed a memory leak in `UnityTransport` that occurred if `StartClient` failed. (#2518)
 - Fixed issue where a client could throw an exception if abruptly disconnected from a network session with one or more spawned `NetworkObject`(s). (#2510)
 - Fixed issue where invalid endpoint addresses were not being detected and returning false from NGO UnityTransport. (#2496)
 - Fixed some errors that could occur if a connection is lost and the loss is detected when attempting to write to the socket. (#2495)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed a memory leak in `UnityTransport` that occurred if `StartClient` failed.
 - Fixed issue where a client could throw an exception if abruptly disconnected from a network session with one or more spawned `NetworkObject`(s). (#2510)
 - Fixed issue where invalid endpoint addresses were not being detected and returning false from NGO UnityTransport. (#2496)
 - Fixed some errors that could occur if a connection is lost and the loss is detected when attempting to write to the socket. (#2495)

--- a/com.unity.netcode.gameobjects/Tests/Editor/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Transports/UnityTransportTests.cs
@@ -120,7 +120,7 @@ namespace Unity.Netcode.EditorTests
             Assert.False(transport.StartServer());
 
             LogAssert.Expect(LogType.Error, "Invalid network endpoint: 127.0.0.:4242.");
-            LogAssert.Expect(LogType.Error, $"Network listen address (127.0.0.) is Invalid!");
+            LogAssert.Expect(LogType.Error, "Network listen address (127.0.0.) is Invalid!");
 #if UTP_TRANSPORT_2_0_ABOVE
             LogAssert.Expect(LogType.Error, "Socket creation failed (error Unity.Baselib.LowLevel.Binding+Baselib_ErrorState: Invalid argument (0x01000003) <argument name stripped>");
 #endif
@@ -139,6 +139,22 @@ namespace Unity.Netcode.EditorTests
 
             transport.SetConnectionData(string.Empty, 4242);
             Assert.True(transport.StartServer());
+
+            transport.Shutdown();
+        }
+
+        // Check that StartClient returns false with bad connection data.
+        [Test]
+        public void UnityTransport_StartClientFailsWithBadAddress()
+        {
+            UnityTransport transport = new GameObject().AddComponent<UnityTransport>();
+            transport.Initialize();
+
+            transport.SetConnectionData("foobar", 4242);
+            Assert.False(transport.StartClient());
+
+            LogAssert.Expect(LogType.Error, "Invalid network endpoint: foobar:4242.");
+            LogAssert.Expect(LogType.Error, "Target server network address (foobar) is Invalid!");
 
             transport.Shutdown();
         }


### PR DESCRIPTION
If `StartClient` failed, then the driver would not be created. But if the driver is not created, we exit early in `Shutdown` which prevents us from disposing of the network settings and send queue (if any). This would result in a memory leak. The fix is simply to always dispose of these resources in `Shutdown`, without guarding it with a check on the driver.

One simple way to trigger that memory leak would be to start a client with an invalid IP address.

## Changelog

- Fixed: Fixed a memory leak in `UnityTransport` that occurred if `StartClient` failed.

## Testing and Documentation

- Includes unit test.
- No documentation changes or additions were necessary.