### PR TITLE
fix: looking for NetworkBehaviour component from the gameobject root

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1084,7 +1084,7 @@ namespace Unity.Netcode
                 }
 
                 m_ChildNetworkBehaviours = new List<NetworkBehaviour>();
-                var networkBehaviours = GetComponentsInChildren<NetworkBehaviour>(true);
+                var networkBehaviours = gameObject.GetComponentsInChildren<NetworkBehaviour>(true);
                 for (int i = 0; i < networkBehaviours.Length; i++)
                 {
                     if (networkBehaviours[i].NetworkObject == this)


### PR DESCRIPTION
… not from the current component, which can end up skipping the NetworkObject, depending on ordering

https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/2489

