### PR TITLE
perf: Remove reflection from NetworkBehaviour code to improve performance. [MTT-1968]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -18,7 +18,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed some errors that could occur if a connection is lost and the loss is detected when attempting to write to the socket. (#2495)
 
 ## Changed
-- Improved performance of NetworkBehaviour initialization, which should help reduce hitching during additive scene loads. (#2522)
+- Improved performance of NetworkBehaviour initialization by replacing reflection when initializing NetworkVariables with compile-time code generation, which should help reduce hitching during additive scene loads. (#2522)
 
 ## [1.4.0]
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -18,6 +18,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed some errors that could occur if a connection is lost and the loss is detected when attempting to write to the socket. (#2495)
 
 ## Changed
+- Improved performance of NetworkBehaviour initialization, which should help reduce hitching during additive scene loads. (#2522)
 
 ## [1.4.0]
 

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -166,6 +166,11 @@ namespace Unity.Netcode.Editor.CodeGen
 
                     foreach (var type in m_WrappedNetworkVariableTypes)
                     {
+                        if (type.Resolve() == null)
+                        {
+                            continue;
+                        }
+
                         if (IsSpecialCaseType(type))
                         {
                             continue;
@@ -251,11 +256,15 @@ namespace Unity.Netcode.Editor.CodeGen
         private FieldReference m_NetworkManager_rpc_name_table_FieldRef;
         private MethodReference m_NetworkManager_rpc_name_table_Add_MethodRef;
         private TypeReference m_NetworkBehaviour_TypeRef;
+        private TypeReference m_NetworkVariableBase_TypeRef;
+        private MethodReference m_NetworkVariableBase_Initialize_MethodRef;
+        private MethodReference m_NetworkBehaviour___nameNetworkVariable_MethodRef;
         private MethodReference m_NetworkBehaviour_beginSendServerRpc_MethodRef;
         private MethodReference m_NetworkBehaviour_endSendServerRpc_MethodRef;
         private MethodReference m_NetworkBehaviour_beginSendClientRpc_MethodRef;
         private MethodReference m_NetworkBehaviour_endSendClientRpc_MethodRef;
         private FieldReference m_NetworkBehaviour_rpc_exec_stage_FieldRef;
+        private FieldReference m_NetworkBehaviour_NetworkVariableFields_FieldRef;
         private MethodReference m_NetworkBehaviour_getNetworkManager_MethodRef;
         private MethodReference m_NetworkBehaviour_getOwnerClientId_MethodRef;
         private MethodReference m_NetworkHandlerDelegateCtor_MethodRef;
@@ -274,6 +283,9 @@ namespace Unity.Netcode.Editor.CodeGen
         private MethodReference m_NetworkVariableSerializationTypes_InitializeEqualityChecker_UnmanagedIEquatable_MethodRef;
         private MethodReference m_NetworkVariableSerializationTypes_InitializeEqualityChecker_UnmanagedValueEquals_MethodRef;
         private MethodReference m_NetworkVariableSerializationTypes_InitializeEqualityChecker_ManagedClassEquals_MethodRef;
+
+        private MethodReference m_ExceptionCtorMethodReference;
+        private MethodReference m_List_NetworkVariableBase_Add;
 
         private MethodReference m_BytePacker_WriteValueBitPacked_Short_MethodRef;
         private MethodReference m_BytePacker_WriteValueBitPacked_UShort_MethodRef;
@@ -348,12 +360,17 @@ namespace Unity.Netcode.Editor.CodeGen
         private const string k_NetworkManager_rpc_name_table = nameof(NetworkManager.__rpc_name_table);
 
         private const string k_NetworkBehaviour_rpc_exec_stage = nameof(NetworkBehaviour.__rpc_exec_stage);
+        private const string k_NetworkBehaviour_NetworkVariableFields = nameof(NetworkBehaviour.NetworkVariableFields);
         private const string k_NetworkBehaviour_beginSendServerRpc = nameof(NetworkBehaviour.__beginSendServerRpc);
         private const string k_NetworkBehaviour_endSendServerRpc = nameof(NetworkBehaviour.__endSendServerRpc);
         private const string k_NetworkBehaviour_beginSendClientRpc = nameof(NetworkBehaviour.__beginSendClientRpc);
         private const string k_NetworkBehaviour_endSendClientRpc = nameof(NetworkBehaviour.__endSendClientRpc);
+        private const string k_NetworkBehaviour___initializeVariables = nameof(NetworkBehaviour.__initializeVariables);
         private const string k_NetworkBehaviour_NetworkManager = nameof(NetworkBehaviour.NetworkManager);
         private const string k_NetworkBehaviour_OwnerClientId = nameof(NetworkBehaviour.OwnerClientId);
+        private const string k_NetworkBehaviour___nameNetworkVariable = nameof(NetworkBehaviour.__nameNetworkVariable);
+
+        private const string k_NetworkVariableBase_Initialize = nameof(NetworkVariableBase.Initialize);
 
         private const string k_RpcAttribute_Delivery = nameof(RpcAttribute.Delivery);
         private const string k_ServerRpcAttribute_RequireOwnership = nameof(ServerRpcAttribute.RequireOwnership);
@@ -379,6 +396,7 @@ namespace Unity.Netcode.Editor.CodeGen
 
             TypeDefinition networkManagerTypeDef = null;
             TypeDefinition networkBehaviourTypeDef = null;
+            TypeDefinition networkVariableBaseTypeDef = null;
             TypeDefinition networkHandlerDelegateTypeDef = null;
             TypeDefinition rpcParamsTypeDef = null;
             TypeDefinition serverRpcParamsTypeDef = null;
@@ -399,6 +417,12 @@ namespace Unity.Netcode.Editor.CodeGen
                 if (networkBehaviourTypeDef == null && netcodeTypeDef.Name == nameof(NetworkBehaviour))
                 {
                     networkBehaviourTypeDef = netcodeTypeDef;
+                    continue;
+                }
+
+                if (networkVariableBaseTypeDef == null && netcodeTypeDef.Name == nameof(NetworkVariableBase))
+                {
+                    networkVariableBaseTypeDef = netcodeTypeDef;
                     continue;
                 }
 
@@ -548,6 +572,9 @@ namespace Unity.Netcode.Editor.CodeGen
                     case k_NetworkBehaviour_endSendClientRpc:
                         m_NetworkBehaviour_endSendClientRpc_MethodRef = moduleDefinition.ImportReference(methodDef);
                         break;
+                    case k_NetworkBehaviour___nameNetworkVariable:
+                        m_NetworkBehaviour___nameNetworkVariable_MethodRef = moduleDefinition.ImportReference(methodDef);
+                        break;
                 }
             }
 
@@ -557,6 +584,22 @@ namespace Unity.Netcode.Editor.CodeGen
                 {
                     case k_NetworkBehaviour_rpc_exec_stage:
                         m_NetworkBehaviour_rpc_exec_stage_FieldRef = moduleDefinition.ImportReference(fieldDef);
+                        break;
+                    case k_NetworkBehaviour_NetworkVariableFields:
+                        m_NetworkBehaviour_NetworkVariableFields_FieldRef = moduleDefinition.ImportReference(fieldDef);
+                        break;
+                }
+            }
+
+
+            m_NetworkVariableBase_TypeRef = moduleDefinition.ImportReference(networkVariableBaseTypeDef);
+            foreach (var methodDef in networkVariableBaseTypeDef.Methods)
+            {
+                Console.WriteLine($"=>Method: {methodDef.Name}");
+                switch (methodDef.Name)
+                {
+                    case k_NetworkVariableBase_Initialize:
+                        m_NetworkVariableBase_Initialize_MethodRef = moduleDefinition.ImportReference(methodDef);
                         break;
                 }
             }
@@ -785,6 +828,18 @@ namespace Unity.Netcode.Editor.CodeGen
                 }
             }
 
+            // Standard stuff is really hard to reliably find using the normal way
+            // It's different in mono vs. .net core
+            // Importing with typeof() is less dangeroud for standard stuff though
+            // so we can just do it
+            var exceptionType = typeof(Exception);
+            var exceptionCtor = exceptionType.GetConstructor(new[] { typeof(string) });
+            m_ExceptionCtorMethodReference = m_MainModule.ImportReference(exceptionCtor);
+
+            var listType = typeof(List<NetworkVariableBase>);
+            var addMethod = listType.GetMethod(nameof(List<NetworkVariableBase>.Add), new[] { typeof(NetworkVariableBase) });
+            m_List_NetworkVariableBase_Add = moduleDefinition.ImportReference(addMethod);
+
             return true;
         }
 
@@ -930,6 +985,8 @@ namespace Unity.Netcode.Editor.CodeGen
                     rpcNames.Add((rpcMethodId, methodDefinition.Name));
                 }
             }
+
+            GenerateVariableInitialization(typeDefinition);
 
             if (!typeDefinition.HasGenericParameters && !typeDefinition.IsGenericInstance)
             {
@@ -1887,6 +1944,109 @@ namespace Unity.Netcode.Editor.CodeGen
 
             instructions.Reverse();
             instructions.ForEach(instruction => processor.Body.Instructions.Insert(0, instruction));
+        }
+
+        private void GenerateVariableInitialization(TypeDefinition type)
+        {
+            var method = new MethodDefinition(
+                k_NetworkBehaviour___initializeVariables,
+                MethodAttributes.Family | MethodAttributes.Virtual | MethodAttributes.HideBySig,
+                m_MainModule.TypeSystem.Void);
+
+            var processor = method.Body.GetILProcessor();
+
+            method.Body.Variables.Add(new VariableDefinition(m_MainModule.TypeSystem.Boolean));
+
+            processor.Emit(OpCodes.Nop);
+
+            foreach (var fieldDefinition in type.Fields)
+            {
+                FieldReference field = fieldDefinition;
+                if (type.HasGenericParameters)
+                {
+                    var genericType = new GenericInstanceType(fieldDefinition.DeclaringType);
+                    foreach (var parameter in fieldDefinition.DeclaringType.GenericParameters)
+                    {
+                        genericType.GenericArguments.Add(parameter);
+                    }
+                    field = new FieldReference(fieldDefinition.Name, fieldDefinition.FieldType, genericType);
+                }
+                if (field.FieldType.IsSubclassOf(m_NetworkVariableBase_TypeRef))
+                {
+                    processor.Emit(OpCodes.Ldarg_0);
+                    processor.Emit(OpCodes.Ldfld, field);
+                    processor.Emit(OpCodes.Ldnull);
+                    processor.Emit(OpCodes.Ceq);
+                    processor.Emit(OpCodes.Stloc_0);
+                    processor.Emit(OpCodes.Ldloc_0);
+
+                    var afterThrowInstruction = processor.Create(OpCodes.Nop);
+
+                    processor.Emit(OpCodes.Brfalse, afterThrowInstruction);
+
+                    processor.Emit(OpCodes.Nop);
+                    processor.Emit(OpCodes.Ldstr, $"{type.Name}.{field.Name} cannot be null. All {nameof(NetworkVariableBase)} instances must be initialized.");
+                    processor.Emit(OpCodes.Newobj, m_ExceptionCtorMethodReference);
+                    processor.Emit(OpCodes.Throw);
+
+                    processor.Append(afterThrowInstruction);
+                    processor.Emit(OpCodes.Ldarg_0);
+                    processor.Emit(OpCodes.Ldfld, field);
+                    processor.Emit(OpCodes.Ldarg_0);
+                    processor.Emit(OpCodes.Callvirt, m_NetworkVariableBase_Initialize_MethodRef);
+
+                    processor.Emit(OpCodes.Nop);
+                    processor.Emit(OpCodes.Ldarg_0);
+                    processor.Emit(OpCodes.Ldarg_0);
+                    processor.Emit(OpCodes.Ldfld, field);
+                    processor.Emit(OpCodes.Ldstr, field.Name);
+                    processor.Emit(OpCodes.Call, m_NetworkBehaviour___nameNetworkVariable_MethodRef);
+
+                    processor.Emit(OpCodes.Nop);
+                    processor.Emit(OpCodes.Ldarg_0);
+                    processor.Emit(OpCodes.Ldfld, m_NetworkBehaviour_NetworkVariableFields_FieldRef);
+                    processor.Emit(OpCodes.Ldarg_0);
+                    processor.Emit(OpCodes.Ldfld, field);
+                    processor.Emit(OpCodes.Callvirt, m_List_NetworkVariableBase_Add);
+                }
+            }
+
+            MethodReference initializeVariablesBaseReference = null;
+            foreach (var methodDefinition in type.BaseType.Resolve().Methods)
+            {
+                if (methodDefinition.Name == k_NetworkBehaviour___initializeVariables)
+                {
+                    initializeVariablesBaseReference = m_MainModule.ImportReference(methodDefinition);
+                    break;
+                }
+            }
+
+            if (initializeVariablesBaseReference == null)
+            {
+                GenerateVariableInitialization(type.BaseType.Resolve());
+                foreach (var methodDefinition in type.BaseType.Resolve().Methods)
+                {
+                    if (methodDefinition.Name == k_NetworkBehaviour___initializeVariables)
+                    {
+                        initializeVariablesBaseReference = m_MainModule.ImportReference(methodDefinition);
+                        break;
+                    }
+                }
+            }
+
+            if (type.BaseType.Resolve().HasGenericParameters)
+            {
+                var baseTypeInstance = (GenericInstanceType)type.BaseType;
+                initializeVariablesBaseReference = initializeVariablesBaseReference.MakeGeneric(baseTypeInstance.GenericArguments.ToArray());
+            }
+
+            processor.Emit(OpCodes.Nop);
+            processor.Emit(OpCodes.Ldarg_0);
+            processor.Emit(OpCodes.Call, initializeVariablesBaseReference);
+            processor.Emit(OpCodes.Nop);
+            processor.Emit(OpCodes.Ret);
+
+            type.Methods.Add(method);
         }
 
         private MethodDefinition GenerateStaticHandler(MethodDefinition methodDefinition, CustomAttribute rpcAttribute, uint rpcMethodId)

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -827,10 +827,8 @@ namespace Unity.Netcode.Editor.CodeGen
                 }
             }
 
-            // Standard stuff is really hard to reliably find using the normal way
-            // It's different in mono vs. .net core
-            // Importing with typeof() is less dangeroud for standard stuff though
-            // so we can just do it
+            // Standard types are really hard to reliably find using the Mono Cecil way, they resolve differently in Mono vs .NET Core
+            // Importing with typeof() is less dangerous for standard framework types though, so we can just do it
             var exceptionType = typeof(Exception);
             var exceptionCtor = exceptionType.GetConstructor(new[] { typeof(string) });
             m_ExceptionCtorMethodReference = m_MainModule.ImportReference(exceptionCtor);
@@ -1951,8 +1949,7 @@ namespace Unity.Netcode.Editor.CodeGen
             {
                 if (methodDefinition.Name == k_NetworkBehaviour___initializeVariables)
                 {
-                    // If this hits, we've already generated the method for this class
-                    // because a child class got processed first.
+                    // If this hits, we've already generated the method for this class because a child class got processed first.
                     return;
                 }
             }

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
@@ -112,7 +112,7 @@ namespace Unity.Netcode.Editor.CodeGen
 
             foreach (var fieldDefinition in typeDefinition.Fields)
             {
-                if (fieldDefinition.Name == nameof(NetworkBehaviour.__rpc_exec_stage))
+                if (fieldDefinition.Name == nameof(NetworkBehaviour.__rpc_exec_stage) || fieldDefinition.Name == nameof(NetworkBehaviour.NetworkVariableFields))
                 {
                     fieldDefinition.IsFamily = true;
                 }
@@ -123,7 +123,7 @@ namespace Unity.Netcode.Editor.CodeGen
                 if (methodDefinition.Name == nameof(NetworkBehaviour.__beginSendServerRpc) ||
                     methodDefinition.Name == nameof(NetworkBehaviour.__endSendServerRpc) ||
                     methodDefinition.Name == nameof(NetworkBehaviour.__beginSendClientRpc) ||
-                    methodDefinition.Name == nameof(NetworkBehaviour.__endSendClientRpc))
+                    methodDefinition.Name == nameof(NetworkBehaviour.__endSendClientRpc) || methodDefinition.Name == nameof(NetworkBehaviour.__initializeVariables) || methodDefinition.Name == nameof(NetworkBehaviour.__nameNetworkVariable))
                 {
                     methodDefinition.IsFamily = true;
                 }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -558,14 +558,12 @@ namespace Unity.Netcode
         internal virtual void __initializeVariables()
 #pragma warning restore IDE1006 // restore naming rule violation check
         {
-            // ILPP generates code for all NetworkBehaviour subtypes to initialize
-            // each type's network variables.
+            // ILPP generates code for all NetworkBehaviour subtypes to initialize each type's network variables.
         }
 
 #pragma warning disable IDE1006 // disable naming rule violation check
         // RuntimeAccessModifiersILPP will make this `protected`
-        // Using this method here because ILPP doesn't seem to let us do visibility
-        // modification on properties.
+        // Using this method here because ILPP doesn't seem to let us do visibility modification on properties.
         internal void __nameNetworkVariable(NetworkVariableBase variable, string varName)
 #pragma warning restore IDE1006 // restore naming rule violation check
         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -50,7 +50,12 @@ namespace Unity.Netcode.RuntimeTests
         public NetworkVariable<T> TheVar;
     }
 
-    public class ClassHavingNetworkBehaviour : TemplateNetworkBehaviourType<TestClass>
+    public class IntermediateNetworkBehavior<T> : TemplateNetworkBehaviourType<T>
+    {
+        public NetworkVariable<T> TheVar2;
+    }
+
+    public class ClassHavingNetworkBehaviour : IntermediateNetworkBehavior<TestClass>
     {
 
     }
@@ -918,12 +923,16 @@ namespace Unity.Netcode.RuntimeTests
 
             bool VerifyClass()
             {
-                return m_Player1OnClient1.GetComponent<ClassHavingNetworkBehaviour>().TheVar.Value != null && m_Player1OnClient1.GetComponent<ClassHavingNetworkBehaviour>().TheVar.Value.SomeBool == m_Player1OnServer.GetComponent<ClassHavingNetworkBehaviour>().TheVar.Value.SomeBool &&
-                       m_Player1OnClient1.GetComponent<ClassHavingNetworkBehaviour>().TheVar.Value.SomeInt == m_Player1OnServer.GetComponent<ClassHavingNetworkBehaviour>().TheVar.Value.SomeInt;
+                return (m_Player1OnClient1.GetComponent<ClassHavingNetworkBehaviour>().TheVar.Value != null && m_Player1OnClient1.GetComponent<ClassHavingNetworkBehaviour>().TheVar.Value.SomeBool == m_Player1OnServer.GetComponent<ClassHavingNetworkBehaviour>().TheVar.Value.SomeBool &&
+                       m_Player1OnClient1.GetComponent<ClassHavingNetworkBehaviour>().TheVar.Value.SomeInt == m_Player1OnServer.GetComponent<ClassHavingNetworkBehaviour>().TheVar.Value.SomeInt)
+                       && (m_Player1OnClient1.GetComponent<ClassHavingNetworkBehaviour>().TheVar2.Value != null && m_Player1OnClient1.GetComponent<ClassHavingNetworkBehaviour>().TheVar2.Value.SomeBool == m_Player1OnServer.GetComponent<ClassHavingNetworkBehaviour>().TheVar2.Value.SomeBool &&
+                       m_Player1OnClient1.GetComponent<ClassHavingNetworkBehaviour>().TheVar2.Value.SomeInt == m_Player1OnServer.GetComponent<ClassHavingNetworkBehaviour>().TheVar2.Value.SomeInt);
             }
 
             m_Player1OnServer.GetComponent<ClassHavingNetworkBehaviour>().TheVar.Value = new TestClass { SomeInt = k_TestUInt, SomeBool = false };
+            m_Player1OnServer.GetComponent<ClassHavingNetworkBehaviour>().TheVar2.Value = new TestClass { SomeInt = k_TestUInt, SomeBool = false };
             m_Player1OnServer.GetComponent<ClassHavingNetworkBehaviour>().TheVar.SetDirty(true);
+            m_Player1OnServer.GetComponent<ClassHavingNetworkBehaviour>().TheVar2.SetDirty(true);
 
             // Wait for the client-side to notify it is finished initializing and spawning.
             Assert.True(WaitForConditionOrTimeOutWithTimeTravel(VerifyClass));


### PR DESCRIPTION
## Changelog

- Changed: Improved performance of NetworkBehaviour initialization by replacing reflection when initializing NetworkVariables with compile-time code generation, which should help reduce hitching during additive scene loads. 

## Testing and Documentation

- No tests have been added... but updated an existing integration test to ensure it covered another ILPP edge case.
- No documentation changes or additions were necessary.