### PR TITLE
fix: Add ILPP error-handling to catch managed INetworkSerializables that don't meet the `new()` constraint so they won't crash the editor [MTT-6211]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -17,6 +17,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed issue where a client could throw an exception if abruptly disconnected from a network session with one or more spawned `NetworkObject`(s). (#2510)
 - Fixed issue where invalid endpoint addresses were not being detected and returning false from NGO UnityTransport. (#2496)
 - Fixed some errors that could occur if a connection is lost and the loss is detected when attempting to write to the socket. (#2495)
+- Making a `NetworkVariable` with an `INetworkSerializable` type that doesn't meet the `new()` constraint will now create a compile-time error instead of an editor crash (#2528)
 
 ## Changed
 

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -205,6 +205,21 @@ namespace Unity.Netcode.Editor.CodeGen
                         {
                             if (type.HasInterface(typeof(INetworkSerializable).FullName))
                             {
+                                var constructors = type.Resolve().GetConstructors();
+                                var hasEmptyConstructor = false;
+                                foreach (var constructor in constructors)
+                                {
+                                    if (constructor.Parameters.Count == 0)
+                                    {
+                                        hasEmptyConstructor = true;
+                                    }
+                                }
+
+                                if (!hasEmptyConstructor)
+                                {
+                                    m_Diagnostics.AddError($"{type} cannot be used in a network variable - Managed {nameof(INetworkSerializable)} instances must meet the new() constraint.");
+                                    continue;
+                                }
                                 serializeMethod = new GenericInstanceMethod(m_NetworkVariableSerializationTypes_InitializeSerializer_ManagedINetworkSerializable_MethodRef);
                             }
 

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -217,7 +217,7 @@ namespace Unity.Netcode.Editor.CodeGen
 
                                 if (!hasEmptyConstructor)
                                 {
-                                    m_Diagnostics.AddError($"{type} cannot be used in a network variable - Managed {nameof(INetworkSerializable)} instances must meet the new() constraint.");
+                                    m_Diagnostics.AddError($"{type} cannot be used in a network variable - Managed {nameof(INetworkSerializable)} instances must meet the `new()` (default empty constructor) constraint.");
                                     continue;
                                 }
                                 serializeMethod = new GenericInstanceMethod(m_NetworkVariableSerializationTypes_InitializeSerializer_ManagedINetworkSerializable_MethodRef);


### PR DESCRIPTION
fixes #2445

## Changelog

- Fixed: Making a `NetworkVariable` with an `INetworkSerializable` type that doesn't meet the `new()` constraint will now create a compile-time error instead of an editor crash

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.