### PR TITLE
fix: NetworkVariables of enum types breaking the inspector [MTT-6212]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -17,6 +17,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed issue where a client could throw an exception if abruptly disconnected from a network session with one or more spawned `NetworkObject`(s). (#2510)
 - Fixed issue where invalid endpoint addresses were not being detected and returning false from NGO UnityTransport. (#2496)
 - Fixed some errors that could occur if a connection is lost and the loss is detected when attempting to write to the socket. (#2495)
+- Fixed the inspector throwing exceptions when attempting to render `NetworkVariable`s of enum types. (#2529)
 
 ## Changed
 

--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -81,7 +81,7 @@ namespace Unity.Netcode.Editor
             EditorGUILayout.BeginHorizontal();
             if (genericType.IsValueType)
             {
-               var isEquatable = false;
+                var isEquatable = false;
                 foreach (var iface in genericType.GetInterfaces())
                 {
                     if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IEquatable<>))
@@ -93,11 +93,11 @@ namespace Unity.Netcode.Editor
                 MethodInfo method;
                 if (isEquatable)
                 {
-                    method = typeof(NetworkBehaviourEditor).GetMethod("RenderNetworkContainerValueTypeIEquatable", BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy | BindingFlags.NonPublic);
+                    method = typeof(NetworkBehaviourEditor).GetMethod(nameof(RenderNetworkContainerValueTypeIEquatable), BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy | BindingFlags.NonPublic);
                 }
                 else
                 {
-                    method = typeof(NetworkBehaviourEditor).GetMethod("RenderNetworkContainerValueType", BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy | BindingFlags.NonPublic);
+                    method = typeof(NetworkBehaviourEditor).GetMethod(nameof(RenderNetworkContainerValueType), BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy | BindingFlags.NonPublic);
                 }
 
                 var genericMethod = method.MakeGenericMethod(genericType);
@@ -274,7 +274,7 @@ namespace Unity.Netcode.Editor
             bool expanded = true;
             while (property.NextVisible(expanded))
             {
-                if (m_NetworkVariableNames.Contains(property.name))
+                if (m_NetworkVariableNames.Contains(ObjectNames.NicifyVariableName(property.name)))
                 {
                     // Skip rendering of NetworkVars, they have special rendering
                     continue;


### PR DESCRIPTION
fixes #2444 

## Changelog

- Fixed: Fixed the inspector throwing exceptions when attempting to render `NetworkVariable`s of enum types.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.
