### PR TITLE
chore: Update UTP dependency to 1.3.4

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -19,6 +19,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed some errors that could occur if a connection is lost and the loss is detected when attempting to write to the socket. (#2495)
 
 ## Changed
+
+- Updated `UnityTransport` dependency on `com.unity.transport` to 1.3.4.
 - Improved performance of NetworkBehaviour initialization by replacing reflection when initializing NetworkVariables with compile-time code generation, which should help reduce hitching during additive scene loads. (#2522)
 
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -20,7 +20,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ## Changed
 
-- Updated `UnityTransport` dependency on `com.unity.transport` to 1.3.4.
+- Updated `UnityTransport` dependency on `com.unity.transport` to 1.3.4. (#2533)
 - Improved performance of NetworkBehaviour initialization by replacing reflection when initializing NetworkVariables with compile-time code generation, which should help reduce hitching during additive scene loads. (#2522)
 
 

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -6,6 +6,6 @@
     "unity": "2020.3",
     "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",
-        "com.unity.transport": "1.3.3"
+        "com.unity.transport": "1.3.4"
     }
 }

--- a/testproject/Packages/packages-lock.json
+++ b/testproject/Packages/packages-lock.json
@@ -89,7 +89,7 @@
       "source": "local",
       "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",
-        "com.unity.transport": "1.3.3"
+        "com.unity.transport": "1.3.4"
       }
     },
     "com.unity.nuget.mono-cecil": {
@@ -219,7 +219,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.transport": {
-      "version": "1.3.3",
+      "version": "1.3.4",
       "depth": 1,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
As the title indicates, this PR simply updates the dependency on UTP to the newly-released 1.3.4 version. This version only contains bug fixes, including one for a bug that could cause possible corruption of internal reliable pipeline data structures, leading to all sorts of weird problems.

## Changelog

- Changed: Updated `UnityTransport` dependency on `com.unity.transport` to 1.3.4.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.