### PR TITLE
fix: fixing an exception and error logging when two different objects are shown and hidden on the same frame [MTT-6303]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -17,6 +17,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed issue where a client could throw an exception if abruptly disconnected from a network session with one or more spawned `NetworkObject`(s). (#2510)
 - Fixed issue where invalid endpoint addresses were not being detected and returning false from NGO UnityTransport. (#2496)
 - Fixed some errors that could occur if a connection is lost and the loss is detected when attempting to write to the socket. (#2495)
+- Fixed an exception and error logging when two different objects are shown and hidden on the same frame (#2524)
 
 ## Changed
 - Improved performance of NetworkBehaviour initialization by replacing reflection when initializing NetworkVariables with compile-time code generation, which should help reduce hitching during additive scene loads. (#2522)

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -67,7 +67,10 @@ namespace Unity.Netcode
                 ret = true;
             }
 
-            networkObject.Observers.Remove(clientId);
+            if (ret)
+            {
+                networkObject.Observers.Remove(clientId);
+            }
 
             return ret;
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkShowHideTests.cs
@@ -287,6 +287,36 @@ namespace Unity.Netcode.RuntimeTests
         }
 
         [UnityTest]
+        public IEnumerator ConcurrentShowAndHideOnDifferentObjects()
+        {
+            m_ClientId0 = m_ClientNetworkManagers[0].LocalClientId;
+            ShowHideObject.ClientTargetedNetworkObjects.Clear();
+            ShowHideObject.ClientIdToTarget = m_ClientId0;
+
+
+            // create 3 objects
+            var spawnedObject1 = SpawnObject(m_PrefabToSpawn, m_ServerNetworkManager);
+            var spawnedObject2 = SpawnObject(m_PrefabToSpawn, m_ServerNetworkManager);
+            var spawnedObject3 = SpawnObject(m_PrefabToSpawn, m_ServerNetworkManager);
+            m_NetSpawnedObject1 = spawnedObject1.GetComponent<NetworkObject>();
+            m_NetSpawnedObject2 = spawnedObject2.GetComponent<NetworkObject>();
+            m_NetSpawnedObject3 = spawnedObject3.GetComponent<NetworkObject>();
+
+            // get the NetworkObject on a client instance
+            yield return WaitForConditionOrTimeOut(RefreshNetworkObjects);
+            AssertOnTimeout($"Could not refresh all NetworkObjects!");
+
+            m_NetSpawnedObject1.NetworkHide(m_ClientId0);
+
+            yield return WaitForTicks(m_ServerNetworkManager, 5);
+
+            m_NetSpawnedObject1.NetworkShow(m_ClientId0);
+            m_NetSpawnedObject2.NetworkHide(m_ClientId0);
+
+            yield return WaitForTicks(m_ServerNetworkManager, 5);
+        }
+
+        [UnityTest]
         public IEnumerator NetworkShowHideQuickTest()
         {
             m_ClientId0 = m_ClientNetworkManagers[0].LocalClientId;


### PR DESCRIPTION
Adds a check on `networkObject.Observers.Remove(clientId);` that the observer can actually be removed as, otherwise, a thrown exception would break the show/hide functionality.

[MTT-6303](https://jira.unity3d.com/browse/MTT-6303)
Pertains to issue #2524.
