### PR TITLE
fix: Nested NetworkTransform synchronization fails when parent has non-Vector3.one scale [MTT-6304]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,7 +11,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Added
 
 ### Fixed
-
+- Fixed issue where parenting a NetworkTransform under a transform with a scale other than Vector3.one would result in incorrect values on non-authoritative instances. (#2538)
 - Fixed Multiplayer Tools package installation docs page link on the NetworkManager popup. (#2526)
 - Fixed a memory leak in `UnityTransport` that occurred if `StartClient` failed. (#2518)
 - Fixed issue where a client could throw an exception if abruptly disconnected from a network session with one or more spawned `NetworkObject`(s). (#2510)

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -2392,16 +2392,6 @@ namespace Unity.Netcode.Components
             m_CachedNetworkManager = NetworkManager;
 
             Initialize();
-            // This assures the initial spawning of the object synchronizes all connected clients
-            // with the current transform values. This should not be placed within Initialize since
-            // that can be invoked when ownership changes.
-            if (CanCommitToTransform)
-            {
-                var currentPosition = GetSpaceRelativePosition();
-                var currentRotation = GetSpaceRelativeRotation();
-                // Teleport to current position
-                SetStateInternal(currentPosition, currentRotation, transform.localScale, true);
-            }
         }
 
         /// <inheritdoc/>
@@ -2472,6 +2462,7 @@ namespace Unity.Netcode.Components
             CanCommitToTransform = IsServerAuthoritative() ? IsServer : IsOwner;
             var replicatedState = ReplicatedNetworkState;
             var currentPosition = GetSpaceRelativePosition();
+            var currentRotation = GetSpaceRelativeRotation();
 
             if (CanCommitToTransform)
             {
@@ -2483,6 +2474,9 @@ namespace Unity.Netcode.Components
                 // Authority only updates once per network tick
                 NetworkManager.NetworkTickSystem.Tick -= NetworkTickSystem_Tick;
                 NetworkManager.NetworkTickSystem.Tick += NetworkTickSystem_Tick;
+
+                // Teleport to current position
+                SetStateInternal(currentPosition, currentRotation, transform.localScale, true);
             }
             else
             {
@@ -2494,9 +2488,9 @@ namespace Unity.Netcode.Components
                 NetworkManager.NetworkTickSystem.Tick -= NetworkTickSystem_Tick;
 
                 ResetInterpolatedStateToCurrentAuthoritativeState();
-                m_CurrentPosition = GetSpaceRelativePosition();
+                m_CurrentPosition = currentPosition;
                 m_CurrentScale = transform.localScale;
-                m_CurrentRotation = GetSpaceRelativeRotation();
+                m_CurrentRotation = currentRotation;
 
             }
 

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -2683,6 +2683,12 @@ namespace Unity.Netcode.Components
                 }
             }
 
+            // If we have not received any additional state updates since the very
+            // initial synchronization, then exit early.
+            if (m_LocalAuthoritativeNetworkState.IsSynchronizing)
+            {
+                return;
+            }
             // Apply the current authoritative state
             ApplyAuthoritativeState();
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -334,9 +334,6 @@ namespace Unity.Netcode.RuntimeTests
         /// </summary>
         private bool AllInstancesKeptLocalTransformValues()
         {
-            //var authorityObjectLocalPosition = ChildObjectComponent.ServerInstance.transform.localPosition;
-            //var authorityObjectLocalRotation = ChildObjectComponent.ServerInstance.transform.localRotation.eulerAngles;
-            //var authorityObjectLocalScale = ChildObjectComponent.ServerInstance.transform.localScale;
             var authorityObjectLocalPosition = m_AuthorityChildObject.transform.localPosition;
             var authorityObjectLocalRotation = m_AuthorityChildObject.transform.localRotation.eulerAngles;
             var authorityObjectLocalScale = m_AuthorityChildObject.transform.localScale;


### PR DESCRIPTION
This resolves the issue where parenting a `NetworkTransform` under a transform with a scale other than Vector3.one would result in incorrect values on non-authoritative instances.
[MTT-6304](https://jira.unity3d.com/browse/MTT-6304)
fix: #2516
fix: #2549

## Changelog
- Fixed: issue where parenting a NetworkTransform under a transform with a scale other than Vector3.one would result in incorrect values on non-authoritative instances.


## Testing and Documentation
- Includes integration test updates.
- No documentation changes or additions were necessary.
