### PR TITLE
fix: avoid throwing exception when using NetworkList without a NetworkManager (#2539)

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -17,6 +17,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 - Fixed issue where `NetworkVariable`s on a `NetworkBehaviour` could fail to synchronize changes if one has `NetworkVariableUpdateTraits` set and is dirty but is not ready to send. (#3465)
 - Fixed issue where when a client changes ownership via RPC the `NetworkBehaviour.OnOwnershipChanged` can result in identical previous and current owner identifiers. (#3434)
+- Fixed `NullReferenceException` on `NetworkList` when used without a NetworkManager in scene. (#2539)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -425,7 +425,7 @@ namespace Unity.Netcode
         public void Add(T item)
         {
             // check write permissions
-            if (!CanClientWrite(m_NetworkBehaviour.NetworkManager.LocalClientId))
+            if (m_NetworkManager && !CanClientWrite(m_NetworkManager.LocalClientId))
             {
                 LogWritePermissionError();
                 return;
@@ -452,7 +452,7 @@ namespace Unity.Netcode
         public void Clear()
         {
             // check write permissions
-            if (!CanClientWrite(m_NetworkBehaviour.NetworkManager.LocalClientId))
+            if (m_NetworkManager && !CanClientWrite(m_NetworkManager.LocalClientId))
             {
                 LogWritePermissionError();
                 return;
@@ -490,7 +490,7 @@ namespace Unity.Netcode
         public bool Remove(T item)
         {
             // check write permissions
-            if (!CanClientWrite(m_NetworkBehaviour.NetworkManager.LocalClientId))
+            if (m_NetworkManager && !CanClientWrite(m_NetworkManager.LocalClientId))
             {
                 LogWritePermissionError();
                 return false;
@@ -539,7 +539,7 @@ namespace Unity.Netcode
         public void Insert(int index, T item)
         {
             // check write permissions
-            if (!CanClientWrite(m_NetworkBehaviour.NetworkManager.LocalClientId))
+            if (m_NetworkManager && !CanClientWrite(m_NetworkManager.LocalClientId))
             {
                 LogWritePermissionError();
                 return;
@@ -575,7 +575,7 @@ namespace Unity.Netcode
         public void RemoveAt(int index)
         {
             // check write permissions
-            if (!CanClientWrite(m_NetworkBehaviour.NetworkManager.LocalClientId))
+            if (m_NetworkManager && !CanClientWrite(m_NetworkManager.LocalClientId))
             {
                 LogWritePermissionError();
                 return;
@@ -608,7 +608,7 @@ namespace Unity.Netcode
             set
             {
                 // check write permissions
-                if (!CanClientWrite(m_NetworkBehaviour.NetworkManager.LocalClientId))
+                if (m_NetworkManager && !CanClientWrite(m_NetworkManager.LocalClientId))
                 {
                     LogWritePermissionError();
                     return;


### PR DESCRIPTION
Resolve #2539

This PR add a check that m_NetworkBehaviour is not null before calling the `CanClientWrite` function.

I did it exactly the same way it's already done for [NetworkVariable<T>](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/blob/dfd08d84e535146e8c709b91f9eea62dd05bff1a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs#L58).

With this PR, operations on the list are done and throws [the anyoning warning](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/2279) ( `NetworkVariable<T>` do the same)

![image](https://user-images.githubusercontent.com/22180158/235377413-4d80ad7f-5f62-4efa-a812-8784a384dabb.png)

## Changelog

- Fixed usage of `NetworkList` throwing exception when used without a NetworkManager in scene. (#2539)

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions are necessary.