### PR TITLE
fix: missing value on NetworkListEvent for EventType.RemoveAt events server side (#2542)

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -20,6 +20,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Making a `NetworkVariable` with an `INetworkSerializable` type that doesn't meet the `new()` constraint will now create a compile-time error instead of an editor crash (#2528)
 - Fixed the inspector throwing exceptions when attempting to render `NetworkVariable`s of enum types. (#2529)
 - Fixed an exception and error logging when two different objects are shown and hidden on the same frame (#2524)
+- Fixed missing value on `NetworkListEvent` for `EventType.RemoveAt` events server side. (#2542)
 
 ## Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -490,12 +490,14 @@ namespace Unity.Netcode
                 throw new InvalidOperationException("Client is not allowed to write to this NetworkList");
             }
 
+            var value = m_List[index];
             m_List.RemoveAt(index);
 
             var listEvent = new NetworkListEvent<T>()
             {
                 Type = NetworkListEvent<T>.EventType.RemoveAt,
-                Index = index
+                Index = index,
+                Value = value
             };
 
             HandleAddListEvent(listEvent);


### PR DESCRIPTION
Resolve #2542

This PR adds the value on `NetworkListEvent` for `EventType.RemoveAt` events server side.
The code for server is now the same as in [ReadDelta function](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/blob/dfd08d84e535146e8c709b91f9eea62dd05bff1a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs#L272) used by the client.

## Changelog

- Fixed missing value on `NetworkListEvent` for `EventType.RemoveAt` events server side. (#2542)

## Testing and Documentation

- No tests have been added, but could be great to add one that check the value for each possible opertations (add, insert, modify value, remove, removeAt, clear) on NetworkList.
- No documentation changes or additions are necessary.