### PR TITLE
feat: Allow configuring the location of the default network prefabs list. [MTT-6209]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,6 +10,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
+- The location of the automatically-created default network prefab list can now be configured (#2544)
+
 ### Fixed
 
 - Fixed Multiplayer Tools package installation docs page link on the NetworkManager popup. (#2526)

--- a/com.unity.netcode.gameobjects/Editor/Configuration/NetcodeForGameObjectsSettings.cs
+++ b/com.unity.netcode.gameobjects/Editor/Configuration/NetcodeForGameObjectsSettings.cs
@@ -43,7 +43,19 @@ namespace Unity.Netcode.Editor.Configuration
     [FilePath("ProjectSettings/NetcodeForGameObjects.settings", FilePathAttribute.Location.ProjectFolder)]
     internal class NetcodeForGameObjectsProjectSettings : ScriptableSingleton<NetcodeForGameObjectsProjectSettings>
     {
+        internal static readonly string DefaultNetworkPrefabsPath = "Assets/DefaultNetworkPrefabs.asset";
         [SerializeField] public bool GenerateDefaultNetworkPrefabs = true;
+        [SerializeField] public string NetworkPrefabsPath = DefaultNetworkPrefabsPath;
+        public string TempNetworkPrefabsPath;
+
+        private void OnEnable()
+        {
+            if (NetworkPrefabsPath == "")
+            {
+                NetworkPrefabsPath = DefaultNetworkPrefabsPath;
+            }
+            TempNetworkPrefabsPath = NetworkPrefabsPath;
+        }
 
         internal void SaveSettings()
         {

--- a/com.unity.netcode.gameobjects/Editor/Configuration/NetcodeForGameObjectsSettings.cs
+++ b/com.unity.netcode.gameobjects/Editor/Configuration/NetcodeForGameObjectsSettings.cs
@@ -56,7 +56,7 @@ namespace Unity.Netcode.Editor.Configuration
             }
             TempNetworkPrefabsPath = NetworkPrefabsPath;
         }
-        
+
         [SerializeField]
         [FormerlySerializedAs("GenerateDefaultNetworkPrefabs")]
         private byte m_GenerateDefaultNetworkPrefabs;

--- a/com.unity.netcode.gameobjects/Editor/Configuration/NetworkPrefabProcessor.cs
+++ b/com.unity.netcode.gameobjects/Editor/Configuration/NetworkPrefabProcessor.cs
@@ -9,16 +9,15 @@ namespace Unity.Netcode.Editor.Configuration
     /// </summary>
     public class NetworkPrefabProcessor : AssetPostprocessor
     {
-        private static string s_DefaultNetworkPrefabsPath = "Assets/DefaultNetworkPrefabs.asset";
         public static string DefaultNetworkPrefabsPath
         {
             get
             {
-                return s_DefaultNetworkPrefabsPath;
+                return NetcodeForGameObjectsProjectSettings.instance.NetworkPrefabsPath;
             }
             internal set
             {
-                s_DefaultNetworkPrefabsPath = value;
+                NetcodeForGameObjectsProjectSettings.instance.NetworkPrefabsPath = value;
                 // Force a recache of the prefab list
                 s_PrefabsList = null;
             }


### PR DESCRIPTION
resolves #2493

## Changelog

- Added: The location of the automatically-created default network prefab list can now be configured

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.