### PR TITLE
fix: Generate Default Network Prefabs List setting not loading correctly

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -17,6 +17,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed issue where a client could throw an exception if abruptly disconnected from a network session with one or more spawned `NetworkObject`(s). (#2510)
 - Fixed issue where invalid endpoint addresses were not being detected and returning false from NGO UnityTransport. (#2496)
 - Fixed some errors that could occur if a connection is lost and the loss is detected when attempting to write to the socket. (#2495)
+- Fixed the "Generate Default Network Prefabs List" setting not loading correctly and always reverting to being checked. (#2545)
 
 ## Changed
 

--- a/com.unity.netcode.gameobjects/Editor/Configuration/NetcodeForGameObjectsSettings.cs
+++ b/com.unity.netcode.gameobjects/Editor/Configuration/NetcodeForGameObjectsSettings.cs
@@ -1,5 +1,6 @@
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 
 namespace Unity.Netcode.Editor.Configuration
@@ -43,7 +44,21 @@ namespace Unity.Netcode.Editor.Configuration
     [FilePath("ProjectSettings/NetcodeForGameObjects.settings", FilePathAttribute.Location.ProjectFolder)]
     internal class NetcodeForGameObjectsProjectSettings : ScriptableSingleton<NetcodeForGameObjectsProjectSettings>
     {
-        [SerializeField] public bool GenerateDefaultNetworkPrefabs = true;
+        [SerializeField]
+        [FormerlySerializedAs("GenerateDefaultNetworkPrefabs")]
+        private byte m_GenerateDefaultNetworkPrefabs;
+
+        public bool GenerateDefaultNetworkPrefabs
+        {
+            get
+            {
+                return m_GenerateDefaultNetworkPrefabs != 0;
+            }
+            set
+            {
+                m_GenerateDefaultNetworkPrefabs = (byte)(value ? 1 : 0);
+            }
+        }
 
         internal void SaveSettings()
         {


### PR DESCRIPTION
## Changelog

- Fixed: Fixed the "Generate Default Network Prefabs List" setting not loading correctly and always reverting to being checked.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.