### PR TITLE
fix: server scene exclusion during synchronization for runtime generated scenes

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where users could not use NetworkSceneManager.VerifySceneBeforeLoading to exclude runtime generated scenes from client synchronization. (#2550)
 - Fixed Multiplayer Tools package installation docs page link on the NetworkManager popup. (#2526)
 - Fixed a memory leak in `UnityTransport` that occurred if `StartClient` failed. (#2518)
 - Fixed issue where a client could throw an exception if abruptly disconnected from a network session with one or more spawned `NetworkObject`(s). (#2510)

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -791,6 +791,10 @@ namespace Unity.Netcode
             return ValidateSceneBeforeLoading(sceneIndex, sceneName, loadSceneMode);
         }
 
+        /// <summary>
+        /// Overloaded version that is invoked by <see cref="ValidateSceneBeforeLoading"/> and <see cref="SynchronizeNetworkObjects"/>.
+        /// This specifically is to allow runtime generated scenes to be excluded by the server during synchronization.
+        /// </summary>
         internal bool ValidateSceneBeforeLoading(int sceneIndex, string sceneName, LoadSceneMode loadSceneMode)
         {
             var validated = true;

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -786,9 +786,14 @@ namespace Unity.Netcode
         /// <returns>true (Valid) or false (Invalid)</returns>
         internal bool ValidateSceneBeforeLoading(uint sceneHash, LoadSceneMode loadSceneMode)
         {
-            var validated = true;
             var sceneName = SceneNameFromHash(sceneHash);
             var sceneIndex = SceneUtility.GetBuildIndexByScenePath(sceneName);
+            return ValidateSceneBeforeLoading(sceneIndex, sceneName, loadSceneMode);
+        }
+
+        internal bool ValidateSceneBeforeLoading(int sceneIndex, string sceneName, LoadSceneMode loadSceneMode)
+        {
+            var validated = true;
             if (VerifySceneBeforeLoading != null)
             {
                 validated = VerifySceneBeforeLoading.Invoke(sceneIndex, sceneName, loadSceneMode);
@@ -1744,24 +1749,22 @@ namespace Unity.Netcode
                     continue;
                 }
 
-                var sceneHash = SceneHashFromNameOrPath(scene.path);
-
                 // This would depend upon whether we are additive or not
                 // If we are the base scene, then we set the root scene index;
                 if (activeScene == scene)
                 {
-                    if (!ValidateSceneBeforeLoading(sceneHash, sceneEventData.LoadSceneMode))
+                    if (!ValidateSceneBeforeLoading(scene.buildIndex, scene.name, sceneEventData.LoadSceneMode))
                     {
                         continue;
                     }
-                    sceneEventData.SceneHash = sceneHash;
+                    sceneEventData.SceneHash = SceneHashFromNameOrPath(scene.path);
                     sceneEventData.SceneHandle = scene.handle;
                 }
-                else if (!ValidateSceneBeforeLoading(sceneHash, LoadSceneMode.Additive))
+                else if (!ValidateSceneBeforeLoading(scene.buildIndex, scene.name, LoadSceneMode.Additive))
                 {
                     continue;
                 }
-                sceneEventData.AddSceneToSynchronize(sceneHash, scene.handle);
+                sceneEventData.AddSceneToSynchronize(SceneHashFromNameOrPath(scene.path), scene.handle);
             }
 
             sceneEventData.AddSpawnedNetworkObjects();


### PR DESCRIPTION
This fix provides users with the ability to use `NetworkSceneManager.VerifySceneBeforeLoading` to exclude runtime generated scenes from being included in the scenes to be synchronized during the initial client synchronization.

Based on [PR-2442](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/2442) submitted by user @brogan89


## Changelog
- Fixed: issue where users could not use `NetworkSceneManager.VerifySceneBeforeLoading` to exclude runtime generated scenes from client synchronization.

## Testing and Documentation

- Includes integration test.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
