### PR TITLE
fix: Misleading error messages when not setting up Relay correctly

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -524,7 +524,7 @@ namespace Unity.Netcode.Transports.UTP
                 //reflection, but this does not live in the context of a performance-critical loop, it runs once at initial connection time.
                 if (m_RelayServerData.Equals(default(RelayServerData)))
                 {
-                    Debug.LogError("You must call SetRelayServerData() at least once before calling StartRelayServer.");
+                    Debug.LogError("You must call SetRelayServerData() at least once before calling StartClient.");
                     return false;
                 }
 
@@ -710,7 +710,7 @@ namespace Unity.Netcode.Transports.UTP
             //reflection, but this does not live in the context of a performance-critical loop, it runs once at initial connection time.
             if (m_RelayServerData.Equals(default(RelayServerData)))
             {
-                Debug.LogError("You must call SetRelayServerData() at least once before calling StartRelayServer.");
+                Debug.LogError("You must call SetRelayServerData() at least once before calling StartServer.");
                 return false;
             }
             else


### PR DESCRIPTION
Minor fix to the error messages displayed if one forgets to call `SetRelayServerData`.

## Changelog

N/A (Didn't think it was worthy of a changelog entry.)

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.