### PR TITLE
fix: Fixes warning logged on double-initialize of prefabs lists.

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed warning "Runtime Network Prefabs was not empty at initialization time." being erroneously logged when no runtime network prefabs had been added (#2565)
 - Fixed issue where some temporary debug console logging was left in a merged PR. (#2562)
 - Fixed the "Generate Default Network Prefabs List" setting not loading correctly and always reverting to being checked. (#2545)
 - Fixed issue where users could not use NetworkSceneManager.VerifySceneBeforeLoading to exclude runtime generated scenes from client synchronization. (#2550)
@@ -26,14 +27,13 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed issue where a client could throw an exception if abruptly disconnected from a network session with one or more spawned `NetworkObject`(s). (#2510)
 - Fixed issue where invalid endpoint addresses were not being detected and returning false from NGO UnityTransport. (#2496)
 - Fixed some errors that could occur if a connection is lost and the loss is detected when attempting to write to the socket. (#2495)
-- Fixed warning "Runtime Network Prefabs was not empty at initialization time." being erroneously logged when no runtime network prefabs had been added (#2565)
 
 ## Changed
 
+- Adding network prefabs before NetworkManager initialization is now supported. (#2565)
 - Connecting clients being synchronized now switch to the server's active scene before spawning and synchronizing NetworkObjects. (#2532)
 - Updated `UnityTransport` dependency on `com.unity.transport` to 1.3.4. (#2533)
 - Improved performance of NetworkBehaviour initialization by replacing reflection when initializing NetworkVariables with compile-time code generation, which should help reduce hitching during additive scene loads. (#2522)
-- Adding network prefabs before NetworkManager initialization is now supported. (#2565)
 
 ## [1.4.0] - 2023-04-10
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -26,12 +26,14 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed issue where a client could throw an exception if abruptly disconnected from a network session with one or more spawned `NetworkObject`(s). (#2510)
 - Fixed issue where invalid endpoint addresses were not being detected and returning false from NGO UnityTransport. (#2496)
 - Fixed some errors that could occur if a connection is lost and the loss is detected when attempting to write to the socket. (#2495)
+- Fixed warning "Runtime Network Prefabs was not empty at initialization time." being erroneously logged when no runtime network prefabs had been added (#2565)
 
 ## Changed
 
 - Connecting clients being synchronized now switch to the server's active scene before spawning and synchronizing NetworkObjects. (#2532)
 - Updated `UnityTransport` dependency on `com.unity.transport` to 1.3.4. (#2533)
 - Improved performance of NetworkBehaviour initialization by replacing reflection when initializing NetworkVariables with compile-time code generation, which should help reduce hitching during additive scene loads. (#2522)
+- Adding network prefabs before NetworkManager initialization is now supported. (#2565)
 
 ## [1.4.0] - 2023-04-10
 

--- a/com.unity.netcode.gameobjects/Tests/Editor/NetworkManagerConfigurationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/NetworkManagerConfigurationTests.cs
@@ -305,5 +305,164 @@ namespace Unity.Netcode.EditorTests
             Assert.IsTrue(sharedList.Contains(object2.gameObject));
             Assert.IsTrue(sharedList.Contains(object3.gameObject));
         }
+
+        [Test]
+        public void WhenCallingInitializeAfterAddingAPrefabUsingPrefabsAPI_ThePrefabStillExists()
+        {
+            // Setup
+            var networkManagerObject = new GameObject(nameof(NestedNetworkObjectPrefabCheck));
+            var networkManager = networkManagerObject.AddComponent<NetworkManager>();
+            networkManager.NetworkConfig = new NetworkConfig
+            {
+                NetworkTransport = networkManager.gameObject.AddComponent<UnityTransport>()
+            };
+
+            var networkManagerObject2 = new GameObject(nameof(NestedNetworkObjectPrefabCheck));
+            var networkManager2 = networkManagerObject2.AddComponent<NetworkManager>();
+            networkManager2.NetworkConfig = new NetworkConfig
+            {
+                NetworkTransport = networkManager.gameObject.AddComponent<UnityTransport>()
+            };
+
+            var object1 = new GameObject("Object 1").AddComponent<NetworkObject>();
+            var object2 = new GameObject("Object 2").AddComponent<NetworkObject>();
+            var object3 = new GameObject("Object 3").AddComponent<NetworkObject>();
+
+            object1.GlobalObjectIdHash = 1;
+            object2.GlobalObjectIdHash = 2;
+            object3.GlobalObjectIdHash = 3;
+
+            var sharedList = ScriptableObject.CreateInstance<NetworkPrefabsList>();
+            sharedList.List.Add(new NetworkPrefab { Prefab = object1.gameObject });
+
+            networkManager.NetworkConfig.Prefabs.NetworkPrefabsLists = new List<NetworkPrefabsList> { sharedList };
+            networkManager2.NetworkConfig.Prefabs.NetworkPrefabsLists = new List<NetworkPrefabsList> { sharedList };
+
+            networkManager.NetworkConfig.Prefabs.Add(new NetworkPrefab { Prefab = object2.gameObject });
+            networkManager2.NetworkConfig.Prefabs.Add(new NetworkPrefab { Prefab = object3.gameObject });
+
+            networkManager.Initialize(true);
+            networkManager2.Initialize(false);
+
+            Assert.IsTrue(networkManager.NetworkConfig.Prefabs.Contains(object1.gameObject));
+            Assert.IsTrue(networkManager2.NetworkConfig.Prefabs.Contains(object1.gameObject));
+            Assert.IsTrue(networkManager.NetworkConfig.Prefabs.Contains(object2.gameObject));
+            Assert.IsFalse(networkManager2.NetworkConfig.Prefabs.Contains(object2.gameObject));
+            Assert.IsTrue(networkManager2.NetworkConfig.Prefabs.Contains(object3.gameObject));
+            Assert.IsFalse(networkManager.NetworkConfig.Prefabs.Contains(object3.gameObject));
+
+            Assert.IsTrue(sharedList.Contains(object1.gameObject));
+            Assert.IsFalse(sharedList.Contains(object2.gameObject));
+            Assert.IsFalse(sharedList.Contains(object3.gameObject));
+        }
+
+        [Test]
+        public void WhenShuttingDownAndReinitializingPrefabs_RuntimeAddedPrefabsStillExists()
+        {
+            // Setup
+            var networkManagerObject = new GameObject(nameof(NestedNetworkObjectPrefabCheck));
+            var networkManager = networkManagerObject.AddComponent<NetworkManager>();
+            networkManager.NetworkConfig = new NetworkConfig
+            {
+                NetworkTransport = networkManager.gameObject.AddComponent<UnityTransport>()
+            };
+
+            var networkManagerObject2 = new GameObject(nameof(NestedNetworkObjectPrefabCheck));
+            var networkManager2 = networkManagerObject2.AddComponent<NetworkManager>();
+            networkManager2.NetworkConfig = new NetworkConfig
+            {
+                NetworkTransport = networkManager.gameObject.AddComponent<UnityTransport>()
+            };
+
+            var object1 = new GameObject("Object 1").AddComponent<NetworkObject>();
+            var object2 = new GameObject("Object 2").AddComponent<NetworkObject>();
+            var object3 = new GameObject("Object 3").AddComponent<NetworkObject>();
+
+            object1.GlobalObjectIdHash = 1;
+            object2.GlobalObjectIdHash = 2;
+            object3.GlobalObjectIdHash = 3;
+
+            var sharedList = ScriptableObject.CreateInstance<NetworkPrefabsList>();
+            sharedList.List.Add(new NetworkPrefab { Prefab = object1.gameObject });
+
+            networkManager.NetworkConfig.Prefabs.NetworkPrefabsLists = new List<NetworkPrefabsList> { sharedList };
+            networkManager2.NetworkConfig.Prefabs.NetworkPrefabsLists = new List<NetworkPrefabsList> { sharedList };
+
+            networkManager.Initialize(true);
+            networkManager2.Initialize(false);
+
+            networkManager.NetworkConfig.Prefabs.Add(new NetworkPrefab { Prefab = object2.gameObject });
+            networkManager2.NetworkConfig.Prefabs.Add(new NetworkPrefab { Prefab = object3.gameObject });
+
+            networkManager.ShutdownInternal();
+            networkManager2.ShutdownInternal();
+
+            networkManager.Initialize(true);
+            networkManager2.Initialize(false);
+
+            Assert.IsTrue(networkManager.NetworkConfig.Prefabs.Contains(object1.gameObject));
+            Assert.IsTrue(networkManager2.NetworkConfig.Prefabs.Contains(object1.gameObject));
+            Assert.IsTrue(networkManager.NetworkConfig.Prefabs.Contains(object2.gameObject));
+            Assert.IsFalse(networkManager2.NetworkConfig.Prefabs.Contains(object2.gameObject));
+            Assert.IsTrue(networkManager2.NetworkConfig.Prefabs.Contains(object3.gameObject));
+            Assert.IsFalse(networkManager.NetworkConfig.Prefabs.Contains(object3.gameObject));
+
+            Assert.IsTrue(sharedList.Contains(object1.gameObject));
+            Assert.IsFalse(sharedList.Contains(object2.gameObject));
+            Assert.IsFalse(sharedList.Contains(object3.gameObject));
+        }
+
+        [Test]
+        public void WhenCallingInitializeMultipleTimes_NothingBreaks()
+        {
+            // Setup
+            var networkManagerObject = new GameObject(nameof(NestedNetworkObjectPrefabCheck));
+            var networkManager = networkManagerObject.AddComponent<NetworkManager>();
+            networkManager.NetworkConfig = new NetworkConfig
+            {
+                NetworkTransport = networkManager.gameObject.AddComponent<UnityTransport>()
+            };
+
+            var networkManagerObject2 = new GameObject(nameof(NestedNetworkObjectPrefabCheck));
+            var networkManager2 = networkManagerObject2.AddComponent<NetworkManager>();
+            networkManager2.NetworkConfig = new NetworkConfig
+            {
+                NetworkTransport = networkManager.gameObject.AddComponent<UnityTransport>()
+            };
+
+            var object1 = new GameObject("Object 1").AddComponent<NetworkObject>();
+            var object2 = new GameObject("Object 2").AddComponent<NetworkObject>();
+            var object3 = new GameObject("Object 3").AddComponent<NetworkObject>();
+
+            object1.GlobalObjectIdHash = 1;
+            object2.GlobalObjectIdHash = 2;
+            object3.GlobalObjectIdHash = 3;
+
+            var sharedList = ScriptableObject.CreateInstance<NetworkPrefabsList>();
+            sharedList.List.Add(new NetworkPrefab { Prefab = object1.gameObject });
+
+            networkManager.NetworkConfig.Prefabs.NetworkPrefabsLists = new List<NetworkPrefabsList> { sharedList };
+            networkManager2.NetworkConfig.Prefabs.NetworkPrefabsLists = new List<NetworkPrefabsList> { sharedList };
+
+            networkManager.Initialize(true);
+            networkManager2.Initialize(false);
+
+            networkManager.NetworkConfig.Prefabs.Add(new NetworkPrefab { Prefab = object2.gameObject });
+            networkManager2.NetworkConfig.Prefabs.Add(new NetworkPrefab { Prefab = object3.gameObject });
+
+            networkManager.NetworkConfig.Prefabs.Initialize();
+            networkManager2.NetworkConfig.Prefabs.Initialize();
+
+            Assert.IsTrue(networkManager.NetworkConfig.Prefabs.Contains(object1.gameObject));
+            Assert.IsTrue(networkManager2.NetworkConfig.Prefabs.Contains(object1.gameObject));
+            Assert.IsTrue(networkManager.NetworkConfig.Prefabs.Contains(object2.gameObject));
+            Assert.IsFalse(networkManager2.NetworkConfig.Prefabs.Contains(object2.gameObject));
+            Assert.IsTrue(networkManager2.NetworkConfig.Prefabs.Contains(object3.gameObject));
+            Assert.IsFalse(networkManager.NetworkConfig.Prefabs.Contains(object3.gameObject));
+
+            Assert.IsTrue(sharedList.Contains(object1.gameObject));
+            Assert.IsFalse(sharedList.Contains(object2.gameObject));
+            Assert.IsFalse(sharedList.Contains(object3.gameObject));
+        }
     }
 }


### PR DESCRIPTION
Also, makes adding prefabs before initializing the list no longer an error case - those prefabs are stored in a separate list so that during initialization, they can be re-added to the prefabs list after pulling in data from the NetworkPrefabsList ScriptableObjects.

## Changelog

- Fixed: Fixed warning "Runtime Network Prefabs was not empty at initialization time." being erroneously logged when no runtime network prefabs had been added
- Changed: Adding network prefabs before NetworkManager initialization is now supported.

## Testing and Documentation

- Includes unit tests.
- No documentation changes or additions were necessary.