### PR TITLE
fix: Provide SpawnWithObservers property alternative to CheckObjectVisibility [MTT-6353]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,6 +10,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
+- Added `NetworkObject.SpawnWithObservers` property (default is true) that when set to false will spawn a `NetworkObject` with no observers and will not be spawned on any client until `NetworkObject.NetworkShow` is invoked. (#2568)
+
 ### Fixed
 
 - Fixed warning "Runtime Network Prefabs was not empty at initialization time." being erroneously logged when no runtime network prefabs had been added (#2565)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -189,6 +189,12 @@ namespace Unity.Netcode
         public Action OnMigratedToNewScene;
 
         /// <summary>
+        /// When set to false, the NetworkObject will be spawned with no observers initially (other than the server)
+        /// </summary>
+        [Tooltip("When false, the NetworkObject will spawn with no observers initially. (default is true)")]
+        public bool SpawnWithObservers = true;
+
+        /// <summary>
         /// Delegate type for checking visibility
         /// </summary>
         /// <param name="clientId">The clientId to check visibility for</param>

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -617,8 +617,10 @@ namespace Unity.Netcode
                 }
             }
 
-            if (NetworkManager.IsServer)
+            // If we are the server and should spawn with observers
+            if (NetworkManager.IsServer && networkObject.SpawnWithObservers)
             {
+                // Add client observers
                 for (int i = 0; i < NetworkManager.ConnectedClientsList.Count; i++)
                 {
                     if (networkObject.CheckObjectVisibility == null || networkObject.CheckObjectVisibility(NetworkManager.ConnectedClientsList[i].ClientId))


### PR DESCRIPTION
This PR provides users with an alternate way to handle spawning NetworkObjects with no observers via the `NetworkObject.SpawnWithObservers` property (default is true). This will help to avoid issue #2546 where using a CheckObjectVisibility handler that always returns false (i.e. never is changed) would result in NetworkShow not being able to function correctly.

[MTT-6353](https://jira.unity3d.com/browse/MTT-6353)

## Changelog

- Added: `NetworkObject.SpawnWithObservers` property (default is true) that when set to false will spawn a `NetworkObject` with no observers and will not be spawned on any client until `NetworkObject.NetworkShow` is invoked.

## Testing and Documentation

- Includes integration test `NetworkObjectOnSpawnTests.ObserverSpawnTests`.
- Documentation was updated ([PR-1060](https://github.com/Unity-Technologies/com.unity.multiplayer.docs/pull/1060))

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
