### PR TITLE
fix: OnClientDisconnected client identifier is incorrect when pending client connection is denied [MTT-6376]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -14,7 +14,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where the `OnClientDisconnected` client identifier was incorrect when trigger after a pending client connection was denied. (#2569)
+- Fixed issue where the `OnClientDisconnected` client identifier was incorrect after a pending client connection was denied. (#2569)
 - Fixed warning "Runtime Network Prefabs was not empty at initialization time." being erroneously logged when no runtime network prefabs had been added (#2565)
 - Fixed issue where some temporary debug console logging was left in a merged PR. (#2562)
 - Fixed the "Generate Default Network Prefabs List" setting not loading correctly and always reverting to being checked. (#2545)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -14,6 +14,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where the `OnClientDisconnected` client identifier was incorrect when trigger after a pending client connection was denied. (#2569)
 - Fixed warning "Runtime Network Prefabs was not empty at initialization time." being erroneously logged when no runtime network prefabs had been added (#2565)
 - Fixed issue where some temporary debug console logging was left in a merged PR. (#2562)
 - Fixed the "Generate Default Network Prefabs List" setting not loading correctly and always reverting to being checked. (#2545)

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -844,6 +844,16 @@ namespace Unity.Netcode
             {
                 var transportId = ClientIdToTransportId(clientId);
                 NetworkManager.NetworkConfig.NetworkTransport.DisconnectRemoteClient(transportId);
+
+                try
+                {
+                    OnClientDisconnectCallback?.Invoke(clientId);
+                }
+                catch (Exception exception)
+                {
+                    Debug.LogException(exception);
+                }
+
                 // Clean up the transport to client (and vice versa) mappings
                 TransportIdCleanUp(transportId);
             }

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -438,7 +438,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// <remarks>
         /// Use this for testing connection and disconnection scenarios
         /// </remarks>
-        protected virtual bool WaitForNewClientToConnect(NetworkManager networkManager)
+        protected virtual bool ShouldWaitForNewClientToConnect(NetworkManager networkManager)
         {
             return true;
         }

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -467,7 +467,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
             OnNewClientStarted(networkManager);
 
-            if (WaitForNewClientToConnect(networkManager))
+            if (ShouldWaitForNewClientToConnect(networkManager))
             {
                 // Wait for the new client to connect
                 yield return WaitForClientsConnectedOrTimeOut();

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -432,6 +432,18 @@ namespace Unity.Netcode.TestHelpers.Runtime
         }
 
         /// <summary>
+        /// CreateAndStartNewClient Only
+        /// Override this method to bypass the waiting for a client to connect.
+        /// </summary>
+        /// <remarks>
+        /// Use this for testing connection and disconnection scenarios
+        /// </remarks>
+        protected virtual bool WaitForNewClientToConnect(NetworkManager networkManager)
+        {
+            return true;
+        }
+
+        /// <summary>
         /// This will create, start, and connect a new client while in the middle of an
         /// integration test.
         /// </summary>
@@ -455,19 +467,22 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
             OnNewClientStarted(networkManager);
 
-            // Wait for the new client to connect
-            yield return WaitForClientsConnectedOrTimeOut();
-
-            OnNewClientStartedAndConnected(networkManager);
-            if (s_GlobalTimeoutHelper.TimedOut)
+            if (WaitForNewClientToConnect(networkManager))
             {
-                AddRemoveNetworkManager(networkManager, false);
-                Object.DestroyImmediate(networkManager.gameObject);
-            }
+                // Wait for the new client to connect
+                yield return WaitForClientsConnectedOrTimeOut();
 
-            AssertOnTimeout($"{nameof(CreateAndStartNewClient)} timed out waiting for the new client to be connected!");
-            ClientNetworkManagerPostStart(networkManager);
-            VerboseDebug($"[{networkManager.name}] Created and connected!");
+                OnNewClientStartedAndConnected(networkManager);
+                if (s_GlobalTimeoutHelper.TimedOut)
+                {
+                    AddRemoveNetworkManager(networkManager, false);
+                    Object.DestroyImmediate(networkManager.gameObject);
+                }
+
+                AssertOnTimeout($"{nameof(CreateAndStartNewClient)} timed out waiting for the new client to be connected!");
+                ClientNetworkManagerPostStart(networkManager);
+                VerboseDebug($"[{networkManager.name}] Created and connected!");
+            }
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ClientApprovalDenied.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ClientApprovalDenied.cs
@@ -1,0 +1,64 @@
+using System.Collections;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine.TestTools;
+
+
+namespace Unity.Netcode.RuntimeTests
+{
+    public class ClientApprovalDenied : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 0;
+        private bool m_ApproveConnection = true;
+        private ulong m_PendingClientId = 0;
+        private ulong m_DisconnectedClientId = 0;
+
+        protected override void OnServerAndClientsCreated()
+        {
+            m_ServerNetworkManager.NetworkConfig.ConnectionApproval = true;
+            m_ServerNetworkManager.ConnectionApprovalCallback = ConnectionApproval;
+        }
+
+        private void ConnectionApproval(NetworkManager.ConnectionApprovalRequest connectionApprovalRequest, NetworkManager.ConnectionApprovalResponse connectionApprovalResponse)
+        {
+            connectionApprovalResponse.Approved = m_ApproveConnection;
+            connectionApprovalResponse.CreatePlayerObject = true;
+            // When denied, store the client identifier to use for validating the client disconnected notification identifier matches
+            if (!m_ApproveConnection)
+            {
+                m_PendingClientId = connectionApprovalRequest.ClientNetworkId;
+            }
+        }
+
+        protected override void OnNewClientCreated(NetworkManager networkManager)
+        {
+            networkManager.NetworkConfig.ConnectionApproval = true;
+            base.OnNewClientCreated(networkManager);
+        }
+
+        protected override bool WaitForNewClientToConnect(NetworkManager networkManager)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// Validates that when a pending client is denied approval the server-host
+        /// OnClientDisconnected method will return the valid pending client identifier.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ClientApprovalDeniedNotificationTest()
+        {
+            m_ApproveConnection = false;
+            m_ServerNetworkManager.OnClientDisconnectCallback += OnClientDisconnectCallback;
+            yield return CreateAndStartNewClient();
+            m_ServerNetworkManager.OnClientDisconnectCallback -= OnClientDisconnectCallback;
+
+            yield return WaitForConditionOrTimeOut(() => m_PendingClientId == m_DisconnectedClientId);
+            AssertOnTimeout($"Timed out waiting for disconnect notification for pending Client-{m_PendingClientId}!");
+        }
+
+        private void OnClientDisconnectCallback(ulong clientId)
+        {
+            m_DisconnectedClientId = clientId;
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ClientApprovalDenied.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ClientApprovalDenied.cs
@@ -1,6 +1,6 @@
-using NUnit.Framework;
 using System.Collections;
 using System.Collections.Generic;
+using NUnit.Framework;
 using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine.TestTools;
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ClientApprovalDenied.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ClientApprovalDenied.cs
@@ -35,7 +35,7 @@ namespace Unity.Netcode.RuntimeTests
             base.OnNewClientCreated(networkManager);
         }
 
-        protected override bool WaitForNewClientToConnect(NetworkManager networkManager)
+        protected override bool ShouldWaitForNewClientToConnect(NetworkManager networkManager)
         {
             return false;
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ClientApprovalDenied.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ClientApprovalDenied.cs
@@ -54,8 +54,9 @@ namespace Unity.Netcode.RuntimeTests
             AssertOnTimeout($"Timed out waiting for disconnect notification for pending Client-{m_PendingClientId}!");
 
             // Validate that we don't get multiple disconnect notifications for clients being disconnected
-            // Have a client disconnect
+            // Have a client disconnect remotely
             m_ClientNetworkManagers[0].Shutdown();
+
             // Have the server disconnect a client
             m_ServerNetworkManager.DisconnectClient(m_ClientNetworkManagers[1].LocalClientId);
             m_ServerNetworkManager.OnClientDisconnectCallback -= OnClientDisconnectCallback;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ClientApprovalDenied.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ClientApprovalDenied.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e46e2cb14a6d49c48bc8c33094467961
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This resolves the issue where the server-host was not receiving the correct client identifier when OnClientDisconnected is invoked if a pending client is denied approval.

[MTT-6376](https://jira.unity3d.com/browse/MTT-6376)
Resolves issue #2566 


## Changelog

- Fixed: issue where the `OnClientDisconnected` client identifier was incorrect when trigger after a pending client connection was denied.


## Testing and Documentation

- Includes integration test `ClientApprovalDenied.ClientApprovalDeniedNotificationTest`.
- No documentation changes or additions were necessary.
