### PR TITLE
Added null ref check into CodeGenHelpers.cs

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/CodeGen/CodeGenHelpers.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/CodeGenHelpers.cs
@@ -155,7 +155,7 @@ namespace Unity.Netcode.Editor.CodeGen
         public static bool IsSubclassOf(this TypeReference typeReference, TypeReference baseClass)
         {
             var type = typeReference.Resolve();
-            if (type.BaseType == null || type.BaseType.Name == nameof(Object))
+            if (type == null || type.BaseType == null || type.BaseType.Name == nameof(Object))
             {
                 return false;
             }


### PR DESCRIPTION
Fixed NullRefference exception in CodeGenHelpers after package update
`
(0,0): error  - System.NullReferenceException: Object reference not set to an instance of an object.||   at Unity.Netcode.Editor.CodeGen.CodeGenHelpers.IsSubclassOf(TypeReference typeReference, TypeReference baseClass)`
