### PR TITLE
fix: compile error with generic NetworkBehaviour singletons

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed an ILPP compile error when creating a generic NetworkBehaviour singleton with a static T instance. (#2603)
+
 ## [1.5.1] - 2023-06-07
 
 ### Added

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/CodeGenHelpers.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/CodeGenHelpers.cs
@@ -59,7 +59,7 @@ namespace Unity.Netcode.Editor.CodeGen
 
         public static bool IsSubclassOf(this TypeDefinition typeDefinition, string classTypeFullName)
         {
-            if (!typeDefinition.IsClass)
+            if (typeDefinition == null || !typeDefinition.IsClass)
             {
                 return false;
             }
@@ -154,6 +154,10 @@ namespace Unity.Netcode.Editor.CodeGen
 
         public static bool IsSubclassOf(this TypeReference typeReference, TypeReference baseClass)
         {
+            if (typeReference == null)
+            {
+                return false;
+            }
             var type = typeReference.Resolve();
             if (type?.BaseType == null || type.BaseType.Name == nameof(Object))
             {

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -2225,6 +2225,12 @@ namespace Unity.Netcode.Editor.CodeGen
                     }
                     field = new FieldReference(fieldDefinition.Name, fieldDefinition.FieldType, genericType);
                 }
+
+                if (field.FieldType.Resolve() == null)
+                {
+                    continue;
+                }
+
                 if (!field.FieldType.IsArray && !field.FieldType.Resolve().IsArray && field.FieldType.IsSubclassOf(m_NetworkVariableBase_TypeRef))
                 {
                     // if({variable} == null) {


### PR DESCRIPTION
fixes #2592 

## Changelog

- Fixed: Fixed an ILPP compile error when creating a generic NetworkBehaviour singleton with a static T instance.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.
