### PR TITLE
fix: UTP test that was failing when you install Unity Transport package 2.0.0 or newer

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
+## [1.5.2] - 2023-07-11
+
+### Fixed
+- Fixed a failing UTP test that was failing when you install Unity Transport package 2.0.0 or newer.
+
 ## [1.5.1] - 2023-06-07
 
 ### Added

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,10 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
-## [1.5.2] - 2023-07-11
+## [Unreleased]
+
+### Added
 
 ### Fixed
 - Fixed a failing UTP test that was failing when you install Unity Transport package 2.0.0 or newer.
+
+## Changed
 
 ## [1.5.1] - 2023-06-07
 

--- a/com.unity.netcode.gameobjects/Tests/Editor/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Transports/UnityTransportTests.cs
@@ -121,9 +121,7 @@ namespace Unity.Netcode.EditorTests
 
             LogAssert.Expect(LogType.Error, "Invalid network endpoint: 127.0.0.:4242.");
             LogAssert.Expect(LogType.Error, "Network listen address (127.0.0.) is Invalid!");
-#if UTP_TRANSPORT_2_0_ABOVE
-            LogAssert.Expect(LogType.Error, "Socket creation failed (error Unity.Baselib.LowLevel.Binding+Baselib_ErrorState: Invalid argument (0x01000003) <argument name stripped>");
-#endif
+
             transport.SetConnectionData("127.0.0.1", 4242, "127.0.0.1");
             Assert.True(transport.StartServer());
 

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -2,7 +2,7 @@
     "name": "com.unity.netcode.gameobjects",
     "displayName": "Netcode for GameObjects",
     "description": "Netcode for GameObjects is a high-level netcode SDK that provides networking capabilities to GameObject/MonoBehaviour workflows within Unity and sits on top of underlying transport layer.",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "unity": "2020.3",
     "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",


### PR DESCRIPTION
Fixing a UnityTransport_RestartSucceedsAfterFailure test that was failing when you install NGO package with UTP 2.0.0.
Removing a LogAssert that is not needed in UTP 2.0.0.

Yamato jobs:
-  [Package Compatibility Test NGO develop, Tools release/1.1.0 and UTP master - [linux, 2022.2]](https://unity-ci.cds.internal.unity3d.com/job/26531309/results)
- [Package Compatibility Test NGO develop, Tools release/1.0.0 and UTP master - [mac, trunk]](https://unity-ci.cds.internal.unity3d.com/job/26531311/results)
- [Package Compatibility Test NGO develop, Tools develop and UTP master - [win, trunk]](https://unity-ci.cds.internal.unity3d.com/job/26531308/results)

## Changelog
- Fixed a failing UTP test that was failing when you install Unity Transport package 2.0.0 or newer.

## Testing and Documentation

Ran automated CI run
