### PR TITLE
fix: UTP test that was failing when you install Unity Transport package 2.0.0 or newer in Release 1.5.1

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
+## [1.5.2] - 2023-07-11
+
+### Fixed
+- Fixed a failing UTP test that was failing when you install Unity Transport package 2.0.0 or newer.
+
 ## [1.5.1] - 2023-06-07
 
 ### Added

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -34,7 +34,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed issue where a client could throw an exception if abruptly disconnected from a network session with one or more spawned `NetworkObject`(s). (#2510)
 - Fixed issue where invalid endpoint addresses were not being detected and returning false from NGO UnityTransport. (#2496)
 - Fixed some errors that could occur if a connection is lost and the loss is detected when attempting to write to the socket. (#2495)
-- Fixed a failing UTP test that was failing when you install Unity Transport package 2.0.0 or newer.
 
 ## Changed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,11 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
-## [1.5.2] - 2023-07-11
-
-### Fixed
-- Fixed a failing UTP test that was failing when you install Unity Transport package 2.0.0 or newer.
-
 ## [1.5.1] - 2023-06-07
 
 ### Added
@@ -39,6 +34,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed issue where a client could throw an exception if abruptly disconnected from a network session with one or more spawned `NetworkObject`(s). (#2510)
 - Fixed issue where invalid endpoint addresses were not being detected and returning false from NGO UnityTransport. (#2496)
 - Fixed some errors that could occur if a connection is lost and the loss is detected when attempting to write to the socket. (#2495)
+- Fixed a failing UTP test that was failing when you install Unity Transport package 2.0.0 or newer.
 
 ## Changed
 

--- a/com.unity.netcode.gameobjects/Tests/Editor/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Transports/UnityTransportTests.cs
@@ -121,9 +121,7 @@ namespace Unity.Netcode.EditorTests
 
             LogAssert.Expect(LogType.Error, "Invalid network endpoint: 127.0.0.:4242.");
             LogAssert.Expect(LogType.Error, "Network listen address (127.0.0.) is Invalid!");
-#if UTP_TRANSPORT_2_0_ABOVE
-            LogAssert.Expect(LogType.Error, "Socket creation failed (error Unity.Baselib.LowLevel.Binding+Baselib_ErrorState: Invalid argument (0x01000003) <argument name stripped>");
-#endif
+
             transport.SetConnectionData("127.0.0.1", 4242, "127.0.0.1");
             Assert.True(transport.StartServer());
 


### PR DESCRIPTION
Fixing a UnityTransport_RestartSucceedsAfterFailure test that was failing when you install NGO package with UTP 2.0.0.
Removing a LogAssert that is not needed in UTP 2.0.0.

Yamato jobs:
- [Package Compatibility Test NGO release/1.5.1, Tools develop and UTP master - [win, trunk]](https://unity-ci.cds.internal.unity3d.com/job/26529714/results)
- [Package Compatibility Test NGO release/1.5.1, Tools release/2.0.0-pre.3 and UTP master - [mac, 2022.2]](https://unity-ci.cds.internal.unity3d.com/job/26529710/results)
- [Package Compatibility Test NGO release/1.5.1, Tools release/1.1.0 and UTP master - [linux, 2022.2]](https://unity-ci.cds.internal.unity3d.com/job/26529723/results)

## Changelog
- Fixed a failing UTP test that was failing when you install Unity Transport package 2.0.0 or newer.


## Testing and Documentation
- Ran automated CI run