### PR TITLE
fix: RemoveOwnership not locally notifying server that it gained ownership [MTT-6377] [MTT-6937][MTT-6936]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
+## [Unreleased]
+
+### Added
+
+
+### Fixed
+
+- Fixed issue where removing ownership would not notify the server that it gained ownership. This also resolves the issue where an owner authoritative NetworkTransform would not properly initialize upon removing ownership from a remote client. (#2618)
+
+
+### Changed
+
 
 ## [1.5.1] - 2023-06-07
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
+
 ## [Unreleased]
 
 ### Added
@@ -17,15 +18,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
-
-## [Unreleased]
-
-### Added
-
-### Fixed
-- Fixed a failing UTP test that was failing when you install Unity Transport package 2.0.0 or newer.
-
-## Changed
 
 ## [1.5.1] - 2023-06-07
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1029,6 +1029,8 @@ namespace Unity.Netcode
         // Ensures that the NetworkManager is cleaned up before OnDestroy is run on NetworkObjects and NetworkBehaviours when quitting the application.
         private void OnApplicationQuit()
         {
+            // Make sure ShutdownInProgress returns true during this time
+            m_ShuttingDown = true;
             OnDestroy();
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -303,17 +303,11 @@ namespace Unity.Netcode
                 throw new SpawnStateException("Object is not spawned");
             }
 
-            // Determine if the server is gong to lose ownership
-            var serverWillLoseOwnership = networkObject.OwnerClientId == NetworkManager.LocalClientId;
-
             // Assign the new owner
             networkObject.OwnerClientId = clientId;
 
-            // Notify locally that the server lost ownership
-            if (serverWillLoseOwnership)
-            {
-                networkObject.InvokeBehaviourOnLostOwnership();
-            }
+            // Always notify locally on the server when ownership is lost
+            networkObject.InvokeBehaviourOnLostOwnership();
 
             networkObject.MarkVariablesDirty(true);
             NetworkManager.BehaviourUpdater.AddForUpdate(networkObject);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
@@ -66,8 +66,7 @@ namespace Unity.Netcode.RuntimeTests
 
             // Set the child object to be inactive in the hierarchy
             childObject.SetActive(false);
-
-            LogAssert.Expect(LogType.Warning, $"{childObject.name} is disabled! Netcode for GameObjects does not support disabled NetworkBehaviours! The {childBehaviour.GetType().Name} component was skipped during ownership assignment!");
+            
             LogAssert.Expect(LogType.Warning, $"{childObject.name} is disabled! Netcode for GameObjects does not support spawning disabled NetworkBehaviours! The {childBehaviour.GetType().Name} component was skipped during spawn!");
 
             parentNetworkObject.Spawn();

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
@@ -66,7 +66,7 @@ namespace Unity.Netcode.RuntimeTests
 
             // Set the child object to be inactive in the hierarchy
             childObject.SetActive(false);
-            
+
             LogAssert.Expect(LogType.Warning, $"{childObject.name} is disabled! Netcode for GameObjects does not support spawning disabled NetworkBehaviours! The {childBehaviour.GetType().Name} component was skipped during spawn!");
 
             parentNetworkObject.Spawn();

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOwnershipTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOwnershipTests.cs
@@ -5,7 +5,6 @@ using NUnit.Framework;
 using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
 using UnityEngine.TestTools;
-using static Unity.Netcode.RuntimeTests.NetworkObjectOwnershipTests;
 
 namespace Unity.Netcode.RuntimeTests
 {


### PR DESCRIPTION
This resolves a few ownership related issues specifically noticed when using an owner authoritative NetworkTransform and ownership is removed. 

This also assures NetworkVariables will be updated if ownership is removed just like they are when ownership is changed. 

This also fixes an issue where NetworkManager's ShutdownInProgress was not true upon the application quitting which was causing an exception to occur within NetworkVariableBase under specific conditions.

[MTT-6936](https://jira.unity3d.com/browse/MTT-6936)
[MTT-6937](https://jira.unity3d.com/browse/MTT-6937)
[MTT-6377](https://jira.unity3d.com/browse/MTT-6377)





fix: #2563
fix: #2606
fix: #2511
fix: #2629


## Changelog

- Fixed: issue where removing ownership would not notify the server that it gained ownership. This also resolves the issue where an owner authoritative NetworkTransform would not properly initialize upon removing ownership from a remote client.

## Testing and Documentation
- Includes modifications to existing integration tests.
- No documentation changes or additions were necessary.
