### PR TITLE
fix: shutdown causes exception if invoked twice [MTT-6752]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -14,7 +14,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Fixed
 
 - Fixed issue where invoking `NetworkManager.Shutdown` multiple times, depending upon the timing, could cause an exception. (#2622)
-- Fixed a failing UTP test that was failing when you install Unity Transport package 2.0.0 or newer. (#2616)
 
 ## Changed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,10 +10,14 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
+
 ### Fixed
-- Fixed a failing UTP test that was failing when you install Unity Transport package 2.0.0 or newer.
+
+- Fixed issue where invoking `NetworkManager.Shutdown` multiple times, depending upon the timing, could cause an exception. (#2622)
+- Fixed a failing UTP test that was failing when you install Unity Transport package 2.0.0 or newer. (#2616)
 
 ## Changed
+
 
 ## [1.5.1] - 2023-06-07
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -942,10 +942,16 @@ namespace Unity.Netcode
             if (IsServer || IsClient)
             {
                 m_ShuttingDown = true;
-                MessageManager.StopProcessing = discardMessageQueue;
+                if (MessageManager != null)
+                {
+                    MessageManager.StopProcessing = discardMessageQueue;
+                }
             }
 
-            NetworkConfig.NetworkTransport.OnTransportEvent -= ConnectionManager.HandleNetworkEvent;
+            if (NetworkConfig != null && NetworkConfig.NetworkTransport != null)
+            {
+                NetworkConfig.NetworkTransport.OnTransportEvent -= ConnectionManager.HandleNetworkEvent;
+            }
         }
 
         // Ensures that the NetworkManager is cleaned up before OnDestroy is run on NetworkObjects and NetworkBehaviours when unloading a scene with a NetworkManager

--- a/testproject/Assets/Tests/Runtime/NetworkManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkManagerTests.cs
@@ -4,6 +4,7 @@ using Unity.Netcode;
 using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
 
 namespace TestProject.RuntimeTests
 {
@@ -93,6 +94,26 @@ namespace TestProject.RuntimeTests
             Assert.IsTrue(m_NetworkBehaviourIsClientWasSet, $"IsClient was not true when OnClientConnectedCallback was invoked!");
             Assert.IsTrue(m_NumberOfTimesInvoked == 1, $"OnClientConnectedCallback was invoked {m_NumberOfTimesInvoked} as opposed to just once!");
             Assert.IsTrue(m_NetworkBehaviourIsServerWasSet, $"IsServer was not true when OnClientConnectedCallback was invoked!");
+        }
+
+        /// <summary>
+        /// Validate shutting down a second time does not cause an exception.
+        /// </summary>        
+        [UnityTest]
+        public IEnumerator ValidateShutdown()
+        {
+            // Register for the server stopped notification so we know we have shutdown completely
+            m_ServerNetworkManager.OnServerStopped += M_ServerNetworkManager_OnServerStopped;
+            // Shutdown
+            m_ServerNetworkManager.Shutdown();
+            yield return s_DefaultWaitForTick;
+        }
+
+        private void M_ServerNetworkManager_OnServerStopped(bool obj)
+        {
+            m_ServerNetworkManager.OnServerStopped -= M_ServerNetworkManager_OnServerStopped;
+            // Verify that we can invoke shutdown again without an exception
+            m_ServerNetworkManager.Shutdown();
         }
     }
 }


### PR DESCRIPTION
This fixes the issue where invoking shutdown a second time (within a specific time frame) could throw an exception.

[MTT-6752](https://jira.unity3d.com/browse/MTT-6752)


## Changelog
- Fixed: issue where invoking `NetworkManager.Shutdown` multiple times, depending upon the timing, could cause an exception.

## Testing and Documentation

- Includes integration tests.
- No documentation changes or additions were necessary.
