### PR TITLE
fix: NetworkObject.SpawnWithObservers was not being honored for late joining clients [MTT-6934]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,10 +10,14 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
+
 ### Fixed
-- Fixed a failing UTP test that was failing when you install Unity Transport package 2.0.0 or newer.
+
+- Fixed issue where `NetworkObject.SpawnWithObservers` was not being honored for late joining clients. (#2623)
+- Fixed a failing UTP test that was failing when you install Unity Transport package 2.0.0 or newer. (#2616)
 
 ## Changed
+
 
 ## [1.5.1] - 2023-06-07
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -14,7 +14,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Fixed
 
 - Fixed issue where `NetworkObject.SpawnWithObservers` was not being honored for late joining clients. (#2623)
-- Fixed a failing UTP test that was failing when you install Unity Transport package 2.0.0 or newer. (#2616)
 
 ## Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -628,6 +628,8 @@ namespace Unity.Netcode
                     };
                     if (!NetworkManager.NetworkConfig.EnableSceneManagement)
                     {
+                        // Update the observed spawned NetworkObjects for the newly connected player when scene management is disabled
+                        NetworkManager.SpawnManager.UpdateObservedNetworkObjects(ownerClientId);
                         if (NetworkManager.SpawnManager.SpawnedObjectsList.Count != 0)
                         {
                             message.SpawnedObjectsList = NetworkManager.SpawnManager.SpawnedObjectsList;
@@ -651,12 +653,12 @@ namespace Unity.Netcode
                     SendMessage(ref message, NetworkDelivery.ReliableFragmentedSequenced, ownerClientId);
                     message.MessageVersions.Dispose();
 
-                    // If scene management is enabled, then let NetworkSceneManager handle the initial scene and NetworkObject synchronization
+                    // If scene management is disabled, then we are done and notify the local host-server the client is connected
                     if (!NetworkManager.NetworkConfig.EnableSceneManagement)
                     {
                         InvokeOnClientConnectedCallback(ownerClientId);
                     }
-                    else
+                    else // Otherwise, let NetworkSceneManager handle the initial scene and NetworkObject synchronization
                     {
                         NetworkManager.SceneManager.SynchronizeNetworkObjects(ownerClientId);
                     }

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -952,27 +952,35 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// Updates all spawned <see cref="NetworkObject.Observers"/> for the specified client
+        /// Updates all spawned <see cref="NetworkObject.Observers"/> for the specified newly connected client 
         /// Note: if the clientId is the server then it is observable to all spawned <see cref="NetworkObject"/>'s
         /// </summary>
+        /// <remarks>
+        /// This method is to only to be used for newly connected clients in order to update the observers list for
+        /// each NetworkObject instance.
+        /// </remarks>
         internal void UpdateObservedNetworkObjects(ulong clientId)
         {
             foreach (var sobj in SpawnedObjectsList)
             {
-                if (sobj.CheckObjectVisibility == null)
+                // If the NetworkObject has no visibility check then prepare to add this client as an observer
+                if (sobj.CheckObjectVisibility == null )
                 {
-                    if (!sobj.Observers.Contains(clientId))
+                    // If the client is not part of the observers and spawn with observers is enabled on this instance or the clientId is the server
+                    if (!sobj.Observers.Contains(clientId) && (sobj.SpawnWithObservers || clientId == NetworkManager.ServerClientId))
                     {
                         sobj.Observers.Add(clientId);
                     }
                 }
                 else
                 {
+                    // CheckObject visibility overrides SpawnWithObservers under this condition
                     if (sobj.CheckObjectVisibility(clientId))
                     {
                         sobj.Observers.Add(clientId);
                     }
-                    else if (sobj.Observers.Contains(clientId))
+                    else // Otherwise, if the observers contains the clientId (shouldn't happen) then remove it since CheckObjectVisibility returned false
+                    if (sobj.Observers.Contains(clientId))
                     {
                         sobj.Observers.Remove(clientId);
                     }

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -964,7 +964,7 @@ namespace Unity.Netcode
             foreach (var sobj in SpawnedObjectsList)
             {
                 // If the NetworkObject has no visibility check then prepare to add this client as an observer
-                if (sobj.CheckObjectVisibility == null )
+                if (sobj.CheckObjectVisibility == null)
                 {
                     // If the client is not part of the observers and spawn with observers is enabled on this instance or the clientId is the server
                     if (!sobj.Observers.Contains(clientId) && (sobj.SpawnWithObservers || clientId == NetworkManager.ServerClientId))


### PR DESCRIPTION
This resolves the issue where `NetworkObject.SpawnWithObservers` was not being honored for late joining clients.

[MTT-6934](https://jira.unity3d.com/browse/MTT-6934)
fix: #2609

## Changelog

- Fixed: Issue where `NetworkObject.SpawnWithObservers` was not being honored for late joining clients.

## Testing and Documentation

- Includes integration test modifications to `NetworkObjectOnSpawnTests`.
- No documentation changes or additions were necessary.

