### PR TITLE
fix: NetworkTransform full precision state updates being lost when interpolating [MTT-6799]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -13,7 +13,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where a `NetworkTransform` using full precision state updates was losing transform state updates when interpolation was enabled.
+- Fixed issue where a `NetworkTransform` using full precision state updates was losing transform state updates when interpolation was enabled. (#2624)
 - Fixed issue where `NetworkObject.SpawnWithObservers` was not being honored for late joining clients. (#2623)
 
 ## Changed

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -13,6 +13,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where a `NetworkTransform` using full precision state updates was losing transform state updates when interpolation was enabled.
 - Fixed issue where `NetworkObject.SpawnWithObservers` was not being honored for late joining clients. (#2623)
 
 ## Changed

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -2185,7 +2185,7 @@ namespace Unity.Netcode.Components
 
             if (m_LocalAuthoritativeNetworkState.HasScaleChange)
             {
-                var currentScale = transform.localScale;
+                var currentScale = m_TargetScale;
                 if (UseHalfFloatPrecision)
                 {
                     for (int i = 0; i < 3; i++)
@@ -2198,7 +2198,6 @@ namespace Unity.Netcode.Components
                 }
                 else
                 {
-                    currentScale = m_TargetScale;
                     if (m_LocalAuthoritativeNetworkState.HasScaleX)
                     {
                         currentScale.x = m_LocalAuthoritativeNetworkState.ScaleX;
@@ -2213,8 +2212,8 @@ namespace Unity.Netcode.Components
                     {
                         currentScale.z = m_LocalAuthoritativeNetworkState.ScaleZ;
                     }
-                    m_TargetScale = currentScale;
                 }
+                m_TargetScale = currentScale;
                 m_ScaleInterpolator.AddMeasurement(currentScale, sentTime);
             }
 
@@ -2231,6 +2230,7 @@ namespace Unity.Netcode.Components
                 {
                     currentEulerAngles = m_TargetRotation;
                     // Adjust based on which axis changed
+                    // (both half precision and full precision apply Eulers to the RotAngle properties when reading the update)
                     if (m_LocalAuthoritativeNetworkState.HasRotAngleX)
                     {
                         currentEulerAngles.x = m_LocalAuthoritativeNetworkState.RotAngleX;


### PR DESCRIPTION
This PR resolves the issue with `NetworkTransform` losing part of a state update for any given axis when using full precision and interpolating on non-authoritative instances. The fix involves saving the targeted state update for position, rotation, and scale as opposed to using the current position, rotation, or scale.

[MTT-6799](https://jira.unity3d.com/browse/MTT-6799)

fix: #2595


## Changelog

- Fixed: issue where a `NetworkTransform` using full precision state updates was losing transform state updates when interpolation was enabled.

## Testing and Documentation

- Includes integration test updates (WIP).
- No documentation changes or additions were necessary.
