### PR TITLE
fix: Add null check in TrySetParent

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -15,6 +15,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 - Fixed issue where `NetworkObject.SpawnWithObservers` was not being honored for late joining clients. (#2623)
 - Fixed issue where invoking `NetworkManager.Shutdown` multiple times, depending upon the timing, could cause an exception. (#2622)
+- Fixed a crash when calling TrySetParent with a null Transform (#2625)
 
 ## Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -733,6 +733,12 @@ namespace Unity.Netcode
         /// <returns>Whether or not reparenting was successful.</returns>
         public bool TrySetParent(Transform parent, bool worldPositionStays = true)
         {
+            // If we are removing ourself from a parent
+            if (parent == null)
+            {
+                return TrySetParent((NetworkObject)null, worldPositionStays);
+            }
+
             var networkObject = parent.GetComponent<NetworkObject>();
 
             // If the parent doesn't have a NetworkObjet then return false, otherwise continue trying to parent

--- a/testproject/Assets/Tests/Runtime/ObjectParenting/NetworkObjectParentingTests.cs
+++ b/testproject/Assets/Tests/Runtime/ObjectParenting/NetworkObjectParentingTests.cs
@@ -309,6 +309,49 @@ namespace TestProject.RuntimeTests
                 Assert.That(m_Cube_NetObjs[setIndex + 1].parent, Is.EqualTo(m_Dude_LeftArm_NetObjs[setIndex + 1]));
                 Assert.That(m_Cube_NetBhvs[setIndex + 1].ParentNetworkObject, Is.EqualTo(m_Dude_LeftArm_NetObjs[setIndex + 1].GetComponent<NetworkObject>()));
             }
+
+            Transform nullTransform = null;
+            GameObject nullGameObject = null;
+            NetworkObject nullNetworkObject = null;
+
+
+            Assert.That(m_Cube_NetObjs[0].GetComponent<NetworkObject>().TrySetParent(nullTransform));
+            Assert.That(m_Cube_NetBhvs[0].ParentNetworkObject, Is.EqualTo(null));
+
+            nextFrameNumber = Time.frameCount + 2;
+            yield return new WaitUntil(() => Time.frameCount >= nextFrameNumber);
+
+            for (int setIndex = 0; setIndex < k_ClientInstanceCount; setIndex++)
+            {
+                Assert.That(m_Cube_NetObjs[setIndex + 1].parent, Is.EqualTo(null));
+                Assert.That(m_Cube_NetBhvs[setIndex + 1].ParentNetworkObject, Is.EqualTo(null));
+            }
+
+
+            Assert.That(m_Cube_NetObjs[0].GetComponent<NetworkObject>().TrySetParent(nullGameObject));
+            Assert.That(m_Cube_NetBhvs[0].ParentNetworkObject, Is.EqualTo(null));
+
+            nextFrameNumber = Time.frameCount + 2;
+            yield return new WaitUntil(() => Time.frameCount >= nextFrameNumber);
+
+            for (int setIndex = 0; setIndex < k_ClientInstanceCount; setIndex++)
+            {
+                Assert.That(m_Cube_NetObjs[setIndex + 1].parent, Is.EqualTo(null));
+                Assert.That(m_Cube_NetBhvs[setIndex + 1].ParentNetworkObject, Is.EqualTo(null));
+            }
+
+
+            Assert.That(m_Cube_NetObjs[0].GetComponent<NetworkObject>().TrySetParent(nullNetworkObject));
+            Assert.That(m_Cube_NetBhvs[0].ParentNetworkObject, Is.EqualTo(null));
+
+            nextFrameNumber = Time.frameCount + 2;
+            yield return new WaitUntil(() => Time.frameCount >= nextFrameNumber);
+
+            for (int setIndex = 0; setIndex < k_ClientInstanceCount; setIndex++)
+            {
+                Assert.That(m_Cube_NetObjs[setIndex + 1].parent, Is.EqualTo(null));
+                Assert.That(m_Cube_NetBhvs[setIndex + 1].ParentNetworkObject, Is.EqualTo(null));
+            }
         }
     }
 }


### PR DESCRIPTION
fixes #2621

## Changelog

- Fixed: Fixed a crash when calling TrySetParent with a null Transform

## Testing and Documentation

- Includes integration tests.
