### PR TITLE
fix: NetworkClient.OwnedObjects always returning a count of zero

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where `NetworkClient.OwnedObjects` was not returning any owned objects due to the `NetworkClient.IsConnected` not being properly set. (#2631)
 - Fixed issue where a `NetworkTransform` using full precision state updates was losing transform state updates when interpolation was enabled. (#2624)
 - Fixed issue where `NetworkObject.SpawnWithObservers` was not being honored for late joining clients. (#2623)
 - Fixed issue where invoking `NetworkManager.Shutdown` multiple times, depending upon the timing, could cause an exception. (#2622)

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkClient.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkClient.cs
@@ -36,15 +36,11 @@ namespace Unity.Netcode
         /// <summary>
         /// The ClientId of the NetworkClient
         /// </summary>
-        // TODO-2023-Q2: Determine if we want to make this property a public get and internal/private set
-        // There is no reason for a user to want to set this, but this will fail the package-validation-suite
         public ulong ClientId;
 
         /// <summary>
         /// The PlayerObject of the Client
         /// </summary>
-        // TODO-2023-Q2: Determine if we want to make this property a public get and internal/private set
-        // There is no reason for a user to want to set this, but this will fail the package-validation-suite
         public NetworkObject PlayerObject;
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
@@ -118,7 +118,7 @@ namespace Unity.Netcode
             m_NetworkManager.NetworkTickSystem.Tick -= NetworkBehaviourUpdater_Tick;
         }
 
-        // TODO 2023-Q2: Order of operations requires NetworkVariable updates first then showing NetworkObjects
+        // Order of operations requires NetworkVariable updates first then showing NetworkObjects
         private void NetworkBehaviourUpdater_Tick()
         {
             // First update NetworkVariables

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -59,13 +59,12 @@ namespace Unity.Netcode
                         // Metrics update needs to be driven by NetworkConnectionManager's update to assure metrics are dispatched after the send queue is processed.
                         MetricsManager.UpdateMetrics();
 
-                        // TODO 2023-Q2: Determine a better way to handle this
+                        // TODO: Determine a better way to handle this
                         NetworkObject.VerifyParentingStatus();
 
                         // This is "ok" to invoke when not processing messages since it is just cleaning up messages that never got handled within their timeout period.
                         DeferredMessageManager.CleanupStaleTriggers();
 
-                        // TODO 2023-Q2: Determine a better way to handle this
                         if (m_ShuttingDown)
                         {
                             ShutdownInternal();
@@ -834,9 +833,7 @@ namespace Unity.Netcode
             }
 
             ConnectionManager.LocalClient.SetRole(true, true, this);
-
             Initialize(true);
-
             try
             {
                 IsListening = NetworkConfig.NetworkTransport.StartServer();

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -2191,6 +2191,10 @@ namespace Unity.Netcode
                             ClientId = clientId
                         });
 
+                        // At this point the client is considered fully "connected"
+                        NetworkManager.ConnectedClients[clientId].IsConnected = true;
+
+                        // All scenes are synchronized, let the server know we are done synchronizing
                         OnSynchronizeComplete?.Invoke(clientId);
 
                         // At this time the client is fully synchronized with all loaded scenes and

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -566,7 +566,6 @@ namespace Unity.Netcode
                     }
                     NetworkManager.ConnectedClients[ownerClientId].PlayerObject = networkObject;
                 }
-                UpdateOwnershipTable(networkObject, ownerClientId);
             }
             else if (ownerClientId == NetworkManager.LocalClientId)
             {
@@ -579,7 +578,6 @@ namespace Unity.Netcode
                     }
                     NetworkManager.LocalClient.PlayerObject = networkObject;
                 }
-                UpdateOwnershipTable(networkObject, ownerClientId);
             }
 
             // If we are the server and should spawn with observers

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -566,6 +566,7 @@ namespace Unity.Netcode
                     }
                     NetworkManager.ConnectedClients[ownerClientId].PlayerObject = networkObject;
                 }
+                UpdateOwnershipTable(networkObject, ownerClientId);
             }
             else if (ownerClientId == NetworkManager.LocalClientId)
             {
@@ -578,6 +579,7 @@ namespace Unity.Netcode
                     }
                     NetworkManager.LocalClient.PlayerObject = networkObject;
                 }
+                UpdateOwnershipTable(networkObject, ownerClientId);
             }
 
             // If we are the server and should spawn with observers

--- a/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTimeSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTimeSystem.cs
@@ -9,9 +9,6 @@ namespace Unity.Netcode
     /// </summary>
     public class NetworkTimeSystem
     {
-        /// <summary>
-        /// TODO 2023-Q2: Not sure if this just needs to go away, but there is nothing that ever replaces this
-        /// </summary>
         /// <remarks>
         /// This was the original comment when it lived in NetworkManager:
         /// todo talk with UX/Product, find good default value for this

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOwnershipTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOwnershipTests.cs
@@ -313,9 +313,13 @@ namespace Unity.Netcode.RuntimeTests
 
         private bool ServerHasCorrectClientOwnedObjectCount()
         {
-            if (m_ServerNetworkManager.LocalClient.OwnedObjects.Count < k_NumberOfSpawnedObjects)
+            // Only check when we are the host
+            if (m_ServerNetworkManager.IsHost)
             {
-                return false;
+                if (m_ServerNetworkManager.LocalClient.OwnedObjects.Count < k_NumberOfSpawnedObjects)
+                {
+                    return false;
+                }
             }
 
             foreach (var connectedClient in m_ServerNetworkManager.ConnectedClients)
@@ -331,9 +335,12 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator TestOwnedObjectCounts()
         {
-            for (int i = 0; i < 5; i++)
+            if (m_ServerNetworkManager.IsHost)
             {
-                SpawnObject(m_OwnershipPrefab, m_ServerNetworkManager);
+                for (int i = 0; i < 5; i++)
+                {
+                    SpawnObject(m_OwnershipPrefab, m_ServerNetworkManager);
+                }
             }
 
             foreach (var clientNetworkManager in m_ClientNetworkManagers)
@@ -349,6 +356,7 @@ namespace Unity.Netcode.RuntimeTests
 
             yield return WaitForConditionOrTimeOut(ServerHasCorrectClientOwnedObjectCount);
             AssertOnTimeout($"Server does not have the correct count for all clients spawned {k_NumberOfSpawnedObjects} {nameof(NetworkObject)}s!");
+
         }
     }
 }


### PR DESCRIPTION
This PR resolves the issue where `NetworkClient.OwnedObjects` was not returning any owned objects due to the `NetworkClient.IsConnected` not being properly set.

fix: #2626

## Changelog

- Fixed:  issue where `NetworkClient.OwnedObjects` was not returning any owned objects due to the `NetworkClient.IsConnected` not being properly set.

## Testing and Documentation

- Includes integration test in `NetworkObjectOwnershipTests`.
- No documentation changes or additions were necessary.
