### PR TITLE
fix: NetworkTransform synchronization fixes and owner authoritative performance improvement on server-host [MTT-6971]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,19 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue with client synchronization of position when using half precision and the delta position reaches the maximum value and is collapsed on the host prior to being forwarded to the non-owner clients. (#2636)
+- Fixed issue with scale not synchronizing properly depending upon the spawn order of NetworkObjects. (#2636)
+- Fixed issue position was not properly transitioning between ownership changes with an owner authoritative NetworkTransform. (#2636)
+- Fixed issue where a late joining non-owner client could update an owner authoritative NetworkTransform if ownership changed without any updates to position prior to the non-owner client joining. (#2636)
+
+### Changed
+
+## [1.5.2] - 2023-07-24
+
+### Added
+
+### Fixed
+
 - Fixed issue where `NetworkClient.OwnedObjects` was not returning any owned objects due to the `NetworkClient.IsConnected` not being properly set. (#2631)
 - Fixed a crash when calling TrySetParent with a null Transform (#2625)
 - Fixed issue where a `NetworkTransform` using full precision state updates was losing transform state updates when interpolation was enabled. (#2624)

--- a/com.unity.netcode.gameobjects/Components/HalfVector3.cs
+++ b/com.unity.netcode.gameobjects/Components/HalfVector3.cs
@@ -27,7 +27,7 @@ namespace Unity.Netcode.Components
         /// <summary>
         /// The half float precision value of the z-axis as a <see cref="half"/>.
         /// </summary>
-        public half Z => Axis.x;
+        public half Z => Axis.z;
 
         /// <summary>
         /// Used to store the half float precision values as a <see cref="half3"/>
@@ -38,6 +38,17 @@ namespace Unity.Netcode.Components
         /// Determine which axis will be synchronized during serialization
         /// </summary>
         public bool3 AxisToSynchronize;
+
+        /// <summary>
+        /// Directly sets each axial value to the passed in full precision values
+        /// that are converted to half precision
+        /// </summary>
+        internal void Set(float x, float y, float z)
+        {
+            Axis.x = math.half(x);
+            Axis.y = math.half(y);
+            Axis.z = math.half(z);
+        }
 
         private void SerializeWrite(FastBufferWriter writer)
         {

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using Unity.Collections;
 using Unity.Mathematics;
@@ -1291,11 +1290,14 @@ namespace Unity.Netcode.Components
         protected override void OnSynchronize<T>(ref BufferSerializer<T> serializer)
         {
             var targetClientId = m_TargetIdBeingSynchronized;
-            var synchronizationState = new NetworkTransformState();
-            synchronizationState.HalfEulerRotation = new HalfVector3();
-            synchronizationState.HalfVectorRotation = new HalfVector4();
-            synchronizationState.HalfVectorScale = new HalfVector3();
-            synchronizationState.NetworkDeltaPosition = new NetworkDeltaPosition();
+            var synchronizationState = new NetworkTransformState()
+            {
+                HalfEulerRotation = new HalfVector3(),
+                HalfVectorRotation = new HalfVector4(),
+                HalfVectorScale = new HalfVector3(),
+                NetworkDeltaPosition = new NetworkDeltaPosition(),
+            };
+
             if (serializer.IsWriter)
             {
                 synchronizationState.IsTeleportingNextFrame = true;

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -2530,7 +2530,7 @@ namespace Unity.Netcode.Components
         /// </summary>
         /// <param name="replicatedState">the current <see cref="NetworkTransformState"/> after initializing</param>
         protected virtual void OnInitialize(ref NetworkTransformState replicatedState)
-        {            
+        {
         }
 
         /// <summary>
@@ -2590,14 +2590,14 @@ namespace Unity.Netcode.Components
                 m_CurrentRotation = currentRotation;
                 m_TargetRotation = currentRotation.eulerAngles;
 
-            }            
+            }
             OnInitialize(ref m_LocalAuthoritativeNetworkState);
-            
+
             if (IsOwner)
             {
                 m_InternalStatNetVar.Value = m_LocalAuthoritativeNetworkState;
                 OnInitialize(ref m_InternalStatNetVar);
-            }            
+            }
         }
 
         /// <inheritdoc/>

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -2177,7 +2177,7 @@ namespace Unity.Netcode.Components
         /// <remarks>
         /// Only non-authoritative instances should invoke this
         /// </remarks>
-        private void UpdateState(NetworkTransformState oldState, NetworkTransformState newState)
+        private void ApplyUpdatedState(NetworkTransformState newState)
         {
             // Set the transforms's synchronization modes
             InLocalSpace = newState.InLocalSpace;
@@ -2339,8 +2339,8 @@ namespace Unity.Netcode.Components
             // Get the time when this new state was sent
             newState.SentTime = new NetworkTime(NetworkManager.NetworkConfig.TickRate, newState.NetworkTick).Time;
 
-            // Update the state
-            UpdateState(oldState, newState);
+            // Apply the new state
+            ApplyUpdatedState(newState);
 
             // Provide notifications when the state has been updated
             OnNetworkTransformStateUpdated(ref oldState, ref newState);
@@ -2785,12 +2785,6 @@ namespace Unity.Netcode.Components
                 }
             }
 
-            // If we have not received any additional state updates since the very
-            // initial synchronization, then exit early.
-            if (m_LocalAuthoritativeNetworkState.IsSynchronizing)
-            {
-                return;
-            }
             // Apply the current authoritative state
             ApplyAuthoritativeState();
         }

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -2530,6 +2530,19 @@ namespace Unity.Netcode.Components
         /// </summary>
         /// <param name="replicatedState">the current <see cref="NetworkTransformState"/> after initializing</param>
         protected virtual void OnInitialize(ref NetworkTransformState replicatedState)
+        {            
+        }
+
+        /// <summary>
+        /// An owner read and owner write NetworkVariable so it doesn't generate any messages
+        /// </summary>
+        private NetworkVariable<NetworkTransformState> m_InternalStatNetVar = new NetworkVariable<NetworkTransformState>(default, NetworkVariableReadPermission.Owner, NetworkVariableWritePermission.Owner);
+        /// <summary>
+        /// This method is only invoked by the owner
+        /// Use: OnInitialize(ref NetworkTransformState replicatedState) to be notified on all instances
+        /// </summary>
+        /// <param name="replicatedState"></param>
+        protected virtual void OnInitialize(ref NetworkVariable<NetworkTransformState> replicatedState)
         {
 
         }
@@ -2577,8 +2590,14 @@ namespace Unity.Netcode.Components
                 m_CurrentRotation = currentRotation;
                 m_TargetRotation = currentRotation.eulerAngles;
 
-            }
+            }            
             OnInitialize(ref m_LocalAuthoritativeNetworkState);
+            
+            if (IsOwner)
+            {
+                m_InternalStatNetVar.Value = m_LocalAuthoritativeNetworkState;
+                OnInitialize(ref m_InternalStatNetVar);
+            }            
         }
 
         /// <inheritdoc/>

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -82,6 +82,11 @@ namespace Unity.Netcode.Components
 
             // Stores persistent and state relative flags
             private uint m_Bitset;
+            internal uint BitSet
+            {
+                get { return m_Bitset; }
+                set { m_Bitset = value; }
+            }
 
             // Used to store the tick calculated sent time
             internal double SentTime;
@@ -426,10 +431,10 @@ namespace Unity.Netcode.Components
 
             internal bool IsParented
             {
-                get => GetFlag(k_PositionSlerp);
+                get => GetFlag(k_IsParented);
                 set
                 {
-                    SetFlag(value, k_PositionSlerp);
+                    SetFlag(value, k_IsParented);
                 }
             }
 

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NamedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NamedMessage.cs
@@ -28,7 +28,7 @@ namespace Unity.Netcode
             if (!networkManager.ShutdownInProgress)
             {
                 ((NetworkManager)context.SystemOwner).CustomMessagingManager.InvokeNamedMessage(Hash, context.SenderId, m_ReceiveData, context.SerializedHeaderSize);
-            }            
+            }
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NamedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NamedMessage.cs
@@ -24,7 +24,11 @@ namespace Unity.Netcode
 
         public void Handle(ref NetworkContext context)
         {
-            ((NetworkManager)context.SystemOwner).CustomMessagingManager.InvokeNamedMessage(Hash, context.SenderId, m_ReceiveData, context.SerializedHeaderSize);
+            var networkManager = (NetworkManager)context.SystemOwner;
+            if (!networkManager.ShutdownInProgress)
+            {
+                ((NetworkManager)context.SystemOwner).CustomMessagingManager.InvokeNamedMessage(Hash, context.SenderId, m_ReceiveData, context.SerializedHeaderSize);
+            }            
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/NetworkMessageManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/NetworkMessageManager.cs
@@ -518,15 +518,18 @@ namespace Unity.Netcode
         {
             if (!m_PerClientMessageVersions.TryGetValue(clientId, out var versionMap))
             {
-                if (forReceive)
+                var networkManager = NetworkManager.Singleton;
+                if (networkManager != null && networkManager.LogLevel == LogLevel.Developer)
                 {
-                    Debug.LogWarning($"Trying to receive {type.Name} from client {clientId} which is not in a connected state.");
+                    if (forReceive)
+                    {
+                        NetworkLog.LogWarning($"Trying to receive {type.Name} from client {clientId} which is not in a connected state.");
+                    }
+                    else
+                    {
+                        NetworkLog.LogWarning($"Trying to send {type.Name} to client {clientId} which is not in a connected state.");
+                    }
                 }
-                else
-                {
-                    Debug.LogWarning($"Trying to send {type.Name} to client {clientId} which is not in a connected state.");
-                }
-
                 return -1;
             }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
@@ -7,7 +7,6 @@ using Unity.Netcode.Components;
 using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
 using UnityEngine.TestTools;
-
 namespace Unity.Netcode.RuntimeTests
 {
     public class NetworkTransformOwnershipTests : IntegrationTestWithApproximation

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
@@ -7,6 +7,7 @@ using Unity.Netcode.Components;
 using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
 using UnityEngine.TestTools;
+
 namespace Unity.Netcode.RuntimeTests
 {
     public class NetworkTransformOwnershipTests : IntegrationTestWithApproximation
@@ -44,6 +45,93 @@ namespace Unity.Netcode.RuntimeTests
             networkTransform.UseHalfFloatPrecision = false;
 
             base.OnServerAndClientsCreated();
+        }
+
+        /// <summary>
+        /// Clients created during a test need to have their prefabs list updated to
+        /// match the server's prefab list.
+        /// </summary>
+        protected override void OnNewClientCreated(NetworkManager networkManager)
+        {
+            foreach (var networkPrefab in m_ServerNetworkManager.NetworkConfig.Prefabs.Prefabs)
+            {
+                networkManager.NetworkConfig.Prefabs.Add(networkPrefab);
+            }
+
+            base.OnNewClientCreated(networkManager);
+        }
+
+        private bool ClientIsOwner()
+        {
+            var clientId = m_ClientNetworkManagers[0].LocalClientId;
+            if (!VerifyObjectIsSpawnedOnClient.GetClientsThatSpawnedThisPrefab().Contains(clientId))
+            {
+                return false;
+            }
+            if (VerifyObjectIsSpawnedOnClient.GetClientInstance(clientId).OwnerClientId != clientId)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// This test verifies a late joining client cannot change the transform when:
+        /// - A NetworkObject is spawned with a host and one or more connected clients
+        /// - The NetworkTransform is owner authoritative and spawned with the host as the owner
+        /// - The host does not change the transform values
+        /// - One of the already connected clients gains ownership of the spawned NetworkObject
+        /// - The new client owner does not change the transform values
+        /// - A new late joining client connects and is synchronized
+        /// - The newly connected late joining client tries to change the transform of the NetworkObject
+        /// it does not own
+        /// </summary>
+        [UnityTest]
+        public IEnumerator LateJoinedNonOwnerClientCannotChangeTransform()
+        {
+            // Spawn the m_ClientNetworkTransformPrefab with the host starting as the owner
+            var hostInstance = SpawnObject(m_ClientNetworkTransformPrefab, m_ServerNetworkManager);
+
+            // Wait for the client to spawn it
+            yield return WaitForConditionOrTimeOut(() => VerifyObjectIsSpawnedOnClient.GetClientsThatSpawnedThisPrefab().Contains(m_ClientNetworkManagers[0].LocalClientId));
+
+            // Change the ownership to the connectd client
+            hostInstance.GetComponent<NetworkObject>().ChangeOwnership(m_ClientNetworkManagers[0].LocalClientId);
+
+            // Wait until the client gains ownership
+            yield return WaitForConditionOrTimeOut(ClientIsOwner);
+
+            // Spawn a new client
+            yield return CreateAndStartNewClient();
+
+            // Get the instance of the object relative to the newly joined client
+            var newClientObjectInstance = VerifyObjectIsSpawnedOnClient.GetClientInstance(m_ClientNetworkManagers[1].LocalClientId);
+
+            // Attempt to change the transform values
+            var currentPosition = newClientObjectInstance.transform.position;
+            newClientObjectInstance.transform.position = GetRandomVector3(0.5f, 10.0f);
+            var rotation = newClientObjectInstance.transform.rotation;
+            var currentRotation = rotation.eulerAngles;
+            rotation.eulerAngles = GetRandomVector3(1.0f, 180.0f);
+            var currentScale = newClientObjectInstance.transform.localScale;
+            newClientObjectInstance.transform.localScale = GetRandomVector3(0.25f, 4.0f);
+
+            // Wait one frame so the NetworkTransform can apply the owner's last state received on the late joining client side
+            // (i.e. prevent the non-owner from changing the transform)
+            yield return null;
+
+            // Get the owner instance
+            var ownerInstance = VerifyObjectIsSpawnedOnClient.GetClientInstance(m_ClientNetworkManagers[0].LocalClientId);
+
+            // Verify that the non-owner instance transform values are the same before they were changed last frame
+            Assert.True(Approximately(currentPosition, newClientObjectInstance.transform.position), $"Non-owner instance was able to change the position!");
+            Assert.True(Approximately(currentRotation, newClientObjectInstance.transform.rotation.eulerAngles), $"Non-owner instance was able to change the rotation!");
+            Assert.True(Approximately(currentScale, newClientObjectInstance.transform.localScale), $"Non-owner instance was able to change the scale!");
+
+            // Verify that the non-owner instance transform is still the same as the owner instance transform
+            Assert.True(Approximately(ownerInstance.transform.position, newClientObjectInstance.transform.position), "Non-owner and owner instance position values are not the same!");
+            Assert.True(Approximately(ownerInstance.transform.rotation.eulerAngles, newClientObjectInstance.transform.rotation.eulerAngles), "Non-owner and owner instance rotation values are not the same!");
+            Assert.True(Approximately(ownerInstance.transform.localScale, newClientObjectInstance.transform.localScale), "Non-owner and owner instance scale values are not the same!");
         }
 
         public enum StartingOwnership

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformStateTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformStateTests.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using Unity.Netcode.Components;
 using UnityEngine;
 
+
 namespace Unity.Netcode.RuntimeTests
 {
 
@@ -87,6 +88,125 @@ namespace Unity.Netcode.RuntimeTests
             return networkTransform.SyncScaleX || networkTransform.SyncScaleY || networkTransform.SyncScaleZ ||
                 networkTransform.SyncRotAngleX || networkTransform.SyncRotAngleY || networkTransform.SyncRotAngleZ ||
                 networkTransform.SyncPositionX || networkTransform.SyncPositionY || networkTransform.SyncPositionZ;
+        }
+
+        [Test]
+        public void NetworkTransformStateFlags()
+        {
+            var indexValues = new System.Collections.Generic.List<uint>();
+            var currentFlag = (uint)0x00000001;
+            for (int j = 0; j < 18; j++)
+            {
+                indexValues.Add(currentFlag);
+                currentFlag = currentFlag << 1;
+            }
+
+            // TrackByStateId is unique
+            indexValues.Add(0x10000000);
+
+            var boolSet = new System.Collections.Generic.List<bool>();
+            var transformState = new NetworkTransform.NetworkTransformState();
+            // Test setting one at a time.
+            for (int j = 0; j < 19; j++)
+            {
+                boolSet = new System.Collections.Generic.List<bool>();
+                for (int i = 0; i < 19; i++)
+                {
+                    if (i == j)
+                    {
+                        boolSet.Add(true);
+                    }
+                    else
+                    {
+                        boolSet.Add(false);
+                    }
+                }
+                transformState = new NetworkTransform.NetworkTransformState()
+                {
+                    InLocalSpace = boolSet[0],
+                    HasPositionX = boolSet[1],
+                    HasPositionY = boolSet[2],
+                    HasPositionZ = boolSet[3],
+                    HasRotAngleX = boolSet[4],
+                    HasRotAngleY = boolSet[5],
+                    HasRotAngleZ = boolSet[6],
+                    HasScaleX = boolSet[7],
+                    HasScaleY = boolSet[8],
+                    HasScaleZ = boolSet[9],
+                    IsTeleportingNextFrame = boolSet[10],
+                    UseInterpolation = boolSet[11],
+                    QuaternionSync = boolSet[12],
+                    QuaternionCompression = boolSet[13],
+                    UseHalfFloatPrecision = boolSet[14],
+                    IsSynchronizing = boolSet[15],
+                    UsePositionSlerp = boolSet[16],
+                    IsParented = boolSet[17],
+                    TrackByStateId = boolSet[18],
+                };
+                Assert.True((transformState.BitSet & indexValues[j]) == indexValues[j], $"[FlagTest][Individual] Set flag value {indexValues[j]} at index {j}, but BitSet value did not match!");
+            }
+
+            // Test setting all flag values
+            boolSet = new System.Collections.Generic.List<bool>();
+            for (int i = 0; i < 19; i++)
+            {
+                boolSet.Add(true);
+            }
+
+            transformState = new NetworkTransform.NetworkTransformState()
+            {
+                InLocalSpace = boolSet[0],
+                HasPositionX = boolSet[1],
+                HasPositionY = boolSet[2],
+                HasPositionZ = boolSet[3],
+                HasRotAngleX = boolSet[4],
+                HasRotAngleY = boolSet[5],
+                HasRotAngleZ = boolSet[6],
+                HasScaleX = boolSet[7],
+                HasScaleY = boolSet[8],
+                HasScaleZ = boolSet[9],
+                IsTeleportingNextFrame = boolSet[10],
+                UseInterpolation = boolSet[11],
+                QuaternionSync = boolSet[12],
+                QuaternionCompression = boolSet[13],
+                UseHalfFloatPrecision = boolSet[14],
+                IsSynchronizing = boolSet[15],
+                UsePositionSlerp = boolSet[16],
+                IsParented = boolSet[17],
+                TrackByStateId = boolSet[18],
+            };
+
+            for (int j = 0; j < 19; j++)
+            {
+                Assert.True((transformState.BitSet & indexValues[j]) == indexValues[j], $"[FlagTest][All] All flag values are set but failed to detect flag value {indexValues[j]}!");
+            }
+
+            // Test getting all flag values
+            transformState = new NetworkTransform.NetworkTransformState();
+            for (int i = 0; i < 19; i++)
+            {
+                transformState.BitSet |= indexValues[i];
+            }
+
+            Assert.True(transformState.InLocalSpace, $"[FlagTest][Get] Failed to detect {nameof(NetworkTransform.NetworkTransformState.InLocalSpace)}!");
+            Assert.True(transformState.HasPositionX, $"[FlagTest][Get] Failed to detect {nameof(NetworkTransform.NetworkTransformState.HasPositionX)}!");
+            Assert.True(transformState.HasPositionY, $"[FlagTest][Get] Failed to detect {nameof(NetworkTransform.NetworkTransformState.HasPositionY)}!");
+            Assert.True(transformState.HasPositionZ, $"[FlagTest][Get] Failed to detect {nameof(NetworkTransform.NetworkTransformState.HasPositionZ)}!");
+            Assert.True(transformState.HasRotAngleX, $"[FlagTest][Get] Failed to detect {nameof(NetworkTransform.NetworkTransformState.HasRotAngleX)}!");
+            Assert.True(transformState.HasRotAngleY, $"[FlagTest][Get] Failed to detect {nameof(NetworkTransform.NetworkTransformState.HasRotAngleY)}!");
+            Assert.True(transformState.HasRotAngleZ, $"[FlagTest][Get] Failed to detect {nameof(NetworkTransform.NetworkTransformState.HasRotAngleZ)}!");
+            Assert.True(transformState.HasScaleX, $"[FlagTest][Get] Failed to detect {nameof(NetworkTransform.NetworkTransformState.HasScaleX)}!");
+            Assert.True(transformState.HasScaleY, $"[FlagTest][Get] Failed to detect {nameof(NetworkTransform.NetworkTransformState.HasScaleY)}!");
+            Assert.True(transformState.HasScaleZ, $"[FlagTest][Get] Failed to detect {nameof(NetworkTransform.NetworkTransformState.HasScaleZ)}!");
+            Assert.True(transformState.IsTeleportingNextFrame, $"[FlagTest][Get] Failed to detect {nameof(NetworkTransform.NetworkTransformState.IsTeleportingNextFrame)}!");
+            Assert.True(transformState.UseInterpolation, $"[FlagTest][Get] Failed to detect {nameof(NetworkTransform.NetworkTransformState.UseInterpolation)}!");
+            Assert.True(transformState.QuaternionSync, $"[FlagTest][Get] Failed to detect {nameof(NetworkTransform.NetworkTransformState.QuaternionSync)}!");
+            Assert.True(transformState.QuaternionCompression, $"[FlagTest][Get] Failed to detect {nameof(NetworkTransform.NetworkTransformState.QuaternionCompression)}!");
+            Assert.True(transformState.UseHalfFloatPrecision, $"[FlagTest][Get] Failed to detect {nameof(NetworkTransform.NetworkTransformState.UseHalfFloatPrecision)}!");
+            Assert.True(transformState.IsSynchronizing, $"[FlagTest][Get] Failed to detect {nameof(NetworkTransform.NetworkTransformState.IsSynchronizing)}!");
+            Assert.True(transformState.UsePositionSlerp, $"[FlagTest][Get] Failed to detect {nameof(NetworkTransform.NetworkTransformState.UsePositionSlerp)}!");
+            Assert.True(transformState.IsParented, $"[FlagTest][Get] Failed to detect {nameof(NetworkTransform.NetworkTransformState.IsParented)}!");
+            Assert.True(transformState.TrackByStateId, $"[FlagTest][Get] Failed to detect {nameof(NetworkTransform.NetworkTransformState.TrackByStateId)}!");
         }
 
         [Test]

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -500,6 +500,11 @@ namespace Unity.Netcode.RuntimeTests
             success = WaitForConditionOrTimeOutWithTimeTravel(AllChildObjectInstancesAreSpawned);
             Assert.True(success, "Timed out waiting for all child instances to be spawned!");
 
+
+            // This waits for all child instances to be parented
+            success = WaitForConditionOrTimeOutWithTimeTravel(AllChildObjectInstancesHaveChild);
+            Assert.True(success, "Timed out waiting for all instances to have parented a child!");
+
             // Assure the newly connected client's child object's transform values are correct
             AllChildrenLocalTransformValuesMatch();
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -1054,7 +1054,7 @@ namespace Unity.Netcode.RuntimeTests
 
             m_AuthoritativeTransform.transform.rotation = Quaternion.Euler(1, 2, 3);
             var serverLastSentState = m_AuthoritativeTransform.AuthorityLastSentState;
-            var clientReplicatedState = m_NonAuthoritativeTransform.ReplicatedNetworkState.Value;
+            var clientReplicatedState = m_NonAuthoritativeTransform.LocalAuthoritativeNetworkState;
             var success = WaitForConditionOrTimeOutWithTimeTravel(() => ValidateBitSetValues(serverLastSentState, clientReplicatedState));
             Assert.True(success, $"Timed out waiting for Authoritative Bitset state to equal NonAuthoritative replicated Bitset state!");
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TransformInterpolationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TransformInterpolationTests.cs
@@ -37,7 +37,7 @@ namespace Unity.Netcode.RuntimeTests
             return TestComplete;
         }
 
-        protected override void OnInitialize(ref NetworkVariable<NetworkTransformState> replicatedState)
+        protected override void OnInitialize(ref NetworkTransformState replicatedState)
         {
             m_LocalSpaceToggles = 0;
             m_FrameRateFractional = 1.0f / Application.targetFrameRate;

--- a/testproject/Assets/Tests/Manual/Scripts/IntegrationNetworkTransform.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/IntegrationNetworkTransform.cs
@@ -318,48 +318,24 @@ namespace TestProject.ManualTests
 
             OnNetworkTransformStateUpdate(ref m_NetworkTransformStateUpdate);
         }
-#endif
-
-        private NetworkVariable<NetworkTransformState> m_CurrentReplicatedState = new NetworkVariable<NetworkTransformState>();
-
-        protected override void OnInitialize(ref NetworkVariable<NetworkTransformState> replicatedState)
-        {
-            if (CanCommitToTransform && DebugTransform)
-            {
-                m_CurrentReplicatedState = replicatedState;
-                // Sanity check to assure we only subscribe to OnValueChanged once
-                replicatedState.OnValueChanged -= OnStateUpdate;
-                replicatedState.OnValueChanged += OnStateUpdate;
-            }
-        }
-
-        public override void OnNetworkDespawn()
-        {
-            if (DebugTransform)
-            {
-                m_CurrentReplicatedState.OnValueChanged -= OnStateUpdate;
-            }
-
-            base.OnNetworkDespawn();
-        }
-
+#endif       
         /// <summary>
         /// Authoritative State Update
         /// </summary>
-        private void OnStateUpdate(NetworkTransformState oldState, NetworkTransformState newState)
-        {
-            if (DebugTransform)
-            {
-                if (IsOwner && !IsServerAuthoritative() && !m_StopLoggingStates)
-                {
-                    if (IsServer && NetworkManager.ConnectedClientsIds.Count < 2)
-                    {
-                        return;
-                    }
-                    InternalAddLogEntry(ref newState, OwnerClientId);
-                }
-            }
-        }
+        //private void OnStateUpdate(NetworkTransformState oldState, NetworkTransformState newState)
+        //{
+        //    if (DebugTransform)
+        //    {
+        //        if (IsOwner && !IsServerAuthoritative() && !m_StopLoggingStates)
+        //        {
+        //            if (IsServer && NetworkManager.ConnectedClientsIds.Count < 2)
+        //            {
+        //                return;
+        //            }
+        //            InternalAddLogEntry(ref newState, OwnerClientId);
+        //        }
+        //    }
+        //}
 
 #if DEBUG_NETWORKTRANSFORM || UNITY_INCLUDE_TESTS
         /// <summary>

--- a/testproject/Assets/Tests/Manual/Scripts/IntegrationNetworkTransform.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/IntegrationNetworkTransform.cs
@@ -319,23 +319,6 @@ namespace TestProject.ManualTests
             OnNetworkTransformStateUpdate(ref m_NetworkTransformStateUpdate);
         }
 #endif       
-        /// <summary>
-        /// Authoritative State Update
-        /// </summary>
-        //private void OnStateUpdate(NetworkTransformState oldState, NetworkTransformState newState)
-        //{
-        //    if (DebugTransform)
-        //    {
-        //        if (IsOwner && !IsServerAuthoritative() && !m_StopLoggingStates)
-        //        {
-        //            if (IsServer && NetworkManager.ConnectedClientsIds.Count < 2)
-        //            {
-        //                return;
-        //            }
-        //            InternalAddLogEntry(ref newState, OwnerClientId);
-        //        }
-        //    }
-        //}
 
 #if DEBUG_NETWORKTRANSFORM || UNITY_INCLUDE_TESTS
         /// <summary>


### PR DESCRIPTION
**This PR address the following issues:**

- When an owner authoritative client uses half precision with position synchronization, it was possible for the server-host to forward the owner's state updates with already processed NetworkDeltaPosition values.
  - This could cause visual anomalies on non-authoritative remote clients during the collapsing of the position delta into the total local position.
- Due to the non-guaranteed spawn order of NetworkObjects, scale synchronization could potentially not synchronize properly if the child NetworkObject had not yet been parented.
  - Now NetworkTransform will send both local and lossy scale values if scale synchronization is enabled during teleporting and/or the initial synchronization and the NetworkObject is parented. The receiver determines which to apply based on whether the receiver's instance is parented yet (or not) and whether world position stays was used when the NetworkObject was parented.
- NetworkTransform no longer uses NetworkVariables for updating transform state due to the processing cost when updating owner write permission NetworkVariables on the server-host.
  - The NetworkVariable serialization cost of owner authoritative NetworkTransforms was:
    - The deserialization on the server-host side at the beginning of the frame
    - The re-serialization cost for each connected client at the end of the frame
  - With the switch over to named messages, the serialization cost of owner authoritative NetworkTransforms is now:
    - The deserialization on the server-host side at the beginning of the frame
      - The named message payload is forwarded just prior to the host deserializing.

[MTT-7057](https://jira.unity3d.com/browse/MTT-7057)
[MTT-7056](https://jira.unity3d.com/browse/MTT-7056)
[MTT-6971](https://jira.unity3d.com/browse/MTT-6971)

fix: #2628
fix: #2639

## Changelog

- Fixed: Issue with client synchronization of position when using half precision and the delta position reaches the maximum value and is collapsed on the host prior to being forwarded to the non-owner clients.
- Fixed: Issue with scale not synchronizing properly depending upon the spawn order of `NetworkObject`s.
- Fixed: Issue position was not properly transitioning between ownership changes with an owner authoritative `NetworkTransform`.
- Fixed: Issue where a late joining non-owner client could update an owner authoritative `NetworkTransform` if ownership changed without any updates to position prior to the non-owner client joining.

## Testing and Documentation

- Includes new and updated integration tests.
- No documentation changes or additions were necessary.
