### PR TITLE
fix: NetworkBehaviourEditor exception when using the inspector view while in play mode

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -345,8 +345,8 @@ namespace Unity.Netcode.Editor
         /// <param name="networkObjectRemoved">used internally</param>
         public static void CheckForNetworkObject(GameObject gameObject, bool networkObjectRemoved = false)
         {
-            // If there are no NetworkBehaviours or no gameObject, then exit early
-            if (gameObject == null || (gameObject.GetComponent<NetworkBehaviour>() == null && gameObject.GetComponentInChildren<NetworkBehaviour>() == null))
+            // If there are no NetworkBehaviours or no gameObject or we are in play mode and inspecting something, then exit early
+            if (EditorApplication.isPlaying || gameObject == null || (gameObject.GetComponent<NetworkBehaviour>() == null && gameObject.GetComponentInChildren<NetworkBehaviour>() == null))
             {
                 return;
             }

--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -345,7 +345,8 @@ namespace Unity.Netcode.Editor
         /// <param name="networkObjectRemoved">used internally</param>
         public static void CheckForNetworkObject(GameObject gameObject, bool networkObjectRemoved = false)
         {
-            // If there are no NetworkBehaviours or no gameObject or we are in play mode and inspecting something, then exit early
+            // If there are no NetworkBehaviours or gameObjects then exit early
+            // If we are in play mode and a user is inspecting something then exit early (we don't add NetworkObjects to something when in play mode)
             if (EditorApplication.isPlaying || gameObject == null || (gameObject.GetComponent<NetworkBehaviour>() == null && gameObject.GetComponentInChildren<NetworkBehaviour>() == null))
             {
                 return;


### PR DESCRIPTION
This resolves an issue where NetworkBehaviourEditor can throw an exception when viewing a parented child of a GameObject that has been parented under a standard GameObject when in play mode (a valid thing to do). This fix just exits the code that validates a NetworkBehaviour component is on a GameObject with a NetworkObject component or a child of one.

## Changelog

- Fixed: issue where `NetworkBehaviourEditor` could throw an exception when inspecting a `NetworkObject` (or child of) when in play mode.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.
