### PR TITLE
feat: Adds nested NetworkObject support in prefabs

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,6 +10,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
+- Added the ability to spawn prefabs with nested NetworkObjects
+
 ### Fixed
 
 - Fixed issue where `NetworkClient.OwnedObjects` was not returning any owned objects due to the `NetworkClient.IsConnected` not being properly set. (#2631)

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -614,6 +614,11 @@ namespace Unity.Netcode
                         ownerClientId,
                         destroyWithScene: false);
 
+                    foreach (var dependingNetworkObject in networkObject.DependingNetworkObjects)
+                    {
+                        NetworkManager.SpawnManager.SpawnNetworkObjectLocally(dependingNetworkObject, NetworkManager.SpawnManager.GetNetworkObjectId(), false, false, ownerClientId, false);
+                    }
+
                     client.AssignPlayerObject(ref networkObject);
                 }
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1432,15 +1432,12 @@ namespace Unity.Netcode
                 // scene handle that the NetworkObject resides in.
                 writer.WriteValue(OwnerObject.GetSceneOriginHandle());
 
-                { // Synchronize NetworkVariables and NetworkBehaviours
-                    var bufferSerializer = new BufferSerializer<BufferSerializerWriter>(new BufferSerializerWriter(writer));
-                    OwnerObject.SynchronizeNetworkBehaviours(ref bufferSerializer, TargetClientId);
-                }
+                // Synchronize NetworkVariables and NetworkBehaviours
+                var bufferSerializer = new BufferSerializer<BufferSerializerWriter>(new BufferSerializerWriter(writer));
+                OwnerObject.SynchronizeNetworkBehaviours(ref bufferSerializer, TargetClientId);
 
-                // Synchronize NetworkVariables and NetworkBehaviours of depending objects
                 for (int i = 0; i < dependingCount; i++)
                 {
-                    var bufferSerializer = new BufferSerializer<BufferSerializerWriter>(new BufferSerializerWriter(writer));
                     OwnerObject.DependingNetworkObjects[i].SynchronizeNetworkBehaviours(ref bufferSerializer, TargetClientId);
                 }
             }
@@ -1736,18 +1733,18 @@ namespace Unity.Netcode
                 return null;
             }
 
-            {
-                // This will get set again when the NetworkObject is spawned locally, but we set it here ahead of spawning
-                // in order to be able to determine which NetworkVariables the client will be allowed to read.
-                networkObject.OwnerClientId = sceneObject.OwnerClientId;
 
-                // Synchronize NetworkBehaviours
-                var bufferSerializer = new BufferSerializer<BufferSerializerReader>(new BufferSerializerReader(reader));
-                networkObject.SynchronizeNetworkBehaviours(ref bufferSerializer, networkManager.LocalClientId);
+            // This will get set again when the NetworkObject is spawned locally, but we set it here ahead of spawning
+            // in order to be able to determine which NetworkVariables the client will be allowed to read.
+            networkObject.OwnerClientId = sceneObject.OwnerClientId;
 
-                // Spawn the NetworkObject
-                networkManager.SpawnManager.SpawnNetworkObjectLocally(networkObject, sceneObject, sceneObject.DestroyWithScene);
-            }
+            // Synchronize NetworkBehaviours
+            var bufferSerializer = new BufferSerializer<BufferSerializerReader>(new BufferSerializerReader(reader));
+            networkObject.SynchronizeNetworkBehaviours(ref bufferSerializer, networkManager.LocalClientId);
+
+            // Spawn the NetworkObject
+            networkManager.SpawnManager.SpawnNetworkObjectLocally(networkObject, sceneObject, sceneObject.DestroyWithScene);
+
 
             // Repeat Steps for depending NetworkObjects
             for (int i = 0; i < networkObject.DependingNetworkObjects.Count; i++)
@@ -1757,7 +1754,6 @@ namespace Unity.Netcode
 
                 dependingObj.OwnerClientId = sceneObject.OwnerClientId;
 
-                var bufferSerializer = new BufferSerializer<BufferSerializerReader>(new BufferSerializerReader(reader));
                 dependingObj.SynchronizeNetworkBehaviours(ref bufferSerializer, networkManager.LocalClientId);
 
                 networkManager.SpawnManager.SpawnNetworkObjectLocally(dependingObj, dependingObjData.NetworkObjectId, sceneObject.IsSceneObject, false, dependingObjData.OwnerClientId, sceneObject.DestroyWithScene);

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1444,7 +1444,10 @@ namespace Unity.Netcode
 
                 for (int i = 0; i < dependingCount; i++)
                 {
-                    OwnerObject.m_DependingNetworkObjects[i].SynchronizeNetworkBehaviours(ref bufferSerializer, TargetClientId);
+                    if (DependingObjects[i].IsSpawned)
+                    {
+                        OwnerObject.m_DependingNetworkObjects[i].SynchronizeNetworkBehaviours(ref bufferSerializer, TargetClientId);
+                    }
                 }
             }
 
@@ -1765,11 +1768,14 @@ namespace Unity.Netcode
                 var dependingObj = networkObject.m_DependingNetworkObjects[i];
                 var dependingObjData = sceneObject.DependingObjects[i];
 
-                dependingObj.OwnerClientId = sceneObject.OwnerClientId;
+                if (dependingObjData.IsSpawned)
+                {
+                    dependingObj.OwnerClientId = sceneObject.OwnerClientId;
 
-                dependingObj.SynchronizeNetworkBehaviours(ref bufferSerializer, networkManager.LocalClientId);
+                    dependingObj.SynchronizeNetworkBehaviours(ref bufferSerializer, networkManager.LocalClientId);
 
-                networkManager.SpawnManager.SpawnNetworkObjectLocally(dependingObj, dependingObjData.NetworkObjectId, sceneObject.IsSceneObject, false, dependingObjData.OwnerClientId, sceneObject.DestroyWithScene);
+                    networkManager.SpawnManager.SpawnNetworkObjectLocally(dependingObj, dependingObjData.NetworkObjectId, sceneObject.IsSceneObject, false, dependingObjData.OwnerClientId, sceneObject.DestroyWithScene);
+                }
             }
 
             return networkObject;

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1678,9 +1678,16 @@ namespace Unity.Netcode
                     { // Set parentage info
                         NetworkObject parentNetworkObject = null;
 
-                        if (!AlwaysReplicateAsRoot && m_DependingNetworkObjects[i].transform.parent != null)
+                        if (!m_DependingNetworkObjects[i].AlwaysReplicateAsRoot && m_DependingNetworkObjects[i].transform.parent != null)
                         {
                             parentNetworkObject = m_DependingNetworkObjects[i].transform.parent.GetComponent<NetworkObject>();
+
+                            // If a dependent NetworkObject has a parent but not a network parent, the
+                            // HasParent flag needs to be set.
+                            if (parentNetworkObject == null)
+                            {
+                                DependingObjects[i].HasParent = true;
+                            }
                         }
 
                         if (parentNetworkObject != null)

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
@@ -45,6 +45,9 @@ namespace Unity.Netcode
                 // Serialize NetworkVariable data
                 foreach (var sobj in SpawnedObjectsList)
                 {
+                    // Depending Network Objects will be spawned by their Dependent Network Object
+                    if (sobj.DependentNetworkObject != null) { continue; }
+
                     if (sobj.CheckObjectVisibility == null || sobj.CheckObjectVisibility(OwnerClientId))
                     {
                         sobj.Observers.Add(OwnerClientId);

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
@@ -250,7 +250,7 @@ namespace Unity.Netcode
             m_NetworkObjectsSync.Clear();
             foreach (var sobj in m_NetworkManager.SpawnManager.SpawnedObjectsList)
             {
-                if (sobj.Observers.Contains(TargetClientId))
+                if (sobj.Observers.Contains(TargetClientId) && !sobj.IsDependent)
                 {
                     m_NetworkObjectsSync.Add(sobj);
                 }

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -473,6 +473,36 @@ namespace Unity.Netcode
                 {
                     UnityEngine.Object.DontDestroyOnLoad(networkObject.gameObject);
                 }
+
+                // Hook up NetworkObjects that depend on this NetworkObject. Usually used for nested NetworkObjects in prefabs,
+                for (int i = 0; i < sceneObject.DependingObjects.Length; i++)
+                {
+                    var childData = sceneObject.DependingObjects[i];
+                    var childNetworkObject = networkObject.DependingNetworkObjects[i];
+
+                    if (childData.IsSpawned)
+                    {
+                        childNetworkObject.DestroyWithScene = sceneObject.DestroyWithScene;
+                        childNetworkObject.NetworkSceneHandle = sceneObject.NetworkSceneHandle;
+
+                        if (childData.HasParent)
+                        {
+                            // Go ahead and set network parenting properties, if the latest parent is not set then pass in null
+                            // (we always want to set worldPositionStays)
+                            ulong? parentId = null;
+                            if (childData.IsLatestParentSet)
+                            {
+                                parentId = childData.HasParent ? childData.ParentObjectId : default;
+                            }
+                            childNetworkObject.SetNetworkParenting(parentId, true);
+                        }
+                    }
+                    else
+                    {
+                        // Remove unspawned child NetworkObjects
+                        GameObject.Destroy(networkObject.DependingNetworkObjects[i].gameObject);
+                    }
+                }
             }
             return networkObject;
         }
@@ -488,15 +518,6 @@ namespace Unity.Netcode
             if (networkObject.IsSpawned)
             {
                 throw new SpawnStateException("Object is already spawned");
-            }
-
-            if (!sceneObject)
-            {
-                var networkObjectChildren = networkObject.GetComponentsInChildren<NetworkObject>();
-                if (networkObjectChildren.Length > 1)
-                {
-                    Debug.LogError("Spawning NetworkObjects with nested NetworkObjects is only supported for scene objects. Child NetworkObjects will not be spawned over the network!");
-                }
             }
 
             SpawnNetworkObjectLocallyCommon(networkObject, networkId, sceneObject, playerObject, ownerClientId, destroyWithScene);
@@ -820,6 +841,12 @@ namespace Unity.Netcode
             // and only attempt to remove the child's parent on the server-side
             if (!NetworkManager.ShutdownInProgress && NetworkManager.IsServer)
             {
+                // Destroy GameObjects that depend on the despawned GameObject
+                foreach (var dependingNetworkObject in networkObject.DependingNetworkObjects)
+                {
+                    dependingNetworkObject.Despawn();
+                }
+
                 // Move child NetworkObjects to the root when parent NetworkObject is destroyed
                 foreach (var spawnedNetObj in SpawnedObjectsList)
                 {

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -475,33 +475,36 @@ namespace Unity.Netcode
                 }
 
                 // Hook up NetworkObjects that depend on this NetworkObject. Usually used for nested NetworkObjects in prefabs,
-                var DependingNetworkObjects = networkObject.DependingNetworkObjects;
-                for (int i = 0; i < sceneObject.DependingObjects.Length; i++)
+                if (sceneObject.DependingObjects != null)
                 {
-                    var childData = sceneObject.DependingObjects[i];
-                    var childNetworkObject = DependingNetworkObjects[i];
-
-                    if (childData.IsSpawned)
+                    var DependingNetworkObjects = networkObject.DependingNetworkObjects;
+                    for (int i = 0; i < sceneObject.DependingObjects.Length; i++)
                     {
-                        childNetworkObject.DestroyWithScene = sceneObject.DestroyWithScene;
-                        childNetworkObject.NetworkSceneHandle = sceneObject.NetworkSceneHandle;
+                        var childData = sceneObject.DependingObjects[i];
+                        var childNetworkObject = DependingNetworkObjects[i];
 
-                        if (childData.HasParent)
+                        if (childData.IsSpawned)
                         {
-                            // Go ahead and set network parenting properties, if the latest parent is not set then pass in null
-                            // (we always want to set worldPositionStays)
-                            ulong? parentId = null;
-                            if (childData.IsLatestParentSet)
+                            childNetworkObject.DestroyWithScene = sceneObject.DestroyWithScene;
+                            childNetworkObject.NetworkSceneHandle = sceneObject.NetworkSceneHandle;
+
+                            if (childData.HasParent)
                             {
-                                parentId = childData.HasParent ? childData.ParentObjectId : default;
+                                // Go ahead and set network parenting properties, if the latest parent is not set then pass in null
+                                // (we always want to set worldPositionStays)
+                                ulong? parentId = null;
+                                if (childData.IsLatestParentSet)
+                                {
+                                    parentId = childData.HasParent ? childData.ParentObjectId : default;
+                                }
+                                childNetworkObject.SetNetworkParenting(parentId, true);
                             }
-                            childNetworkObject.SetNetworkParenting(parentId, true);
                         }
-                    }
-                    else
-                    {
-                        // Remove unspawned child NetworkObjects
-                        GameObject.Destroy(networkObject.DependingNetworkObjects[i].gameObject);
+                        else
+                        {
+                            // Remove unspawned child NetworkObjects
+                            GameObject.Destroy(networkObject.DependingNetworkObjects[i].gameObject);
+                        }
                     }
                 }
             }

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -488,6 +488,12 @@ namespace Unity.Netcode
                             childNetworkObject.DestroyWithScene = sceneObject.DestroyWithScene;
                             childNetworkObject.NetworkSceneHandle = sceneObject.NetworkSceneHandle;
 
+                            // If a dependent NetworkObject does not have the HasParent flag set, it needs to be unparented
+                            if (!sceneObject.HasParent && childNetworkObject.transform.parent != null)
+                            {
+                                childNetworkObject.ApplyNetworkParenting(true, true);
+                            }
+
                             if (childData.HasParent)
                             {
                                 // Go ahead and set network parenting properties, if the latest parent is not set then pass in null

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -475,10 +475,11 @@ namespace Unity.Netcode
                 }
 
                 // Hook up NetworkObjects that depend on this NetworkObject. Usually used for nested NetworkObjects in prefabs,
+                var DependingNetworkObjects = networkObject.DependingNetworkObjects;
                 for (int i = 0; i < sceneObject.DependingObjects.Length; i++)
                 {
                     var childData = sceneObject.DependingObjects[i];
-                    var childNetworkObject = networkObject.DependingNetworkObjects[i];
+                    var childNetworkObject = DependingNetworkObjects[i];
 
                     if (childData.IsSpawned)
                     {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectDependencyTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectDependencyTests.cs
@@ -1,0 +1,146 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Object = UnityEngine.Object;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    /// <summary>
+    /// Tests ensuring that dependent <see cref="NetworkObject"/>s are functioning properly. Expected behavior:
+    /// - 
+    /// </summary>
+    public class NetworkObjectDependencyTests : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 1;
+
+        private GameObject m_PrefabToSpawn;
+
+        protected override void OnCreatePlayerPrefab()
+        {
+            NetworkObject playerNetworkObject = m_PlayerPrefab.GetComponent<NetworkObject>();
+            GameObject childObject = NetcodeIntegrationTestHelpers.AddNetworkObjectChildToPrefab(playerNetworkObject, "child");
+        }
+
+        protected override void OnServerAndClientsCreated()
+        {
+            m_PrefabToSpawn = CreateNetworkObjectPrefab("PrefabWithChildNetworkObject");
+            NetcodeIntegrationTestHelpers.AddNetworkObjectChildToPrefab(m_PrefabToSpawn.GetComponent<NetworkObject>(), "child");
+        }
+
+        protected override void OnNewClientCreated(NetworkManager networkManager)
+        {
+            var networkPrefab = new NetworkPrefab() { Prefab = m_PrefabToSpawn };
+            networkManager.NetworkConfig.Prefabs.Add(networkPrefab);
+        }
+
+
+        /// <summary>
+        /// Tests that depending <see cref="NetworkObject"/> on a player objects will be synchronized.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestPlayerDependingObjects()
+        {
+            // This is the *SERVER VERSION* of the *CLIENT PLAYER*
+            var serverClientPlayerResult = new NetcodeIntegrationTestHelpers.ResultWrapper<NetworkObject>();
+            yield return NetcodeIntegrationTestHelpers.GetNetworkObjectByRepresentation(x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId, m_ServerNetworkManager, serverClientPlayerResult);
+
+            // This is the *CLIENT VERSION* of the *CLIENT PLAYER*
+            var clientClientPlayerResult = new NetcodeIntegrationTestHelpers.ResultWrapper<NetworkObject>();
+            yield return NetcodeIntegrationTestHelpers.GetNetworkObjectByRepresentation(x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId, m_ClientNetworkManagers[0], clientClientPlayerResult);
+
+            Assert.IsNotNull(serverClientPlayerResult.Result.gameObject);
+            Assert.IsNotNull(clientClientPlayerResult.Result.gameObject);
+
+            var serverClientPlayerChild = serverClientPlayerResult.Result.transform.GetChild(0)?.GetComponent<NetworkObject>();
+            var clientClientPlayerChild = clientClientPlayerResult.Result.transform.GetChild(0)?.GetComponent<NetworkObject>();
+
+            Assert.IsNotNull(serverClientPlayerChild);
+            Assert.IsNotNull(clientClientPlayerChild);
+
+            Assert.IsTrue(serverClientPlayerChild.NetworkObjectId == clientClientPlayerChild.NetworkObjectId); // They should have the same NetworkObjectId
+            Assert.IsTrue(serverClientPlayerChild.NetworkObjectId > default(ulong)); // and that id should have been set 
+        }
+
+        /// <summary>
+        /// Tests that depending <see cref="NetworkObject"/>s can be reparented
+        /// and that the reparenting will be synchronized to late-joining clients.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestDependingObjectReparenting()
+        {
+            var serverDependingInstance = SpawnObject(m_PrefabToSpawn, m_ServerNetworkManager).transform.GetChild(0)?.GetComponent<NetworkObject>();
+            Assert.IsNotNull(serverDependingInstance); // Sanity check
+
+            yield return NetcodeIntegrationTestHelpers.WaitForMessageOfTypeHandled<CreateObjectMessage>(m_ClientNetworkManagers[0]);
+
+            serverDependingInstance.transform.parent = null;
+
+            yield return NetcodeIntegrationTestHelpers.WaitForMessageOfTypeHandled<ParentSyncMessage>(m_ClientNetworkManagers[0]);
+
+            var clientDepending1Instance = s_GlobalNetworkObjects[m_ClientNetworkManagers[0].LocalClientId][serverDependingInstance.NetworkObjectId];
+            Assert.IsNull(clientDepending1Instance.transform.parent); // Make sure the client instance was reparented
+
+            yield return CreateAndStartNewClient();
+
+            var clientDepending2Instance = s_GlobalNetworkObjects[m_ClientNetworkManagers[1].LocalClientId][serverDependingInstance.NetworkObjectId];
+            Assert.IsNull(clientDepending2Instance.transform.parent); // Make sure the late-joining client instance was reparented
+        }
+
+        /// <summary>
+        /// Tests that depending <see cref="NetworkObject"/>s can be deleted,
+        /// and that those deletions will be synchronized across both connected 
+        /// and late-joining clients.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestDependingObjectDeletion()
+        {
+            var serverDependentInstance = SpawnObject(m_PrefabToSpawn, m_ServerNetworkManager).GetComponent<NetworkObject>();
+            var serverDependingInstance = serverDependentInstance.transform.GetChild(0)?.GetComponent<NetworkObject>();
+            Assert.IsNotNull(serverDependingInstance); // Sanity check
+
+            yield return NetcodeIntegrationTestHelpers.WaitForMessageOfTypeHandled<CreateObjectMessage>(m_ClientNetworkManagers[0]);
+
+            var clientDepending1Instance = s_GlobalNetworkObjects[m_ClientNetworkManagers[0].LocalClientId][serverDependingInstance.NetworkObjectId];
+            Object.Destroy(serverDependingInstance.gameObject);
+
+            yield return NetcodeIntegrationTestHelpers.WaitForMessageOfTypeHandled<DestroyObjectMessage>(m_ClientNetworkManagers[0]);
+
+            Assert.IsTrue(clientDepending1Instance == null, "Dependent NetworkObject was not destroyed on connected client.");
+
+            yield return CreateAndStartNewClient();
+
+            Assert.IsTrue(
+                !s_GlobalNetworkObjects[m_ClientNetworkManagers[1].LocalClientId].ContainsKey(serverDependingInstance.NetworkObjectId) ||
+                s_GlobalNetworkObjects[m_ClientNetworkManagers[1].LocalClientId][serverDependingInstance.NetworkObjectId] == null,
+                "Dependent NetworkObject was not destroyed on late-joining client.");
+        }
+
+        /// <summary>
+        /// Tests that deleting <see cref="NetworkObject"/>s also deletes any
+        /// <see cref="NetworkObject"/>s that are dependent on the deleted one.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestDependentObjectDeletion()
+        {
+            var serverDependentInstance = SpawnObject(m_PrefabToSpawn, m_ServerNetworkManager).GetComponent<NetworkObject>();
+            Assert.IsTrue(serverDependentInstance.DependingNetworkObjects.Count > 0); // Make sure the prefab has a dependent NetworkObject
+            var serverDependingInstance = serverDependentInstance.DependingNetworkObjects[0];
+
+            yield return NetcodeIntegrationTestHelpers.WaitForMessageOfTypeHandled<CreateObjectMessage>(m_ClientNetworkManagers[0]);
+
+            var clientDependentInstance = s_GlobalNetworkObjects[m_ClientNetworkManagers[0].LocalClientId][serverDependentInstance.NetworkObjectId];
+            var clientDependingInstance = clientDependentInstance.DependingNetworkObjects[0];
+            Object.Destroy(serverDependentInstance.gameObject);
+
+            yield return NetcodeIntegrationTestHelpers.WaitForMessageOfTypeHandled<DestroyObjectMessage>(m_ClientNetworkManagers[0]); // Wait for parent deleting
+
+            Assert.IsTrue(serverDependentInstance == null, "Dependent NetworkObject was not destroyed on host.");
+            Assert.IsTrue(serverDependingInstance == null, "Depending NetworkObject was not destroyed on host.");
+            Assert.IsTrue(clientDependentInstance == null, "Dependent NetworkObject was not destroyed on connected client.");
+            Assert.IsTrue(clientDependingInstance == null, "Depending NetworkObject was not destroyed on connected client.");
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectDependencyTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectDependencyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 454b226302b5d784f9b15b10c3d516ad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Allows users to spawn nested NetworkObjects in prefabs. This is done using a new dependent NetworkObjects system.

When you spawn a prefab with nested NetworkObjects, all of the nested NetworkObjects will also be spawned/synchronized. These nested NetworkObjects will be dependent on the root NetworkObject. This means they are initially synchronized in the same message as the root NetworkObject, and cannot outlive the root NetworkObject (when the root gets destroyed the depending NetworkObjects will be destroyed as well). Aside from these two exceptions, depending NetworkObjects behave identically to normal NetworkObjects.

To achieve this I made 3 major changes:
1. I added two hidden serialized fields to `NetworkObject` for saving its dependent NetworkObject and depending NetworkObjects. Respectively, these are `m_DependentNetworkObject ` and `m_DependingNetworkObjects`. They are determined in `OnValidate` and have public getters.
2. When `Spawn()` is called on a NetworkObject, it locally spawns depending NetworkObjects as well.
3. The `SceneObject` struct (which contains the data needed to spawn or initially synchronize NetworkObjects) now contains a list of `DependingSceneObject`s. This is a new struct that contains a subset of the properties of `SceneObject` along with a `IsSpawned` boolean.  When a SceneObject is spawned remotely, the information in the `DependingSceneObject` list is used to initialize the depending NetworkObjects. Any `DependingSceneObject` where `IsSpawned` is false has its corresponding NetworkObject destroyed instead of initialized. This occurs when a depending NetworkObject has been destroyed before the NetworkObject it is dependent on.

Resolves #2637

## Changelog

- Added: The ability to spawn (and properly network) prefabs with nested NetworkObjects

## Testing and Documentation

- Adds tests to ensure that:
    1. Player prefabs can have nested NetworkObjects
    2. Depending NetworkObjects are reparented properly
    4. Depending NetworkObjects are deleted properly
    5. Dependent NetworkObjects are deleted properly
