### PR TITLE
feat(NetworkManager): expose methods for clientId to transportId mappings

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -904,6 +904,20 @@ namespace Unity.Netcode
         }
 
         /// <summary>
+        /// Get the transportId from the associated clientId.
+        /// </summary>
+        /// <param name="clientId">The ClientId to get the TransportId from</param>
+        /// <returns></returns>
+        public ulong GetTransportIdFromClientId(ulong clientId) => ConnectionManager.ClientIdToTransportId(clientId);
+
+        /// <summary>
+        /// Get the clientId from the associated transportId.
+        /// </summary>
+        /// <param name="clientId">The TransportId to get the ClientId from</param>
+        /// <returns></returns>
+        public ulong GetClientIdFromTransportId(ulong transportId) => ConnectionManager.TransportIdToClientId(transportId);
+
+        /// <summary>
         /// Disconnects the remote client.
         /// </summary>
         /// <param name="clientId">The ClientId to disconnect</param>


### PR DESCRIPTION
This feature gives access to 2 new get methods in NetworkManager that allow the user to convert between `clientId` and `transportId` and vice versa.

Our use case for this feature was using [Facepunch.Steamworks](https://github.com/Facepunch/Facepunch.Steamworks) and our own twist on the [community transport](https://github.com/Unity-Technologies/multiplayer-community-contributions/tree/main/Transports/com.community.netcode.transport.facepunch) that pairs with it. We need to be able to get the `SteamId` of any connected client from their `clientId` for various reasons, one being server-side saving of client specific data that is then identified via `SteamId`.

This feature resolves #2359.

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->

<!-- Add RFC link here if applicable. -->

## Changelog

- Added: A getter function in NetworkManager that can convert from `clientId` to `transportId` and vice versa.

## Testing and Documentation

- No tests have been added.