### PR TITLE
fix: client not tracking changes to layer weights [MTT-7166]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -7,10 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
 ## [Unreleased]
+### Added
 
 ### Fixed
 
-- Fixed "writing past the end of the buffer" error when calling ResetDirty() on managed network variables that are larger than 256 bytes when serialized.
+- Fixed issue where `NetworkAnimator` was not internally tracking changes to layer weights which prevented proper layer weight synchronization.(#2674)
+- Fixed "writing past the end of the buffer" error when calling ResetDirty() on managed network variables that are larger than 256 bytes when serialized. (#2670)
+
+### Changed
 
 ## [1.5.2] - 2023-07-24
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,7 +11,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where `NetworkAnimator` was not internally tracking changes to layer weights which prevented proper layer weight synchronization.(#2674)
+- Fixed issue where `NetworkAnimator` was not internally tracking changes to layer weights which prevented proper layer weight synchronization back to the original layer weight value. (#2674)
 - Fixed "writing past the end of the buffer" error when calling ResetDirty() on managed network variables that are larger than 256 bytes when serialized. (#2670)
 
 ### Changed

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -1137,6 +1137,7 @@ namespace Unity.Netcode.Components
                 if (m_LayerWeights[animationState.Layer] != animationState.Weight)
                 {
                     m_Animator.SetLayerWeight(animationState.Layer, animationState.Weight);
+                    m_LayerWeights[animationState.Layer] = animationState.Weight;
                 }
             }
 

--- a/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
@@ -495,17 +495,32 @@ namespace TestProject.RuntimeTests
                 animatorTestHelper = AnimatorTestHelper.ServerSideInstance;
             }
 
+            var originalWeight = animatorTestHelper.GetLayerWeight(1);
+
             animatorTestHelper.SetLayerWeight(1, 0.75f);
             // Wait for all instances to update their weight value for layer 1
             success = WaitForConditionOrTimeOutWithTimeTravel(() => AllInstancesSameLayerWeight(ownerShipMode, 1, 0.75f));
             Assert.True(success, $"Timed out waiting for all instances to match weight 0.75 on layer 1!");
 
+            animatorTestHelper.SetLayerWeight(1, originalWeight);
+            // Wait for all instances to update their weight value for layer 1
+            success = WaitForConditionOrTimeOutWithTimeTravel(() => AllInstancesSameLayerWeight(ownerShipMode, 1, originalWeight));
+            Assert.True(success, $"Timed out waiting for all instances to match weight {originalWeight} on layer 1!");
+
+            // Now set the layer weight to 0
+            animatorTestHelper.SetLayerWeight(1, 0.0f);
+
             // Now late join a client
             CreateAndStartNewClientWithTimeTravel();
 
             // Verify the late joined client is synchronized to the changed weight
-            success = WaitForConditionOrTimeOutWithTimeTravel(() => AllInstancesSameLayerWeight(ownerShipMode, 1, 0.75f));
-            Assert.True(success, $"[Late-Join] Timed out waiting for all instances to match weight 0.75 on layer 1!");
+            success = WaitForConditionOrTimeOutWithTimeTravel(() => AllInstancesSameLayerWeight(ownerShipMode, 1, 0.0f));
+            Assert.True(success, $"[Late-Join] Timed out waiting for all instances to match weight 0 on layer 1!");
+
+            animatorTestHelper.SetLayerWeight(1, originalWeight);
+            // Wait for all instances to update their weight value for layer 1
+            success = WaitForConditionOrTimeOutWithTimeTravel(() => AllInstancesSameLayerWeight(ownerShipMode, 1, originalWeight));
+            Assert.True(success, $"Timed out waiting for all instances to match weight {originalWeight} on layer 1!");
 
             AnimatorTestHelper.IsTriggerTest = false;
             VerboseDebug($" ------------------ Weight Test [{ownerShipMode}] Stopping ------------------ ");


### PR DESCRIPTION
This resolves the issue where clients were not applying layer weight changes to their internal layer weight table which prevented clients from detecting layer weight changes back to the original layer weight values.

[MTT-7166](https://jira.unity3d.com/browse/MTT-7166)

fix: #2663

## Changelog

- Fixed: Issue where `NetworkAnimator` was not internally tracking changes to layer weights which prevented proper layer weight synchronization back to the original layer weight value.

## Testing and Documentation

- Includes integration test updates to `NetworkAnimatorTests`.
- No documentation changes or additions were necessary.
