### PR TITLE
feat: per-peer MTU

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -7,7 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
 ## [Unreleased]
+
 ### Added
+
+- Added methods NetworkManager.SetPeerMTU and NetworkManager.GetPeerMTU to be able to set MTU sizes per-peer (#2676)
 
 ### Fixed
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -596,15 +596,15 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// Set the maximum transmission unit for a specific client.
+        /// Set the maximum transmission unit for a specific peer.
         /// This determines the maximum size of a message batch that can be sent to that client.
         /// If not set for any given client, <see cref="MaximumTransmissionUnitSize"/> will be used instead.
         /// </summary>
         /// <param name="clientId"></param>
         /// <param name="size"></param>
-        public void SetClientMTU(ulong clientId, int size)
+        public void SetPeerMTU(ulong clientId, int size)
         {
-            MessageManager.ClientMTUSizes[clientId] = size;
+            MessageManager.PeerMTUSizes[clientId] = size;
         }
 
         /// <summary>
@@ -613,9 +613,9 @@ namespace Unity.Netcode
         /// </summary>
         /// <param name="clientId"></param>
         /// <returns></returns>
-        public int GetClientMTU(ulong clientId)
+        public int GetPeerMTU(ulong clientId)
         {
-            return MessageManager.ClientMTUSizes.GetValueOrDefault(clientId, MessageManager.NonFragmentedMessageMaxSize);
+            return MessageManager.PeerMTUSizes.GetValueOrDefault(clientId, MessageManager.NonFragmentedMessageMaxSize);
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -581,13 +581,41 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Sets the maximum size of a single non-fragmented message (or message batch) passed through the transport.
-        /// This should represent the transport's MTU size, minus any transport-level overhead.
+        /// This should represent the transport's default MTU size, minus any transport-level overhead.
+        /// This value will be used for any remote endpoints that haven't had per-endpoint MTUs set.
+        /// This value is also used as the size of the temporary buffer used when serializing
+        /// a single message (to avoid serializing multiple times when sending to multiple endpoints),
+        /// and thus should be large enough to ensure it can hold each message type.
+        /// This value defaults to 1296.
         /// </summary>
         /// <param name="size"></param>
         public int MaximumTransmissionUnitSize
         {
             set => MessageManager.NonFragmentedMessageMaxSize = value & ~7; // Round down to nearest word aligned size
             get => MessageManager.NonFragmentedMessageMaxSize;
+        }
+
+        /// <summary>
+        /// Set the maximum transmission unit for a specific client.
+        /// This determines the maximum size of a message batch that can be sent to that client.
+        /// If not set for any given client, <see cref="MaximumTransmissionUnitSize"/> will be used instead.
+        /// </summary>
+        /// <param name="clientId"></param>
+        /// <param name="size"></param>
+        public void SetClientMTU(ulong clientId, int size)
+        {
+            MessageManager.ClientMTUSizes[clientId] = size;
+        }
+
+        /// <summary>
+        /// Queries the current MTU size for a client.
+        /// If no MTU has been set for that client, will return <see cref="MaximumTransmissionUnitSize"/>
+        /// </summary>
+        /// <param name="clientId"></param>
+        /// <returns></returns>
+        public int GetClientMTU(ulong clientId)
+        {
+            return MessageManager.ClientMTUSizes.GetValueOrDefault(clientId, MessageManager.NonFragmentedMessageMaxSize);
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -615,7 +615,12 @@ namespace Unity.Netcode
         /// <returns></returns>
         public int GetPeerMTU(ulong clientId)
         {
-            return MessageManager.PeerMTUSizes.GetValueOrDefault(clientId, MessageManager.NonFragmentedMessageMaxSize);
+            if (MessageManager.PeerMTUSizes.TryGetValue(clientId, out var ret))
+            {
+                return ret;
+            }
+
+            return MessageManager.NonFragmentedMessageMaxSize;
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/NetworkMessageManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/NetworkMessageManager.cs
@@ -101,7 +101,7 @@ namespace Unity.Netcode
         public int NonFragmentedMessageMaxSize = DefaultNonFragmentedMessageMaxSize;
         public int FragmentedMessageMaxSize = int.MaxValue;
 
-        public Dictionary<ulong, int> ClientMTUSizes = new Dictionary<ulong, int>();
+        public Dictionary<ulong, int> PeerMTUSizes = new Dictionary<ulong, int>();
 
         internal struct MessageWithHandler
         {
@@ -501,7 +501,7 @@ namespace Unity.Netcode
             m_SendQueues.Remove(clientId);
 
             m_PerClientMessageVersions.Remove(clientId);
-            ClientMTUSizes.Remove(clientId);
+            PeerMTUSizes.Remove(clientId);
         }
 
         internal void CleanupDisconnectedClients()
@@ -686,7 +686,7 @@ namespace Unity.Netcode
                 var startSize = NonFragmentedMessageMaxSize;
                 if (delivery != NetworkDelivery.ReliableFragmentedSequenced)
                 {
-                    maxSize = ClientMTUSizes.GetValueOrDefault(clientId, maxSize);
+                    maxSize = PeerMTUSizes.GetValueOrDefault(clientId, maxSize);
                     startSize = maxSize;
                     if (tmpSerializer.Position >= maxSize)
                     {

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/NetworkMessageManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/NetworkMessageManager.cs
@@ -5,9 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
-using UnityEditor.PackageManager;
 using UnityEngine;
-using UnityEngine.UI;
 
 namespace Unity.Netcode
 {
@@ -686,7 +684,10 @@ namespace Unity.Netcode
                 var startSize = NonFragmentedMessageMaxSize;
                 if (delivery != NetworkDelivery.ReliableFragmentedSequenced)
                 {
-                    maxSize = PeerMTUSizes.GetValueOrDefault(clientId, maxSize);
+                    if (PeerMTUSizes.TryGetValue(clientId, out var clientMaxSize))
+                    {
+                        maxSize = clientMaxSize;
+                    }
                     startSize = maxSize;
                     if (tmpSerializer.Position >= maxSize)
                     {

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageSendingTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageSendingTests.cs
@@ -182,6 +182,64 @@ namespace Unity.Netcode.EditorTests
         }
 
         [Test]
+        public void WhenExceedingPerClientBatchSizeLessThanDefault_NewBatchesAreCreated([Values(500, 1000, 1300, 2000)] int maxMessageSize)
+        {
+            var message = GetMessage();
+            m_MessageManager.NonFragmentedMessageMaxSize = maxMessageSize * 5;
+            var clients = new ulong[]{ 0, 1, 2 };
+            m_MessageManager.ClientConnected(1);
+            m_MessageManager.ClientConnected(2);
+            m_MessageManager.SetVersion(1, XXHash.Hash32(typeof(TestMessage).FullName), 0);
+            m_MessageManager.SetVersion(2, XXHash.Hash32(typeof(TestMessage).FullName), 0);
+
+            for (var i = 0; i < clients.Length; ++i)
+            {
+                m_MessageManager.ClientMTUSizes[clients[i]] = maxMessageSize * (i + 1);
+            }
+
+            var size = UnsafeUtility.SizeOf<TestMessage>() + 2; // MessageHeader packed with this message will be 2 bytes
+            for (var i = 0; i < clients.Length; ++i)
+            {
+                for (var j = 0; j < ((m_MessageManager.ClientMTUSizes[clients[i]] - UnsafeUtility.SizeOf<NetworkBatchHeader>()) / size) + 1; ++j)
+                {
+                    m_MessageManager.SendMessage(ref message, NetworkDelivery.Reliable, clients[i]);
+                }
+            }
+
+            m_MessageManager.ProcessSendQueues();
+            Assert.AreEqual(2 * clients.Length, m_MessageSender.MessageQueue.Count);
+        }
+
+        [Test]
+        public void WhenExceedingPerClientBatchSizeGreaterThanDefault_OnlyOneNewBatcheIsCreated([Values(500, 1000, 1300, 2000)] int maxMessageSize)
+        {
+            var message = GetMessage();
+            m_MessageManager.NonFragmentedMessageMaxSize = 128;
+            var clients = new ulong[]{ 0, 1, 2 };
+            m_MessageManager.ClientConnected(1);
+            m_MessageManager.ClientConnected(2);
+            m_MessageManager.SetVersion(1, XXHash.Hash32(typeof(TestMessage).FullName), 0);
+            m_MessageManager.SetVersion(2, XXHash.Hash32(typeof(TestMessage).FullName), 0);
+
+            for (var i = 0; i < clients.Length; ++i)
+            {
+                m_MessageManager.ClientMTUSizes[clients[i]] = maxMessageSize * (i + 1);
+            }
+
+            var size = UnsafeUtility.SizeOf<TestMessage>() + 2; // MessageHeader packed with this message will be 2 bytes
+            for (var i = 0; i < clients.Length; ++i)
+            {
+                for (var j = 0; j < ((m_MessageManager.ClientMTUSizes[clients[i]] - UnsafeUtility.SizeOf<NetworkBatchHeader>()) / size) + 1; ++j)
+                {
+                    m_MessageManager.SendMessage(ref message, NetworkDelivery.Reliable, clients[i]);
+                }
+            }
+
+            m_MessageManager.ProcessSendQueues();
+            Assert.AreEqual(2 * clients.Length, m_MessageSender.MessageQueue.Count);
+        }
+
+        [Test]
         public void WhenExceedingMTUSizeWithFragmentedDelivery_NewBatchesAreNotCreated([Values(500, 1000, 1300, 2000)] int maxMessageSize)
         {
             var message = GetMessage();

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageSendingTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageSendingTests.cs
@@ -186,7 +186,7 @@ namespace Unity.Netcode.EditorTests
         {
             var message = GetMessage();
             m_MessageManager.NonFragmentedMessageMaxSize = maxMessageSize * 5;
-            var clients = new ulong[]{ 0, 1, 2 };
+            var clients = new ulong[] { 0, 1, 2 };
             m_MessageManager.ClientConnected(1);
             m_MessageManager.ClientConnected(2);
             m_MessageManager.SetVersion(1, XXHash.Hash32(typeof(TestMessage).FullName), 0);
@@ -215,7 +215,7 @@ namespace Unity.Netcode.EditorTests
         {
             var message = GetMessage();
             m_MessageManager.NonFragmentedMessageMaxSize = 128;
-            var clients = new ulong[]{ 0, 1, 2 };
+            var clients = new ulong[] { 0, 1, 2 };
             m_MessageManager.ClientConnected(1);
             m_MessageManager.ClientConnected(2);
             m_MessageManager.SetVersion(1, XXHash.Hash32(typeof(TestMessage).FullName), 0);

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageSendingTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageSendingTests.cs
@@ -194,13 +194,13 @@ namespace Unity.Netcode.EditorTests
 
             for (var i = 0; i < clients.Length; ++i)
             {
-                m_MessageManager.ClientMTUSizes[clients[i]] = maxMessageSize * (i + 1);
+                m_MessageManager.PeerMTUSizes[clients[i]] = maxMessageSize * (i + 1);
             }
 
             var size = UnsafeUtility.SizeOf<TestMessage>() + 2; // MessageHeader packed with this message will be 2 bytes
             for (var i = 0; i < clients.Length; ++i)
             {
-                for (var j = 0; j < ((m_MessageManager.ClientMTUSizes[clients[i]] - UnsafeUtility.SizeOf<NetworkBatchHeader>()) / size) + 1; ++j)
+                for (var j = 0; j < ((m_MessageManager.PeerMTUSizes[clients[i]] - UnsafeUtility.SizeOf<NetworkBatchHeader>()) / size) + 1; ++j)
                 {
                     m_MessageManager.SendMessage(ref message, NetworkDelivery.Reliable, clients[i]);
                 }
@@ -223,13 +223,13 @@ namespace Unity.Netcode.EditorTests
 
             for (var i = 0; i < clients.Length; ++i)
             {
-                m_MessageManager.ClientMTUSizes[clients[i]] = maxMessageSize * (i + 1);
+                m_MessageManager.PeerMTUSizes[clients[i]] = maxMessageSize * (i + 1);
             }
 
             var size = UnsafeUtility.SizeOf<TestMessage>() + 2; // MessageHeader packed with this message will be 2 bytes
             for (var i = 0; i < clients.Length; ++i)
             {
-                for (var j = 0; j < ((m_MessageManager.ClientMTUSizes[clients[i]] - UnsafeUtility.SizeOf<NetworkBatchHeader>()) / size) + 1; ++j)
+                for (var j = 0; j < ((m_MessageManager.PeerMTUSizes[clients[i]] - UnsafeUtility.SizeOf<NetworkBatchHeader>()) / size) + 1; ++j)
                 {
                     m_MessageManager.SendMessage(ref message, NetworkDelivery.Reliable, clients[i]);
                 }


### PR DESCRIPTION
[MTT-7202](https://jira.unity3d.com/browse/MTT-7202)

fix: #2671



## Changelog

- Added: Added methods `NetworkManager.SetPeerMTU` and `NetworkManager.GetPeerMTU` to be able to set MTU sizes per-peer

## Testing and Documentation

- Includes unit tests.
- No documentation changes or additions were necessary.
