### PR TITLE
fix: SpawnWithObservers not honored when EnableSceneManagement is disabled [MTT-7237]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,6 +11,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where `SpawnWithObservers` was not being honored when `NetworkConfig.EnableSceneManagement` was disabled. (#2682)
 - Fixed issue where `NetworkAnimator` was not internally tracking changes to layer weights which prevented proper layer weight synchronization back to the original layer weight value. (#2674)
 - Fixed "writing past the end of the buffer" error when calling ResetDirty() on managed network variables that are larger than 256 bytes when serialized. (#2670)
 - Fixed issue where generation of the `DefaultNetworkPrefabs` asset was not enabled by default. (#2662)

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
@@ -37,6 +37,9 @@ namespace Unity.Netcode
             BytePacker.WriteValueBitPacked(writer, NetworkTick);
 
             uint sceneObjectCount = 0;
+
+            // When SpawnedObjectsList is not null then scene management is disabled. Provide a list of
+            // all observed and spawned NetworkObjects that the approved client needs to synchronize.
             if (SpawnedObjectsList != null)
             {
                 var pos = writer.Position;
@@ -45,7 +48,7 @@ namespace Unity.Netcode
                 // Serialize NetworkVariable data
                 foreach (var sobj in SpawnedObjectsList)
                 {
-                    if (sobj.CheckObjectVisibility == null || sobj.CheckObjectVisibility(OwnerClientId))
+                    if (sobj.SpawnWithObservers && (sobj.CheckObjectVisibility == null || sobj.CheckObjectVisibility(OwnerClientId)))
                     {
                         sobj.Observers.Add(OwnerClientId);
                         var sceneObject = sobj.GetMessageSceneObject(OwnerClientId);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOnSpawnTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOnSpawnTests.cs
@@ -74,6 +74,7 @@ namespace Unity.Netcode.RuntimeTests
                     networkManager.NetworkConfig.Prefabs.Add(networkPrefab);
                 }
             }
+            networkManager.NetworkConfig.EnableSceneManagement = m_ServerNetworkManager.NetworkConfig.EnableSceneManagement;
             base.OnNewClientCreated(networkManager);
         }
 
@@ -82,8 +83,46 @@ namespace Unity.Netcode.RuntimeTests
         /// </summary>
         /// <param name="observerTestTypes">whether to spawn with or without observers</param>
         [UnityTest]
-        public IEnumerator ObserverSpawnTests([Values] ObserverTestTypes observerTestTypes)
+        public IEnumerator ObserverSpawnTests([Values] ObserverTestTypes observerTestTypes, [Values] bool sceneManagement)
         {
+            if (!sceneManagement)
+            {
+                // Disable prefabs to prevent them from being destroyed
+                foreach (var networkPrefab in m_ServerNetworkManager.NetworkConfig.Prefabs.Prefabs)
+                {
+                    networkPrefab.Prefab.SetActive(false);
+                }
+
+                // Shutdown and clean up the current client NetworkManager instances
+                foreach (var networkManager in m_ClientNetworkManagers)
+                {
+                    m_PlayerNetworkObjects[networkManager.LocalClientId].Clear();
+                    m_PlayerNetworkObjects.Remove(networkManager.LocalClientId);
+                    yield return StopOneClient(networkManager, true);
+                }
+
+                // Shutdown and clean up the server NetworkManager instance
+                m_PlayerNetworkObjects[m_ServerNetworkManager.LocalClientId].Clear();
+                yield return StopOneClient(m_ServerNetworkManager);
+
+                // Set the prefabs to active again
+                foreach (var networkPrefab in m_ServerNetworkManager.NetworkConfig.Prefabs.Prefabs)
+                {
+                    networkPrefab.Prefab.SetActive(true);
+                }
+
+                // Disable scene management and start the host
+                m_ServerNetworkManager.NetworkConfig.EnableSceneManagement = false;
+                m_ServerNetworkManager.StartHost();
+                yield return s_DefaultWaitForTick;
+
+                // Create 2 new clients and connect them
+                for (int i = 0; i < NumberOfClients; i++)
+                {
+                    yield return CreateAndStartNewClient();
+                }
+            }
+
             m_ObserverTestType = observerTestTypes;
             var prefabNetworkObject = m_ObserverPrefab.GetComponent<NetworkObject>();
             prefabNetworkObject.SpawnWithObservers = observerTestTypes == ObserverTestTypes.WithObservers;
@@ -129,6 +168,7 @@ namespace Unity.Netcode.RuntimeTests
                 AssertOnTimeout($"{k_WithObserversError} {k_ObserverTestObjName} object!");
             }
         }
+
         /// <summary>
         /// Tests that instantiating a <see cref="NetworkObject"/> and destroying without spawning it
         /// does not run <see cref="NetworkBehaviour.OnNetworkSpawn"/> or <see cref="NetworkBehaviour.OnNetworkSpawn"/>.


### PR DESCRIPTION
This fixes the issue where the `SpawnWithObservers` check was not implemented within `ConnectionApprovedMessage` when scene management is disabled.

[MTT-7237](https://jira.unity3d.com/browse/MTT-7237)

fix: #2680 

## Changelog

- Fixed:  issue where `SpawnWithObservers` was not being honored when `NetworkConfig.EnableSceneManagement` was disabled.

## Testing and Documentation

- Includes update to `NetworkObjectOnSpawnTests.ObserverSpawnTests` to validate this fix.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
