### PR TITLE
fix: NetworkObject component should always precede NetworkBehaviour components [MTT-7216]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,7 +11,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where a `NetworkBehaviour` component's `OnNetworkDespawn` was not being invoked on the host-server side for an in-scene placed `NetworkObject` when a scene was unloaded (during a scene transition) and the `NetworkBehaviour` component was positioned/ordered before the `NetworkObject` component.
+- Fixed issue where a `NetworkBehaviour` component's `OnNetworkDespawn` was not being invoked on the host-server side for an in-scene placed `NetworkObject` when a scene was unloaded (during a scene transition) and the `NetworkBehaviour` component was positioned/ordered before the `NetworkObject` component. (#2685)
 - Fixed issue where `NetworkAnimator` was not internally tracking changes to layer weights which prevented proper layer weight synchronization back to the original layer weight value. (#2674)
 - Fixed "writing past the end of the buffer" error when calling ResetDirty() on managed network variables that are larger than 256 bytes when serialized. (#2670)
 - Fixed issue where generation of the `DefaultNetworkPrefabs` asset was not enabled by default. (#2662)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,6 +11,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where a `NetworkBehaviour` component's `OnNetworkDespawn` was not being invoked on the host-server side for an in-scene placed `NetworkObject` when a scene was unloaded (during a scene transition) and the `NetworkBehaviour` component was positioned/ordered before the `NetworkObject` component.
 - Fixed issue where `NetworkAnimator` was not internally tracking changes to layer weights which prevented proper layer weight synchronization back to the original layer weight value. (#2674)
 - Fixed "writing past the end of the buffer" error when calling ResetDirty() on managed network variables that are larger than 256 bytes when serialized. (#2670)
 - Fixed issue where generation of the `DefaultNetworkPrefabs` asset was not enabled by default. (#2662)

--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -419,7 +419,10 @@ namespace Unity.Netcode.Editor
                 }
             }
 
-            OrderNetworkObject(networkObject);
+            if(networkObject != null)
+            {
+                OrderNetworkObject(networkObject);
+            }            
         }
 
         // Assures the NetworkObject precedes any NetworkBehaviour on the same GameObject as the NetworkObject

--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -1,4 +1,3 @@
-using Codice.Client.Common.GameUI;
 using System;
 using System.Collections.Generic;
 using System.Reflection;

--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -1,3 +1,4 @@
+using Codice.Client.Common.GameUI;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -416,6 +417,45 @@ namespace Unity.Netcode.Editor
                         UnityEditor.SceneManagement.EditorSceneManager.SaveScene(activeScene);
                     }
                 }
+            }
+
+            OrderNetworkObject(networkObject);
+        }
+
+        // Assures the NetworkObject precedes any NetworkBehaviour on the same GameObject as the NetworkObject
+        private static void OrderNetworkObject(NetworkObject networkObject)
+        {
+            var monoBehaviours = networkObject.gameObject.GetComponents<MonoBehaviour>();
+            var networkObjectIndex = 0;
+            var firstNetworkBehaviourIndex = -1;
+            for (int i = 0; i < monoBehaviours.Length; i++)
+            {
+                if (monoBehaviours[i] == networkObject)
+                {
+                    networkObjectIndex = i;
+                    break;
+                }
+
+                var networkBehaviour = monoBehaviours[i] as NetworkBehaviour;
+                if (networkBehaviour != null)
+                {
+                    // Get the index of the first NetworkBehaviour Component
+                    if (firstNetworkBehaviourIndex == -1)
+                    {
+                        firstNetworkBehaviourIndex = i;
+                    }
+                }
+            }
+
+            if (firstNetworkBehaviourIndex != -1 && networkObjectIndex > firstNetworkBehaviourIndex)
+            {
+                var positionsToMove = networkObjectIndex - firstNetworkBehaviourIndex;
+                for (int i = 0; i < positionsToMove; i++)
+                {
+                    UnityEditorInternal.ComponentUtility.MoveComponentUp(networkObject);
+                }
+
+                EditorUtility.SetDirty(networkObject.gameObject);
             }
         }
     }

--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -419,10 +419,10 @@ namespace Unity.Netcode.Editor
                 }
             }
 
-            if(networkObject != null)
+            if (networkObject != null)
             {
                 OrderNetworkObject(networkObject);
-            }            
+            }
         }
 
         // Assures the NetworkObject precedes any NetworkBehaviour on the same GameObject as the NetworkObject

--- a/com.unity.netcode.gameobjects/Tests/Editor/NetworkObjectTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/NetworkObjectTests.cs
@@ -1,7 +1,6 @@
 using System.Text.RegularExpressions;
 using NUnit.Framework;
 using Unity.Netcode.Editor;
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.TestTools;
 


### PR DESCRIPTION
This fixes the issue where it was possible for a `NetworkObject` component to be positioned after `NetworkBehaviour` components which could result in the `NetworkBehaviour `components that preceded the `NetworkObject` component to not have their `OnNetworkDespawn` method invoked on an in-scene placed `NetworkObject` when the scene was unloaded during a scene transition.

[MTT-7216](https://jira.unity3d.com/browse/MTT-7216)

## Changelog

- Fixed: Issue where a `NetworkBehaviour` component's `OnNetworkDespawn` was not being invoked on the host-server side for an in-scene placed `NetworkObject` when a scene was unloaded (during a scene transition) and the `NetworkBehaviour` component was positioned/ordered before the `NetworkObject` component.

## Testing and Documentation

- Includes unit test `NetworkObjectTests.NetworkObjectComponentOrder`
- No documentation changes or additions were necessary.
