### PR TITLE
fix: ClientNetworkTransform ownership change with half precision synchronization issues [MTT-7271]

### DIFF
--- a/com.unity.netcode.gameobjects/Components/NetworkDeltaPosition.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkDeltaPosition.cs
@@ -23,12 +23,18 @@ namespace Unity.Netcode.Components
         internal Vector3 DeltaPosition;
         internal int NetworkTick;
 
+        internal bool SynchronizeBase;
+
         /// <summary>
         /// The serialization implementation of <see cref="INetworkSerializable"/>
         /// </summary>
         public void NetworkSerialize<T>(BufferSerializer<T> serializer) where T : IReaderWriter
         {
             HalfVector3.NetworkSerialize(serializer);
+            if (SynchronizeBase)
+            {
+                serializer.SerializeValue(ref CurrentBasePosition);
+            }
         }
 
         /// <summary>
@@ -164,6 +170,7 @@ namespace Unity.Netcode.Components
             DeltaPosition = Vector3.zero;
             HalfDeltaConvertedBack = Vector3.zero;
             HalfVector3 = new HalfVector3(vector3, axisToSynchronize);
+            SynchronizeBase = false;
             UpdateFrom(ref vector3, networkTick);
         }
 

--- a/com.unity.netcode.gameobjects/Components/NetworkDeltaPosition.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkDeltaPosition.cs
@@ -25,6 +25,8 @@ namespace Unity.Netcode.Components
 
         internal bool SynchronizeBase;
 
+        internal bool CollapsedDeltaIntoBase;
+
         /// <summary>
         /// The serialization implementation of <see cref="INetworkSerializable"/>
         /// </summary>
@@ -128,6 +130,7 @@ namespace Unity.Netcode.Components
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void UpdateFrom(ref Vector3 vector3, int networkTick)
         {
+            CollapsedDeltaIntoBase = false;
             NetworkTick = networkTick;
             DeltaPosition = (vector3 + PrecisionLossDelta) - CurrentBasePosition;
             for (int i = 0; i < HalfVector3.Length; i++)
@@ -142,6 +145,7 @@ namespace Unity.Netcode.Components
                         CurrentBasePosition[i] += HalfDeltaConvertedBack[i];
                         HalfDeltaConvertedBack[i] = 0.0f;
                         DeltaPosition[i] = 0.0f;
+                        CollapsedDeltaIntoBase = true;
                     }
                 }
             }
@@ -171,6 +175,7 @@ namespace Unity.Netcode.Components
             HalfDeltaConvertedBack = Vector3.zero;
             HalfVector3 = new HalfVector3(vector3, axisToSynchronize);
             SynchronizeBase = false;
+            CollapsedDeltaIntoBase = false;
             UpdateFrom(ref vector3, networkTick);
         }
 

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -2632,8 +2632,7 @@ namespace Unity.Netcode.Components
             // If we were the previous owner or the newly assigned owner then reinitialize
             if (current == NetworkManager.LocalClientId || previous == NetworkManager.LocalClientId)
             {
-                Initialize(true);
-
+                InternalInitialization(true);
             }
             base.OnOwnershipChanged(previous, current);
         }
@@ -2663,9 +2662,10 @@ namespace Unity.Netcode.Components
         private int m_HalfFloatTargetTickOwnership;
 
         /// <summary>
-        /// Initializes NetworkTransform when spawned and ownership changes.
+        /// The internal initialzation method to allow for internal API adjustments
         /// </summary>
-        protected void Initialize(bool isOwnershipChange = false)
+        /// <param name="isOwnershipChange"></param>
+        private void InternalInitialization(bool isOwnershipChange = false)
         {
             if (!IsSpawned)
             {
@@ -2701,7 +2701,6 @@ namespace Unity.Netcode.Components
             }
             else
             {
-
                 // Assure we no longer subscribe to the tick event
                 NetworkManager.NetworkTickSystem.Tick -= NetworkTickSystem_Tick;
 
@@ -2722,6 +2721,14 @@ namespace Unity.Netcode.Components
                 m_InternalStatNetVar.Value = m_LocalAuthoritativeNetworkState;
                 OnInitialize(ref m_InternalStatNetVar);
             }
+        }
+
+        /// <summary>
+        /// Initializes NetworkTransform when spawned and ownership changes.
+        /// </summary>
+        protected void Initialize()
+        {
+            InternalInitialization();
         }
 
         /// <inheritdoc/>

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -2541,6 +2541,18 @@ namespace Unity.Netcode.Components
             base.OnDestroy();
         }
 
+        /// <inheritdoc/>
+        public override void OnLostOwnership()
+        {
+            base.OnLostOwnership();
+        }
+
+        /// <inheritdoc/>
+        public override void OnGainedOwnership()
+        {
+            base.OnGainedOwnership();
+        }
+
         protected override void OnOwnershipChanged(ulong previous, ulong current)
         {
             // If we were the previous owner or the newly assigned owner then reinitialize

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -1690,7 +1690,7 @@ namespace Unity.Netcode.Components
                             networkState.NetworkDeltaPosition = m_HalfPositionState;
                             networkState.SynchronizeBaseHalfFloat = false;
                         }
-                        
+
                     }
                     else // If synchronizing is set, then use the current full position value on the server side
                     {
@@ -2855,7 +2855,7 @@ namespace Unity.Netcode.Components
         }
 
 
-        private void UpdateInterpolation(bool isBlend = false )
+        private void UpdateInterpolation(bool isBlend = false)
         {
             // Non-Authority
             if (Interpolate)
@@ -3036,7 +3036,7 @@ namespace Unity.Netcode.Components
 
             var writer = new FastBufferWriter(128, Allocator.Temp);
 
-            var sendMode = m_LocalAuthoritativeNetworkState.IsTeleportingNextFrame | m_LocalAuthoritativeNetworkState.IsSynchronizing ? NetworkDelivery.ReliableFragmentedSequenced : NetworkDelivery.UnreliableSequenced; 
+            var sendMode = m_LocalAuthoritativeNetworkState.IsTeleportingNextFrame | m_LocalAuthoritativeNetworkState.IsSynchronizing ? NetworkDelivery.ReliableFragmentedSequenced : NetworkDelivery.UnreliableSequenced;
 
             using (writer)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -533,6 +533,23 @@ namespace Unity.Netcode
         }
 
         /// <summary>
+        /// Invoked on all clients, override this method to be notified of any
+        /// ownership changes (even if the instance was niether the previous or
+        /// newly assigned current owner). 
+        /// </summary>
+        /// <param name="previous">the previous owner</param>
+        /// <param name="current">the current owner</param>
+        protected virtual void OnOwnershipChanged(ulong previous, ulong current)
+        {
+
+        }
+
+        internal void InternalOnOwnershipChanged(ulong previous, ulong current)
+        {
+            OnOwnershipChanged(previous, current);
+        }
+
+        /// <summary>
         /// Gets called when we loose ownership of this object
         /// </summary>
         public virtual void OnLostOwnership() { }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -753,6 +753,21 @@ namespace Unity.Netcode
             }
         }
 
+        internal void InvokeOwnershipChanged(ulong previous, ulong next)
+        {
+            for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
+            {
+                if (ChildNetworkBehaviours[i].gameObject.activeInHierarchy)
+                {
+                    ChildNetworkBehaviours[i].InternalOnOwnershipChanged(previous, next);
+                }
+                else
+                {
+                    Debug.LogWarning($"{ChildNetworkBehaviours[i].gameObject.name} is disabled! Netcode for GameObjects does not support disabled NetworkBehaviours! The {ChildNetworkBehaviours[i].GetType().Name} component was skipped during ownership assignment!");
+                }
+            }
+        }
+
         internal void InvokeBehaviourOnNetworkObjectParentChanged(NetworkObject parentNetworkObject)
         {
             for (int i = 0; i < ChildNetworkBehaviours.Count; i++)

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ChangeOwnershipMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ChangeOwnershipMessage.cs
@@ -60,6 +60,8 @@ namespace Unity.Netcode
                 }
             }
 
+            networkObject.InvokeOwnershipChanged(originalOwner, OwnerClientId);
+
             networkManager.NetworkMetrics.TrackOwnershipChangeReceived(context.SenderId, networkObject, context.MessageSize);
         }
     }

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -257,6 +257,7 @@ namespace Unity.Netcode
                 throw new SpawnStateException("Object is not spawned");
             }
 
+            var previous = networkObject.OwnerClientId;
             // Assign the new owner
             networkObject.OwnerClientId = clientId;
 
@@ -286,6 +287,12 @@ namespace Unity.Netcode
                     NetworkManager.NetworkMetrics.TrackOwnershipChangeSent(client.Key, networkObject, size);
                 }
             }
+
+            // After we have sent the change ownership message to all client observers, invoke the ownership changed notification.
+            /// !!Important!!
+            /// This gets called specifically *after* sending the ownership message so any additional messages that need to proceed an ownership
+            /// change can be sent from NetworkBehaviours that override the <see cref="NetworkBehaviour.OnOwnershipChanged"></see>
+            networkObject.InvokeOwnershipChanged(previous, clientId);
         }
 
         internal bool HasPrefab(NetworkObject.SceneObject sceneObject)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformStateTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformStateTests.cs
@@ -230,6 +230,11 @@ namespace Unity.Netcode.RuntimeTests
             var gameObject = new GameObject($"Test-{nameof(NetworkTransformStateTests)}.{nameof(TestSyncAxes)}");
             var networkObject = gameObject.AddComponent<NetworkObject>();
             var networkTransform = gameObject.AddComponent<NetworkTransform>();
+
+            var manager = new GameObject($"Test-{nameof(NetworkManager)}.{nameof(TestSyncAxes)}");
+            var networkManager = manager.AddComponent<NetworkManager>();
+            networkObject.NetworkManagerOwner = networkManager;
+
             networkTransform.enabled = false; // do not tick `FixedUpdate()` or `Update()`
 
             var initialPosition = Vector3.zero;
@@ -269,6 +274,7 @@ namespace Unity.Netcode.RuntimeTests
 
                 if (syncPosX || syncPosY || syncPosZ || syncRotX || syncRotY || syncRotZ || syncScaX || syncScaY || syncScaZ)
                 {
+                    Assert.IsTrue(networkTransform.NetworkManager != null, "NetworkManager is NULL!");
                     Assert.IsTrue(networkTransform.ApplyTransformToNetworkState(ref networkTransformState, 0, networkTransform.transform));
                 }
             }
@@ -714,6 +720,7 @@ namespace Unity.Netcode.RuntimeTests
             }
 
             Object.DestroyImmediate(gameObject);
+            Object.DestroyImmediate(manager);
         }
 
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -588,6 +588,7 @@ namespace Unity.Netcode.RuntimeTests
             success = WaitForConditionOrTimeOutWithTimeTravel(AllChildObjectInstancesHaveChild);
             Assert.True(success, "Timed out waiting for all instances to have parented a child!");
 
+            TimeTravelToNextTick();
             // This validates each child instance has preserved their local space values
             AllChildrenLocalTransformValuesMatch(false);
 
@@ -689,7 +690,7 @@ namespace Unity.Netcode.RuntimeTests
 
         private Precision m_Precision = Precision.Full;
         private float m_CurrentHalfPrecision = 0.0f;
-        private const float k_HalfPrecisionPosScale = 0.03f;
+        private const float k_HalfPrecisionPosScale = 0.041f;
         private const float k_HalfPrecisionRot = 0.725f;
 
         protected override float GetDeltaVarianceThreshold()

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -470,7 +470,7 @@ namespace Unity.Netcode.RuntimeTests
                     var childLocalRotation = childInstance.transform.localRotation.eulerAngles;
                     var childLocalScale = childInstance.transform.localScale;
                     // Adjust approximation based on precision
-                    if (m_Precision == Precision.Half)
+                    if (m_Precision == Precision.Half || m_RotationCompression == RotationCompression.QuaternionCompress)
                     {
                         m_CurrentHalfPrecision = k_HalfPrecisionPosScale;
                     }
@@ -486,7 +486,7 @@ namespace Unity.Netcode.RuntimeTests
                     }
 
                     // Adjust approximation based on precision
-                    if (m_Precision == Precision.Half)
+                    if (m_Precision == Precision.Half || m_RotationCompression == RotationCompression.QuaternionCompress)
                     {
                         m_CurrentHalfPrecision = k_HalfPrecisionRot;
                     }
@@ -523,6 +523,7 @@ namespace Unity.Netcode.RuntimeTests
         {
             // Set the precision being used for threshold adjustments
             m_Precision = precision;
+            m_RotationCompression = rotationCompression;
 
             // Get the NetworkManager that will have authority in order to spawn with the correct authority
             var isServerAuthority = m_Authority == Authority.ServerAuthority;
@@ -577,6 +578,9 @@ namespace Unity.Netcode.RuntimeTests
 
             // Allow one tick for authority to update these changes
             TimeTravelToNextTick();
+            success = WaitForConditionOrTimeOutWithTimeTravel(PositionRotationScaleMatches);
+
+            Assert.True(success, "All transform values did not match prior to parenting!");
 
             // Parent the child under the parent with the current world position stays setting
             Assert.True(serverSideChild.TrySetParent(serverSideParent.transform, worldPositionStays), "[Server-Side Child] Failed to set child's parent!");
@@ -689,6 +693,7 @@ namespace Unity.Netcode.RuntimeTests
         }
 
         private Precision m_Precision = Precision.Full;
+        private RotationCompression m_RotationCompression = RotationCompression.None;
         private float m_CurrentHalfPrecision = 0.0f;
         private const float k_HalfPrecisionPosScale = 0.041f;
         private const float k_HalfPrecisionRot = 0.725f;


### PR DESCRIPTION
This PR resolves an issue with owner to host-server ownership transfer where the synchronization could get corrupted by noise due to:

- The ownership message would proceed the NetworkTransform initialization message when transferring ownership from a client to a host when the ownership message should precede the NetworkTransform initialization message.
- In transit NetworkTransform states from the client owner could get forwarded back to the client owner after ownership had already been transferred (on the host-server side) back to the host which would introduce echo "noise" of previous state updates by the original client owner.
- Some client owner generated state updates could be skipped/ignored due to an edge case scenario where the client side network tick was the same even though the next tick event had been triggered.

fix: #2628

## Changelog

- Fixed: WIP

## Testing and Documentation

- Includes integration test (WIP)
- No documentation changes or additions were necessary.
