### PR TITLE
fix: GlobalObjectIdHash Generation (missed changes)

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -51,6 +51,7 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Object Types <see href="https://docs.unity3d.com/ScriptReference/GlobalObjectId.html"/>
+        /// Parameter 0 of <see cref="k_GlobalIdTemplate"/>
         /// </summary>
         // 0 = Null (when considered a null object type we can ignore)
         // 1 = Imported Asset
@@ -147,8 +148,6 @@ namespace Unity.Netcode
                         // We must invoke this in order for the modifications to get saved with the scene (does not mark scene as dirty)
                         PrefabUtility.RecordPrefabInstancePropertyModifications(this);
                     }
-
-                    NetworkObjectRefreshTool.ProcessScene(gameObject.scene.path);
                 }
                 else // Otherwise, this is a standard network prefab asset so we just mark it dirty for the AssetDatabase to update it
                 {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -99,11 +99,6 @@ namespace Unity.Netcode
 
         private void OnValidate()
         {
-            GenerateGlobalObjectIdHash();
-        }
-
-        internal void GenerateGlobalObjectIdHash()
-        {
             // do NOT regenerate GlobalObjectIdHash for NetworkPrefabs while Editor is in PlayMode
             if (EditorApplication.isPlaying && !string.IsNullOrEmpty(gameObject.scene.name))
             {


### PR DESCRIPTION
There were two updates to #2707 that did not get merged.

## Changelog
NA

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
