### PR TITLE
fix: Active scene not being added to server side NetworkSceneManager scenes loaded [MTT-7537]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -18,6 +18,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Added `NetworkVariableBase.MarkNetworkBehaviourDirty` so that user-created network variable types can mark their containing `NetworkBehaviour` to be processed by the update loop. (#2694)
 
 ### Fixed
+
+- Fixed issue where the server side `NetworkSceneManager` instance was not adding the currently active scene to its list of scenes loaded. (#2723)
 - Generic NetworkBehaviour types no longer result in compile errors or runtime errors (#2720)
 - Rpcs within Generic NetworkBehaviour types can now serialize parameters of the class's generic types (but may not have generic types of their own) (#2720)
 - Errors are no longer thrown when entering play mode with domain reload disabled (#2720)

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -740,6 +740,14 @@ namespace Unity.Netcode
             // Since NetworkManager is now always migrated to the DDOL we will use this to get the DDOL scene
             DontDestroyOnLoadScene = networkManager.gameObject.scene;
 
+            // Since the server tracks loaded scenes, we need to add the currently active scene
+            // to the list of scenes that can be unloaded.
+            if (networkManager.IsServer)
+            {
+                var activeScene = SceneManager.GetActiveScene();
+                ScenesLoaded.Add(activeScene.handle, activeScene);
+            }
+
             // Add to the server to client scene handle table
             UpdateServerClientSceneHandle(DontDestroyOnLoadScene.handle, DontDestroyOnLoadScene.handle, DontDestroyOnLoadScene);
         }

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
@@ -913,6 +913,9 @@ namespace Unity.Netcode.TestHelpers.Runtime
             if (CoroutineRunner == null)
             {
                 CoroutineRunner = new GameObject("UnitTestSceneHandlerCoroutine").AddComponent<CoroutineRunner>();
+                // Move the CoroutineRunner into the DDOL in case we unload the scene it was instantiated in.
+                // (which if that gets destroyed then it basically stops all integration test queue processing)
+                Object.DontDestroyOnLoad(CoroutineRunner);
             }
         }
 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -886,7 +886,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
         {
             IntegrationTestSceneHandler.CanClientsLoad += ClientSceneHandler_CanClientsLoad;
             IntegrationTestSceneHandler.CanClientsUnload += ClientSceneHandler_CanClientsUnload;
-            NetcodeIntegrationTestHelpers.RegisterSceneManagerHandler(m_ServerNetworkManager, true);
         }
 
         private bool ClientSceneHandler_CanClientsUnload()

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
@@ -165,7 +165,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
             if (!networkManager.IsServer || networkManager.IsServer && serverSideSceneManager)
             {
-                RegisterSceneManagerHandler(networkManager);
+                // Pass along the serverSideSceneManager property (otherwise the server won't register properly)
+                RegisterSceneManagerHandler(networkManager, serverSideSceneManager);
             }
         }
 
@@ -405,7 +406,10 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 // scene to synchronize NetworkObjects.  Next, add the currently active test runner scene to the scenes
                 // loaded and register the server to client scene handle since host-server shares the test runner scene
                 // with the clients.
-                networkManager.SceneManager.GetAndAddNewlyLoadedSceneByName(scene.name);
+                if (!networkManager.SceneManager.ScenesLoaded.ContainsKey(scene.handle))
+                {
+                    networkManager.SceneManager.ScenesLoaded.Add(scene.handle, scene);
+                }
                 networkManager.SceneManager.ServerSceneHandleToClientSceneHandle.Add(scene.handle, scene.handle);
             }
         }
@@ -443,8 +447,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
             server.ConnectionManager.MessageManager.Hook(hooks);
             s_Hooks[server] = hooks;
 
-            // if set, then invoke this for the server
-            RegisterHandlers(server);
+            // Register the server side handler (always pass true for server)
+            RegisterHandlers(server, true);
 
             callback?.Invoke();
 

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerFixValidationTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerFixValidationTests.cs
@@ -199,9 +199,6 @@ namespace TestProject.RuntimeTests
         [UnityTest]
         public IEnumerator InitialActiveSceneUnload()
         {
-            m_EnableVerboseDebug = true;
-
-            IntegrationTestSceneHandler.VerboseDebugMode = true;
             SceneManager.sceneLoaded += SceneManager_sceneLoaded;
             SceneManager.LoadScene(k_SceneToLoad, LoadSceneMode.Additive);
 


### PR DESCRIPTION
This resolves the issue where the server side NetworkSceneManager instance was not adding the currently active scene to its list of scenes loaded which would result in a permanently scene event in progress state if you:
- Had a scene already loaded (Scene1) prior to starting the server-host
- Loaded another scene (Scene2) additively after starting the server-host and then setting the newly loaded scene as the currently active scene.
- Then unloaded the first scene (Scene1).
Any attempt to load or unload a scene after this point would fail.

[MTT-7537](https://jira.unity3d.com/browse/MTT-7537)

fix: #2722

## Changelog

- Fixed: Issue where the server side `NetworkSceneManager` instance was not adding the currently active scene to its list of scenes loaded.

## Testing and Documentation

- Includes integration test: `NetworkSceneManagerFixValidationTests.InitialActiveSceneUnload`
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
