### PR TITLE
fix: Fix for objects being spawned into a scene which is currently loading in on clients. [MTT-7539]

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1806,7 +1806,14 @@ namespace Unity.Netcode
             // Clients need to update the NetworkSceneHandle
             if (!NetworkManager.IsServer && NetworkManager.SceneManager.ClientSceneHandleToServerSceneHandle.ContainsKey(SceneOriginHandle))
             {
-                NetworkSceneHandle = NetworkManager.SceneManager.ClientSceneHandleToServerSceneHandle[SceneOriginHandle];
+                // If the object is part of the DontDestroyOnLoad scene and the objects NetworkSceneHandle currently has a
+                // 'loading' scene event in progress, we leave the NetworkSceneHandle as is, this will allow it to be moved
+                // to the correct scene when the 'loading' event completes
+
+                if ( !( gameObject.scene.buildIndex == -1 && NetworkManager.SceneManager.IsSceneEventInProgressForScene(NetworkSceneHandle, new[] {SceneEventType.Synchronize, SceneEventType.Load })) )
+                {
+                    NetworkSceneHandle = NetworkManager.SceneManager.ClientSceneHandleToServerSceneHandle[SceneOriginHandle];
+                }
             }
             else if (NetworkManager.IsServer)
             {

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -2542,6 +2542,22 @@ namespace Unity.Netcode
             EndSceneEvent(sceneEvent.SceneEventId);
         }
 
+        /// <summary>
+        /// Query if a scene event is in progress for a specific NetworkSceneHandle
+        /// </summary>
+        internal bool IsSceneEventInProgressForScene( int networkSceneHandle, SceneEventType[] validEventTypes = null )
+        {
+            foreach ( var sceneEvent in SceneEventDataStore.Values )
+            {
+                if ( validEventTypes == null || validEventTypes.Contains(sceneEvent.SceneEventType ) )
+                {
+                    return sceneEvent.NetworkSceneHandle == networkSceneHandle || sceneEvent.SceneHandlesToSynchronize.Contains((uint)networkSceneHandle);
+                }
+            }
+
+            return false;
+        }
+
         // Used to handle client-side scene migration messages received while
         // a client is synchronizing
         internal struct DeferredObjectsMovedEvent


### PR DESCRIPTION
Fixes the issue where scene load and object spawns for that scene are actioned on the client at the same time.  The object spawns will complete before the scene is loaded and they are added to the wrong scene causing a fatal error.

[MTT-7539](https://jira.unity3d.com/browse/MTT-7539)

## Changelog

- Fixed: Spawing objects for a currently loading scene on clients

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

