### PR TITLE
fix: Parented in-scene objects under dynamically spawned objects are destroyed when the network session ends but original scene remains loaded. [MTT-7560]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -5,15 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
-## [Unreleased]
-
-### Added
-
-### Fixed
-
-- Fixed issue where a parented in-scene placed NetworkObject would be destroyed upon a client or server exiting a network session but not unloading the original scene in which the NetworkObject was placed. (#2737)
-
-### Changed
 
 ## [Unreleased]
 
@@ -28,23 +19,26 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Added `SceneEventProgress.SceneManagementNotEnabled` return status to be returned when a `NetworkSceneManager` method is invoked and scene management is not enabled. (#2735)
 - Added `SceneEventProgress.ServerOnlyAction` return status to be returned when a `NetworkSceneManager` method is invoked by a client. (#2735)
 
-### Changed
-
-- `NetworkManager.ConnectedClientsIds` is now accessible on the client side and will contain the list of all clients in the session, including the host client if the server is operating in host mode (#2762)
-
 ### Fixed
 
-- Fixed a bug where having a class with Rpcs that inherits from a class without Rpcs that inherits from NetworkVariable would cause a compile error. (#2751)
-- Fixed issue where during client synchronization and scene loading, when client synchronization or the scene loading mode are set to `LoadSceneMode.Single`, a `CreateObjectMessage` could be received, processed, and the resultant spawned `NetworkObject` could be instantiated in the client's currently active scene that could, towards the end of the client synchronization or loading process, be unloaded and cause the newly created `NetworkObject` to be destroyed (and throw and exception). (#2735)
-- Fixed issue where `NetworkBehaviour.Synchronize` was not truncating the write buffer if nothing was serialized during `NetworkBehaviour.OnSynchronize` causing an additional 6 bytes to be written per `NetworkBehaviour` component instance. (#2749)
 - Fixed issue where a parented in-scene placed NetworkObject would be destroyed upon a client or server exiting a network session but not unloading the original scene in which the NetworkObject was placed. (#2737)
 - Fixed issue where during client synchronization and scene loading, when client synchronization or the scene loading mode are set to `LoadSceneMode.Single`, a `CreateObjectMessage` could be received, processed, and the resultant spawned `NetworkObject` could be instantiated in the client's currently active scene that could, towards the end of the client synchronization or loading process, be unloaded and cause the newly created `NetworkObject` to be destroyed (and throw and exception). (#2735)
 - Fixed issue where a `NetworkTransform` instance with interpolation enabled would result in wide visual motion gaps (stuttering) under above normal latency conditions and a 1-5% or higher packet are drop rate. (#2713)
 
 ### Changed
+
+- `NetworkManager.ConnectedClientsIds` is now accessible on the client side and will contain the list of all clients in the session, including the host client if the server is operating in host mode (#2762)
+- Changed `NetworkSceneManager` to return a `SceneEventProgress` status and not throw exceptions for methods invoked when scene management is disabled and when a client attempts to access a `NetworkSceneManager` method by a client. (#2735)
 - Changed `NetworkTransform` authoritative instance tick registration so a single `NetworkTransform` specific tick event update will update all authoritative instances to improve perofmance. (#2713)
 
-- Changed `NetworkSceneManager` to return a `SceneEventProgress` status and not throw exceptions for methods invoked when scene management is disabled and when a client attempts to access a `NetworkSceneManager` method by a client. (#2735)
+## [1.7.1] - 2023-11-15
+
+### Added
+
+### Fixed
+
+- Fixed a bug where having a class with Rpcs that inherits from a class without Rpcs that inherits from NetworkVariable would cause a compile error. (#2751)
+- Fixed issue where `NetworkBehaviour.Synchronize` was not truncating the write buffer if nothing was serialized during `NetworkBehaviour.OnSynchronize` causing an additional 6 bytes to be written per `NetworkBehaviour` component instance. (#2749)
 
 ## [1.7.0] - 2023-10-11
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -5,21 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
-
-## [1.7.0] - 2023-10-11
+## [Unreleased]
 
 ### Added
-
 
 ### Fixed
 
 - Fixed issue where a parented in-scene placed NetworkObject would be destroyed upon a client or server exiting a network session but not unloading the original scene in which the NetworkObject was placed. (#2737)
-- Fixed issue where during client synchronization and scene loading, when client synchronization or the scene loading mode are set to `LoadSceneMode.Single`, a `CreateObjectMessage` could be received, processed, and the resultant spawned `NetworkObject` could be instantiated in the client's currently active scene that could, towards the end of the client synchronization or loading process, be unloaded and cause the newly created `NetworkObject` to be destroyed (and throw and exception). (#2735)
 
 ### Changed
 
-
-## [1.7.0]
+## [1.7.0] - 2023-10-11
 
 ### Added
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,6 +10,19 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
+
+### Fixed
+
+- Fixed issue where a parented in-scene placed NetworkObject would be destroyed upon a client or server exiting a network session but not unloading the original scene in which the NetworkObject was placed. (#2737)
+- Fixed issue where during client synchronization, when set to LoadSceneMode.Single, a CreateObjectMessage could be received, processed, and the resultant spawned NetworkObject could be instantiated in the client's currently active scene that could, towards the end of the client synchronization process, be unloaded and cause the newly created NetworkObject to be destroyed (and throw and exception). (#2735)
+
+### Changed
+
+
+## [1.7.0]
+
+### Added
+
 - exposed NetworkObject.GetNetworkBehaviourAtOrderIndex as a public API (#2724)
 - Added context menu tool that provides users with the ability to quickly update the GlobalObjectIdHash value for all in-scene placed prefab instances that were created prior to adding a NetworkObject component to it. (#2707)
 - Added methods NetworkManager.SetPeerMTU and NetworkManager.GetPeerMTU to be able to set MTU sizes per-peer (#2676)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -14,7 +14,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Fixed
 
 - Fixed issue where a parented in-scene placed NetworkObject would be destroyed upon a client or server exiting a network session but not unloading the original scene in which the NetworkObject was placed. (#2737)
-- Fixed issue where during client synchronization, when set to LoadSceneMode.Single, a CreateObjectMessage could be received, processed, and the resultant spawned NetworkObject could be instantiated in the client's currently active scene that could, towards the end of the client synchronization process, be unloaded and cause the newly created NetworkObject to be destroyed (and throw and exception). (#2735)
+- Fixed issue where during client synchronization and scene loading, when client synchronization or the scene loading mode are set to `LoadSceneMode.Single`, a `CreateObjectMessage` could be received, processed, and the resultant spawned `NetworkObject` could be instantiated in the client's currently active scene that could, towards the end of the client synchronization or loading process, be unloaded and cause the newly created `NetworkObject` to be destroyed (and throw and exception). (#2735)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -979,7 +979,7 @@ namespace Unity.Netcode
             // - This instance is not spawned and the parent is.
             // Basically, don't allow parenting when either the child or parent is not spawned.
             // Caveat: if the parent is null then we can allow parenting whether the instance is or is not spawned.
-            if (parent != null && (IsSpawned && !parent.IsSpawned || !IsSpawned && parent.IsSpawned))
+            if (parent != null && (IsSpawned ^ parent.IsSpawned))
             {
                 return false;
             }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -974,9 +974,9 @@ namespace Unity.Netcode
                 return false;
             }
 
-            // If the parent is not null fail only if:
-            // If this instance is spawned and the parent is not.
-            // If this instance is not spawned and the parent is.
+            // If the parent is not null fail only if either of the two is true:
+            // - This instance is spawned and the parent is not.
+            // - This instance is not spawned and the parent is.
             // Basically, don't allow parenting when either the child or parent is not spawned.
             // Caveat: if the parent is null then we can allow parenting whether the instance is or is not spawned.
             if (parent != null && (IsSpawned && !parent.IsSpawned || !IsSpawned && parent.IsSpawned))

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -745,9 +745,10 @@ namespace Unity.Netcode
                                 {
                                     continue;
                                 }
-                                // If the child is an in-scene placed NetworkObject and we are a client or we are a server and the child should not destroy with the owner,
-                                // then remove the child from the parent and set its parent to root
-                                if (childObject.IsSceneObject != null && childObject.IsSceneObject.Value && (!NetworkManager.IsServer || NetworkManager.IsServer && childObject.DontDestroyWithOwner))
+
+                                // If the child is an in-scene placed NetworkObject then remove the child from the parent (which was dynamically spawned)
+                                // and set its parent to root
+                                if (childObject.IsSceneObject != null && childObject.IsSceneObject.Value)
                                 {
                                     childObject.TryRemoveParent(childObject.WorldPositionStays());
                                 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectDestroyTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectDestroyTests.cs
@@ -58,6 +58,9 @@ namespace Unity.Netcode.RuntimeTests
             ShuttingDown,
             ActiveSession
         }
+
+        private string m_ClientPlayerName;
+        private ulong m_ClientNetworkObjectId;
         /// <summary>
         /// Validates the expected behavior when the client-side destroys a <see cref="NetworkObject"/>
         /// </summary>
@@ -78,7 +81,8 @@ namespace Unity.Netcode.RuntimeTests
                 LogAssert.ignoreFailingMessages = true;
                 NetworkLog.NetworkManagerOverride = m_ClientNetworkManagers[0];
             }
-
+            m_ClientPlayerName = clientPlayer.gameObject.name;
+            m_ClientNetworkObjectId = clientPlayer.NetworkObjectId;
             Object.DestroyImmediate(clientPlayer.gameObject);
 
             // destroying a NetworkObject while a session is active is not allowed
@@ -91,12 +95,12 @@ namespace Unity.Netcode.RuntimeTests
 
         private bool HaveLogsBeenReceived()
         {
-            if (!NetcodeLogAssert.HasLogBeenReceived(LogType.Error, "[Netcode] Destroy a spawned NetworkObject on a non-host client is not valid. Call Destroy or Despawn on the server/host instead."))
+            if (!NetcodeLogAssert.HasLogBeenReceived(LogType.Error, $"[Netcode] [Invalid Destroy][{m_ClientPlayerName}][NetworkObjectId:{m_ClientNetworkObjectId}] Destroy a spawned {nameof(NetworkObject)} on a non-host client is not valid. Call Destroy or Despawn on the server/host instead."))
             {
                 return false;
             }
 
-            if (!NetcodeLogAssert.HasLogBeenReceived(LogType.Error, $"[Netcode-Server Sender={m_ClientNetworkManagers[0].LocalClientId}] Destroy a spawned NetworkObject on a non-host client is not valid. Call Destroy or Despawn on the server/host instead."))
+            if (!NetcodeLogAssert.HasLogBeenReceived(LogType.Error, $"[Netcode-Server Sender={m_ClientNetworkManagers[0].LocalClientId}] [Invalid Destroy][{m_ClientPlayerName}][NetworkObjectId:{m_ClientNetworkObjectId}] Destroy a spawned {nameof(NetworkObject)} on a non-host client is not valid. Call Destroy or Despawn on the server/host instead."))
             {
                 return false;
             }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -588,7 +588,10 @@ namespace Unity.Netcode.RuntimeTests
             success = WaitForConditionOrTimeOutWithTimeTravel(AllChildObjectInstancesHaveChild);
             Assert.True(success, "Timed out waiting for all instances to have parented a child!");
 
+            // Provide two network ticks for interpolation to finalize
             TimeTravelToNextTick();
+            TimeTravelToNextTick();
+
             // This validates each child instance has preserved their local space values
             AllChildrenLocalTransformValuesMatch(false);
 

--- a/testproject/Assets/Tests/Runtime/SceneObjectsNotDestroyedOnShutdownTest.cs
+++ b/testproject/Assets/Tests/Runtime/SceneObjectsNotDestroyedOnShutdownTest.cs
@@ -114,7 +114,7 @@ namespace TestProject.RuntimeTests
 
         private bool PlayerNoLongerExistsWithChildren(ulong clientId)
         {
-            if (m_PlayerNetworkObjects[0].ContainsKey(clientId))
+            if (m_PlayerNetworkObjects[0].ContainsKey(clientId) && m_PlayerNetworkObjects[0][clientId] != null)
             {
                 return m_PlayerNetworkObjects[0][clientId].transform.childCount == 0;
             }

--- a/testproject/Assets/Tests/Runtime/SceneObjectsNotDestroyedOnShutdownTest.cs
+++ b/testproject/Assets/Tests/Runtime/SceneObjectsNotDestroyedOnShutdownTest.cs
@@ -1,5 +1,3 @@
-
-using System;
 using System.Collections;
 using System.Linq;
 using NUnit.Framework;
@@ -12,136 +10,59 @@ using Object = UnityEngine.Object;
 
 namespace TestProject.RuntimeTests
 {
-    public class SceneObjectsNotDestroyedOnShutdownTest
+    public class SceneObjectsNotDestroyedOnShutdownTest : NetcodeIntegrationTest
     {
+        protected override int NumberOfClients => 0;
+
         private const string k_TestScene = "InSceneNetworkObject";
         private const string k_SceneObjectName = "InSceneObject";
         private Scene m_TestScene;
-        private NetworkManager m_ClientNetworkManager;
-        private GameObject m_NetworkManagerGameObject;
         private WaitForSeconds m_DefaultWaitForTick = new WaitForSeconds(1.0f / 30);
-
-        [SetUp]
-        public void Setup()
-        {
-            m_NetworkManagerGameObject = new GameObject();
-            m_ClientNetworkManager = m_NetworkManagerGameObject.AddComponent<NetworkManager>();
-            m_ClientNetworkManager.NetworkConfig = new NetworkConfig
-            {
-                NetworkTransport = m_NetworkManagerGameObject.AddComponent<BlankTestingTransport>()
-            };
-            SceneManager.sceneLoaded += SceneManager_sceneLoaded;
-            SceneManager.LoadSceneAsync(k_TestScene, LoadSceneMode.Additive);
-        }
-
-        private void SceneManager_sceneLoaded(Scene scene, LoadSceneMode loadSceneMode)
-        {
-            if (scene.name == k_TestScene)
-            {
-                m_TestScene = scene;
-            }
-        }
 
         [UnityTest]
         public IEnumerator SceneObjectsNotDestroyedOnShutdown()
         {
-            var timeoutHelper = new TimeoutHelper(2);
+            m_ServerNetworkManager.SceneManager.OnSceneEvent += SceneManager_OnSceneEvent;
+            m_ServerNetworkManager.SceneManager.LoadScene(k_TestScene, LoadSceneMode.Additive);
 
-            // Wait for the scene with the in-scene placed NetworkObject to be loaded.
-            yield return NetcodeIntegrationTest.WaitForConditionOrTimeOut(() => m_TestScene.IsValid() && m_TestScene.isLoaded, timeoutHelper);
-            Assert.False(timeoutHelper.TimedOut, "Timed out waiting for scene to load!");
+            yield return WaitForConditionOrTimeOut(() => m_TestScene.IsValid() && m_TestScene.isLoaded);
+            AssertOnTimeout($"Timed out waiting for scene {k_TestScene} to load!");
 
 #if UNITY_2023_1_OR_NEWER
             var loadedInSceneObject = Object.FindObjectsByType<NetworkObject>(FindObjectsSortMode.InstanceID).Where((c) => c.name == k_SceneObjectName).FirstOrDefault();
 #else
-            var loadedInSceneObject = Object.FindObjectsOfType<NetworkObject>().Where((c) => c.name == k_SceneObjectName).FirstOrDefault();
-#endif
-
+            var loadedInSceneObject = Object.FindObjectsOfType<NetworkObject>().Where((c) => c.name.Contains(k_SceneObjectName)).FirstOrDefault();
+#endif            
             Assert.IsNotNull(loadedInSceneObject, $"Failed to find {k_SceneObjectName} before starting client!");
+            yield return CreateAndStartNewClient();
 
-            // Only start the client
-            m_ClientNetworkManager.StartClient();
 
-            // Wait for a tick
-            yield return m_DefaultWaitForTick;
-
-            // Shutdown the client
-            m_ClientNetworkManager.Shutdown();
-
-            // Wait for a tick
-            yield return m_DefaultWaitForTick;
-
-            // Find the same object
 #if UNITY_2023_1_OR_NEWER
-            loadedInSceneObject = Object.FindObjectsByType<NetworkObject>(FindObjectsSortMode.InstanceID).Where((c) => c.name == k_SceneObjectName).FirstOrDefault();
+            var loadedInSceneObjects = Object.FindObjectsByType<NetworkObject>(FindObjectsSortMode.InstanceID).Where((c) => c.name == k_SceneObjectName);
 #else
-            loadedInSceneObject = Object.FindObjectsOfType<NetworkObject>().Where((c) => c.name == k_SceneObjectName).FirstOrDefault();
+            var loadedInSceneObjects = Object.FindObjectsOfType<NetworkObject>().Where((c) => c.name.Contains(k_SceneObjectName));
 #endif
-
-            // Verify it still exists
-            Assert.IsNotNull(loadedInSceneObject, $"Failed to find {k_SceneObjectName} after starting client!");
+            Assert.IsTrue(loadedInSceneObjects.Count() > 1, $"Only found one instance of {k_SceneObjectName} after client connected!");
+            m_ClientNetworkManagers[0].Shutdown();
+            yield return m_DefaultWaitForTick;
+#if UNITY_2023_1_OR_NEWER
+            loadedInSceneObjects = Object.FindObjectsByType<NetworkObject>(FindObjectsSortMode.InstanceID).Where((c) => c.name == k_SceneObjectName);
+#else
+            loadedInSceneObjects = Object.FindObjectsOfType<NetworkObject>().Where((c) => c.name.Contains(k_SceneObjectName));
+#endif
+            Assert.IsTrue(loadedInSceneObjects.Count() > 1, $"Only found one instance of {k_SceneObjectName} after client shutdown!");
         }
 
-        [TearDown]
-        public void TearDown()
+        private void SceneManager_OnSceneEvent(SceneEvent sceneEvent)
         {
-            SceneManager.sceneLoaded -= SceneManager_sceneLoaded;
-
-            if (m_TestScene.IsValid() && m_TestScene.isLoaded)
+            if (sceneEvent.ClientId != m_ServerNetworkManager.LocalClientId)
             {
-                SceneManager.UnloadSceneAsync(m_TestScene);
+                return;
             }
 
-            if (m_NetworkManagerGameObject != null)
+            if (sceneEvent.SceneEventType == SceneEventType.LoadComplete && sceneEvent.SceneName == k_TestScene)
             {
-                Object.DestroyImmediate(m_NetworkManagerGameObject);
-            }
-        }
-
-        internal class BlankTestingTransport : TestingNetworkTransport
-        {
-            public override ulong ServerClientId { get; } = 0;
-            public override void Send(ulong clientId, ArraySegment<byte> payload, NetworkDelivery networkDelivery)
-            {
-            }
-
-            public override NetworkEvent PollEvent(out ulong clientId, out ArraySegment<byte> payload, out float receiveTime)
-            {
-                clientId = 0;
-                payload = new ArraySegment<byte>();
-                receiveTime = 0;
-                return NetworkEvent.Nothing;
-            }
-
-            public override bool StartClient()
-            {
-                return true;
-            }
-
-            public override bool StartServer()
-            {
-                return true;
-            }
-
-            public override void DisconnectRemoteClient(ulong clientId)
-            {
-            }
-
-            public override void DisconnectLocalClient()
-            {
-            }
-
-            public override ulong GetCurrentRtt(ulong clientId)
-            {
-                return 0;
-            }
-
-            public override void Shutdown()
-            {
-            }
-
-            public override void Initialize(NetworkManager networkManager = null)
-            {
+                m_TestScene = sceneEvent.Scene;
             }
         }
     }

--- a/testproject/Assets/Tests/Runtime/SceneObjectsNotDestroyedOnShutdownTest.cs
+++ b/testproject/Assets/Tests/Runtime/SceneObjectsNotDestroyedOnShutdownTest.cs
@@ -32,10 +32,9 @@ namespace TestProject.RuntimeTests
             var loadedInSceneObject = Object.FindObjectsByType<NetworkObject>(FindObjectsSortMode.InstanceID).Where((c) => c.name == k_SceneObjectName).FirstOrDefault();
 #else
             var loadedInSceneObject = Object.FindObjectsOfType<NetworkObject>().Where((c) => c.name.Contains(k_SceneObjectName)).FirstOrDefault();
-#endif            
+#endif
             Assert.IsNotNull(loadedInSceneObject, $"Failed to find {k_SceneObjectName} before starting client!");
             yield return CreateAndStartNewClient();
-
 
 #if UNITY_2023_1_OR_NEWER
             var loadedInSceneObjects = Object.FindObjectsByType<NetworkObject>(FindObjectsSortMode.InstanceID).Where((c) => c.name == k_SceneObjectName);
@@ -51,6 +50,75 @@ namespace TestProject.RuntimeTests
             loadedInSceneObjects = Object.FindObjectsOfType<NetworkObject>().Where((c) => c.name.Contains(k_SceneObjectName));
 #endif
             Assert.IsTrue(loadedInSceneObjects.Count() > 1, $"Only found one instance of {k_SceneObjectName} after client shutdown!");
+        }
+
+        [UnityTest]
+        public IEnumerator ChildSceneObjectsDoNotDestroyOnShutdown()
+        {
+            m_ServerNetworkManager.SceneManager.OnSceneEvent += SceneManager_OnSceneEvent;
+            m_ServerNetworkManager.SceneManager.LoadScene(k_TestScene, LoadSceneMode.Additive);
+
+            yield return WaitForConditionOrTimeOut(() => m_TestScene.IsValid() && m_TestScene.isLoaded);
+            AssertOnTimeout($"Timed out waiting for scene {k_TestScene} to load!");
+
+#if UNITY_2023_1_OR_NEWER
+            var loadedInSceneObject = Object.FindObjectsByType<NetworkObject>(FindObjectsSortMode.InstanceID).Where((c) => c.name == k_SceneObjectName).FirstOrDefault();
+#else
+            var loadedInSceneObject = Object.FindObjectsOfType<NetworkObject>().Where((c) => c.name.Contains(k_SceneObjectName)).FirstOrDefault();
+#endif
+            Assert.IsNotNull(loadedInSceneObject, $"Failed to find {k_SceneObjectName} before starting client!");
+            yield return CreateAndStartNewClient();
+
+            var clientId = m_ClientNetworkManagers[0].LocalClientId;
+            Assert.IsTrue(loadedInSceneObject.TrySetParent(m_PlayerNetworkObjects[0][clientId]), $"Failed to parent in-scene object under client player");
+
+            yield return WaitForConditionOrTimeOut(() => PlayerHasChildren(clientId));
+            AssertOnTimeout($"Client-{clientId} player never parented {k_SceneObjectName}!");
+
+#if UNITY_2023_1_OR_NEWER
+            var loadedInSceneObjects = Object.FindObjectsByType<NetworkObject>(FindObjectsSortMode.InstanceID).Where((c) => c.name == k_SceneObjectName);
+#else
+            var loadedInSceneObjects = Object.FindObjectsOfType<NetworkObject>().Where((c) => c.name.Contains(k_SceneObjectName));
+#endif
+            Assert.IsTrue(loadedInSceneObjects.Count() > 1, $"Only found one instance of {k_SceneObjectName} after client connected!");
+            m_ClientNetworkManagers[0].Shutdown();
+            yield return m_DefaultWaitForTick;
+
+            // Sanity check to make sure the client's player no longer has any children
+            yield return WaitForConditionOrTimeOut(() => PlayerNoLongerExistsWithChildren(clientId));
+            AssertOnTimeout($"Client-{clientId} player still exits with children after client shutdown!");
+#if UNITY_2023_1_OR_NEWER
+            loadedInSceneObjects = Object.FindObjectsByType<NetworkObject>(FindObjectsSortMode.InstanceID).Where((c) => c.name == k_SceneObjectName);
+#else
+            loadedInSceneObjects = Object.FindObjectsOfType<NetworkObject>().Where((c) => c.name.Contains(k_SceneObjectName));
+#endif
+            // Make sure any in-scene placed NetworkObject instantiated has no parent
+            foreach (var insceneObject in loadedInSceneObjects)
+            {
+                Assert.IsTrue(insceneObject.transform.parent == null, $"{insceneObject.name} is still parented!");
+            }
+
+            // We should have exactly 2 in-scene placed NetworkObjects remaining:
+            // One instance on host side and one on the disconnected client side.
+            Assert.IsTrue(loadedInSceneObjects.Count() == 2, $"Only found one instance of {k_SceneObjectName} after client shutdown!");
+        }
+
+        private bool PlayerHasChildren(ulong clientId)
+        {
+            if (m_PlayerNetworkObjects[clientId].ContainsKey(clientId) && m_PlayerNetworkObjects[clientId][clientId] != null)
+            {
+                return m_PlayerNetworkObjects[clientId][clientId].transform.childCount > 0;
+            }
+            return false;
+        }
+
+        private bool PlayerNoLongerExistsWithChildren(ulong clientId)
+        {
+            if (m_PlayerNetworkObjects[0].ContainsKey(clientId))
+            {
+                return m_PlayerNetworkObjects[0][clientId].transform.childCount == 0;
+            }
+            return true;
         }
 
         private void SceneManager_OnSceneEvent(SceneEvent sceneEvent)


### PR DESCRIPTION
_(Discovered using internal modified Client Driven Testing Tool)_
In-scene placed NetworkObjects that are parented under dynamically spawned Networkobjects should not be destroyed on the client side _(i.e. when the scene is unloaded it will/should be destroyed_). Likewise, on the server-host side, if the in-scene placed NetworkObject is marked with "Don't Destroy with Owner" then the server-host should not allow it to be destroyed when shutting down a session (_i.e. when the scene is unloaded it will/should be destroyed_).

[MTT-7560](https://jira.unity3d.com/browse/MTT-7560)

## Changelog

- Fixed: Issue where a parented in-scene placed `NetworkObject` would be destroyed upon a client or server exiting a network session but not unloading the original scene in which the `NetworkObject` was placed.


## Testing and Documentation

- Includes updated integration test `SceneObjectsNotDestroyedOnShutdownTest.SceneObjectsNotDestroyedOnShutdown`.
- Includes new integration test `SceneObjectsNotDestroyedOnShutdownTest.ChildSceneObjectsDoNotDestroyOnShutdown`.
- No documentation updates required.

