### PR TITLE
docs: Fixed link to API ref

### DIFF
--- a/com.unity.netcode.gameobjects/Documentation~/index.md
+++ b/com.unity.netcode.gameobjects/Documentation~/index.md
@@ -9,7 +9,7 @@ See guides below to install Unity Netcode for GameObjects, set up your project, 
 - [Documentation](https://docs-multiplayer.unity3d.com/netcode/current/about)
 - [Installation](https://docs-multiplayer.unity3d.com/netcode/current/installation)
 - [First Steps](https://docs-multiplayer.unity3d.com/netcode/current/tutorials/get-started-ngo)
-- [API Reference](https://docs-multiplayer.unity3d.com/netcode/current/api/introduction)
+- [API Reference](https://docs.unity3d.com/Packages/com.unity.netcode.gameobjects@1.6/api/index.html)
 
 # Technical details
 


### PR DESCRIPTION
Fixed link in index.md. Current branch only.
Fixes DOCATT 4192.


