### PR TITLE
fix: truncate when reverting writes during NetworkBehaviour synchronize

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,7 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
-## [Unreleased]
+### Added
+
+
+### Fixed
+
+- Fixed issue where `NetworkBehaviour.Synchronize` was not truncating the write buffer if nothing was serialized during `NetworkBehaviour.OnSynchronize` causing an additional 6 bytes to be written per `NetworkBehaviour` component instance. (#2749)
+
+### Changed
+
+
+## [1.7.0]
 
 ### Added
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -993,7 +993,7 @@ namespace Unity.Netcode
                 if (finalPosition == positionBeforeSynchronize || threwException)
                 {
                     writer.Seek(positionBeforeWrite);
-
+                    // Truncate back to the size before
                     writer.Truncate();
                     return false;
                 }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -993,6 +993,8 @@ namespace Unity.Netcode
                 if (finalPosition == positionBeforeSynchronize || threwException)
                 {
                     writer.Seek(positionBeforeWrite);
+
+                    writer.Truncate();
                     return false;
                 }
                 else


### PR DESCRIPTION
This fixes an issue where a NetworkBehaviour would add an additional 6 bytes to its serialization data if nothing was written during the synchronize call.

[MTT-7719](https://jira.unity3d.com/browse/MTT-7719)

## Changelog

- Fixed: Issue where `NetworkBehaviour.Synchronize` was not truncating the write buffer if nothing was serialized during `NetworkBehaviour.OnSynchronize` causing an additional 6 bytes to be written per `NetworkBehaviour` component instance.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

