### PR TITLE
fix: Compile error when a class with Rpcs inherits from an intermediate base class with no Rpcs.

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed a bug where having a class with Rpcs that inherits from a class without Rpcs that inherits from NetworkVariable would cause a compile error. (#2751)
+
 ## [1.7.0] - 2023-10-11
 
 ### Added

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -1242,9 +1242,9 @@ namespace Unity.Netcode.Editor.CodeGen
 
                 // This always needs to generate even if it's empty.
                 var initializeRpcsMethodDef = new MethodDefinition(
-                    k_NetworkBehaviour___initializeRpcs,
-                    MethodAttributes.Family | MethodAttributes.Virtual | MethodAttributes.HideBySig,
-                    typeDefinition.Module.TypeSystem.Void);
+                        k_NetworkBehaviour___initializeRpcs,
+                        MethodAttributes.Family | MethodAttributes.Virtual | MethodAttributes.HideBySig,
+                        typeDefinition.Module.TypeSystem.Void);
                 initializeRpcsMethodDef.Body.Instructions.Add(Instruction.Create(OpCodes.Ret));
 
                 typeDefinition.Methods.Add(initializeRpcsMethodDef);

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -1237,16 +1237,17 @@ namespace Unity.Netcode.Editor.CodeGen
                 }
             }
 
+            // This always needs to generate even if it's empty.
+            var initializeRpcsMethodDef = new MethodDefinition(
+                k_NetworkBehaviour___initializeRpcs,
+                MethodAttributes.Family | MethodAttributes.Virtual | MethodAttributes.HideBySig,
+                typeDefinition.Module.TypeSystem.Void);
+            initializeRpcsMethodDef.Body.Instructions.Add(Instruction.Create(OpCodes.Ret));
+
+            typeDefinition.Methods.Add(initializeRpcsMethodDef);
+
             if (rpcHandlers.Count > 0)
             {
-                var initializeRpcsMethodDef = new MethodDefinition(
-                        k_NetworkBehaviour___initializeRpcs,
-                        MethodAttributes.Family | MethodAttributes.Virtual | MethodAttributes.HideBySig,
-                        typeDefinition.Module.TypeSystem.Void);
-                initializeRpcsMethodDef.Body.Instructions.Add(Instruction.Create(OpCodes.Ret));
-
-                typeDefinition.Methods.Add(initializeRpcsMethodDef);
-
                 var instructions = new List<Instruction>();
                 var processor = initializeRpcsMethodDef.Body.GetILProcessor();
 

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -1237,17 +1237,18 @@ namespace Unity.Netcode.Editor.CodeGen
                 }
             }
 
-            // This always needs to generate even if it's empty.
-            var initializeRpcsMethodDef = new MethodDefinition(
-                k_NetworkBehaviour___initializeRpcs,
-                MethodAttributes.Family | MethodAttributes.Virtual | MethodAttributes.HideBySig,
-                typeDefinition.Module.TypeSystem.Void);
-            initializeRpcsMethodDef.Body.Instructions.Add(Instruction.Create(OpCodes.Ret));
-
-            typeDefinition.Methods.Add(initializeRpcsMethodDef);
-
-            if (rpcHandlers.Count > 0)
+            //if (rpcHandlers.Count > 0)
             {
+
+                // This always needs to generate even if it's empty.
+                var initializeRpcsMethodDef = new MethodDefinition(
+                    k_NetworkBehaviour___initializeRpcs,
+                    MethodAttributes.Family | MethodAttributes.Virtual | MethodAttributes.HideBySig,
+                    typeDefinition.Module.TypeSystem.Void);
+                initializeRpcsMethodDef.Body.Instructions.Add(Instruction.Create(OpCodes.Ret));
+
+                typeDefinition.Methods.Add(initializeRpcsMethodDef);
+
                 var instructions = new List<Instruction>();
                 var processor = initializeRpcsMethodDef.Body.GetILProcessor();
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/RpcTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/RpcTests.cs
@@ -12,6 +12,20 @@ namespace Unity.Netcode.RuntimeTests
 {
     public class RpcTests : NetcodeIntegrationTest
     {
+        public class CompileTimeNoRpcsBaseClassTest : NetworkBehaviour
+        {
+
+        }
+
+        public class CompileTimeHasRpcsChildClassDerivedFromNoRpcsBaseClassTest : CompileTimeNoRpcsBaseClassTest
+        {
+            [ServerRpc]
+            public void SomeDummyServerRpc()
+            {
+
+            }
+        }
+
         public class GenericRpcTestNB<T> : NetworkBehaviour where T : unmanaged
         {
             public event Action<T, ServerRpcParams> OnServer_Rpc;


### PR DESCRIPTION
## Changelog

- Fixed: Fixed a bug where having a class with Rpcs that inherits from a class without Rpcs that inherits from NetworkVariable would cause a compile error.

## Testing and Documentation

- Includes unit tests.
- No documentation changes or additions were necessary.
