### PR TITLE
feat: Added a universal RPC attribute [MTT-7482] [MTT-7578] [MTT-7579] [MTT-7580] [MTT-7581]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -14,11 +14,14 @@ Additional documentation and release notes are available at [Multiplayer Documen
   - This is a generic attribute that can perform the functions of both Server and Client RPCs, as well as enabling client-to-client RPCs. Includes several default targets: `Server`, `NotServer`, `Owner`, `NotOwner`, `Me`, `NotMe`, `ClientsAndHost`, and `Everyone`. Runtime overrides are available for any of these targets, as well as for sending to a specific ID or groups of IDs.
   - This attribute also includes the ability to defer RPCs that are sent to the local process to the start of the next frame instead of executing them immediately, treating them as if they had gone across the network. The default behavior is to execute immediately.
   - This attribute effectively replaces `ServerRpc` and `ClientRpc`. `ServerRpc` and `ClientRpc` remain in their existing forms for backward compatibility, but `Rpc` will be the recommended and most supported option.
-- Added: `NetworkManager.PeerClientIds` containing the client IDs of other clients connected to the same server (#2762)
-- Added: `NetworkManager.OnPeerConnectedCallback` and `NetworkManager.OnPeerDisconnectCallback` so clients can respond to connection and disconnection of other clients (#2762)
+- Added: `NetworkManager.OnConnectionEvent` as a unified connection event callback to notify clients and servers of all client connections and disconnections within the session (#2762)
 - Added: `NetworkManager.ServerIsHost` and `NetworkBehaviour.ServerIsHost` to allow a client to tell if it is connected to a host or to a dedicated server (#2762)
 - Added `SceneEventProgress.SceneManagementNotEnabled` return status to be returned when a `NetworkSceneManager` method is invoked and scene management is not enabled. (#2735)
 - Added `SceneEventProgress.ServerOnlyAction` return status to be returned when a `NetworkSceneManager` method is invoked by a client. (#2735)
+
+### Changed
+
+- `NetworkManager.ConnectedClientsIds` is now accessible on the client side and will contain the list of all clients in the session, including the host client if the server is operating in host mode (#2762)
 
 ### Fixed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,12 +10,12 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
-- Added: Added a new RPC attribute, which is simply `Rpc`. (#2762)
+- Added a new RPC attribute, which is simply `Rpc`. (#2762)
   - This is a generic attribute that can perform the functions of both Server and Client RPCs, as well as enabling client-to-client RPCs. Includes several default targets: `Server`, `NotServer`, `Owner`, `NotOwner`, `Me`, `NotMe`, `ClientsAndHost`, and `Everyone`. Runtime overrides are available for any of these targets, as well as for sending to a specific ID or groups of IDs.
   - This attribute also includes the ability to defer RPCs that are sent to the local process to the start of the next frame instead of executing them immediately, treating them as if they had gone across the network. The default behavior is to execute immediately.
   - This attribute effectively replaces `ServerRpc` and `ClientRpc`. `ServerRpc` and `ClientRpc` remain in their existing forms for backward compatibility, but `Rpc` will be the recommended and most supported option.
-- Added: `NetworkManager.OnConnectionEvent` as a unified connection event callback to notify clients and servers of all client connections and disconnections within the session (#2762)
-- Added: `NetworkManager.ServerIsHost` and `NetworkBehaviour.ServerIsHost` to allow a client to tell if it is connected to a host or to a dedicated server (#2762)
+- Added `NetworkManager.OnConnectionEvent` as a unified connection event callback to notify clients and servers of all client connections and disconnections within the session (#2762)
+- Added `NetworkManager.ServerIsHost` and `NetworkBehaviour.ServerIsHost` to allow a client to tell if it is connected to a host or to a dedicated server (#2762)
 - Added `SceneEventProgress.SceneManagementNotEnabled` return status to be returned when a `NetworkSceneManager` method is invoked and scene management is not enabled. (#2735)
 - Added `SceneEventProgress.ServerOnlyAction` return status to be returned when a `NetworkSceneManager` method is invoked by a client. (#2735)
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,6 +10,13 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
+- Added: Added a new RPC attribute, which is simply `Rpc`. (#2762)
+  - This is a generic attribute that can perform the functions of both Server and Client RPCs, as well as enabling client-to-client RPCs. Includes several default targets: `Server`, `NotServer`, `Owner`, `NotOwner`, `Me`, `NotMe`, `ClientsAndHost`, and `Everyone`. Runtime overrides are available for any of these targets, as well as for sending to a specific ID or groups of IDs.
+  - This attribute also includes the ability to defer RPCs that are sent to the local process to the start of the next frame instead of executing them immediately, treating them as if they had gone across the network. The default behavior is to execute immediately.
+  - This attribute effectively replaces `ServerRpc` and `ClientRpc`. `ServerRpc` and `ClientRpc` remain in their existing forms for backward compatibility, but `Rpc` will be the recommended and most supported option.
+- Added: `NetworkManager.PeerClientIds` containing the client IDs of other clients connected to the same server (#2762)
+- Added: `NetworkManager.OnPeerConnectedCallback` and `NetworkManager.OnPeerDisconnectCallback` so clients can respond to connection and disconnection of other clients (#2762)
+- Added: `NetworkManager.ServerIsHost` and `NetworkBehaviour.ServerIsHost` to allow a client to tell if it is connected to a host or to a dedicated server (#2762)
 - Added `SceneEventProgress.SceneManagementNotEnabled` return status to be returned when a `NetworkSceneManager` method is invoked and scene management is not enabled. (#2735)
 - Added `SceneEventProgress.ServerOnlyAction` return status to be returned when a `NetworkSceneManager` method is invoked by a client. (#2735)
 

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/CodeGenHelpers.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/CodeGenHelpers.cs
@@ -26,8 +26,10 @@ namespace Unity.Netcode.Editor.CodeGen
         public static readonly string INetworkMessage_FullName = typeof(INetworkMessage).FullName;
         public static readonly string ServerRpcAttribute_FullName = typeof(ServerRpcAttribute).FullName;
         public static readonly string ClientRpcAttribute_FullName = typeof(ClientRpcAttribute).FullName;
+        public static readonly string RpcAttribute_FullName = typeof(RpcAttribute).FullName;
         public static readonly string ServerRpcParams_FullName = typeof(ServerRpcParams).FullName;
         public static readonly string ClientRpcParams_FullName = typeof(ClientRpcParams).FullName;
+        public static readonly string RpcParams_FullName = typeof(RpcParams).FullName;
         public static readonly string ClientRpcSendParams_FullName = typeof(ClientRpcSendParams).FullName;
         public static readonly string ClientRpcReceiveParams_FullName = typeof(ClientRpcReceiveParams).FullName;
         public static readonly string ServerRpcSendParams_FullName = typeof(ServerRpcSendParams).FullName;

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -363,11 +363,14 @@ namespace Unity.Netcode.Editor.CodeGen
         private FieldReference m_NetworkManager_LogLevel_FieldRef;
         private MethodReference m_NetworkBehaviour___registerRpc_MethodRef;
         private TypeReference m_NetworkBehaviour_TypeRef;
+        private TypeReference m_AttributeParamsType_TypeRef;
         private TypeReference m_NetworkVariableBase_TypeRef;
         private MethodReference m_NetworkVariableBase_Initialize_MethodRef;
         private MethodReference m_NetworkBehaviour___nameNetworkVariable_MethodRef;
         private MethodReference m_NetworkBehaviour_beginSendServerRpc_MethodRef;
         private MethodReference m_NetworkBehaviour_endSendServerRpc_MethodRef;
+        private MethodReference m_NetworkBehaviour_beginSendRpc_MethodRef;
+        private MethodReference m_NetworkBehaviour_endSendRpc_MethodRef;
         private MethodReference m_NetworkBehaviour_beginSendClientRpc_MethodRef;
         private MethodReference m_NetworkBehaviour_endSendClientRpc_MethodRef;
         private FieldReference m_NetworkBehaviour_rpc_exec_stage_FieldRef;
@@ -378,9 +381,13 @@ namespace Unity.Netcode.Editor.CodeGen
         private TypeReference m_RpcParams_TypeRef;
         private FieldReference m_RpcParams_Server_FieldRef;
         private FieldReference m_RpcParams_Client_FieldRef;
+        private FieldReference m_RpcParams_Ext_FieldRef;
         private TypeReference m_ServerRpcParams_TypeRef;
         private FieldReference m_ServerRpcParams_Receive_FieldRef;
         private FieldReference m_ServerRpcParams_Receive_SenderClientId_FieldRef;
+        private FieldReference m_UniversalRpcParams_Receive_FieldRef;
+        private FieldReference m_UniversalRpcParams_Receive_SenderClientId_FieldRef;
+        private TypeReference m_UniversalRpcParams_TypeRef;
         private TypeReference m_ClientRpcParams_TypeRef;
         private MethodReference m_NetworkVariableSerializationTypes_InitializeSerializer_UnmanagedByMemcpy_MethodRef;
         private MethodReference m_NetworkVariableSerializationTypes_InitializeSerializer_UnmanagedByMemcpyArray_MethodRef;
@@ -495,6 +502,8 @@ namespace Unity.Netcode.Editor.CodeGen
         private const string k_NetworkBehaviour_NetworkVariableFields = nameof(NetworkBehaviour.NetworkVariableFields);
         private const string k_NetworkBehaviour_beginSendServerRpc = nameof(NetworkBehaviour.__beginSendServerRpc);
         private const string k_NetworkBehaviour_endSendServerRpc = nameof(NetworkBehaviour.__endSendServerRpc);
+        private const string k_NetworkBehaviour_beginSendRpc = nameof(NetworkBehaviour.__beginSendRpc);
+        private const string k_NetworkBehaviour_endSendRpc = nameof(NetworkBehaviour.__endSendRpc);
         private const string k_NetworkBehaviour_beginSendClientRpc = nameof(NetworkBehaviour.__beginSendClientRpc);
         private const string k_NetworkBehaviour_endSendClientRpc = nameof(NetworkBehaviour.__endSendClientRpc);
         private const string k_NetworkBehaviour___initializeVariables = nameof(NetworkBehaviour.__initializeVariables);
@@ -511,8 +520,11 @@ namespace Unity.Netcode.Editor.CodeGen
         private const string k_ServerRpcAttribute_RequireOwnership = nameof(ServerRpcAttribute.RequireOwnership);
         private const string k_RpcParams_Server = nameof(__RpcParams.Server);
         private const string k_RpcParams_Client = nameof(__RpcParams.Client);
+        private const string k_RpcParams_Ext = nameof(__RpcParams.Ext);
         private const string k_ServerRpcParams_Receive = nameof(ServerRpcParams.Receive);
+        private const string k_RpcParams_Receive = nameof(RpcParams.Receive);
         private const string k_ServerRpcReceiveParams_SenderClientId = nameof(ServerRpcReceiveParams.SenderClientId);
+        private const string k_RpcReceiveParams_SenderClientId = nameof(RpcReceiveParams.SenderClientId);
 
         // CodeGen cannot reference the collections assembly to do a typeof() on it due to a bug that causes that to crash.
         private const string k_INativeListBool_FullName = "Unity.Collections.INativeList`1<System.Byte>";
@@ -545,13 +557,20 @@ namespace Unity.Netcode.Editor.CodeGen
             TypeDefinition rpcParamsTypeDef = null;
             TypeDefinition serverRpcParamsTypeDef = null;
             TypeDefinition clientRpcParamsTypeDef = null;
+            TypeDefinition universalRpcParamsTypeDef = null;
             TypeDefinition fastBufferWriterTypeDef = null;
             TypeDefinition fastBufferReaderTypeDef = null;
             TypeDefinition networkVariableSerializationTypesTypeDef = null;
             TypeDefinition bytePackerTypeDef = null;
             TypeDefinition byteUnpackerTypeDef = null;
+            TypeDefinition attributeParamsType = null;
             foreach (var netcodeTypeDef in m_NetcodeModule.GetAllTypes())
             {
+                if (attributeParamsType == null && netcodeTypeDef.Name == nameof(RpcAttribute.RpcAttributeParams))
+                {
+                    attributeParamsType = netcodeTypeDef;
+                    continue;
+                }
                 if (networkManagerTypeDef == null && netcodeTypeDef.Name == nameof(NetworkManager))
                 {
                     networkManagerTypeDef = netcodeTypeDef;
@@ -585,6 +604,12 @@ namespace Unity.Netcode.Editor.CodeGen
                 if (serverRpcParamsTypeDef == null && netcodeTypeDef.Name == nameof(ServerRpcParams))
                 {
                     serverRpcParamsTypeDef = netcodeTypeDef;
+                    continue;
+                }
+
+                if (universalRpcParamsTypeDef == null && netcodeTypeDef.Name == nameof(RpcParams))
+                {
+                    universalRpcParamsTypeDef = netcodeTypeDef;
                     continue;
                 }
 
@@ -662,6 +687,8 @@ namespace Unity.Netcode.Editor.CodeGen
                 }
             }
 
+            m_AttributeParamsType_TypeRef = moduleDefinition.ImportReference(attributeParamsType);
+
             foreach (var fieldDef in networkManagerTypeDef.Fields)
             {
                 switch (fieldDef.Name)
@@ -695,6 +722,12 @@ namespace Unity.Netcode.Editor.CodeGen
                         break;
                     case k_NetworkBehaviour_endSendServerRpc:
                         m_NetworkBehaviour_endSendServerRpc_MethodRef = moduleDefinition.ImportReference(methodDef);
+                        break;
+                    case k_NetworkBehaviour_beginSendRpc:
+                        m_NetworkBehaviour_beginSendRpc_MethodRef = moduleDefinition.ImportReference(methodDef);
+                        break;
+                    case k_NetworkBehaviour_endSendRpc:
+                        m_NetworkBehaviour_endSendRpc_MethodRef = moduleDefinition.ImportReference(methodDef);
                         break;
                     case k_NetworkBehaviour_beginSendClientRpc:
                         m_NetworkBehaviour_beginSendClientRpc_MethodRef = moduleDefinition.ImportReference(methodDef);
@@ -763,6 +796,9 @@ namespace Unity.Netcode.Editor.CodeGen
                     case k_RpcParams_Client:
                         m_RpcParams_Client_FieldRef = moduleDefinition.ImportReference(fieldDef);
                         break;
+                    case k_RpcParams_Ext:
+                        m_RpcParams_Ext_FieldRef = moduleDefinition.ImportReference(fieldDef);
+                        break;
                 }
             }
 
@@ -783,6 +819,26 @@ namespace Unity.Netcode.Editor.CodeGen
                         }
 
                         m_ServerRpcParams_Receive_FieldRef = moduleDefinition.ImportReference(fieldDef);
+                        break;
+                }
+            }
+            m_UniversalRpcParams_TypeRef = moduleDefinition.ImportReference(rpcParamsTypeDef);
+            foreach (var fieldDef in rpcParamsTypeDef.Fields)
+            {
+                switch (fieldDef.Name)
+                {
+                    case k_RpcParams_Receive:
+                        foreach (var recvFieldDef in fieldDef.FieldType.Resolve().Fields)
+                        {
+                            switch (recvFieldDef.Name)
+                            {
+                                case k_RpcReceiveParams_SenderClientId:
+                                    m_UniversalRpcParams_Receive_SenderClientId_FieldRef = moduleDefinition.ImportReference(recvFieldDef);
+                                    break;
+                            }
+                        }
+
+                        m_UniversalRpcParams_Receive_FieldRef = moduleDefinition.ImportReference(fieldDef);
                         break;
                 }
             }
@@ -1352,7 +1408,8 @@ namespace Unity.Netcode.Editor.CodeGen
                 var customAttributeType_FullName = customAttribute.AttributeType.FullName;
 
                 if (customAttributeType_FullName == CodeGenHelpers.ServerRpcAttribute_FullName ||
-                    customAttributeType_FullName == CodeGenHelpers.ClientRpcAttribute_FullName)
+                    customAttributeType_FullName == CodeGenHelpers.ClientRpcAttribute_FullName ||
+                    customAttributeType_FullName == CodeGenHelpers.RpcAttribute_FullName)
                 {
                     bool isValid = true;
 
@@ -1387,6 +1444,13 @@ namespace Unity.Netcode.Editor.CodeGen
                         isValid = false;
                     }
 
+                    if (customAttributeType_FullName == CodeGenHelpers.RpcAttribute_FullName &&
+                        !methodDefinition.Name.EndsWith("Rpc", StringComparison.OrdinalIgnoreCase))
+                    {
+                        m_Diagnostics.AddError(methodDefinition, "Rpc method must end with 'Rpc' suffix!");
+                        isValid = false;
+                    }
+
                     if (customAttributeType_FullName == CodeGenHelpers.ClientRpcAttribute_FullName &&
                         !methodDefinition.Name.EndsWith("ClientRpc", StringComparison.OrdinalIgnoreCase))
                     {
@@ -1409,11 +1473,15 @@ namespace Unity.Netcode.Editor.CodeGen
             {
                 if (methodDefinition.Name.EndsWith("ServerRpc", StringComparison.OrdinalIgnoreCase))
                 {
-                    m_Diagnostics.AddError(methodDefinition, "ServerRpc method must be marked with 'ServerRpc' attribute!");
+                    m_Diagnostics.AddError(methodDefinition, $"ServerRpc method {methodDefinition} must be marked with 'ServerRpc' attribute!");
                 }
                 else if (methodDefinition.Name.EndsWith("ClientRpc", StringComparison.OrdinalIgnoreCase))
                 {
-                    m_Diagnostics.AddError(methodDefinition, "ClientRpc method must be marked with 'ClientRpc' attribute!");
+                    m_Diagnostics.AddError(methodDefinition, $"ClientRpc method {methodDefinition} must be marked with 'ClientRpc' attribute!");
+                }
+                else if (methodDefinition.Name.EndsWith("ExtRpc", StringComparison.OrdinalIgnoreCase))
+                {
+                    m_Diagnostics.AddError(methodDefinition, $"Ext Rpc method {methodDefinition} must be marked with 'ExtRpc' attribute!");
                 }
 
                 return null;
@@ -1885,8 +1953,17 @@ namespace Unity.Netcode.Editor.CodeGen
             var instructions = new List<Instruction>();
             var processor = methodDefinition.Body.GetILProcessor();
             var isServerRpc = rpcAttribute.AttributeType.FullName == CodeGenHelpers.ServerRpcAttribute_FullName;
+            var isClientRpc = rpcAttribute.AttributeType.FullName == CodeGenHelpers.ClientRpcAttribute_FullName;
+            var isGenericRpc = rpcAttribute.AttributeType.FullName == CodeGenHelpers.RpcAttribute_FullName;
             var requireOwnership = true; // default value MUST be == `ServerRpcAttribute.RequireOwnership`
             var rpcDelivery = RpcDelivery.Reliable; // default value MUST be == `RpcAttribute.Delivery`
+            var defaultTarget = SendTo.Everyone;
+            var allowTargetOverride = false;
+
+            if (isGenericRpc)
+            {
+                defaultTarget = (SendTo)rpcAttribute.ConstructorArguments[0].Value;
+            }
             foreach (var attrField in rpcAttribute.Fields)
             {
                 switch (attrField.Name)
@@ -1897,6 +1974,9 @@ namespace Unity.Netcode.Editor.CodeGen
                     case k_ServerRpcAttribute_RequireOwnership:
                         requireOwnership = attrField.Argument.Type == typeSystem.Boolean && (bool)attrField.Argument.Value;
                         break;
+                    case nameof(RpcAttribute.AllowTargetOverride):
+                        allowTargetOverride = attrField.Argument.Type == typeSystem.Boolean && (bool)attrField.Argument.Value;
+                        break;
                 }
             }
 
@@ -1904,7 +1984,33 @@ namespace Unity.Netcode.Editor.CodeGen
             var hasRpcParams =
                 paramCount > 0 &&
                 ((isServerRpc && methodDefinition.Parameters[paramCount - 1].ParameterType.FullName == CodeGenHelpers.ServerRpcParams_FullName) ||
-                 (!isServerRpc && methodDefinition.Parameters[paramCount - 1].ParameterType.FullName == CodeGenHelpers.ClientRpcParams_FullName));
+                 (isClientRpc && methodDefinition.Parameters[paramCount - 1].ParameterType.FullName == CodeGenHelpers.ClientRpcParams_FullName) ||
+                 (isGenericRpc && methodDefinition.Parameters[paramCount - 1].ParameterType.FullName == CodeGenHelpers.RpcParams_FullName));
+
+            if (isGenericRpc && defaultTarget == SendTo.SpecifiedInParams)
+            {
+                if (!hasRpcParams)
+                {
+                    m_Diagnostics.AddError($"{methodDefinition}: {nameof(SendTo)}.{nameof(SendTo.SpecifiedInParams)} cannot be used without a final parameter of type {CodeGenHelpers.RpcParams_FullName}.");
+                }
+
+                foreach (var attrField in rpcAttribute.Fields)
+                {
+                    switch (attrField.Name)
+                    {
+                        case nameof(RpcAttribute.AllowTargetOverride):
+                            m_Diagnostics.AddWarning($"{methodDefinition}: {nameof(RpcAttribute.AllowTargetOverride)} is ignored with {nameof(SendTo)}.{nameof(SendTo.SpecifiedInParams)}");
+                            break;
+                    }
+                }
+            }
+            if (isGenericRpc && allowTargetOverride)
+            {
+                if (!hasRpcParams)
+                {
+                    m_Diagnostics.AddError($"{methodDefinition}: {nameof(RpcAttribute.AllowTargetOverride)} cannot be used without a final parameter of type {CodeGenHelpers.RpcParams_FullName}.");
+                }
+            }
 
             methodDefinition.Body.InitLocals = true;
             // NetworkManager networkManager;
@@ -1917,9 +2023,16 @@ namespace Unity.Netcode.Editor.CodeGen
             // XXXRpcParams
             if (!hasRpcParams)
             {
-                methodDefinition.Body.Variables.Add(new VariableDefinition(isServerRpc ? m_ServerRpcParams_TypeRef : m_ClientRpcParams_TypeRef));
+                methodDefinition.Body.Variables.Add(new VariableDefinition(isServerRpc ? m_ServerRpcParams_TypeRef : (isClientRpc ? m_ClientRpcParams_TypeRef : m_UniversalRpcParams_TypeRef)));
             }
             int rpcParamsIdx = !hasRpcParams ? methodDefinition.Body.Variables.Count - 1 : -1;
+
+            if (isGenericRpc)
+            {
+                methodDefinition.Body.Variables.Add(new VariableDefinition(m_AttributeParamsType_TypeRef));
+            }
+
+            int rpcAttributeParamsIdx = isGenericRpc ? methodDefinition.Body.Variables.Count - 1 : -1;
 
             {
                 var returnInstr = processor.Create(OpCodes.Ret);
@@ -1950,20 +2063,23 @@ namespace Unity.Netcode.Editor.CodeGen
                 // if (__rpc_exec_stage != __RpcExecStage.Client) -> ClientRpc
                 instructions.Add(processor.Create(OpCodes.Ldarg_0));
                 instructions.Add(processor.Create(OpCodes.Ldfld, m_NetworkBehaviour_rpc_exec_stage_FieldRef));
-                instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)(isServerRpc ? NetworkBehaviour.__RpcExecStage.Server : NetworkBehaviour.__RpcExecStage.Client)));
+                instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)NetworkBehaviour.__RpcExecStage.Execute));
                 instructions.Add(processor.Create(OpCodes.Ceq));
                 instructions.Add(processor.Create(OpCodes.Ldc_I4, 0));
                 instructions.Add(processor.Create(OpCodes.Ceq));
                 instructions.Add(processor.Create(OpCodes.Brfalse, lastInstr));
 
-                // if (networkManager.IsClient || networkManager.IsHost) { ... } -> ServerRpc
-                // if (networkManager.IsServer || networkManager.IsHost) { ... } -> ClientRpc
-                instructions.Add(processor.Create(OpCodes.Ldloc, netManLocIdx));
-                instructions.Add(processor.Create(OpCodes.Callvirt, isServerRpc ? m_NetworkManager_getIsClient_MethodRef : m_NetworkManager_getIsServer_MethodRef));
-                instructions.Add(processor.Create(OpCodes.Brtrue, beginInstr));
-                instructions.Add(processor.Create(OpCodes.Ldloc, netManLocIdx));
-                instructions.Add(processor.Create(OpCodes.Callvirt, m_NetworkManager_getIsHost_MethodRef));
-                instructions.Add(processor.Create(OpCodes.Brfalse, lastInstr));
+                if (!isGenericRpc)
+                {
+                    // if (networkManager.IsClient || networkManager.IsHost) { ... } -> ServerRpc
+                    // if (networkManager.IsServer || networkManager.IsHost) { ... } -> ClientRpc
+                    instructions.Add(processor.Create(OpCodes.Ldloc, netManLocIdx));
+                    instructions.Add(processor.Create(OpCodes.Callvirt, isServerRpc ? m_NetworkManager_getIsClient_MethodRef : m_NetworkManager_getIsServer_MethodRef));
+                    instructions.Add(processor.Create(OpCodes.Brtrue, beginInstr));
+                    instructions.Add(processor.Create(OpCodes.Ldloc, netManLocIdx));
+                    instructions.Add(processor.Create(OpCodes.Callvirt, m_NetworkManager_getIsHost_MethodRef));
+                    instructions.Add(processor.Create(OpCodes.Brfalse, lastInstr));
+                }
 
                 instructions.Add(beginInstr);
 
@@ -2025,7 +2141,7 @@ namespace Unity.Netcode.Editor.CodeGen
                     instructions.Add(processor.Create(OpCodes.Call, m_NetworkBehaviour_beginSendServerRpc_MethodRef));
                     instructions.Add(processor.Create(OpCodes.Stloc, bufWriterLocIdx));
                 }
-                else
+                else if (isClientRpc)
                 {
                     // ClientRpc
 
@@ -2043,6 +2159,89 @@ namespace Unity.Netcode.Editor.CodeGen
 
                     // __beginSendClientRpc
                     instructions.Add(processor.Create(OpCodes.Call, m_NetworkBehaviour_beginSendClientRpc_MethodRef));
+                    instructions.Add(processor.Create(OpCodes.Stloc, bufWriterLocIdx));
+                }
+                else
+                {
+                    // Generic RPC
+
+                    // var bufferWriter = __beginSendRpc(rpcMethodId, rpcParams, rpcAttributeParams, defaultTarget, rpcDelivery);
+                    instructions.Add(processor.Create(OpCodes.Ldarg_0));
+
+                    // rpcMethodId
+                    instructions.Add(processor.Create(OpCodes.Ldc_I4, unchecked((int)rpcMethodId)));
+
+                    // rpcParams
+                    instructions.Add(hasRpcParams ? processor.Create(OpCodes.Ldarg, paramCount) : processor.Create(OpCodes.Ldloc, rpcParamsIdx));
+
+                    // rpcAttributeParams
+                    instructions.Add(processor.Create(OpCodes.Ldloca, rpcAttributeParamsIdx));
+                    instructions.Add(processor.Create(OpCodes.Initobj, m_AttributeParamsType_TypeRef));
+
+                    RpcAttribute.RpcAttributeParams dflt = default;
+                    foreach (var field in rpcAttribute.Fields)
+                    {
+                        var found = false;
+                        foreach (var attrField in m_AttributeParamsType_TypeRef.Resolve().Fields)
+                        {
+                            if (attrField.Name == field.Name)
+                            {
+                                found = true;
+                                var value = field.Argument.Value;
+                                var paramField = dflt.GetType().GetField(attrField.Name);
+                                if (value != paramField.GetValue(dflt))
+                                {
+                                    instructions.Add(processor.Create(OpCodes.Ldloca, rpcAttributeParamsIdx));
+                                    var type = value.GetType();
+                                    if (type == typeof(bool))
+                                    {
+                                        instructions.Add(processor.Create(OpCodes.Ldc_I4, (bool)value ? 1 : 0));
+                                    }
+                                    else if (type == typeof(short) || type == typeof(int) || type == typeof(ushort)
+                                       || type == typeof(byte) || type == typeof(sbyte) || type == typeof(char))
+                                    {
+                                        instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)value));
+                                    }
+                                    else if (type == typeof(long) || type == typeof(ulong))
+                                    {
+                                        instructions.Add(processor.Create(OpCodes.Ldc_I8, (long)value));
+                                    }
+                                    else if (type == typeof(float))
+                                    {
+                                        instructions.Add(processor.Create(OpCodes.Ldc_R8, (float)value));
+
+                                    }
+                                    else if (type == typeof(double))
+                                    {
+                                        instructions.Add(processor.Create(OpCodes.Ldc_R8, (double)value));
+                                    }
+                                    else
+                                    {
+                                        m_Diagnostics.AddError("Unsupported attribute parameter type.");
+                                    }
+                                }
+
+                                instructions.Add(processor.Create(OpCodes.Stfld, m_MainModule.ImportReference(attrField)));
+
+                                break;
+                            }
+                        }
+
+                        if (!found)
+                        {
+                            m_Diagnostics.AddError($"{nameof(RpcAttribute)} contains field {field} which is not present in {nameof(RpcAttribute.RpcAttributeParams)}.");
+                        }
+                    }
+                    instructions.Add(processor.Create(OpCodes.Ldloc, rpcAttributeParamsIdx));
+
+                    // defaultTarget
+                    instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)defaultTarget));
+
+                    // rpcDelivery
+                    instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)rpcDelivery));
+
+                    // __beginSendRpc
+                    instructions.Add(processor.Create(OpCodes.Call, m_NetworkBehaviour_beginSendRpc_MethodRef));
                     instructions.Add(processor.Create(OpCodes.Stloc, bufWriterLocIdx));
                 }
 
@@ -2073,7 +2272,7 @@ namespace Unity.Netcode.Editor.CodeGen
                         }
                         if (!isServerRpc)
                         {
-                            m_Diagnostics.AddError($"ClientRpcs may not accept {nameof(ServerRpcParams)} as a parameter.");
+                            m_Diagnostics.AddError($"Only ServerRpcs may accept {nameof(ServerRpcParams)} as a parameter.");
                         }
                         continue;
                     }
@@ -2084,9 +2283,22 @@ namespace Unity.Netcode.Editor.CodeGen
                         {
                             m_Diagnostics.AddError(methodDefinition, $"{nameof(ClientRpcParams)} must be the last parameter in a ClientRpc.");
                         }
-                        if (isServerRpc)
+                        if (!isClientRpc)
                         {
-                            m_Diagnostics.AddError($"ServerRpcs may not accept {nameof(ClientRpcParams)} as a parameter.");
+                            m_Diagnostics.AddError($"Only clientRpcs may accept {nameof(ClientRpcParams)} as a parameter.");
+                        }
+                        continue;
+                    }
+                    // RpcParams
+                    if (paramType.FullName == CodeGenHelpers.RpcParams_FullName)
+                    {
+                        if (paramIndex != paramCount - 1)
+                        {
+                            m_Diagnostics.AddError(methodDefinition, $"{nameof(RpcParams)} must be the last parameter in a ClientRpc.");
+                        }
+                        if (!isGenericRpc)
+                        {
+                            m_Diagnostics.AddError($"Only Rpcs may accept {nameof(RpcParams)} as a parameter.");
                         }
                         continue;
                     }
@@ -2249,7 +2461,7 @@ namespace Unity.Netcode.Editor.CodeGen
                     // __endSendServerRpc
                     instructions.Add(processor.Create(OpCodes.Call, m_NetworkBehaviour_endSendServerRpc_MethodRef));
                 }
-                else
+                else if (isClientRpc)
                 {
                     // ClientRpc
 
@@ -2277,6 +2489,41 @@ namespace Unity.Netcode.Editor.CodeGen
                     // __endSendClientRpc
                     instructions.Add(processor.Create(OpCodes.Call, m_NetworkBehaviour_endSendClientRpc_MethodRef));
                 }
+                else
+                {
+                    // Generic Rpc
+
+                    // __endSendRpc(ref bufferWriter, rpcMethodId, rpcParams, rpcAttributeParams, defaultTarget, rpcDelivery);
+                    instructions.Add(processor.Create(OpCodes.Ldarg_0));
+
+                    // bufferWriter
+                    instructions.Add(processor.Create(OpCodes.Ldloca, bufWriterLocIdx));
+
+                    // rpcMethodId
+                    instructions.Add(processor.Create(OpCodes.Ldc_I4, unchecked((int)rpcMethodId)));
+                    if (hasRpcParams)
+                    {
+                        // rpcParams
+                        instructions.Add(processor.Create(OpCodes.Ldarg, paramCount));
+                    }
+                    else
+                    {
+                        // default
+                        instructions.Add(processor.Create(OpCodes.Ldloc, rpcParamsIdx));
+                    }
+
+                    // rpcAttributeParams
+                    instructions.Add(processor.Create(OpCodes.Ldloc, rpcAttributeParamsIdx));
+
+                    // defaultTarget
+                    instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)defaultTarget));
+
+                    // rpcDelivery
+                    instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)rpcDelivery));
+
+                    // __endSendClientRpc
+                    instructions.Add(processor.Create(OpCodes.Call, m_NetworkBehaviour_endSendRpc_MethodRef));
+                }
 
                 instructions.Add(lastInstr);
             }
@@ -2285,25 +2532,53 @@ namespace Unity.Netcode.Editor.CodeGen
                 var returnInstr = processor.Create(OpCodes.Ret);
                 var lastInstr = processor.Create(OpCodes.Nop);
 
-                // if (__rpc_exec_stage == __RpcExecStage.Server) -> ServerRpc
-                // if (__rpc_exec_stage == __RpcExecStage.Client) -> ClientRpc
-                instructions.Add(processor.Create(OpCodes.Ldarg_0));
-                instructions.Add(processor.Create(OpCodes.Ldfld, m_NetworkBehaviour_rpc_exec_stage_FieldRef));
-                instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)(isServerRpc ? NetworkBehaviour.__RpcExecStage.Server : NetworkBehaviour.__RpcExecStage.Client)));
-                instructions.Add(processor.Create(OpCodes.Ceq));
-                instructions.Add(processor.Create(OpCodes.Brfalse, returnInstr));
+                if (!isGenericRpc)
+                {
+                    // if (__rpc_exec_stage == __RpcExecStage.Execute)
+                    instructions.Add(processor.Create(OpCodes.Ldarg_0));
+                    instructions.Add(processor.Create(OpCodes.Ldfld, m_NetworkBehaviour_rpc_exec_stage_FieldRef));
+                    instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)NetworkBehaviour.__RpcExecStage.Execute));
+                    instructions.Add(processor.Create(OpCodes.Ceq));
+                    instructions.Add(processor.Create(OpCodes.Brfalse, returnInstr));
 
-                // if (networkManager.IsServer || networkManager.IsHost) -> ServerRpc
-                // if (networkManager.IsClient || networkManager.IsHost) -> ClientRpc
-                instructions.Add(processor.Create(OpCodes.Ldloc, netManLocIdx));
-                instructions.Add(processor.Create(OpCodes.Callvirt, isServerRpc ? m_NetworkManager_getIsServer_MethodRef : m_NetworkManager_getIsClient_MethodRef));
-                instructions.Add(processor.Create(OpCodes.Brtrue, lastInstr));
-                instructions.Add(processor.Create(OpCodes.Ldloc, netManLocIdx));
-                instructions.Add(processor.Create(OpCodes.Callvirt, m_NetworkManager_getIsHost_MethodRef));
-                instructions.Add(processor.Create(OpCodes.Brtrue, lastInstr));
+                    // if (networkManager.IsServer || networkManager.IsHost) -> ServerRpc
+                    // if (networkManager.IsClient || networkManager.IsHost) -> ClientRpc
+                    instructions.Add(processor.Create(OpCodes.Ldloc, netManLocIdx));
+                    instructions.Add(processor.Create(OpCodes.Callvirt, isServerRpc ? m_NetworkManager_getIsServer_MethodRef : m_NetworkManager_getIsClient_MethodRef));
+                    instructions.Add(processor.Create(OpCodes.Brtrue, lastInstr));
+                    instructions.Add(processor.Create(OpCodes.Ldloc, netManLocIdx));
+                    instructions.Add(processor.Create(OpCodes.Callvirt, m_NetworkManager_getIsHost_MethodRef));
+                    instructions.Add(processor.Create(OpCodes.Brtrue, lastInstr));
+                    instructions.Add(returnInstr);
+                    instructions.Add(lastInstr);
 
-                instructions.Add(returnInstr);
-                instructions.Add(lastInstr);
+                    // This needs to be set back before executing the callback or else sending another RPC
+                    // from within an RPC will not work.
+                    // __rpc_exec_stage = __RpcExecStage.Send
+                    instructions.Add(processor.Create(OpCodes.Ldarg_0));
+                    instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)NetworkBehaviour.__RpcExecStage.Send));
+                    instructions.Add(processor.Create(OpCodes.Stfld, m_NetworkBehaviour_rpc_exec_stage_FieldRef));
+                }
+                else
+                {
+                    // if (__rpc_exec_stage == __RpcExecStage.Execute)
+                    instructions.Add(processor.Create(OpCodes.Ldarg_0));
+                    instructions.Add(processor.Create(OpCodes.Ldfld, m_NetworkBehaviour_rpc_exec_stage_FieldRef));
+                    instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)NetworkBehaviour.__RpcExecStage.Execute));
+                    instructions.Add(processor.Create(OpCodes.Ceq));
+                    instructions.Add(processor.Create(OpCodes.Brtrue, lastInstr));
+
+                    instructions.Add(returnInstr);
+                    instructions.Add(lastInstr);
+
+                    // This needs to be set back before executing the callback or else sending another RPC
+                    // from within an RPC will not work.
+                    // __rpc_exec_stage = __RpcExecStage.Send
+                    instructions.Add(processor.Create(OpCodes.Ldarg_0));
+                    instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)NetworkBehaviour.__RpcExecStage.Send));
+                    instructions.Add(processor.Create(OpCodes.Stfld, m_NetworkBehaviour_rpc_exec_stage_FieldRef));
+                }
+
             }
 
             instructions.Reverse();
@@ -2456,6 +2731,8 @@ namespace Unity.Netcode.Editor.CodeGen
             var processor = rpcHandler.Body.GetILProcessor();
 
             var isServerRpc = rpcAttribute.AttributeType.FullName == CodeGenHelpers.ServerRpcAttribute_FullName;
+            var isCientRpc = rpcAttribute.AttributeType.FullName == CodeGenHelpers.ClientRpcAttribute_FullName;
+            var isGenericRpc = rpcAttribute.AttributeType.FullName == CodeGenHelpers.RpcAttribute_FullName;
             var requireOwnership = true; // default value MUST be == `ServerRpcAttribute.RequireOwnership`
             foreach (var attrField in rpcAttribute.Fields)
             {
@@ -2559,6 +2836,15 @@ namespace Unity.Netcode.Editor.CodeGen
                     {
                         processor.Emit(OpCodes.Ldarg_2);
                         processor.Emit(OpCodes.Ldfld, m_RpcParams_Client_FieldRef);
+                        processor.Emit(OpCodes.Stloc, localIndex);
+                        continue;
+                    }
+
+                    // RpcParams
+                    if (paramType.FullName == CodeGenHelpers.RpcParams_FullName)
+                    {
+                        processor.Emit(OpCodes.Ldarg_2);
+                        processor.Emit(OpCodes.Ldfld, m_RpcParams_Ext_FieldRef);
                         processor.Emit(OpCodes.Stloc, localIndex);
                         continue;
                     }
@@ -2688,7 +2974,7 @@ namespace Unity.Netcode.Editor.CodeGen
             // NetworkBehaviour.__rpc_exec_stage = __RpcExecStage.Server; -> ServerRpc
             // NetworkBehaviour.__rpc_exec_stage = __RpcExecStage.Client; -> ClientRpc
             processor.Emit(OpCodes.Ldarg_0);
-            processor.Emit(OpCodes.Ldc_I4, (int)(isServerRpc ? NetworkBehaviour.__RpcExecStage.Server : NetworkBehaviour.__RpcExecStage.Client));
+            processor.Emit(OpCodes.Ldc_I4, (int)(NetworkBehaviour.__RpcExecStage.Execute));
             processor.Emit(OpCodes.Stfld, m_NetworkBehaviour_rpc_exec_stage_FieldRef);
 
             // NetworkBehaviour.XXXRpc(...);
@@ -2711,7 +2997,7 @@ namespace Unity.Netcode.Editor.CodeGen
 
             // NetworkBehaviour.__rpc_exec_stage = __RpcExecStage.None;
             processor.Emit(OpCodes.Ldarg_0);
-            processor.Emit(OpCodes.Ldc_I4, (int)NetworkBehaviour.__RpcExecStage.None);
+            processor.Emit(OpCodes.Ldc_I4, (int)NetworkBehaviour.__RpcExecStage.Send);
             processor.Emit(OpCodes.Stfld, m_NetworkBehaviour_rpc_exec_stage_FieldRef);
 
             processor.Emit(OpCodes.Ret);

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+using Mono.Cecil.Rocks;
 using Unity.CompilationPipeline.Common.Diagnostics;
 using Unity.CompilationPipeline.Common.ILPostProcessing;
 using ILPPInterface = Unity.CompilationPipeline.Common.ILPostProcessing.ILPostProcessor;
@@ -51,6 +52,15 @@ namespace Unity.Netcode.Editor.CodeGen
                             break;
                         case nameof(NetworkBehaviour):
                             ProcessNetworkBehaviour(typeDefinition);
+                            break;
+                        case nameof(RpcAttribute):
+                            foreach (var methodDefinition in typeDefinition.GetConstructors())
+                            {
+                                if (methodDefinition.Parameters.Count == 0)
+                                {
+                                    methodDefinition.IsPublic = true;
+                                }
+                            }
                             break;
                         case nameof(__RpcParams):
                         case nameof(RpcFallbackSerialization):

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -93,7 +93,7 @@ namespace Unity.Netcode
 
             if (!NetworkManager.IsServer)
             {
-                var peerClientIds = new NativeArray<ulong>(NetworkManager.ConnectedClientsIds.Count - 1, Allocator.Temp);
+                var peerClientIds = new NativeArray<ulong>(Math.Max(NetworkManager.ConnectedClientsIds.Count - 1, 0), Allocator.Temp);
                 // `using var peerClientIds` or `using(peerClientIds)` renders it immutable...
                 using var sentinel = peerClientIds;
 

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -971,14 +971,7 @@ namespace Unity.Netcode
                 // TODO: Could(should?) be replaced with more memory per client, by storing the visibility
                 foreach (var sobj in NetworkManager.SpawnManager.SpawnedObjectsList)
                 {
-                    if (sobj.Observers.Contains(clientId))
-                    {
-                        sobj.Observers.Remove(clientId);
-                        /*foreach (var behaviour in sobj.ChildNetworkBehaviours)
-                        {
-                            behaviour.Observers.Remove(clientId);
-                        }*/
-                    }
+                    sobj.Observers.Remove(clientId);
                 }
 
                 if (ConnectedClients.ContainsKey(clientId))

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -122,7 +122,7 @@ namespace Unity.Netcode
             {
                 try
                 {
-                    OnConnectionEvent?.Invoke(NetworkManager, new ConnectionEventData{ClientId = clientId, EventType = ConnectionEvent.ClientConnected});
+                    OnConnectionEvent?.Invoke(NetworkManager, new ConnectionEventData { ClientId = clientId, EventType = ConnectionEvent.ClientConnected });
                 }
                 catch (Exception exception)
                 {
@@ -143,7 +143,7 @@ namespace Unity.Netcode
             }
             try
             {
-                OnConnectionEvent?.Invoke(NetworkManager, new ConnectionEventData{ClientId = clientId, EventType = ConnectionEvent.ClientDisconnected});
+                OnConnectionEvent?.Invoke(NetworkManager, new ConnectionEventData { ClientId = clientId, EventType = ConnectionEvent.ClientDisconnected });
             }
             catch (Exception exception)
             {
@@ -155,7 +155,7 @@ namespace Unity.Netcode
         {
             try
             {
-                OnConnectionEvent?.Invoke(NetworkManager, new ConnectionEventData{ClientId = clientId, EventType = ConnectionEvent.PeerConnected});
+                OnConnectionEvent?.Invoke(NetworkManager, new ConnectionEventData { ClientId = clientId, EventType = ConnectionEvent.PeerConnected });
             }
             catch (Exception exception)
             {
@@ -166,7 +166,7 @@ namespace Unity.Netcode
         {
             try
             {
-                OnConnectionEvent?.Invoke(NetworkManager, new ConnectionEventData{ClientId = clientId, EventType = ConnectionEvent.PeerDisconnected});
+                OnConnectionEvent?.Invoke(NetworkManager, new ConnectionEventData { ClientId = clientId, EventType = ConnectionEvent.PeerDisconnected });
             }
             catch (Exception exception)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -430,8 +430,12 @@ namespace Unity.Netcode
         /// runtime-bound targets like <see cref="Unity.Netcode.RpcTarget.Single"/>,
         /// <see cref="Unity.Netcode.RpcTarget.Group(NativeArray{ulong})"/>,
         /// <see cref="Unity.Netcode.RpcTarget.Group(NativeList{ulong})"/>,
-        /// <see cref="Unity.Netcode.RpcTarget.Group(ulong[])"/>, and
-        /// <see cref="Unity.Netcode.RpcTarget.Group{T}(T)"/>
+        /// <see cref="Unity.Netcode.RpcTarget.Group(ulong[])"/>,
+        /// <see cref="Unity.Netcode.RpcTarget.Group{T}(T)"/>, <see cref="Unity.Netcode.RpcTarget.Not(ulong)"/>,
+        /// <see cref="Unity.Netcode.RpcTarget.Not(NativeArray{ulong})"/>,
+        /// <see cref="Unity.Netcode.RpcTarget.Not(NativeList{ulong})"/>,
+        /// <see cref="Unity.Netcode.RpcTarget.Not(ulong[])"/>, and
+        /// <see cref="Unity.Netcode.RpcTarget.Not{T}(T)"/>
         /// </summary>
 #pragma warning restore IDE0001
         public RpcTarget RpcTarget => NetworkManager.RpcTarget;

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -6,6 +6,14 @@ using UnityEngine;
 
 namespace Unity.Netcode
 {
+    public class RpcException : Exception
+    {
+        public RpcException(string message) : base(message)
+        {
+
+        }
+    }
+
     /// <summary>
     /// The base class to override to write network code. Inherits MonoBehaviour
     /// </summary>
@@ -27,16 +35,22 @@ namespace Unity.Netcode
         // RuntimeAccessModifiersILPP will make this `protected`
         internal enum __RpcExecStage
         {
+            // Technically will overlap with None and Server
+            // but it doesn't matter since we don't use None and Server
+            Send = 0,
+            Execute = 1,
+
+            // Backward compatibility, not used...
             None = 0,
             Server = 1,
-            Client = 2
+            Client = 2,
         }
         // NetworkBehaviourILPP will override this in derived classes to return the name of the concrete type
         internal virtual string __getTypeName() => nameof(NetworkBehaviour);
 
         [NonSerialized]
         // RuntimeAccessModifiersILPP will make this `protected`
-        internal __RpcExecStage __rpc_exec_stage = __RpcExecStage.None;
+        internal __RpcExecStage __rpc_exec_stage = __RpcExecStage.Send;
 #pragma warning restore IDE1006 // restore naming rule violation check
 
         private const int k_RpcMessageDefaultSize = 1024; // 1k
@@ -284,6 +298,99 @@ namespace Unity.Netcode
 #endif
         }
 
+
+#pragma warning disable IDE1006 // disable naming rule violation check
+        // RuntimeAccessModifiersILPP will make this `protected`
+        internal FastBufferWriter __beginSendRpc(uint rpcMethodId, RpcParams rpcParams, RpcAttribute.RpcAttributeParams attributeParams, SendTo defaultTarget, RpcDelivery rpcDelivery)
+#pragma warning restore IDE1006 // restore naming rule violation check
+        {
+            if (attributeParams.RequireOwnership && !IsOwner)
+            {
+                throw new RpcException("This RPC can only be sent by its owner.");
+            }
+            return new FastBufferWriter(k_RpcMessageDefaultSize, Allocator.Temp, k_RpcMessageMaximumSize);
+        }
+
+#pragma warning disable IDE1006 // disable naming rule violation check
+        // RuntimeAccessModifiersILPP will make this `protected`
+        internal void __endSendRpc(ref FastBufferWriter bufferWriter, uint rpcMethodId, RpcParams rpcParams, RpcAttribute.RpcAttributeParams attributeParams, SendTo defaultTarget, RpcDelivery rpcDelivery)
+#pragma warning restore IDE1006 // restore naming rule violation check
+        {
+            var rpcMessage = new RpcMessage
+            {
+                Metadata = new RpcMetadata
+                {
+                    NetworkObjectId = NetworkObjectId,
+                    NetworkBehaviourId = NetworkBehaviourId,
+                    NetworkRpcMethodId = rpcMethodId,
+                },
+                SenderClientId = NetworkManager.LocalClientId,
+                WriteBuffer = bufferWriter
+            };
+
+            NetworkDelivery networkDelivery;
+            switch (rpcDelivery)
+            {
+                default:
+                case RpcDelivery.Reliable:
+                    networkDelivery = NetworkDelivery.ReliableFragmentedSequenced;
+                    break;
+                case RpcDelivery.Unreliable:
+                    if (bufferWriter.Length > NetworkManager.MessageManager.NonFragmentedMessageMaxSize)
+                    {
+                        throw new OverflowException("RPC parameters are too large for unreliable delivery.");
+                    }
+                    networkDelivery = NetworkDelivery.Unreliable;
+                    break;
+            }
+
+            if (rpcParams.Send.Target == null)
+            {
+                switch (defaultTarget)
+                {
+                    case SendTo.Everyone:
+                        rpcParams.Send.Target = RpcTarget.Everyone;
+                        break;
+                    case SendTo.Owner:
+                        rpcParams.Send.Target = RpcTarget.Owner;
+                        break;
+                    case SendTo.Server:
+                        rpcParams.Send.Target = RpcTarget.Server;
+                        break;
+                    case SendTo.NotServer:
+                        rpcParams.Send.Target = RpcTarget.NotServer;
+                        break;
+                    case SendTo.NotMe:
+                        rpcParams.Send.Target = RpcTarget.NotMe;
+                        break;
+                    case SendTo.NotOwner:
+                        rpcParams.Send.Target = RpcTarget.NotOwner;
+                        break;
+                    case SendTo.Me:
+                        rpcParams.Send.Target = RpcTarget.Me;
+                        break;
+                    case SendTo.ClientsAndHost:
+                        rpcParams.Send.Target = RpcTarget.ClientsAndHost;
+                        break;
+                    case SendTo.SpecifiedInParams:
+                        throw new RpcException("This method requires a runtime-specified send target.");
+                }
+            }
+            else if (defaultTarget != SendTo.SpecifiedInParams && !attributeParams.AllowTargetOverride)
+            {
+                throw new RpcException("Target override is not allowed for this method.");
+            }
+
+            if (rpcParams.Send.LocalDeferMode == LocalDeferMode.Default)
+            {
+                rpcParams.Send.LocalDeferMode = attributeParams.DeferLocal ? LocalDeferMode.Defer : LocalDeferMode.SendImmediate;
+            }
+
+            rpcParams.Send.Target.Send(this, ref rpcMessage, networkDelivery, rpcParams);
+
+            bufferWriter.Dispose();
+        }
+
 #pragma warning disable IDE1006 // disable naming rule violation check
         // RuntimeAccessModifiersILPP will make this `protected`
         internal static NativeList<T> __createNativeList<T>() where T : unmanaged
@@ -316,6 +423,16 @@ namespace Unity.Netcode
         }
 
         /// <summary>
+        /// Provides access to the various <see cref="SendTo"/> targets at runtime, as well as
+        /// runtime-bound targets like <see cref="Unity.Netcode.RpcTarget.Single"/>,
+        /// <see cref="Unity.Netcode.RpcTarget.Group(NativeArray{ulong})"/>,
+        /// <see cref="Unity.Netcode.RpcTarget.Group(NativeList{ulong})"/>,
+        /// <see cref="Unity.Netcode.RpcTarget.Group(ulong[])"/>, and
+        /// <see cref="Unity.Netcode.RpcTarget.Group{T}(T)"/>
+        /// </summary>
+        public RpcTarget RpcTarget => NetworkManager.RpcTarget;
+
+        /// <summary>
         /// If a NetworkObject is assigned, it will return whether or not this NetworkObject
         /// is the local player object.  If no NetworkObject is assigned it will always return false.
         /// </summary>
@@ -330,6 +447,11 @@ namespace Unity.Netcode
         /// Gets if we are executing as server
         /// </summary>
         public bool IsServer { get; private set; }
+
+        /// <summary>
+        /// Gets if the server (local or remote) is a host - i.e., also a client
+        /// </summary>
+        public bool ServerIsHost { get; private set; }
 
         /// <summary>
         /// Gets if we are executing as client
@@ -472,12 +594,13 @@ namespace Unity.Netcode
                     IsHost = NetworkManager.IsListening && NetworkManager.IsHost;
                     IsClient = NetworkManager.IsListening && NetworkManager.IsClient;
                     IsServer = NetworkManager.IsListening && NetworkManager.IsServer;
+                    ServerIsHost = NetworkManager.IsListening && NetworkManager.ServerIsHost;
                 }
             }
             else // Shouldn't happen, but if so then set the properties to their default value;
             {
                 OwnerClientId = NetworkObjectId = default;
-                IsOwnedByServer = IsOwner = IsHost = IsClient = IsServer = default;
+                IsOwnedByServer = IsOwner = IsHost = IsClient = IsServer = ServerIsHost = default;
                 NetworkBehaviourId = default;
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -422,6 +422,9 @@ namespace Unity.Netcode
             }
         }
 
+        // This erroneously tries to simplify these method references but the docs do not pick it up correctly
+        // because they try to resolve it on the field rather than the class of the same name.
+#pragma warning disable IDE0001
         /// <summary>
         /// Provides access to the various <see cref="SendTo"/> targets at runtime, as well as
         /// runtime-bound targets like <see cref="Unity.Netcode.RpcTarget.Single"/>,
@@ -430,6 +433,7 @@ namespace Unity.Netcode
         /// <see cref="Unity.Netcode.RpcTarget.Group(ulong[])"/>, and
         /// <see cref="Unity.Netcode.RpcTarget.Group{T}(T)"/>
         /// </summary>
+#pragma warning restore IDE0001
         public RpcTarget RpcTarget => NetworkManager.RpcTarget;
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -107,16 +107,7 @@ namespace Unity.Netcode
         /// <summary>
         /// Gets a list of just the IDs of all connected clients. This is only accessible on the server.
         /// </summary>
-        public IReadOnlyList<ulong> ConnectedClientsIds => IsServer ? ConnectionManager.ConnectedClientIds : throw new NotServerException($"{nameof(ConnectionManager.ConnectedClientIds)} should only be accessed on server.");
-
-        /// <summary>
-        /// Gets a list of just the IDs of all known peers.
-        /// This is accessible from client, server, and host.
-        /// Currently, this set contains the list of all client ids connected to the server, but this set
-        /// should be treated as the set of ids that a given process is <b>allowed to send messages to</b>,
-        /// and should not be depended on to always contain the full set of ids connected to the server in the future.
-        /// </summary>
-        public IReadOnlyCollection<ulong> PeerClientIds => ConnectionManager.PeerClientIds;
+        public IReadOnlyList<ulong> ConnectedClientsIds => ConnectionManager.ConnectedClientIds;
 
         /// <summary>
         /// Gets the local <see cref="NetworkClient"/> for this client.
@@ -137,7 +128,7 @@ namespace Unity.Netcode
         /// <summary>
         /// Gets whether or not the current server (local or remote) is a host - i.e., also a client
         /// </summary>
-        public bool ServerIsHost => ConnectionManager.PeerClientIds.Contains(ServerClientId);
+        public bool ServerIsHost => ConnectionManager.ConnectedClientIds.Contains(ServerClientId);
 
         /// <summary>
         /// Gets Whether or not a client is running
@@ -226,6 +217,8 @@ namespace Unity.Netcode
 
         /// <summary>
         /// The callback to invoke once a client connects. This callback is only ran on the server and on the local client that connects.
+        ///
+        /// It is recommended to use OnConnectionEvent instead, as this will eventually be deprecated
         /// </summary>
         public event Action<ulong> OnClientConnectedCallback
         {
@@ -235,6 +228,8 @@ namespace Unity.Netcode
 
         /// <summary>
         /// The callback to invoke when a client disconnects. This callback is only ran on the server and on the local client that disconnects.
+        ///
+        /// It is recommended to use OnConnectionEvent instead, as this will eventually be deprecated
         /// </summary>
         public event Action<ulong> OnClientDisconnectCallback
         {
@@ -243,21 +238,13 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// The callback to invoke once a client connects. This callback is only ran on the server and on the local client that connects.
+        /// The callback to invoke on any connection event. See <see cref="ConnectionEvent"/> and <see cref="ConnectionEventData"/>
+        /// for more info.
         /// </summary>
-        public event Action<ulong> OnPeerConnectedCallback
+        public event Action<NetworkManager, ConnectionEventData> OnConnectionEvent
         {
-            add => ConnectionManager.OnPeerConnectedCallback += value;
-            remove => ConnectionManager.OnPeerConnectedCallback -= value;
-        }
-
-        /// <summary>
-        /// The callback to invoke when a client disconnects. This callback is only ran on the server and on the local client that disconnects.
-        /// </summary>
-        public event Action<ulong> OnPeerDisconnectCallback
-        {
-            add => ConnectionManager.OnPeerDisconnectCallback += value;
-            remove => ConnectionManager.OnPeerDisconnectCallback -= value;
+            add => ConnectionManager.OnConnectionEvent += value;
+            remove => ConnectionManager.OnConnectionEvent -= value;
         }
 
         /// <summary>
@@ -979,7 +966,7 @@ namespace Unity.Netcode
         private void HostServerInitialize()
         {
             LocalClientId = ServerClientId;
-            ConnectionManager.PeerClientIds.Add(ServerClientId);
+            //ConnectionManager.ConnectedClientIds.Add(ServerClientId);
             NetworkMetrics.SetConnectionId(LocalClientId);
             MessageManager.SetLocalClientId(LocalClientId);
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -414,6 +414,9 @@ namespace Unity.Netcode
 
         internal IDeferredNetworkMessageManager DeferredMessageManager { get; private set; }
 
+        // This erroneously tries to simplify these method references but the docs do not pick it up correctly
+        // because they try to resolve it on the field rather than the class of the same name.
+#pragma warning disable IDE0001
         /// <summary>
         /// Provides access to the various <see cref="SendTo"/> targets at runtime, as well as
         /// runtime-bound targets like <see cref="Unity.Netcode.RpcTarget.Single"/>,
@@ -422,6 +425,7 @@ namespace Unity.Netcode
         /// <see cref="Unity.Netcode.RpcTarget.Group(ulong[])"/>, and
         /// <see cref="Unity.Netcode.RpcTarget.Group{T}(T)"/>
         /// </summary>
+#pragma warning restore IDE0001
         public RpcTarget RpcTarget;
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -409,8 +409,12 @@ namespace Unity.Netcode
         /// runtime-bound targets like <see cref="Unity.Netcode.RpcTarget.Single"/>,
         /// <see cref="Unity.Netcode.RpcTarget.Group(NativeArray{ulong})"/>,
         /// <see cref="Unity.Netcode.RpcTarget.Group(NativeList{ulong})"/>,
-        /// <see cref="Unity.Netcode.RpcTarget.Group(ulong[])"/>, and
-        /// <see cref="Unity.Netcode.RpcTarget.Group{T}(T)"/>
+        /// <see cref="Unity.Netcode.RpcTarget.Group(ulong[])"/>,
+        /// <see cref="Unity.Netcode.RpcTarget.Group{T}(T)"/>, <see cref="Unity.Netcode.RpcTarget.Not(ulong)"/>,
+        /// <see cref="Unity.Netcode.RpcTarget.Not(NativeArray{ulong})"/>,
+        /// <see cref="Unity.Netcode.RpcTarget.Not(NativeList{ulong})"/>,
+        /// <see cref="Unity.Netcode.RpcTarget.Not(ulong[])"/>, and
+        /// <see cref="Unity.Netcode.RpcTarget.Not{T}(T)"/>
         /// </summary>
 #pragma warning restore IDE0001
         public RpcTarget RpcTarget;

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -110,13 +110,13 @@ namespace Unity.Netcode
         public IReadOnlyList<ulong> ConnectedClientsIds => IsServer ? ConnectionManager.ConnectedClientIds : throw new NotServerException($"{nameof(ConnectionManager.ConnectedClientIds)} should only be accessed on server.");
 
         /// <summary>
-        /// Gets a list of just the IDs of all known clients.
+        /// Gets a list of just the IDs of all known peers.
         /// This is accessible from client, server, and host.
         /// Currently, this set contains the list of all client ids connected to the server, but this set
         /// should be treated as the set of ids that a given process is <b>allowed to send messages to</b>,
         /// and should not be depended on to always contain the full set of ids connected to the server in the future.
         /// </summary>
-        public IReadOnlyCollection<ulong> KnownClientIds => ConnectionManager.KnownClientIds;
+        public IReadOnlyCollection<ulong> PeerClientIds => ConnectionManager.PeerClientIds;
 
         /// <summary>
         /// Gets the local <see cref="NetworkClient"/> for this client.
@@ -137,7 +137,7 @@ namespace Unity.Netcode
         /// <summary>
         /// Gets whether or not the current server (local or remote) is a host - i.e., also a client
         /// </summary>
-        public bool ServerIsHost => ConnectionManager.KnownClientIds.Contains(ServerClientId);
+        public bool ServerIsHost => ConnectionManager.PeerClientIds.Contains(ServerClientId);
 
         /// <summary>
         /// Gets Whether or not a client is running
@@ -960,7 +960,7 @@ namespace Unity.Netcode
         private void HostServerInitialize()
         {
             LocalClientId = ServerClientId;
-            ConnectionManager.KnownClientIds.Add(ServerClientId);
+            ConnectionManager.PeerClientIds.Add(ServerClientId);
             NetworkMetrics.SetConnectionId(LocalClientId);
             MessageManager.SetLocalClientId(LocalClientId);
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -518,10 +518,7 @@ namespace Unity.Netcode
                 return;
             }
             NetworkManager.SpawnManager.MarkObjectForShowingTo(this, clientId);
-            if (!Observers.Contains(clientId))
-            {
-                Observers.Add(clientId);
-            }
+            Observers.Add(clientId);
         }
 
 
@@ -616,10 +613,7 @@ namespace Unity.Netcode
                 {
                     throw new VisibilityChangeException("The object is already hidden");
                 }
-                if (Observers.Contains(clientId))
-                {
-                    Observers.Remove(clientId);
-                }
+                Observers.Remove(clientId);
 
                 var message = new DestroyObjectMessage
                 {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -518,7 +518,10 @@ namespace Unity.Netcode
                 return;
             }
             NetworkManager.SpawnManager.MarkObjectForShowingTo(this, clientId);
-            Observers.Add(clientId);
+            if (!Observers.Contains(clientId))
+            {
+                Observers.Add(clientId);
+            }
         }
 
 
@@ -613,7 +616,10 @@ namespace Unity.Netcode
                 {
                     throw new VisibilityChangeException("The object is already hidden");
                 }
-                Observers.Remove(clientId);
+                if (Observers.Contains(clientId))
+                {
+                    Observers.Remove(clientId);
+                }
 
                 var message = new DestroyObjectMessage
                 {

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/DeferredMessageManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/DeferredMessageManager.cs
@@ -113,6 +113,7 @@ namespace Unity.Netcode
                 // processed before the object is fully spawned. This must be the last thing done in the spawn process.
                 if (triggers.TryGetValue(key, out var triggerInfo))
                 {
+                    triggers.Remove(key);
                     foreach (var deferredMessage in triggerInfo.TriggerData)
                     {
                         // Reader will be disposed within HandleMessage
@@ -120,7 +121,6 @@ namespace Unity.Netcode
                     }
 
                     triggerInfo.TriggerData.Dispose();
-                    triggers.Remove(key);
                 }
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/IDeferredNetworkMessageManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/IDeferredNetworkMessageManager.cs
@@ -6,6 +6,7 @@ namespace Unity.Netcode
         {
             OnSpawn,
             OnAddPrefab,
+            OnNextFrame,
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/AddObserverMessage.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/AddObserverMessage.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3653bc4a709247a3b84b79d4a758f9d5
+timeCreated: 1699310795

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/AddObserverMessage.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/AddObserverMessage.cs.meta
@@ -1,3 +1,0 @@
-﻿fileFormatVersion: 2
-guid: 3653bc4a709247a3b84b79d4a758f9d5
-timeCreated: 1699310795

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ClientConnectedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ClientConnectedMessage.cs
@@ -1,0 +1,32 @@
+namespace Unity.Netcode
+{
+    internal struct ClientConnectedMessage : INetworkMessage, INetworkSerializeByMemcpy
+    {
+        public int Version => 0;
+
+        public ulong ClientId;
+
+        public void Serialize(FastBufferWriter writer, int targetVersion)
+        {
+            BytePacker.WriteValueBitPacked(writer, ClientId);
+        }
+
+        public bool Deserialize(FastBufferReader reader, ref NetworkContext context, int receivedMessageVersion)
+        {
+            var networkManager = (NetworkManager)context.SystemOwner;
+            if (!networkManager.IsClient)
+            {
+                return false;
+            }
+            ByteUnpacker.ReadValueBitPacked(reader, out ClientId);
+            return true;
+        }
+
+        public void Handle(ref NetworkContext context)
+        {
+            var networkManager = (NetworkManager)context.SystemOwner;
+            networkManager.ConnectionManager.KnownClientIds.Add(ClientId);
+            networkManager.ConnectionManager.InvokeOnPeerConnectedCallback(ClientId);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ClientConnectedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ClientConnectedMessage.cs
@@ -25,7 +25,7 @@ namespace Unity.Netcode
         public void Handle(ref NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
-            networkManager.ConnectionManager.KnownClientIds.Add(ClientId);
+            networkManager.ConnectionManager.PeerClientIds.Add(ClientId);
             networkManager.ConnectionManager.InvokeOnPeerConnectedCallback(ClientId);
         }
     }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ClientConnectedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ClientConnectedMessage.cs
@@ -25,8 +25,11 @@ namespace Unity.Netcode
         public void Handle(ref NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
-            networkManager.ConnectionManager.PeerClientIds.Add(ClientId);
-            networkManager.ConnectionManager.InvokeOnPeerConnectedCallback(ClientId);
+            networkManager.ConnectionManager.ConnectedClientIds.Add(ClientId);
+            if (networkManager.IsConnectedClient)
+            {
+                networkManager.ConnectionManager.InvokeOnPeerConnectedCallback(ClientId);
+            }
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ClientConnectedMessage.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ClientConnectedMessage.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 158454105806474cba54a4ea5a0bfb12
+timeCreated: 1697836112

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ClientDisconnectedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ClientDisconnectedMessage.cs
@@ -1,0 +1,32 @@
+namespace Unity.Netcode
+{
+    internal struct ClientDisconnectedMessage : INetworkMessage, INetworkSerializeByMemcpy
+    {
+        public int Version => 0;
+
+        public ulong ClientId;
+
+        public void Serialize(FastBufferWriter writer, int targetVersion)
+        {
+            BytePacker.WriteValueBitPacked(writer, ClientId);
+        }
+
+        public bool Deserialize(FastBufferReader reader, ref NetworkContext context, int receivedMessageVersion)
+        {
+            var networkManager = (NetworkManager)context.SystemOwner;
+            if (!networkManager.IsClient)
+            {
+                return false;
+            }
+            ByteUnpacker.ReadValueBitPacked(reader, out ClientId);
+            return true;
+        }
+
+        public void Handle(ref NetworkContext context)
+        {
+            var networkManager = (NetworkManager)context.SystemOwner;
+            networkManager.ConnectionManager.KnownClientIds.Remove(ClientId);
+            networkManager.ConnectionManager.InvokeOnPeerDisconnectedCallback(ClientId);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ClientDisconnectedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ClientDisconnectedMessage.cs
@@ -25,8 +25,11 @@ namespace Unity.Netcode
         public void Handle(ref NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
-            networkManager.ConnectionManager.PeerClientIds.Remove(ClientId);
-            networkManager.ConnectionManager.InvokeOnPeerDisconnectedCallback(ClientId);
+            networkManager.ConnectionManager.ConnectedClientIds.Remove(ClientId);
+            if (networkManager.IsConnectedClient)
+            {
+                networkManager.ConnectionManager.InvokeOnPeerDisconnectedCallback(ClientId);
+            }
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ClientDisconnectedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ClientDisconnectedMessage.cs
@@ -25,7 +25,7 @@ namespace Unity.Netcode
         public void Handle(ref NetworkContext context)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
-            networkManager.ConnectionManager.KnownClientIds.Remove(ClientId);
+            networkManager.ConnectionManager.PeerClientIds.Remove(ClientId);
             networkManager.ConnectionManager.InvokeOnPeerDisconnectedCallback(ClientId);
         }
     }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ClientDisconnectedMessage.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ClientDisconnectedMessage.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8f91296c8e5f40b1a2a03d74a31526b6
+timeCreated: 1697836161

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
@@ -58,10 +58,7 @@ namespace Unity.Netcode
                 {
                     if (sobj.SpawnWithObservers && (sobj.CheckObjectVisibility == null || sobj.CheckObjectVisibility(OwnerClientId)))
                     {
-                        if (!sobj.Observers.Contains(OwnerClientId))
-                        {
-                            sobj.Observers.Add(OwnerClientId);
-                        }
+                        sobj.Observers.Add(OwnerClientId);
                         var sceneObject = sobj.GetMessageSceneObject(OwnerClientId);
                         sceneObject.Serialize(writer);
                         ++sceneObjectCount;

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
@@ -18,7 +18,7 @@ namespace Unity.Netcode
 
         public NativeArray<MessageVersionData> MessageVersions;
 
-        public NativeArray<ulong> KnownClientIds;
+        public NativeArray<ulong> PeerClientIds;
 
         public void Serialize(FastBufferWriter writer, int targetVersion)
         {
@@ -41,7 +41,7 @@ namespace Unity.Netcode
 
             if (targetVersion >= k_VersionAddClientIds)
             {
-                writer.WriteValueSafe(KnownClientIds);
+                writer.WriteValueSafe(PeerClientIds);
             }
 
             uint sceneObjectCount = 0;
@@ -120,11 +120,11 @@ namespace Unity.Netcode
 
             if (receivedMessageVersion >= k_VersionAddClientIds)
             {
-                reader.ReadValueSafe(out KnownClientIds, Allocator.TempJob);
+                reader.ReadValueSafe(out PeerClientIds, Allocator.TempJob);
             }
             else
             {
-                KnownClientIds = new NativeArray<ulong>(0, Allocator.TempJob);
+                PeerClientIds = new NativeArray<ulong>(0, Allocator.TempJob);
             }
 
             m_ReceivedSceneObjectData = reader;
@@ -148,10 +148,10 @@ namespace Unity.Netcode
             // Stop the client-side approval timeout coroutine since we are approved.
             networkManager.ConnectionManager.StopClientApprovalCoroutine();
 
-            networkManager.ConnectionManager.KnownClientIds.Clear();
-            foreach (var clientId in KnownClientIds)
+            networkManager.ConnectionManager.PeerClientIds.Clear();
+            foreach (var clientId in PeerClientIds)
             {
-                networkManager.ConnectionManager.KnownClientIds.Add(clientId);
+                networkManager.ConnectionManager.PeerClientIds.Add(clientId);
             }
 
             // Only if scene management is disabled do we handle NetworkObject synchronization at this point
@@ -174,7 +174,7 @@ namespace Unity.Netcode
                 // When scene management is disabled we notify after everything is synchronized
                 networkManager.ConnectionManager.InvokeOnClientConnectedCallback(context.SenderId);
 
-                foreach (var clientId in KnownClientIds)
+                foreach (var clientId in PeerClientIds)
                 {
                     if (clientId == networkManager.LocalClientId)
                     {
@@ -184,7 +184,7 @@ namespace Unity.Netcode
                 }
             }
 
-            KnownClientIds.Dispose();
+            PeerClientIds.Dispose();
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ProxyMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ProxyMessage.cs
@@ -1,0 +1,70 @@
+using System;
+using Unity.Collections;
+
+namespace Unity.Netcode
+{
+    internal struct ProxyMessage : INetworkMessage
+    {
+        public NativeArray<ulong> TargetClientIds;
+        public NetworkDelivery Delivery;
+        public RpcMessage WrappedMessage;
+
+        // Version of ProxyMessage and RpcMessage must always match.
+        // If ProxyMessage needs to change, increment RpcMessage's version
+        public int Version => new RpcMessage().Version;
+
+        public void Serialize(FastBufferWriter writer, int targetVersion)
+        {
+            writer.WriteValueSafe(TargetClientIds);
+            BytePacker.WriteValuePacked(writer, Delivery);
+            WrappedMessage.Serialize(writer, targetVersion);
+        }
+
+        public bool Deserialize(FastBufferReader reader, ref NetworkContext context, int receivedMessageVersion)
+        {
+            reader.ReadValueSafe(out TargetClientIds, Allocator.Temp);
+            ByteUnpacker.ReadValuePacked(reader, out Delivery);
+            WrappedMessage = new RpcMessage();
+            WrappedMessage.Deserialize(reader, ref context, receivedMessageVersion);
+            return true;
+        }
+
+        public unsafe void Handle(ref NetworkContext context)
+        {
+
+            var networkManager = (NetworkManager)context.SystemOwner;
+            if (!networkManager.SpawnManager.SpawnedObjects.TryGetValue(WrappedMessage.Metadata.NetworkObjectId, out var networkObject))
+            {
+                throw new InvalidOperationException($"An RPC called on a {nameof(NetworkObject)} that is not in the spawned objects list. Please make sure the {nameof(NetworkObject)} is spawned before calling RPCs.");
+            }
+
+            var observers = networkObject.Observers;
+
+            var nonServerIds = new NativeList<ulong>(Allocator.Temp);
+            for (var i = 0; i < TargetClientIds.Length; ++i)
+            {
+                if (!observers.Contains(TargetClientIds[i]))
+                {
+                    continue;
+                }
+
+                if (TargetClientIds[i] == NetworkManager.ServerClientId)
+                {
+                    WrappedMessage.Handle(ref context);
+                }
+                else
+                {
+                    nonServerIds.Add(TargetClientIds[i]);
+                }
+            }
+
+            WrappedMessage.WriteBuffer = new FastBufferWriter(WrappedMessage.ReadBuffer.Length, Allocator.Temp);
+
+            using (WrappedMessage.WriteBuffer)
+            {
+                WrappedMessage.WriteBuffer.WriteBytesSafe(WrappedMessage.ReadBuffer.GetUnsafePtr(), WrappedMessage.ReadBuffer.Length);
+                networkManager.MessageManager.SendMessage(ref WrappedMessage, Delivery, nonServerIds);
+            }
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ProxyMessage.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ProxyMessage.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e9ee0457d5b740b38dfe6542658fb522
+timeCreated: 1697825043

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/NetworkMessageManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/NetworkMessageManager.cs
@@ -85,6 +85,8 @@ namespace Unity.Netcode
         private INetworkMessageSender m_Sender;
         private bool m_Disposed;
 
+        private ulong m_LocalClientId;
+
         internal Type[] MessageTypes => m_ReverseTypeMap;
         internal MessageHandler[] MessageHandlers => m_MessageHandlers;
 
@@ -93,6 +95,16 @@ namespace Unity.Netcode
         internal uint GetMessageType(Type t)
         {
             return m_MessageTypes[t];
+        }
+
+        internal object GetOwner()
+        {
+            return m_Owner;
+        }
+
+        internal void SetLocalClientId(ulong id)
+        {
+            m_LocalClientId = id;
         }
 
         public const int DefaultNonFragmentedMessageMaxSize = 1300 & ~7; // Round down to nearest word aligned size (1296)
@@ -551,7 +563,7 @@ namespace Unity.Netcode
             // Special cases because these are the messages that carry the version info - thus the version info isn't
             // populated yet when we get these. The first part of these messages always has to be the version data
             // and can't change.
-            if (typeof(T) != typeof(ConnectionRequestMessage) && typeof(T) != typeof(ConnectionApprovedMessage) && typeof(T) != typeof(DisconnectReasonMessage))
+            if (typeof(T) != typeof(ConnectionRequestMessage) && typeof(T) != typeof(ConnectionApprovedMessage) && typeof(T) != typeof(DisconnectReasonMessage) && context.SenderId != manager.m_LocalClientId)
             {
                 messageVersion = manager.GetMessageVersion(typeof(T), context.SenderId, true);
                 if (messageVersion < 0)

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcAttributes.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcAttributes.cs
@@ -21,12 +21,36 @@ namespace Unity.Netcode
     /// <summary>
     /// <para>Represents the common base class for Rpc attributes.</para>
     /// </summary>
-    public abstract class RpcAttribute : Attribute
+    [AttributeUsage(AttributeTargets.Method)]
+    public class RpcAttribute : Attribute
     {
+        // Must match the set of parameters below
+        public struct RpcAttributeParams
+        {
+            public RpcDelivery Delivery;
+            public bool RequireOwnership;
+            public bool DeferLocal;
+            public bool AllowTargetOverride;
+        }
+
+        // Must match the fields in RemoteAttributeParams
         /// <summary>
         /// Type of RPC delivery method
         /// </summary>
         public RpcDelivery Delivery = RpcDelivery.Reliable;
+        public bool RequireOwnership;
+        public bool DeferLocal;
+        public bool AllowTargetOverride;
+
+        public RpcAttribute(SendTo target)
+        {
+        }
+
+        // To get around an issue with the release validator, RuntimeAccessModifiersILPP will make this 'public'
+        private RpcAttribute()
+        {
+
+        }
     }
 
     /// <summary>
@@ -36,10 +60,12 @@ namespace Unity.Netcode
     [AttributeUsage(AttributeTargets.Method)]
     public class ServerRpcAttribute : RpcAttribute
     {
-        /// <summary>
-        /// Whether or not the ServerRpc should only be run if executed by the owner of the object
-        /// </summary>
-        public bool RequireOwnership = true;
+        public new bool RequireOwnership;
+
+        public ServerRpcAttribute() : base(SendTo.Server)
+        {
+
+        }
     }
 
     /// <summary>
@@ -47,5 +73,11 @@ namespace Unity.Netcode
     /// <para>A ClientRpc marked method will be fired by the server but executed on clients.</para>
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
-    public class ClientRpcAttribute : RpcAttribute { }
+    public class ClientRpcAttribute : RpcAttribute
+    {
+        public ClientRpcAttribute() : base(SendTo.NotServer)
+        {
+
+        }
+    }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcParams.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcParams.cs
@@ -3,6 +3,60 @@ using Unity.Collections;
 
 namespace Unity.Netcode
 {
+    public enum LocalDeferMode
+    {
+        Default,
+        Defer,
+        SendImmediate
+    }
+    /// <summary>
+    /// Generic RPC
+    /// </summary>
+    public struct RpcSendParams
+    {
+        public BaseRpcTarget Target;
+
+        public LocalDeferMode LocalDeferMode;
+
+        public static implicit operator RpcSendParams(BaseRpcTarget target) => new RpcSendParams { Target = target };
+        public static implicit operator RpcSendParams(LocalDeferMode deferMode) => new RpcSendParams { LocalDeferMode = deferMode };
+    }
+
+    /// <summary>
+    /// The receive parameters for server-side remote procedure calls
+    /// </summary>
+    public struct RpcReceiveParams
+    {
+        /// <summary>
+        /// Server-Side RPC
+        /// The client identifier of the sender
+        /// </summary>
+        public ulong SenderClientId;
+    }
+
+    /// <summary>
+    /// Server-Side RPC
+    /// Can be used with any sever-side remote procedure call
+    /// Note: typically this is use primarily for the <see cref="ServerRpcReceiveParams"/>
+    /// </summary>
+    public struct RpcParams
+    {
+        /// <summary>
+        /// The server RPC send parameters (currently a place holder)
+        /// </summary>
+        public RpcSendParams Send;
+
+        /// <summary>
+        /// The client RPC receive parameters provides you with the sender's identifier
+        /// </summary>
+        public RpcReceiveParams Receive;
+
+        public static implicit operator RpcParams(RpcSendParams send) => new RpcParams { Send = send };
+        public static implicit operator RpcParams(BaseRpcTarget target) => new RpcParams { Send = new RpcSendParams { Target = target } };
+        public static implicit operator RpcParams(LocalDeferMode deferMode) => new RpcParams { Send = new RpcSendParams { LocalDeferMode = deferMode } };
+        public static implicit operator RpcParams(RpcReceiveParams receive) => new RpcParams { Receive = receive };
+    }
+
     /// <summary>
     /// Server-Side RPC
     /// Place holder.  <see cref="ServerRpcParams"/>
@@ -99,6 +153,7 @@ namespace Unity.Netcode
     internal struct __RpcParams
 #pragma warning restore IDE1006 // restore naming rule violation check
     {
+        public RpcParams Ext;
         public ServerRpcParams Server;
         public ClientRpcParams Client;
     }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b02186acd1144e20acbd0dcb69b14938
+timeCreated: 1697824888

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/BaseRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/BaseRpcTarget.cs
@@ -1,0 +1,36 @@
+namespace Unity.Netcode
+{
+    public abstract class BaseRpcTarget
+    {
+        protected NetworkManager m_NetworkManager;
+
+        internal BaseRpcTarget(NetworkManager manager)
+        {
+            m_NetworkManager = manager;
+        }
+
+        public abstract void Dispose();
+
+        internal abstract void Send(NetworkBehaviour behaviour, ref RpcMessage message, NetworkDelivery delivery, RpcParams rpcParams);
+
+        private protected void SendMessageToClient(NetworkBehaviour behaviour, ulong clientId, ref RpcMessage message, NetworkDelivery delivery)
+        {
+#if DEVELOPMENT_BUILD || UNITY_EDITOR
+            var size =
+#endif
+                behaviour.NetworkManager.MessageManager.SendMessage(ref message, delivery, clientId);
+
+#if DEVELOPMENT_BUILD || UNITY_EDITOR
+            if (NetworkBehaviour.__rpc_name_table[behaviour.GetType()].TryGetValue(message.Metadata.NetworkRpcMethodId, out var rpcMethodName))
+            {
+                behaviour.NetworkManager.NetworkMetrics.TrackRpcSent(
+                    clientId,
+                    behaviour.NetworkObject,
+                    rpcMethodName,
+                    behaviour.__getTypeName(),
+                    size);
+            }
+#endif
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/BaseRpcTarget.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/BaseRpcTarget.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 07c2620262e24eb5a426b521c09b3091

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ClientsAndHostRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ClientsAndHostRpcTarget.cs
@@ -13,7 +13,7 @@ namespace Unity.Netcode
         {
             if (m_UnderlyingTarget == null)
             {
-                if (behaviour.NetworkManager.ConnectionManager.PeerClientIds.Contains(NetworkManager.ServerClientId))
+                if (behaviour.NetworkManager.ConnectionManager.ConnectedClientIds.Contains(NetworkManager.ServerClientId))
                 {
                     m_UnderlyingTarget = behaviour.RpcTarget.Everyone;
                 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ClientsAndHostRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ClientsAndHostRpcTarget.cs
@@ -13,7 +13,11 @@ namespace Unity.Netcode
         {
             if (m_UnderlyingTarget == null)
             {
-                if (behaviour.NetworkManager.ConnectionManager.ConnectedClientIds.Contains(NetworkManager.ServerClientId))
+                // NotServer treats a host as being a server and will not send to it
+                // ClientsAndHost sends to everyone who runs any client logic
+                // So if the server is a host, this target includes it (as hosts run client logic)
+                // If the server is not a host, this target leaves it out, ergo the selection of NotServer.
+                if (behaviour.NetworkManager.ServerIsHost)
                 {
                     m_UnderlyingTarget = behaviour.RpcTarget.Everyone;
                 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ClientsAndHostRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ClientsAndHostRpcTarget.cs
@@ -1,0 +1,33 @@
+namespace Unity.Netcode
+{
+    internal class ClientsAndHostRpcTarget : BaseRpcTarget
+    {
+        private BaseRpcTarget m_UnderlyingTarget;
+
+        public override void Dispose()
+        {
+            m_UnderlyingTarget = null;
+        }
+
+        internal override void Send(NetworkBehaviour behaviour, ref RpcMessage message, NetworkDelivery delivery, RpcParams rpcParams)
+        {
+            if (m_UnderlyingTarget == null)
+            {
+                if (behaviour.NetworkManager.ConnectionManager.KnownClientIds.Contains(NetworkManager.ServerClientId))
+                {
+                    m_UnderlyingTarget = behaviour.RpcTarget.Everyone;
+                }
+                else
+                {
+                    m_UnderlyingTarget = behaviour.RpcTarget.NotServer;
+                }
+            }
+
+            m_UnderlyingTarget.Send(behaviour, ref message, delivery, rpcParams);
+        }
+
+        internal ClientsAndHostRpcTarget(NetworkManager manager) : base(manager)
+        {
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ClientsAndHostRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ClientsAndHostRpcTarget.cs
@@ -13,7 +13,7 @@ namespace Unity.Netcode
         {
             if (m_UnderlyingTarget == null)
             {
-                if (behaviour.NetworkManager.ConnectionManager.KnownClientIds.Contains(NetworkManager.ServerClientId))
+                if (behaviour.NetworkManager.ConnectionManager.PeerClientIds.Contains(NetworkManager.ServerClientId))
                 {
                     m_UnderlyingTarget = behaviour.RpcTarget.Everyone;
                 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ClientsAndHostRpcTarget.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ClientsAndHostRpcTarget.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c9f883d678ec4715b160dd9497d5f42d
+timeCreated: 1699481382

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/DirectSendRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/DirectSendRpcTarget.cs
@@ -1,0 +1,29 @@
+namespace Unity.Netcode
+{
+    internal class DirectSendRpcTarget : BaseRpcTarget, IIndividualRpcTarget
+    {
+        public BaseRpcTarget Target => this;
+
+        internal ulong ClientId;
+
+        public override void Dispose()
+        {
+
+        }
+
+        internal override void Send(NetworkBehaviour behaviour, ref RpcMessage message, NetworkDelivery delivery, RpcParams rpcParams)
+        {
+            SendMessageToClient(behaviour, ClientId, ref message, delivery);
+        }
+
+        public void SetClientId(ulong clientId)
+        {
+            ClientId = clientId;
+        }
+
+        internal DirectSendRpcTarget(NetworkManager manager) : base(manager)
+        {
+
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/DirectSendRpcTarget.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/DirectSendRpcTarget.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 077544cfd0b94cfc8a2a55d3828b74bb
+timeCreated: 1697824873

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/EveryoneRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/EveryoneRpcTarget.cs
@@ -1,0 +1,26 @@
+namespace Unity.Netcode
+{
+    internal class EveryoneRpcTarget : BaseRpcTarget
+    {
+        private NotServerRpcTarget m_NotServerRpcTarget;
+        private ServerRpcTarget m_ServerRpcTarget;
+
+        public override void Dispose()
+        {
+            m_NotServerRpcTarget.Dispose();
+            m_ServerRpcTarget.Dispose();
+        }
+
+        internal override void Send(NetworkBehaviour behaviour, ref RpcMessage message, NetworkDelivery delivery, RpcParams rpcParams)
+        {
+            m_NotServerRpcTarget.Send(behaviour, ref message, delivery, rpcParams);
+            m_ServerRpcTarget.Send(behaviour, ref message, delivery, rpcParams);
+        }
+
+        internal EveryoneRpcTarget(NetworkManager manager) : base(manager)
+        {
+            m_NotServerRpcTarget = new NotServerRpcTarget(manager);
+            m_ServerRpcTarget = new ServerRpcTarget(manager);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/EveryoneRpcTarget.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/EveryoneRpcTarget.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 675d4a5c79fc47078092ac15d255745d
+timeCreated: 1697824941

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/IGroupRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/IGroupRpcTarget.cs
@@ -1,0 +1,9 @@
+namespace Unity.Netcode
+{
+    internal interface IGroupRpcTarget
+    {
+        void Add(ulong clientId);
+        void Clear();
+        BaseRpcTarget Target { get; }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/IGroupRpcTarget.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/IGroupRpcTarget.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: beb19a6bb1334252a89b21c8490f7cbe
+timeCreated: 1697825109

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/IIndividualRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/IIndividualRpcTarget.cs
@@ -1,0 +1,8 @@
+namespace Unity.Netcode
+{
+    internal interface IIndividualRpcTarget
+    {
+        void SetClientId(ulong clientId);
+        BaseRpcTarget Target { get; }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/IIndividualRpcTarget.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/IIndividualRpcTarget.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c658d9641f564d9890bef4f558f1cea6
+timeCreated: 1697825115

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/LocalSendRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/LocalSendRpcTarget.cs
@@ -1,0 +1,67 @@
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+
+namespace Unity.Netcode
+{
+    internal class LocalSendRpcTarget : BaseRpcTarget
+    {
+        public override void Dispose()
+        {
+
+        }
+
+        internal override void Send(NetworkBehaviour behaviour, ref RpcMessage message, NetworkDelivery delivery, RpcParams rpcParams)
+        {
+            var networkManager = behaviour.NetworkManager;
+            var context = new NetworkContext
+            {
+                SenderId = m_NetworkManager.LocalClientId,
+                Timestamp = networkManager.RealTimeProvider.RealTimeSinceStartup,
+                SystemOwner = networkManager,
+                // header information isn't valid since it's not a real message.
+                // RpcMessage doesn't access this stuff so it's just left empty.
+                Header = new NetworkMessageHeader(),
+                SerializedHeaderSize = 0,
+                MessageSize = 0
+            };
+            int length;
+            if (rpcParams.Send.LocalDeferMode == LocalDeferMode.Defer)
+            {
+                using var serializedWriter = new FastBufferWriter(message.WriteBuffer.Length + UnsafeUtility.SizeOf<RpcMetadata>(), Allocator.Temp, int.MaxValue);
+                message.Serialize(serializedWriter, message.Version);
+                using var reader = new FastBufferReader(serializedWriter, Allocator.None);
+                context.Header = new NetworkMessageHeader
+                {
+                    MessageSize = (uint)reader.Length,
+                    MessageType = m_NetworkManager.MessageManager.GetMessageType(typeof(RpcMessage))
+                };
+
+                behaviour.NetworkManager.DeferredMessageManager.DeferMessage(IDeferredNetworkMessageManager.TriggerType.OnNextFrame, 0, reader, ref context);
+                length = reader.Length;
+            }
+            else
+            {
+                using var tempBuffer = new FastBufferReader(message.WriteBuffer, Allocator.None);
+                message.ReadBuffer = tempBuffer;
+                message.Handle(ref context);
+                length = tempBuffer.Length;
+            }
+#if DEVELOPMENT_BUILD || UNITY_EDITOR
+            if (NetworkBehaviour.__rpc_name_table[behaviour.GetType()].TryGetValue(message.Metadata.NetworkRpcMethodId, out var rpcMethodName))
+            {
+                behaviour.NetworkManager.NetworkMetrics.TrackRpcSent(
+                    behaviour.NetworkManager.LocalClientId,
+                    behaviour.NetworkObject,
+                    rpcMethodName,
+                    behaviour.__getTypeName(),
+                    length);
+            }
+#endif
+        }
+
+        internal LocalSendRpcTarget(NetworkManager manager) : base(manager)
+        {
+
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/LocalSendRpcTarget.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/LocalSendRpcTarget.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c3b290cdc20d4d2293652ec79652962a
+timeCreated: 1697824985

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotMeRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotMeRpcTarget.cs
@@ -1,0 +1,67 @@
+namespace Unity.Netcode
+{
+    internal class NotMeRpcTarget : BaseRpcTarget
+    {
+        private IGroupRpcTarget m_GroupSendTarget;
+        private ServerRpcTarget m_ServerRpcTarget;
+
+        public override void Dispose()
+        {
+            m_ServerRpcTarget.Dispose();
+            if (m_GroupSendTarget != null)
+            {
+                m_GroupSendTarget.Target.Dispose();
+                m_GroupSendTarget = null;
+            }
+        }
+
+        internal override void Send(NetworkBehaviour behaviour, ref RpcMessage message, NetworkDelivery delivery, RpcParams rpcParams)
+        {
+            if (m_GroupSendTarget == null)
+            {
+                if (behaviour.IsServer)
+                {
+                    m_GroupSendTarget = new RpcTargetGroup(m_NetworkManager);
+                }
+                else
+                {
+                    m_GroupSendTarget = new ProxyRpcTargetGroup(m_NetworkManager);
+                }
+            }
+
+            m_GroupSendTarget.Clear();
+            if (behaviour.IsServer)
+            {
+                foreach (var clientId in behaviour.NetworkObject.Observers)
+                {
+                    if (clientId == behaviour.NetworkManager.LocalClientId)
+                    {
+                        continue;
+                    }
+                    m_GroupSendTarget.Add(clientId);
+                }
+            }
+            else
+            {
+                foreach (var clientId in m_NetworkManager.KnownClientIds)
+                {
+                    if (clientId == behaviour.NetworkManager.LocalClientId)
+                    {
+                        continue;
+                    }
+                    m_GroupSendTarget.Add(clientId);
+                }
+            }
+            m_GroupSendTarget.Target.Send(behaviour, ref message, delivery, rpcParams);
+            if (!behaviour.IsServer)
+            {
+                m_ServerRpcTarget.Send(behaviour, ref message, delivery, rpcParams);
+            }
+        }
+
+        internal NotMeRpcTarget(NetworkManager manager) : base(manager)
+        {
+            m_ServerRpcTarget = new ServerRpcTarget(manager);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotMeRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotMeRpcTarget.cs
@@ -43,7 +43,7 @@ namespace Unity.Netcode
             }
             else
             {
-                foreach (var clientId in m_NetworkManager.KnownClientIds)
+                foreach (var clientId in m_NetworkManager.PeerClientIds)
                 {
                     if (clientId == behaviour.NetworkManager.LocalClientId)
                     {

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotMeRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotMeRpcTarget.cs
@@ -43,7 +43,7 @@ namespace Unity.Netcode
             }
             else
             {
-                foreach (var clientId in m_NetworkManager.PeerClientIds)
+                foreach (var clientId in m_NetworkManager.ConnectedClientsIds)
                 {
                     if (clientId == behaviour.NetworkManager.LocalClientId)
                     {

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotMeRpcTarget.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotMeRpcTarget.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 99cd5e8be7bd454bab700ee08b8dad7b
+timeCreated: 1697824966

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotOwnerRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotOwnerRpcTarget.cs
@@ -1,0 +1,83 @@
+namespace Unity.Netcode
+{
+    internal class NotOwnerRpcTarget : BaseRpcTarget
+    {
+        private IGroupRpcTarget m_GroupSendTarget;
+        private ServerRpcTarget m_ServerRpcTarget;
+        private LocalSendRpcTarget m_LocalSendRpcTarget;
+
+        public override void Dispose()
+        {
+            m_ServerRpcTarget.Dispose();
+            m_LocalSendRpcTarget.Dispose();
+            if (m_GroupSendTarget != null)
+            {
+                m_GroupSendTarget.Target.Dispose();
+                m_GroupSendTarget = null;
+            }
+        }
+
+        internal override void Send(NetworkBehaviour behaviour, ref RpcMessage message, NetworkDelivery delivery, RpcParams rpcParams)
+        {
+            if (m_GroupSendTarget == null)
+            {
+                if (behaviour.IsServer)
+                {
+                    m_GroupSendTarget = new RpcTargetGroup(m_NetworkManager);
+                }
+                else
+                {
+                    m_GroupSendTarget = new ProxyRpcTargetGroup(m_NetworkManager);
+                }
+            }
+            m_GroupSendTarget.Clear();
+
+            if (behaviour.IsServer)
+            {
+                foreach (var clientId in behaviour.NetworkObject.Observers)
+                {
+                    if (clientId == behaviour.OwnerClientId)
+                    {
+                        continue;
+                    }
+                    if (clientId == behaviour.NetworkManager.LocalClientId)
+                    {
+                        m_LocalSendRpcTarget.Send(behaviour, ref message, delivery, rpcParams);
+                        continue;
+                    }
+
+                    m_GroupSendTarget.Add(clientId);
+                }
+            }
+            else
+            {
+                foreach (var clientId in m_NetworkManager.KnownClientIds)
+                {
+                    if (clientId == behaviour.OwnerClientId)
+                    {
+                        continue;
+                    }
+                    if (clientId == behaviour.NetworkManager.LocalClientId)
+                    {
+                        m_LocalSendRpcTarget.Send(behaviour, ref message, delivery, rpcParams);
+                        continue;
+                    }
+
+                    m_GroupSendTarget.Add(clientId);
+                }
+            }
+
+            m_GroupSendTarget.Target.Send(behaviour, ref message, delivery, rpcParams);
+            if (behaviour.OwnerClientId != NetworkManager.ServerClientId)
+            {
+                m_ServerRpcTarget.Send(behaviour, ref message, delivery, rpcParams);
+            }
+        }
+
+        internal NotOwnerRpcTarget(NetworkManager manager) : base(manager)
+        {
+            m_ServerRpcTarget = new ServerRpcTarget(manager);
+            m_LocalSendRpcTarget = new LocalSendRpcTarget(manager);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotOwnerRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotOwnerRpcTarget.cs
@@ -51,7 +51,7 @@ namespace Unity.Netcode
             }
             else
             {
-                foreach (var clientId in m_NetworkManager.PeerClientIds)
+                foreach (var clientId in m_NetworkManager.ConnectedClientsIds)
                 {
                     if (clientId == behaviour.OwnerClientId)
                     {

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotOwnerRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotOwnerRpcTarget.cs
@@ -51,7 +51,7 @@ namespace Unity.Netcode
             }
             else
             {
-                foreach (var clientId in m_NetworkManager.KnownClientIds)
+                foreach (var clientId in m_NetworkManager.PeerClientIds)
                 {
                     if (clientId == behaviour.OwnerClientId)
                     {

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotOwnerRpcTarget.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotOwnerRpcTarget.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d7bc66c5253b44d09ad978ea9e51c96f
+timeCreated: 1698789420

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotServerRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotServerRpcTarget.cs
@@ -44,7 +44,7 @@ namespace Unity.Netcode
             }
             else
             {
-                foreach (var clientId in m_NetworkManager.PeerClientIds)
+                foreach (var clientId in m_NetworkManager.ConnectedClientsIds)
                 {
                     if (clientId == NetworkManager.ServerClientId)
                     {

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotServerRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotServerRpcTarget.cs
@@ -44,7 +44,7 @@ namespace Unity.Netcode
             }
             else
             {
-                foreach (var clientId in m_NetworkManager.KnownClientIds)
+                foreach (var clientId in m_NetworkManager.PeerClientIds)
                 {
                     if (clientId == NetworkManager.ServerClientId)
                     {

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotServerRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotServerRpcTarget.cs
@@ -1,0 +1,72 @@
+namespace Unity.Netcode
+{
+    internal class NotServerRpcTarget : BaseRpcTarget
+    {
+        private IGroupRpcTarget m_GroupSendTarget;
+        private LocalSendRpcTarget m_LocalSendRpcTarget;
+
+        public override void Dispose()
+        {
+            m_LocalSendRpcTarget.Dispose();
+            if (m_GroupSendTarget != null)
+            {
+                m_GroupSendTarget.Target.Dispose();
+                m_GroupSendTarget = null;
+            }
+        }
+
+        internal override void Send(NetworkBehaviour behaviour, ref RpcMessage message, NetworkDelivery delivery, RpcParams rpcParams)
+        {
+            if (m_GroupSendTarget == null)
+            {
+                if (behaviour.IsServer)
+                {
+                    m_GroupSendTarget = new RpcTargetGroup(m_NetworkManager);
+                }
+                else
+                {
+                    m_GroupSendTarget = new ProxyRpcTargetGroup(m_NetworkManager);
+                }
+            }
+            m_GroupSendTarget.Clear();
+
+            if (behaviour.IsServer)
+            {
+                foreach (var clientId in behaviour.NetworkObject.Observers)
+                {
+                    if (clientId == NetworkManager.ServerClientId)
+                    {
+                        continue;
+                    }
+
+                    m_GroupSendTarget.Add(clientId);
+                }
+            }
+            else
+            {
+                foreach (var clientId in m_NetworkManager.KnownClientIds)
+                {
+                    if (clientId == NetworkManager.ServerClientId)
+                    {
+                        continue;
+                    }
+
+                    if (clientId == behaviour.NetworkManager.LocalClientId)
+                    {
+                        m_LocalSendRpcTarget.Send(behaviour, ref message, delivery, rpcParams);
+                        continue;
+                    }
+
+                    m_GroupSendTarget.Add(clientId);
+                }
+            }
+
+            m_GroupSendTarget.Target.Send(behaviour, ref message, delivery, rpcParams);
+        }
+
+        internal NotServerRpcTarget(NetworkManager manager) : base(manager)
+        {
+            m_LocalSendRpcTarget = new LocalSendRpcTarget(manager);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotServerRpcTarget.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotServerRpcTarget.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c63787afe52f45ffbd5d801f78e7c0d6
+timeCreated: 1697824954

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/OwnerRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/OwnerRpcTarget.cs
@@ -1,0 +1,54 @@
+namespace Unity.Netcode
+{
+    internal class OwnerRpcTarget : BaseRpcTarget
+    {
+        private IIndividualRpcTarget m_UnderlyingTarget;
+        private LocalSendRpcTarget m_LocalRpcTarget;
+        private ServerRpcTarget m_ServerRpcTarget;
+
+        public override void Dispose()
+        {
+            m_LocalRpcTarget.Dispose();
+            if (m_UnderlyingTarget != null)
+            {
+                m_UnderlyingTarget.Target.Dispose();
+                m_UnderlyingTarget = null;
+            }
+        }
+
+        internal override void Send(NetworkBehaviour behaviour, ref RpcMessage message, NetworkDelivery delivery, RpcParams rpcParams)
+        {
+            if (behaviour.OwnerClientId == behaviour.NetworkManager.LocalClientId)
+            {
+                m_LocalRpcTarget.Send(behaviour, ref message, delivery, rpcParams);
+                return;
+            }
+
+            if (behaviour.OwnerClientId == NetworkManager.ServerClientId)
+            {
+                m_ServerRpcTarget.Send(behaviour, ref message, delivery, rpcParams);
+                return;
+            }
+
+            if (m_UnderlyingTarget == null)
+            {
+                if (behaviour.NetworkManager.IsServer)
+                {
+                    m_UnderlyingTarget = new DirectSendRpcTarget(m_NetworkManager);
+                }
+                else
+                {
+                    m_UnderlyingTarget = new ProxyRpcTarget(behaviour.OwnerClientId, m_NetworkManager);
+                }
+            }
+            m_UnderlyingTarget.SetClientId(behaviour.OwnerClientId);
+            m_UnderlyingTarget.Target.Send(behaviour, ref message, delivery, rpcParams);
+        }
+
+        internal OwnerRpcTarget(NetworkManager manager) : base(manager)
+        {
+            m_LocalRpcTarget = new LocalSendRpcTarget(manager);
+            m_ServerRpcTarget = new ServerRpcTarget(manager);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/OwnerRpcTarget.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/OwnerRpcTarget.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 23c4d52455fc419aaf03094617894257
+timeCreated: 1697824972

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ProxyRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ProxyRpcTarget.cs
@@ -1,0 +1,16 @@
+namespace Unity.Netcode
+{
+    internal class ProxyRpcTarget : ProxyRpcTargetGroup, IIndividualRpcTarget
+    {
+        internal ProxyRpcTarget(ulong clientId, NetworkManager manager) : base(manager)
+        {
+            Add(clientId);
+        }
+
+        public void SetClientId(ulong clientId)
+        {
+            Clear();
+            Add(clientId);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ProxyRpcTarget.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ProxyRpcTarget.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 86002805bb9e422e8b71581d1325357f
+timeCreated: 1697825007

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ProxyRpcTargetGroup.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ProxyRpcTargetGroup.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using Unity.Collections;
+
+namespace Unity.Netcode
+{
+    internal class ProxyRpcTargetGroup : BaseRpcTarget, IDisposable, IGroupRpcTarget
+    {
+        public BaseRpcTarget Target => this;
+
+        private ServerRpcTarget m_ServerRpcTarget;
+        private LocalSendRpcTarget m_LocalSendRpcTarget;
+
+        private bool m_Disposed;
+        public NativeList<ulong> TargetClientIds;
+        internal HashSet<ulong> Ids = new HashSet<ulong>();
+
+        internal override void Send(NetworkBehaviour behaviour, ref RpcMessage message, NetworkDelivery delivery, RpcParams rpcParams)
+        {
+            var proxyMessage = new ProxyMessage { Delivery = delivery, TargetClientIds = TargetClientIds, WrappedMessage = message };
+#if DEVELOPMENT_BUILD || UNITY_EDITOR
+            var size =
+#endif
+                behaviour.NetworkManager.MessageManager.SendMessage(ref proxyMessage, delivery, NetworkManager.ServerClientId);
+
+#if DEVELOPMENT_BUILD || UNITY_EDITOR
+            if (NetworkBehaviour.__rpc_name_table[behaviour.GetType()].TryGetValue(message.Metadata.NetworkRpcMethodId, out var rpcMethodName))
+            {
+                foreach (var clientId in TargetClientIds)
+                {
+                    behaviour.NetworkManager.NetworkMetrics.TrackRpcSent(
+                        clientId,
+                        behaviour.NetworkObject,
+                        rpcMethodName,
+                        behaviour.__getTypeName(),
+                        size);
+                }
+            }
+#endif
+            if (Ids.Contains(NetworkManager.ServerClientId))
+            {
+                m_ServerRpcTarget.Send(behaviour, ref message, delivery, rpcParams);
+            }
+            if (Ids.Contains(m_NetworkManager.LocalClientId))
+            {
+                m_LocalSendRpcTarget.Send(behaviour, ref message, delivery, rpcParams);
+            }
+        }
+
+        internal ProxyRpcTargetGroup(NetworkManager manager) : base(manager)
+        {
+            TargetClientIds = new NativeList<ulong>(Allocator.Persistent);
+            m_ServerRpcTarget = new ServerRpcTarget(manager);
+            m_LocalSendRpcTarget = new LocalSendRpcTarget(manager);
+        }
+
+        public override void Dispose()
+        {
+            if (!m_Disposed)
+            {
+                TargetClientIds.Dispose();
+                m_Disposed = true;
+                m_ServerRpcTarget.Dispose();
+                m_LocalSendRpcTarget.Dispose();
+            }
+        }
+
+        public void Add(ulong clientId)
+        {
+            if (!Ids.Contains(clientId))
+            {
+                Ids.Add(clientId);
+                if (clientId != NetworkManager.ServerClientId && clientId != m_NetworkManager.LocalClientId)
+                {
+                    TargetClientIds.Add(clientId);
+                }
+            }
+        }
+
+        public void Remove(ulong clientId)
+        {
+            Ids.Remove(clientId);
+            for (var i = 0; i < TargetClientIds.Length; ++i)
+            {
+                if (TargetClientIds[i] == clientId)
+                {
+                    TargetClientIds.RemoveAt(i);
+                    break;
+                }
+            }
+        }
+
+        public void Clear()
+        {
+            Ids.Clear();
+            TargetClientIds.Clear();
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ProxyRpcTargetGroup.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ProxyRpcTargetGroup.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5728dbab532e46a88127510b4ec75af9
+timeCreated: 1697825000

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/RpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/RpcTarget.cs
@@ -9,53 +9,60 @@ namespace Unity.Netcode
     public enum SendTo
     {
         /// <summary>
-        /// Send to the NetworkObject's current owner
-        /// Will execute locally if the local process is the owner
+        /// Send to the NetworkObject's current owner.
+        /// Will execute locally if the local process is the owner.
         /// </summary>
         Owner,
         /// <summary>
-        /// Send to everyone but the current owner, filtered to the current observer list
-        /// Will execute locally if the local process is not the owner
+        /// Send to everyone but the current owner, filtered to the current observer list.
+        /// Will execute locally if the local process is not the owner.
         /// </summary>
         NotOwner,
         /// <summary>
-        /// Send to the server, regardless of ownership
-        /// Will execute locally if invoked on the server
+        /// Send to the server, regardless of ownership.
+        /// Will execute locally if invoked on the server.
         /// </summary>
         Server,
         /// <summary>
-        /// Send to everyone but the server, filtered to the current observer list
-        /// Will execute locally if invoked on a client
-        /// Will NOT execute locally if invoked on a server running in host mode
+        /// Send to everyone but the server, filtered to the current observer list.
+        /// Will NOT send to a server running in host mode - it is still treated as a server.
+        /// If you want to send to servers when they are host, but not when they are dedicated server, use
+        /// <see cref="SendTo.ClientsAndHost"/>.
+        /// <br />
+        /// <br />
+        /// Will execute locally if invoked on a client.
+        /// Will NOT execute locally if invoked on a server running in host mode.
         /// </summary>
         NotServer,
         /// <summary>
-        /// Execute this RPC locally
-        ///
+        /// Execute this RPC locally.
+        /// <br />
+        /// <br />
         /// Normally this is no different from a standard function call.
-        ///
+        /// <br />
+        /// <br />
         /// Using the DeferLocal parameter of the attribute or the LocalDeferMode override in RpcSendParams,
         /// this can allow an RPC to be processed on localhost with a one-frame delay as if it were sent over
         /// the network.
         /// </summary>
         Me,
         /// <summary>
-        /// Send this RPC to everyone but the local machine, filtered to the current observer list
+        /// Send this RPC to everyone but the local machine, filtered to the current observer list.
         /// </summary>
         NotMe,
         /// <summary>
-        /// Send this RPC to everone, filtered to the current observer list
-        /// Will execute locally
+        /// Send this RPC to everone, filtered to the current observer list.
+        /// Will execute locally.
         /// </summary>
         Everyone,
         /// <summary>
-        /// Send this RPC to all clients, including the host.
-        /// If the server is running in host mode, this is the same as SendTo.Everyone
-        /// If the server is running in dedicated server mode, this is the same as SendTo.NotServer
+        /// Send this RPC to all clients, including the host, if a host exists.
+        /// If the server is running in host mode, this is the same as <see cref="SendTo.Everyone" />.
+        /// If the server is running in dedicated server mode, this is the same as <see cref="SendTo.NotServer" />.
         /// </summary>
         ClientsAndHost,
         /// <summary>
-        /// This RPC cannot be sent without passing in a target in RpcSendParams
+        /// This RPC cannot be sent without passing in a target in RpcSendParams.
         /// </summary>
         SpecifiedInParams
     }
@@ -109,35 +116,42 @@ namespace Unity.Netcode
 
 
         /// <summary>
-        /// Send to the NetworkObject's current owner
-        /// Will execute locally if the local process is the owner
+        /// Send to the NetworkObject's current owner.
+        /// Will execute locally if the local process is the owner.
         /// </summary>
         public BaseRpcTarget Owner;
 
         /// <summary>
-        /// Send to everyone but the current owner, filtered to the current observer list
-        /// Will execute locally if the local process is not the owner
+        /// Send to everyone but the current owner, filtered to the current observer list.
+        /// Will execute locally if the local process is not the owner.
         /// </summary>
         public BaseRpcTarget NotOwner;
 
         /// <summary>
-        /// Send to the server, regardless of ownership
-        /// Will execute locally if invoked on the server
+        /// Send to the server, regardless of ownership.
+        /// Will execute locally if invoked on the server.
         /// </summary>
         public BaseRpcTarget Server;
 
         /// <summary>
-        /// Send to everyone but the server, filtered to the current observer list
-        /// Will execute locally if invoked on a client
-        /// Will NOT execute locally if invoked on a server running in host mode
+        /// Send to everyone but the server, filtered to the current observer list.
+        /// Will NOT send to a server running in host mode - it is still treated as a server.
+        /// If you want to send to servers when they are host, but not when they are dedicated server, use
+        /// <see cref="SendTo.ClientsAndHost"/>.
+        /// <br />
+        /// <br />
+        /// Will execute locally if invoked on a client.
+        /// Will NOT execute locally if invoked on a server running in host mode.
         /// </summary>
         public BaseRpcTarget NotServer;
 
         /// <summary>
-        /// Execute this RPC locally
-        ///
+        /// Execute this RPC locally.
+        /// <br />
+        /// <br />
         /// Normally this is no different from a standard function call.
-        ///
+        /// <br />
+        /// <br />
         /// Using the DeferLocal parameter of the attribute or the LocalDeferMode override in RpcSendParams,
         /// this can allow an RPC to be processed on localhost with a one-frame delay as if it were sent over
         /// the network.
@@ -145,26 +159,27 @@ namespace Unity.Netcode
         public BaseRpcTarget Me;
 
         /// <summary>
-        /// Send this RPC to everyone but the local machine, filtered to the current observer list
+        /// Send this RPC to everyone but the local machine, filtered to the current observer list.
         /// </summary>
         public BaseRpcTarget NotMe;
 
         /// <summary>
-        /// Send this RPC to everone, filtered to the current observer list
-        /// Will execute locally
+        /// Send this RPC to everone, filtered to the current observer list.
+        /// Will execute locally.
         /// </summary>
         public BaseRpcTarget Everyone;
 
         /// <summary>
-        /// Send this RPC to all clients, including the host.
-        /// If the server is running in host mode, this is the same as SendTo.Everyone
-        /// If the server is running in dedicated server mode, this is the same as SendTo.NotServer
+        /// Send this RPC to all clients, including the host, if a host exists.
+        /// If the server is running in host mode, this is the same as <see cref="RpcTarget.Everyone" />.
+        /// If the server is running in dedicated server mode, this is the same as <see cref="RpcTarget.NotServer" />.
         /// </summary>
         public BaseRpcTarget ClientsAndHost;
 
         /// <summary>
         /// Send to a specific single client ID.
-        ///
+        /// <br />
+        /// <br />
         /// Do not cache or reuse the result of this method.
         /// For performance reasons, the same object is used each time to avoid garbage-collected allocations,
         /// and its contents are simply changed.
@@ -192,7 +207,8 @@ namespace Unity.Netcode
         /// Sends to a group of client IDs.
         /// NativeArrays can be trivially constructed using Allocator.Temp, making this an efficient
         /// Group method if the group list is dynamically constructed.
-        ///
+        /// <br />
+        /// <br />
         /// Do not cache or reuse the result of this method.
         /// For performance reasons, the same object is used each time to avoid garbage-collected allocations,
         /// and its contents are simply changed.
@@ -223,7 +239,8 @@ namespace Unity.Netcode
         /// Sends to a group of client IDs.
         /// NativeList can be trivially constructed using Allocator.Temp, making this an efficient
         /// Group method if the group list is dynamically constructed.
-        ///
+        /// <br />
+        /// <br />
         /// Do not cache or reuse the result of this method.
         /// For performance reasons, the same object is used each time to avoid garbage-collected allocations,
         /// and its contents are simply changed.
@@ -240,7 +257,8 @@ namespace Unity.Netcode
         /// Constructing arrays requires garbage collected allocations. This override is only recommended
         /// if you either have no strict performance requirements, or have the group of client IDs cached so
         /// it is not created each time.
-        ///
+        /// <br />
+        /// <br />
         /// Do not cache or reuse the result of this method.
         /// For performance reasons, the same object is used each time to avoid garbage-collected allocations,
         /// and its contents are simply changed.
@@ -259,7 +277,8 @@ namespace Unity.Netcode
         /// a garbage collected allocation (even if the type itself is a struct type, due to boxing).
         /// This override is only recommended if you either have no strict performance requirements,
         /// or have the group of client IDs cached so it is not created each time.
-        ///
+        /// <br />
+        /// <br />
         /// Do not cache or reuse the result of this method.
         /// For performance reasons, the same object is used each time to avoid garbage-collected allocations,
         /// and its contents are simply changed.

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/RpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/RpcTarget.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using Unity.Collections;
 
 namespace Unity.Netcode
@@ -381,7 +380,7 @@ namespace Unity.Netcode
 
             foreach (var clientId in m_NetworkManager.ConnectedClientsIds)
             {
-                if(!asASet.Contains(clientId))
+                if (!asASet.Contains(clientId))
                 {
                     target.Add(clientId);
                 }
@@ -466,7 +465,7 @@ namespace Unity.Netcode
 
             foreach (var clientId in m_NetworkManager.ConnectedClientsIds)
             {
-                if(!asASet.Contains(clientId))
+                if (!asASet.Contains(clientId))
                 {
                     target.Add(clientId);
                 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/RpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/RpcTarget.cs
@@ -292,7 +292,8 @@ namespace Unity.Netcode
         /// <returns></returns>
         public BaseRpcTarget Group(NativeList<ulong> clientIds)
         {
-            return Group(clientIds.AsArray());
+            var asArray = clientIds.AsArray();
+            return Group(asArray);
         }
 
         /// <summary>
@@ -409,7 +410,8 @@ namespace Unity.Netcode
         /// <returns></returns>
         public BaseRpcTarget Not(NativeList<ulong> excludedClientIds)
         {
-            return Not(excludedClientIds.AsArray());
+            var asArray = excludedClientIds.AsArray();
+            return Not(asArray);
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/RpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/RpcTarget.cs
@@ -27,7 +27,7 @@ namespace Unity.Netcode
         /// Send to everyone but the server, filtered to the current observer list.
         /// Will NOT send to a server running in host mode - it is still treated as a server.
         /// If you want to send to servers when they are host, but not when they are dedicated server, use
-        /// <see cref="SendTo.ClientsAndHost"/>.
+        /// <see cref="ClientsAndHost"/>.
         /// <br />
         /// <br />
         /// Will execute locally if invoked on a client.
@@ -57,8 +57,8 @@ namespace Unity.Netcode
         Everyone,
         /// <summary>
         /// Send this RPC to all clients, including the host, if a host exists.
-        /// If the server is running in host mode, this is the same as <see cref="SendTo.Everyone" />.
-        /// If the server is running in dedicated server mode, this is the same as <see cref="SendTo.NotServer" />.
+        /// If the server is running in host mode, this is the same as <see cref="Everyone" />.
+        /// If the server is running in dedicated server mode, this is the same as <see cref="NotServer" />.
         /// </summary>
         ClientsAndHost,
         /// <summary>
@@ -171,8 +171,8 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Send this RPC to all clients, including the host, if a host exists.
-        /// If the server is running in host mode, this is the same as <see cref="RpcTarget.Everyone" />.
-        /// If the server is running in dedicated server mode, this is the same as <see cref="RpcTarget.NotServer" />.
+        /// If the server is running in host mode, this is the same as <see cref="Everyone" />.
+        /// If the server is running in dedicated server mode, this is the same as <see cref="NotServer" />.
         /// </summary>
         public BaseRpcTarget ClientsAndHost;
 

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/RpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/RpcTarget.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Unity.Collections;
 
 namespace Unity.Netcode
@@ -62,11 +62,11 @@ namespace Unity.Netcode
 
     /// <summary>
     /// Implementations of the various <see cref="SendTo"/> options, as well as additional runtime-only options
-    /// <see cref="RpcTarget.Single"/>,
-    /// <see cref="RpcTarget.Group(NativeArray{ulong})"/>,
-    /// <see cref="RpcTarget.Group(NativeList{ulong})"/>,
-    /// <see cref="RpcTarget.Group(ulong[])"/>, and
-    /// <see cref="RpcTarget.Group{T}(T)"/>
+    /// <see cref="Single"/>,
+    /// <see cref="Group(NativeArray{ulong})"/>,
+    /// <see cref="Group(NativeList{ulong})"/>,
+    /// <see cref="Group(ulong[])"/>, and
+    /// <see cref="Group{T}(T)"/>
     /// </summary>
     public class RpcTarget
     {

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/RpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/RpcTarget.cs
@@ -1,0 +1,294 @@
+﻿using System.Collections.Generic;
+using Unity.Collections;
+
+namespace Unity.Netcode
+{
+    /// <summary>
+    /// Configuration for the default method by which an RPC is communicated across the network
+    /// </summary>
+    public enum SendTo
+    {
+        /// <summary>
+        /// Send to the NetworkObject's current owner
+        /// Will execute locally if the local process is the owner
+        /// </summary>
+        Owner,
+        /// <summary>
+        /// Send to everyone but the current owner, filtered to the current observer list
+        /// Will execute locally if the local process is not the owner
+        /// </summary>
+        NotOwner,
+        /// <summary>
+        /// Send to the server, regardless of ownership
+        /// Will execute locally if invoked on the server
+        /// </summary>
+        Server,
+        /// <summary>
+        /// Send to everyone but the server, filtered to the current observer list
+        /// Will execute locally if invoked on a client
+        /// Will NOT execute locally if invoked on a server running in host mode
+        /// </summary>
+        NotServer,
+        /// <summary>
+        /// Execute this RPC locally
+        ///
+        /// Normally this is no different from a standard function call.
+        ///
+        /// Using the DeferLocal parameter of the attribute or the LocalDeferMode override in RpcSendParams,
+        /// this can allow an RPC to be processed on localhost with a one-frame delay as if it were sent over
+        /// the network.
+        /// </summary>
+        Me,
+        /// <summary>
+        /// Send this RPC to everyone but the local machine, filtered to the current observer list
+        /// </summary>
+        NotMe,
+        /// <summary>
+        /// Send this RPC to everone, filtered to the current observer list
+        /// Will execute locally
+        /// </summary>
+        Everyone,
+        /// <summary>
+        /// Send this RPC to all clients, including the host.
+        /// If the server is running in host mode, this is the same as SendTo.Everyone
+        /// If the server is running in dedicated server mode, this is the same as SendTo.NotServer
+        /// </summary>
+        ClientsAndHost,
+        /// <summary>
+        /// This RPC cannot be sent without passing in a target in RpcSendParams
+        /// </summary>
+        SpecifiedInParams
+    }
+
+    /// <summary>
+    /// Implementations of the various <see cref="SendTo"/> options, as well as additional runtime-only options
+    /// <see cref="RpcTarget.Single"/>,
+    /// <see cref="RpcTarget.Group(NativeArray{ulong})"/>,
+    /// <see cref="RpcTarget.Group(NativeList{ulong})"/>,
+    /// <see cref="RpcTarget.Group(ulong[])"/>, and
+    /// <see cref="RpcTarget.Group{T}(T)"/>
+    /// </summary>
+    public class RpcTarget
+    {
+        private NetworkManager m_NetworkManager;
+        internal RpcTarget(NetworkManager manager)
+        {
+            m_NetworkManager = manager;
+
+            Everyone = new EveryoneRpcTarget(manager);
+            Owner = new OwnerRpcTarget(manager);
+            NotOwner = new NotOwnerRpcTarget(manager);
+            Server = new ServerRpcTarget(manager);
+            NotServer = new NotServerRpcTarget(manager);
+            NotMe = new NotMeRpcTarget(manager);
+            Me = new LocalSendRpcTarget(manager);
+            ClientsAndHost = new ClientsAndHostRpcTarget(manager);
+
+            m_CachedProxyRpcTargetGroup = new ProxyRpcTargetGroup(manager);
+            m_CachedTargetGroup = new RpcTargetGroup(manager);
+            m_CachedDirectSendTarget = new DirectSendRpcTarget(manager);
+            m_CachedProxyRpcTarget = new ProxyRpcTarget(0, manager);
+        }
+
+        public void Dispose()
+        {
+            Everyone.Dispose();
+            Owner.Dispose();
+            NotOwner.Dispose();
+            Server.Dispose();
+            NotServer.Dispose();
+            NotMe.Dispose();
+            Me.Dispose();
+            ClientsAndHost.Dispose();
+
+            m_CachedProxyRpcTargetGroup.Dispose();
+            m_CachedTargetGroup.Dispose();
+            m_CachedDirectSendTarget.Dispose();
+            m_CachedProxyRpcTarget.Dispose();
+        }
+
+
+        /// <summary>
+        /// Send to the NetworkObject's current owner
+        /// Will execute locally if the local process is the owner
+        /// </summary>
+        public BaseRpcTarget Owner;
+
+        /// <summary>
+        /// Send to everyone but the current owner, filtered to the current observer list
+        /// Will execute locally if the local process is not the owner
+        /// </summary>
+        public BaseRpcTarget NotOwner;
+
+        /// <summary>
+        /// Send to the server, regardless of ownership
+        /// Will execute locally if invoked on the server
+        /// </summary>
+        public BaseRpcTarget Server;
+
+        /// <summary>
+        /// Send to everyone but the server, filtered to the current observer list
+        /// Will execute locally if invoked on a client
+        /// Will NOT execute locally if invoked on a server running in host mode
+        /// </summary>
+        public BaseRpcTarget NotServer;
+
+        /// <summary>
+        /// Execute this RPC locally
+        ///
+        /// Normally this is no different from a standard function call.
+        ///
+        /// Using the DeferLocal parameter of the attribute or the LocalDeferMode override in RpcSendParams,
+        /// this can allow an RPC to be processed on localhost with a one-frame delay as if it were sent over
+        /// the network.
+        /// </summary>
+        public BaseRpcTarget Me;
+
+        /// <summary>
+        /// Send this RPC to everyone but the local machine, filtered to the current observer list
+        /// </summary>
+        public BaseRpcTarget NotMe;
+
+        /// <summary>
+        /// Send this RPC to everone, filtered to the current observer list
+        /// Will execute locally
+        /// </summary>
+        public BaseRpcTarget Everyone;
+
+        /// <summary>
+        /// Send this RPC to all clients, including the host.
+        /// If the server is running in host mode, this is the same as SendTo.Everyone
+        /// If the server is running in dedicated server mode, this is the same as SendTo.NotServer
+        /// </summary>
+        public BaseRpcTarget ClientsAndHost;
+
+        /// <summary>
+        /// Send to a specific single client ID.
+        ///
+        /// Do not cache or reuse the result of this method.
+        /// For performance reasons, the same object is used each time to avoid garbage-collected allocations,
+        /// and its contents are simply changed.
+        /// </summary>
+        /// <param name="clientId"></param>
+        /// <returns></returns>
+        public BaseRpcTarget Single(ulong clientId)
+        {
+            if (clientId == m_NetworkManager.LocalClientId)
+            {
+                return Me;
+            }
+
+            if (m_NetworkManager.IsServer || clientId == NetworkManager.ServerClientId)
+            {
+                m_CachedDirectSendTarget.SetClientId(clientId);
+                return m_CachedDirectSendTarget;
+            }
+
+            m_CachedProxyRpcTarget.SetClientId(clientId);
+            return m_CachedProxyRpcTarget;
+        }
+
+        /// <summary>
+        /// Sends to a group of client IDs.
+        /// NativeArrays can be trivially constructed using Allocator.Temp, making this an efficient
+        /// Group method if the group list is dynamically constructed.
+        ///
+        /// Do not cache or reuse the result of this method.
+        /// For performance reasons, the same object is used each time to avoid garbage-collected allocations,
+        /// and its contents are simply changed.
+        /// </summary>
+        /// <param name="clientIds"></param>
+        /// <returns></returns>
+        public BaseRpcTarget Group(NativeArray<ulong> clientIds)
+        {
+            IGroupRpcTarget target;
+            if (m_NetworkManager.IsServer)
+            {
+                target = m_CachedTargetGroup;
+            }
+            else
+            {
+                target = m_CachedProxyRpcTargetGroup;
+            }
+            target.Clear();
+            foreach (var clientId in clientIds)
+            {
+                target.Add(clientId);
+            }
+
+            return target.Target;
+        }
+
+        /// <summary>
+        /// Sends to a group of client IDs.
+        /// NativeList can be trivially constructed using Allocator.Temp, making this an efficient
+        /// Group method if the group list is dynamically constructed.
+        ///
+        /// Do not cache or reuse the result of this method.
+        /// For performance reasons, the same object is used each time to avoid garbage-collected allocations,
+        /// and its contents are simply changed.
+        /// </summary>
+        /// <param name="clientIds"></param>
+        /// <returns></returns>
+        public BaseRpcTarget Group(NativeList<ulong> clientIds)
+        {
+            return Group(clientIds.AsArray());
+        }
+
+        /// <summary>
+        /// Sends to a group of client IDs.
+        /// Constructing arrays requires garbage collected allocations. This override is only recommended
+        /// if you either have no strict performance requirements, or have the group of client IDs cached so
+        /// it is not created each time.
+        ///
+        /// Do not cache or reuse the result of this method.
+        /// For performance reasons, the same object is used each time to avoid garbage-collected allocations,
+        /// and its contents are simply changed.
+        /// </summary>
+        /// <param name="clientIds"></param>
+        /// <returns></returns>
+        public BaseRpcTarget Group(ulong[] clientIds)
+        {
+            return Group(new NativeArray<ulong>(clientIds, Allocator.Temp));
+        }
+
+
+        /// <summary>
+        /// Sends to a group of client IDs.
+        /// This accepts any IEnumerable type, such as List&lt;ulong&gt;, but cannot be called without
+        /// a garbage collected allocation (even if the type itself is a struct type, due to boxing).
+        /// This override is only recommended if you either have no strict performance requirements,
+        /// or have the group of client IDs cached so it is not created each time.
+        ///
+        /// Do not cache or reuse the result of this method.
+        /// For performance reasons, the same object is used each time to avoid garbage-collected allocations,
+        /// and its contents are simply changed.
+        /// </summary>
+        /// <param name="clientIds"></param>
+        /// <returns></returns>
+        public BaseRpcTarget Group<T>(T clientIds) where T : IEnumerable<ulong>
+        {
+            IGroupRpcTarget target;
+            if (m_NetworkManager.IsServer)
+            {
+                target = m_CachedTargetGroup;
+            }
+            else
+            {
+                target = m_CachedProxyRpcTargetGroup;
+            }
+            target.Clear();
+            foreach (var clientId in clientIds)
+            {
+                target.Add(clientId);
+            }
+
+            return target.Target;
+        }
+
+        private ProxyRpcTargetGroup m_CachedProxyRpcTargetGroup;
+        private RpcTargetGroup m_CachedTargetGroup;
+        private DirectSendRpcTarget m_CachedDirectSendTarget;
+        private ProxyRpcTarget m_CachedProxyRpcTarget;
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/RpcTarget.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/RpcTarget.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1b26d0227e71408b918ae25ca2a0179b
+timeCreated: 1699555535

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/RpcTargetGroup.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/RpcTargetGroup.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+
+namespace Unity.Netcode
+{
+    internal class RpcTargetGroup : BaseRpcTarget, IGroupRpcTarget
+    {
+        public BaseRpcTarget Target => this;
+
+        internal List<BaseRpcTarget> Targets = new List<BaseRpcTarget>();
+
+        private LocalSendRpcTarget m_LocalSendRpcTarget;
+        private HashSet<ulong> m_Ids = new HashSet<ulong>();
+        private Stack<DirectSendRpcTarget> m_TargetCache = new Stack<DirectSendRpcTarget>();
+
+        public override void Dispose()
+        {
+            foreach (var target in Targets)
+            {
+                target.Dispose();
+            }
+            foreach (var target in m_TargetCache)
+            {
+                target.Dispose();
+            }
+            m_LocalSendRpcTarget.Dispose();
+        }
+
+        internal override void Send(NetworkBehaviour behaviour, ref RpcMessage message, NetworkDelivery delivery, RpcParams rpcParams)
+        {
+            foreach (var target in Targets)
+            {
+                target.Send(behaviour, ref message, delivery, rpcParams);
+            }
+        }
+
+        public void Add(ulong clientId)
+        {
+            if (!m_Ids.Contains(clientId))
+            {
+                m_Ids.Add(clientId);
+                if (clientId == m_NetworkManager.LocalClientId)
+                {
+                    Targets.Add(m_LocalSendRpcTarget);
+                }
+                else
+                {
+                    if (m_TargetCache.Count == 0)
+                    {
+                        Targets.Add(new DirectSendRpcTarget(m_NetworkManager) { ClientId = clientId });
+                    }
+                    else
+                    {
+                        var target = m_TargetCache.Pop();
+                        target.ClientId = clientId;
+                        Targets.Add(target);
+                    }
+                }
+            }
+        }
+
+        public void Clear()
+        {
+            m_Ids.Clear();
+            foreach (var target in Targets)
+            {
+                if (target is DirectSendRpcTarget directSendRpcTarget)
+                {
+                    m_TargetCache.Push(directSendRpcTarget);
+                }
+            }
+            Targets.Clear();
+        }
+
+        internal RpcTargetGroup(NetworkManager manager) : base(manager)
+        {
+            m_LocalSendRpcTarget = new LocalSendRpcTarget(manager);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/RpcTargetGroup.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/RpcTargetGroup.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7f8c0fc053b64a588c99dd7d706d9f0a
+timeCreated: 1697824991

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ServerRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ServerRpcTarget.cs
@@ -1,0 +1,36 @@
+namespace Unity.Netcode
+{
+    internal class ServerRpcTarget : BaseRpcTarget
+    {
+        private BaseRpcTarget m_UnderlyingTarget;
+
+        public override void Dispose()
+        {
+            if (m_UnderlyingTarget != null)
+            {
+                m_UnderlyingTarget.Dispose();
+                m_UnderlyingTarget = null;
+            }
+        }
+
+        internal override void Send(NetworkBehaviour behaviour, ref RpcMessage message, NetworkDelivery delivery, RpcParams rpcParams)
+        {
+            if (m_UnderlyingTarget == null)
+            {
+                if (behaviour.NetworkManager.IsServer)
+                {
+                    m_UnderlyingTarget = new LocalSendRpcTarget(m_NetworkManager);
+                }
+                else
+                {
+                    m_UnderlyingTarget = new DirectSendRpcTarget(m_NetworkManager) { ClientId = NetworkManager.ServerClientId };
+                }
+            }
+            m_UnderlyingTarget.Send(behaviour, ref message, delivery, rpcParams);
+        }
+
+        internal ServerRpcTarget(NetworkManager manager) : base(manager)
+        {
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ServerRpcTarget.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ServerRpcTarget.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c911725afb6d44f3bb1a1d567d9dee0f
+timeCreated: 1697824979

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -2067,6 +2067,15 @@ namespace Unity.Netcode
                             // Client is now synchronized and fully "connected".  This also means the client can send "RPCs" at this time
                             NetworkManager.ConnectionManager.InvokeOnClientConnectedCallback(NetworkManager.LocalClientId);
 
+                            foreach (var peerId in NetworkManager.KnownClientIds)
+                            {
+                                if (peerId == NetworkManager.LocalClientId)
+                                {
+                                    continue;
+                                }
+                                NetworkManager.ConnectionManager.InvokeOnPeerConnectedCallback(peerId);
+                            }
+
                             // Notify the client that they have finished synchronizing
                             OnSceneEvent?.Invoke(new SceneEvent()
                             {
@@ -2212,6 +2221,11 @@ namespace Unity.Netcode
                         // client progresses through (the name and associated legacy behavior/expected state
                         // of the client was persisted since MLAPI)
                         NetworkManager.ConnectionManager.InvokeOnClientConnectedCallback(clientId);
+
+                        if (NetworkManager.IsHost)
+                        {
+                            NetworkManager.ConnectionManager.InvokeOnPeerConnectedCallback(clientId);
+                        }
 
                         // Check to see if the client needs to resynchronize and before sending the message make sure the client is still connected to avoid
                         // a potential crash within the MessageSystem (i.e. sending to a client that no longer exists)

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -2067,7 +2067,7 @@ namespace Unity.Netcode
                             // Client is now synchronized and fully "connected".  This also means the client can send "RPCs" at this time
                             NetworkManager.ConnectionManager.InvokeOnClientConnectedCallback(NetworkManager.LocalClientId);
 
-                            foreach (var peerId in NetworkManager.KnownClientIds)
+                            foreach (var peerId in NetworkManager.PeerClientIds)
                             {
                                 if (peerId == NetworkManager.LocalClientId)
                                 {

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -2115,15 +2115,6 @@ namespace Unity.Netcode
                             // Client is now synchronized and fully "connected".  This also means the client can send "RPCs" at this time
                             NetworkManager.ConnectionManager.InvokeOnClientConnectedCallback(NetworkManager.LocalClientId);
 
-                            foreach (var peerId in NetworkManager.PeerClientIds)
-                            {
-                                if (peerId == NetworkManager.LocalClientId)
-                                {
-                                    continue;
-                                }
-                                NetworkManager.ConnectionManager.InvokeOnPeerConnectedCallback(peerId);
-                            }
-
                             // Notify the client that they have finished synchronizing
                             OnSceneEvent?.Invoke(new SceneEvent()
                             {

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -69,10 +69,7 @@ namespace Unity.Netcode
 
             if (ret)
             {
-                if (networkObject.Observers.Contains(clientId))
-                {
-                    networkObject.Observers.Remove(clientId);
-                }
+                networkObject.Observers.Remove(clientId);
             }
 
             return ret;
@@ -940,7 +937,7 @@ namespace Unity.Netcode
                 if (sobj.CheckObjectVisibility == null)
                 {
                     // If the client is not part of the observers and spawn with observers is enabled on this instance or the clientId is the server
-                    if (!sobj.Observers.Contains(clientId) && (sobj.SpawnWithObservers || clientId == NetworkManager.ServerClientId))
+                    if (sobj.SpawnWithObservers || clientId == NetworkManager.ServerClientId)
                     {
                         sobj.Observers.Add(clientId);
                     }
@@ -950,13 +947,9 @@ namespace Unity.Netcode
                     // CheckObject visibility overrides SpawnWithObservers under this condition
                     if (sobj.CheckObjectVisibility(clientId))
                     {
-                        if (!sobj.Observers.Contains(clientId))
-                        {
-                            sobj.Observers.Add(clientId);
-                        }
+                        sobj.Observers.Add(clientId);
                     }
                     else // Otherwise, if the observers contains the clientId (shouldn't happen) then remove it since CheckObjectVisibility returned false
-                    if (sobj.Observers.Contains(clientId))
                     {
                         sobj.Observers.Remove(clientId);
                     }

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -69,7 +69,10 @@ namespace Unity.Netcode
 
             if (ret)
             {
-                networkObject.Observers.Remove(clientId);
+                if (networkObject.Observers.Contains(clientId))
+                {
+                    networkObject.Observers.Remove(clientId);
+                }
             }
 
             return ret;
@@ -947,7 +950,10 @@ namespace Unity.Netcode
                     // CheckObject visibility overrides SpawnWithObservers under this condition
                     if (sobj.CheckObjectVisibility(clientId))
                     {
-                        sobj.Observers.Add(clientId);
+                        if (!sobj.Observers.Contains(clientId))
+                        {
+                            sobj.Observers.Add(clientId);
+                        }
                     }
                     else // Otherwise, if the observers contains the clientId (shouldn't happen) then remove it since CheckObjectVisibility returned false
                     if (sobj.Observers.Contains(clientId))

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DeferredMessagingTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DeferredMessagingTests.cs
@@ -94,6 +94,10 @@ namespace Unity.Netcode.RuntimeTests
 
         public override void ProcessTriggers(IDeferredNetworkMessageManager.TriggerType trigger, ulong key)
         {
+            if (trigger == IDeferredNetworkMessageManager.TriggerType.OnNextFrame)
+            {
+                return;
+            }
             ProcessTriggersCalled = true;
             base.ProcessTriggers(trigger, key);
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/InvalidConnectionEventsTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/InvalidConnectionEventsTest.cs
@@ -81,7 +81,7 @@ namespace Unity.Netcode.RuntimeTests
         {
             var message = new ConnectionApprovedMessage
             {
-                PeerClientIds = new NativeArray<ulong>(0, Allocator.Temp)
+                ConnectedClientIds = new NativeArray<ulong>(0, Allocator.Temp)
             };
             m_ServerNetworkManager.ConnectionManager.SendMessage(ref message, NetworkDelivery.Reliable, m_ClientNetworkManagers[0].LocalClientId);
 
@@ -150,7 +150,7 @@ namespace Unity.Netcode.RuntimeTests
         {
             var message = new ConnectionApprovedMessage
             {
-                PeerClientIds = new NativeArray<ulong>(0, Allocator.Temp)
+                ConnectedClientIds = new NativeArray<ulong>(0, Allocator.Temp)
             };
             m_ClientNetworkManagers[0].ConnectionManager.SendMessage(ref message, NetworkDelivery.Reliable, m_ServerNetworkManager.LocalClientId);
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/InvalidConnectionEventsTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/InvalidConnectionEventsTest.cs
@@ -79,7 +79,10 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator WhenSendingConnectionApprovedToAlreadyConnectedClient_ConnectionApprovedMessageIsRejected()
         {
-            var message = new ConnectionApprovedMessage();
+            var message = new ConnectionApprovedMessage
+            {
+                KnownClientIds = new NativeArray<ulong>(0, Allocator.Temp)
+            };
             m_ServerNetworkManager.ConnectionManager.SendMessage(ref message, NetworkDelivery.Reliable, m_ClientNetworkManagers[0].LocalClientId);
 
             // Unnamed message is something to wait for. When this one is received,
@@ -145,7 +148,10 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator WhenSendingConnectionApprovedFromAnyClient_ConnectionApprovedMessageIsRejected()
         {
-            var message = new ConnectionApprovedMessage();
+            var message = new ConnectionApprovedMessage
+            {
+                KnownClientIds = new NativeArray<ulong>(0, Allocator.Temp)
+            };
             m_ClientNetworkManagers[0].ConnectionManager.SendMessage(ref message, NetworkDelivery.Reliable, m_ServerNetworkManager.LocalClientId);
 
             // Unnamed message is something to wait for. When this one is received,

--- a/com.unity.netcode.gameobjects/Tests/Runtime/InvalidConnectionEventsTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/InvalidConnectionEventsTest.cs
@@ -81,7 +81,7 @@ namespace Unity.Netcode.RuntimeTests
         {
             var message = new ConnectionApprovedMessage
             {
-                KnownClientIds = new NativeArray<ulong>(0, Allocator.Temp)
+                PeerClientIds = new NativeArray<ulong>(0, Allocator.Temp)
             };
             m_ServerNetworkManager.ConnectionManager.SendMessage(ref message, NetworkDelivery.Reliable, m_ClientNetworkManagers[0].LocalClientId);
 
@@ -150,7 +150,7 @@ namespace Unity.Netcode.RuntimeTests
         {
             var message = new ConnectionApprovedMessage
             {
-                KnownClientIds = new NativeArray<ulong>(0, Allocator.Temp)
+                PeerClientIds = new NativeArray<ulong>(0, Allocator.Temp)
             };
             m_ClientNetworkManagers[0].ConnectionManager.SendMessage(ref message, NetworkDelivery.Reliable, m_ServerNetworkManager.LocalClientId);
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/PeerDisconnectCallbackTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/PeerDisconnectCallbackTests.cs
@@ -85,7 +85,7 @@ namespace Unity.Netcode.RuntimeTests
             {
                 client.OnClientDisconnectCallback += OnClientDisconnectCallback;
                 client.OnPeerDisconnectCallback += OnPeerDisconnectCallback;
-                if(m_UseHost)
+                if (m_UseHost)
                 {
                     Assert.IsTrue(client.PeerClientIds.Contains(0ul));
                 }
@@ -95,7 +95,7 @@ namespace Unity.Netcode.RuntimeTests
             }
             m_ServerNetworkManager.OnClientDisconnectCallback += OnClientDisconnectCallback;
             m_ServerNetworkManager.OnPeerDisconnectCallback += OnPeerDisconnectCallback;
-            if(m_UseHost)
+            if (m_UseHost)
             {
                 Assert.IsTrue(m_ServerNetworkManager.PeerClientIds.Contains(0ul));
             }
@@ -124,7 +124,7 @@ namespace Unity.Netcode.RuntimeTests
             }
             else
             {
-                yield return StopOneClient(m_ClientNetworkManagers[disconnectedClient-1]);
+                yield return StopOneClient(m_ClientNetworkManagers[disconnectedClient - 1]);
             }
 
             yield return WaitForConditionOrTimeOut(hooks);
@@ -137,7 +137,7 @@ namespace Unity.Netcode.RuntimeTests
                     Assert.IsEmpty(client.PeerClientIds);
                     continue;
                 }
-                if(m_UseHost)
+                if (m_UseHost)
                 {
                     Assert.IsTrue(client.PeerClientIds.Contains(0ul));
                 }
@@ -154,7 +154,7 @@ namespace Unity.Netcode.RuntimeTests
                     }
                 }
             }
-            if(m_UseHost)
+            if (m_UseHost)
             {
                 Assert.IsTrue(m_ServerNetworkManager.PeerClientIds.Contains(0ul));
             }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/PeerDisconnectCallbackTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/PeerDisconnectCallbackTests.cs
@@ -1,0 +1,181 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    /// <summary>
+    /// Validates the client disconnection process.
+    /// This assures that:
+    /// - When a client disconnects from the server that the server:
+    /// -- Detects the client disconnected.
+    /// -- Cleans up the transport to NGO client (and vice versa) mappings.
+    /// - When a server disconnects a client that:
+    /// -- The client detects this disconnection.
+    /// -- The server cleans up the transport to NGO client (and vice versa) mappings.
+    /// - When <see cref="DisconnectTests.OwnerPersistence.DestroyWithOwner"/> the server-side player object is destroyed
+    /// - When <see cref="DisconnectTests.OwnerPersistence.DontDestroyWithOwner"/> the server-side player object ownership is transferred back to the server
+    /// </summary>
+    [TestFixture(HostOrServer.Server)]
+    [TestFixture(HostOrServer.Host)]
+    public class PeerDisconnectCallbackTests : NetcodeIntegrationTest
+    {
+
+        public enum ClientDisconnectType
+        {
+            ServerDisconnectsClient,
+            ClientDisconnectsFromServer
+        }
+
+        protected override int NumberOfClients => 3;
+
+        private int m_ClientDisconnectCount;
+        private int m_PeerDisconnectCount;
+
+
+        public PeerDisconnectCallbackTests(HostOrServer hostOrServer)
+            : base(hostOrServer)
+        {
+        }
+
+        protected override void OnServerAndClientsCreated()
+        {
+            // Adjusting client and server timeout periods to reduce test time
+            // Get the tick frequency in milliseconds and triple it for the heartbeat timeout
+            var heartBeatTimeout = (int)(300 * (1.0f / m_ServerNetworkManager.NetworkConfig.TickRate));
+            var unityTransport = m_ServerNetworkManager.NetworkConfig.NetworkTransport as Transports.UTP.UnityTransport;
+            if (unityTransport != null)
+            {
+                unityTransport.HeartbeatTimeoutMS = heartBeatTimeout;
+            }
+
+            unityTransport = m_ClientNetworkManagers[0].NetworkConfig.NetworkTransport as Transports.UTP.UnityTransport;
+            if (unityTransport != null)
+            {
+                unityTransport.HeartbeatTimeoutMS = heartBeatTimeout;
+            }
+
+            base.OnServerAndClientsCreated();
+        }
+
+        protected override IEnumerator OnSetup()
+        {
+            m_ClientDisconnectCount = 0;
+            m_PeerDisconnectCount = 0;
+            return base.OnSetup();
+        }
+
+        private void OnClientDisconnectCallback(ulong obj)
+        {
+            ++m_ClientDisconnectCount;
+        }
+
+        private void OnPeerDisconnectCallback(ulong obj)
+        {
+            ++m_PeerDisconnectCount;
+        }
+
+        [UnityTest]
+        public IEnumerator TestPeerDisconnectCallback([Values] ClientDisconnectType clientDisconnectType, [Values(1ul, 2ul, 3ul)] ulong disconnectedClient)
+        {
+            foreach (var client in m_ClientNetworkManagers)
+            {
+                client.OnClientDisconnectCallback += OnClientDisconnectCallback;
+                client.OnPeerDisconnectCallback += OnPeerDisconnectCallback;
+                if(m_UseHost)
+                {
+                    Assert.IsTrue(client.KnownClientIds.Contains(0ul));
+                }
+                Assert.IsTrue(client.KnownClientIds.Contains(1ul));
+                Assert.IsTrue(client.KnownClientIds.Contains(2ul));
+                Assert.IsTrue(client.KnownClientIds.Contains(3ul));
+            }
+            m_ServerNetworkManager.OnClientDisconnectCallback += OnClientDisconnectCallback;
+            m_ServerNetworkManager.OnPeerDisconnectCallback += OnPeerDisconnectCallback;
+            if(m_UseHost)
+            {
+                Assert.IsTrue(m_ServerNetworkManager.KnownClientIds.Contains(0ul));
+            }
+            Assert.IsTrue(m_ServerNetworkManager.KnownClientIds.Contains(1ul));
+            Assert.IsTrue(m_ServerNetworkManager.KnownClientIds.Contains(2ul));
+            Assert.IsTrue(m_ServerNetworkManager.KnownClientIds.Contains(3ul));
+
+            // Set up a WaitForMessageReceived hook.
+            // In some cases the message will be received during StopOneClient, but it is not guaranteed
+            // So we start the listener before we call Stop so it will be noticed regardless of whether it happens
+            // during StopOneClient or whether we have to wait for it
+            var messageHookEntriesForSpawn = new List<MessageHookEntry>();
+            foreach (var clientNetworkManager in m_ClientNetworkManagers.Where(c => c.LocalClientId != disconnectedClient))
+            {
+                var messageHook = new MessageHookEntry(clientNetworkManager);
+                messageHook.AssignMessageType<ClientDisconnectedMessage>();
+                messageHookEntriesForSpawn.Add(messageHook);
+            }
+
+            // Used to determine if all clients received the CreateObjectMessage
+            var hooks = new MessageHooksConditional(messageHookEntriesForSpawn);
+
+            if (clientDisconnectType == ClientDisconnectType.ServerDisconnectsClient)
+            {
+                m_ServerNetworkManager.DisconnectClient(disconnectedClient);
+            }
+            else
+            {
+                yield return StopOneClient(m_ClientNetworkManagers[disconnectedClient-1]);
+            }
+
+            yield return WaitForConditionOrTimeOut(hooks);
+            Assert.False(s_GlobalTimeoutHelper.TimedOut);
+
+            foreach (var client in m_ClientNetworkManagers)
+            {
+                if (!client.IsConnectedClient)
+                {
+                    Assert.IsEmpty(client.KnownClientIds);
+                    continue;
+                }
+                if(m_UseHost)
+                {
+                    Assert.IsTrue(client.KnownClientIds.Contains(0ul));
+                }
+
+                for (var i = 1ul; i < 3ul; ++i)
+                {
+                    if (i == disconnectedClient)
+                    {
+                        Assert.IsFalse(client.KnownClientIds.Contains(i));
+                    }
+                    else
+                    {
+                        Assert.IsTrue(client.KnownClientIds.Contains(i));
+                    }
+                }
+            }
+            if(m_UseHost)
+            {
+                Assert.IsTrue(m_ServerNetworkManager.KnownClientIds.Contains(0ul));
+            }
+
+            for (var i = 1ul; i < 3ul; ++i)
+            {
+                if (i == disconnectedClient)
+                {
+                    Assert.IsFalse(m_ServerNetworkManager.KnownClientIds.Contains(i));
+                }
+                else
+                {
+                    Assert.IsTrue(m_ServerNetworkManager.KnownClientIds.Contains(i));
+                }
+            }
+
+            // If disconnected client-side, only server will receive it.
+            // If disconnected server-side, one for server, one for self
+            Assert.AreEqual(clientDisconnectType == ClientDisconnectType.ClientDisconnectsFromServer ? 1 : 2, m_ClientDisconnectCount);
+            // Host receives peer disconnect, dedicated server does not
+            Assert.AreEqual(m_UseHost ? 3 : 2, m_PeerDisconnectCount);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/PeerDisconnectCallbackTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/PeerDisconnectCallbackTests.cs
@@ -87,21 +87,21 @@ namespace Unity.Netcode.RuntimeTests
                 client.OnPeerDisconnectCallback += OnPeerDisconnectCallback;
                 if(m_UseHost)
                 {
-                    Assert.IsTrue(client.KnownClientIds.Contains(0ul));
+                    Assert.IsTrue(client.PeerClientIds.Contains(0ul));
                 }
-                Assert.IsTrue(client.KnownClientIds.Contains(1ul));
-                Assert.IsTrue(client.KnownClientIds.Contains(2ul));
-                Assert.IsTrue(client.KnownClientIds.Contains(3ul));
+                Assert.IsTrue(client.PeerClientIds.Contains(1ul));
+                Assert.IsTrue(client.PeerClientIds.Contains(2ul));
+                Assert.IsTrue(client.PeerClientIds.Contains(3ul));
             }
             m_ServerNetworkManager.OnClientDisconnectCallback += OnClientDisconnectCallback;
             m_ServerNetworkManager.OnPeerDisconnectCallback += OnPeerDisconnectCallback;
             if(m_UseHost)
             {
-                Assert.IsTrue(m_ServerNetworkManager.KnownClientIds.Contains(0ul));
+                Assert.IsTrue(m_ServerNetworkManager.PeerClientIds.Contains(0ul));
             }
-            Assert.IsTrue(m_ServerNetworkManager.KnownClientIds.Contains(1ul));
-            Assert.IsTrue(m_ServerNetworkManager.KnownClientIds.Contains(2ul));
-            Assert.IsTrue(m_ServerNetworkManager.KnownClientIds.Contains(3ul));
+            Assert.IsTrue(m_ServerNetworkManager.PeerClientIds.Contains(1ul));
+            Assert.IsTrue(m_ServerNetworkManager.PeerClientIds.Contains(2ul));
+            Assert.IsTrue(m_ServerNetworkManager.PeerClientIds.Contains(3ul));
 
             // Set up a WaitForMessageReceived hook.
             // In some cases the message will be received during StopOneClient, but it is not guaranteed
@@ -134,40 +134,40 @@ namespace Unity.Netcode.RuntimeTests
             {
                 if (!client.IsConnectedClient)
                 {
-                    Assert.IsEmpty(client.KnownClientIds);
+                    Assert.IsEmpty(client.PeerClientIds);
                     continue;
                 }
                 if(m_UseHost)
                 {
-                    Assert.IsTrue(client.KnownClientIds.Contains(0ul));
+                    Assert.IsTrue(client.PeerClientIds.Contains(0ul));
                 }
 
                 for (var i = 1ul; i < 3ul; ++i)
                 {
                     if (i == disconnectedClient)
                     {
-                        Assert.IsFalse(client.KnownClientIds.Contains(i));
+                        Assert.IsFalse(client.PeerClientIds.Contains(i));
                     }
                     else
                     {
-                        Assert.IsTrue(client.KnownClientIds.Contains(i));
+                        Assert.IsTrue(client.PeerClientIds.Contains(i));
                     }
                 }
             }
             if(m_UseHost)
             {
-                Assert.IsTrue(m_ServerNetworkManager.KnownClientIds.Contains(0ul));
+                Assert.IsTrue(m_ServerNetworkManager.PeerClientIds.Contains(0ul));
             }
 
             for (var i = 1ul; i < 3ul; ++i)
             {
                 if (i == disconnectedClient)
                 {
-                    Assert.IsFalse(m_ServerNetworkManager.KnownClientIds.Contains(i));
+                    Assert.IsFalse(m_ServerNetworkManager.PeerClientIds.Contains(i));
                 }
                 else
                 {
-                    Assert.IsTrue(m_ServerNetworkManager.KnownClientIds.Contains(i));
+                    Assert.IsTrue(m_ServerNetworkManager.PeerClientIds.Contains(i));
                 }
             }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/PeerDisconnectCallbackTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/PeerDisconnectCallbackTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 283ae7cc9a0641c8b49dacad79242287
+timeCreated: 1699978638

--- a/com.unity.netcode.gameobjects/Tests/Runtime/RpcTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/RpcTests.cs
@@ -48,7 +48,6 @@ namespace Unity.Netcode.RuntimeTests
             }
 #endif
 
-
             [ClientRpc]
             public void MyClientRpc()
             {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
@@ -1,0 +1,1550 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine;
+using Object = UnityEngine.Object;
+using Random = System.Random;
+
+// NOTE:
+// Unity's test runner cannot handle a single test fixture with thousands of tests in it.
+// Since this file contains thousands of tests (once all parameters have been taken into account),
+// I had to split up the tests into separate fixtures for each test case.
+// That was the only way to get Unity to actually be able to handle this number of tests.
+// I put them in their own namespace so they would be easier to navigate in the test list.
+namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
+{
+    public class UniversalRpcNetworkBehaviour : NetworkBehaviour
+    {
+        public bool Stop = false;
+        public string Received = string.Empty;
+        public Tuple<int, bool, float, string> ReceivedParams = null;
+        public ulong ReceivedFrom = ulong.MaxValue;
+
+        public void OnRpcReceived()
+        {
+            var st = new StackTrace();
+            var sf = st.GetFrame(1);
+
+            var currentMethod = sf.GetMethod();
+            Received = currentMethod.Name;
+        }
+        public void OnRpcReceivedWithParams(int a, bool b, float f, string s)
+        {
+            var st = new StackTrace();
+            var sf = st.GetFrame(1);
+
+            var currentMethod = sf.GetMethod();
+            Received = currentMethod.Name;
+            ReceivedParams = new Tuple<int, bool, float, string>(a, b, f, s);
+        }
+
+        // Basic RPCs
+
+        [Rpc(SendTo.Everyone)]
+        public void DefaultToEveryoneRpc()
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.Me)]
+        public void DefaultToMeRpc()
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.Owner)]
+        public void DefaultToOwnerRpc()
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.NotOwner)]
+        public void DefaultToNotOwnerRpc()
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.Server)]
+        public void DefaultToServerRpc()
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.NotMe)]
+        public void DefaultToNotMeRpc()
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.NotServer)]
+        public void DefaultToNotServerRpc()
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.ClientsAndHost)]
+        public void DefaultToClientsAndHostRpc()
+        {
+            OnRpcReceived();
+        }
+
+        // RPCs with parameters
+
+        [Rpc(SendTo.Everyone)]
+        public void DefaultToEveryoneWithParamsRpc(int i, bool b, float f, string s)
+        {
+            OnRpcReceivedWithParams(i, b, f, s);
+        }
+
+        [Rpc(SendTo.Me)]
+        public void DefaultToMeWithParamsRpc(int i, bool b, float f, string s)
+        {
+            OnRpcReceivedWithParams(i, b, f, s);
+        }
+
+        [Rpc(SendTo.Owner)]
+        public void DefaultToOwnerWithParamsRpc(int i, bool b, float f, string s)
+        {
+            OnRpcReceivedWithParams(i, b, f, s);
+        }
+
+        [Rpc(SendTo.NotOwner)]
+        public void DefaultToNotOwnerWithParamsRpc(int i, bool b, float f, string s)
+        {
+            OnRpcReceivedWithParams(i, b, f, s);
+        }
+
+        [Rpc(SendTo.Server)]
+        public void DefaultToServerWithParamsRpc(int i, bool b, float f, string s)
+        {
+            OnRpcReceivedWithParams(i, b, f, s);
+        }
+
+        [Rpc(SendTo.NotMe)]
+        public void DefaultToNotMeWithParamsRpc(int i, bool b, float f, string s)
+        {
+            OnRpcReceivedWithParams(i, b, f, s);
+        }
+
+        [Rpc(SendTo.NotServer)]
+        public void DefaultToNotServerWithParamsRpc(int i, bool b, float f, string s)
+        {
+            OnRpcReceivedWithParams(i, b, f, s);
+        }
+
+        [Rpc(SendTo.ClientsAndHost)]
+        public void DefaultToClientsAndHostWithParamsRpc(int i, bool b, float f, string s)
+        {
+            OnRpcReceivedWithParams(i, b, f, s);
+        }
+
+        // RPCs with RPC parameters
+
+        [Rpc(SendTo.Everyone)]
+        public void DefaultToEveryoneWithRpcParamsRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+            ReceivedFrom = rpcParams.Receive.SenderClientId;
+        }
+
+        [Rpc(SendTo.Me)]
+        public void DefaultToMeWithRpcParamsRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+            ReceivedFrom = rpcParams.Receive.SenderClientId;
+        }
+
+        [Rpc(SendTo.Owner)]
+        public void DefaultToOwnerWithRpcParamsRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+            ReceivedFrom = rpcParams.Receive.SenderClientId;
+        }
+
+        [Rpc(SendTo.NotOwner)]
+        public void DefaultToNotOwnerWithRpcParamsRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+            ReceivedFrom = rpcParams.Receive.SenderClientId;
+        }
+
+        [Rpc(SendTo.Server)]
+        public void DefaultToServerWithRpcParamsRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+            ReceivedFrom = rpcParams.Receive.SenderClientId;
+        }
+
+        [Rpc(SendTo.NotMe)]
+        public void DefaultToNotMeWithRpcParamsRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+            ReceivedFrom = rpcParams.Receive.SenderClientId;
+        }
+
+        [Rpc(SendTo.NotServer)]
+        public void DefaultToNotServerWithRpcParamsRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+            ReceivedFrom = rpcParams.Receive.SenderClientId;
+        }
+
+        [Rpc(SendTo.ClientsAndHost)]
+        public void DefaultToClientsAndHostWithRpcParamsRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+            ReceivedFrom = rpcParams.Receive.SenderClientId;
+        }
+
+
+        // RPCs with parameters and RPC parameters
+
+        [Rpc(SendTo.Everyone)]
+        public void DefaultToEveryoneWithParamsAndRpcParamsRpc(int i, bool b, float f, string s, RpcParams rpcParams)
+        {
+            OnRpcReceivedWithParams(i, b, f, s);
+        }
+
+        [Rpc(SendTo.Me)]
+        public void DefaultToMeWithParamsAndRpcParamsRpc(int i, bool b, float f, string s, RpcParams rpcParams)
+        {
+            OnRpcReceivedWithParams(i, b, f, s);
+        }
+
+        [Rpc(SendTo.Owner)]
+        public void DefaultToOwnerWithParamsAndRpcParamsRpc(int i, bool b, float f, string s, RpcParams rpcParams)
+        {
+            OnRpcReceivedWithParams(i, b, f, s);
+        }
+
+        [Rpc(SendTo.NotOwner)]
+        public void DefaultToNotOwnerWithParamsAndRpcParamsRpc(int i, bool b, float f, string s, RpcParams rpcParams)
+        {
+            OnRpcReceivedWithParams(i, b, f, s);
+        }
+
+        [Rpc(SendTo.Server)]
+        public void DefaultToServerWithParamsAndRpcParamsRpc(int i, bool b, float f, string s, RpcParams rpcParams)
+        {
+            OnRpcReceivedWithParams(i, b, f, s);
+        }
+
+        [Rpc(SendTo.NotMe)]
+        public void DefaultToNotMeWithParamsAndRpcParamsRpc(int i, bool b, float f, string s, RpcParams rpcParams)
+        {
+            OnRpcReceivedWithParams(i, b, f, s);
+        }
+
+        [Rpc(SendTo.NotServer)]
+        public void DefaultToNotServerWithParamsAndRpcParamsRpc(int i, bool b, float f, string s, RpcParams rpcParams)
+        {
+            OnRpcReceivedWithParams(i, b, f, s);
+        }
+
+        [Rpc(SendTo.ClientsAndHost)]
+        public void DefaultToClientsAndHostWithParamsAndRpcParamsRpc(int i, bool b, float f, string s, RpcParams rpcParams)
+        {
+            OnRpcReceivedWithParams(i, b, f, s);
+        }
+
+        // RPCs with AllowTargetOverride = true
+
+        // AllowTargetOverried is implied with SpecifiedInParams and does not need to be stated
+        // Including it will cause a compiler warning
+        [Rpc(SendTo.SpecifiedInParams)]
+        public void DefaultToSpecifiedInParamsAllowOverrideRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.Everyone, AllowTargetOverride = true)]
+        public void DefaultToEveryoneAllowOverrideRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.Me, AllowTargetOverride = true)]
+        public void DefaultToMeAllowOverrideRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.Owner, AllowTargetOverride = true)]
+        public void DefaultToOwnerAllowOverrideRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.NotOwner, AllowTargetOverride = true)]
+        public void DefaultToNotOwnerAllowOverrideRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.Server, AllowTargetOverride = true)]
+        public void DefaultToServerAllowOverrideRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.NotMe, AllowTargetOverride = true)]
+        public void DefaultToNotMeAllowOverrideRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.NotServer, AllowTargetOverride = true)]
+        public void DefaultToNotServerAllowOverrideRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.ClientsAndHost, AllowTargetOverride = true)]
+        public void DefaultToClientsAndHostAllowOverrideRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+        }
+
+        // RPCs with DeferLocal = true
+
+        [Rpc(SendTo.Everyone, DeferLocal = true)]
+        public void DefaultToEveryoneDeferLocalRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.Me, DeferLocal = true)]
+        public void DefaultToMeDeferLocalRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.Owner, DeferLocal = true)]
+        public void DefaultToOwnerDeferLocalRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.NotOwner, DeferLocal = true)]
+        public void DefaultToNotOwnerDeferLocalRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.Server, DeferLocal = true)]
+        public void DefaultToServerDeferLocalRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.NotServer, DeferLocal = true)]
+        public void DefaultToNotServerDeferLocalRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.ClientsAndHost, DeferLocal = true)]
+        public void DefaultToClientsAndHostDeferLocalRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+        }
+
+        // RPCs with RequireOwnership = true
+
+        [Rpc(SendTo.Everyone, RequireOwnership = true)]
+        public void DefaultToEveryoneRequireOwnershipRpc()
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.Me, RequireOwnership = true)]
+        public void DefaultToMeRequireOwnershipRpc()
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.Owner, RequireOwnership = true)]
+        public void DefaultToOwnerRequireOwnershipRpc()
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.NotOwner, RequireOwnership = true)]
+        public void DefaultToNotOwnerRequireOwnershipRpc()
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.Server, RequireOwnership = true)]
+        public void DefaultToServerRequireOwnershipRpc()
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.NotMe, RequireOwnership = true)]
+        public void DefaultToNotMeRequireOwnershipRpc()
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.NotServer, RequireOwnership = true)]
+        public void DefaultToNotServerRequireOwnershipRpc()
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.ClientsAndHost, RequireOwnership = true)]
+        public void DefaultToClientsAndHostRequireOwnershipRpc()
+        {
+            OnRpcReceived();
+        }
+
+        [Rpc(SendTo.SpecifiedInParams, RequireOwnership = true)]
+        public void SpecifiedInParamsRequireOwnershipRpc(RpcParams rpcParams)
+        {
+            OnRpcReceived();
+        }
+
+
+        // Mutual RPC Recursion
+
+        [Rpc(SendTo.Server, DeferLocal = true)]
+        public void MutualRecursionServerRpc()
+        {
+            if (Stop)
+            {
+                Stop = false;
+                return;
+            }
+            OnRpcReceived();
+            MutualRecursionClientRpc();
+        }
+
+        [Rpc(SendTo.NotServer, DeferLocal = true)]
+        public void MutualRecursionClientRpc()
+        {
+            OnRpcReceived();
+            MutualRecursionServerRpc();
+        }
+
+        // Self recursion
+        [Rpc(SendTo.Server, DeferLocal = true)]
+        public void SelfRecursiveRpc()
+        {
+            if (Stop)
+            {
+                Stop = false;
+                return;
+            }
+            OnRpcReceived();
+            SelfRecursiveRpc();
+        }
+    }
+
+    public class UniversalRpcTestsBase : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 2;
+
+        public UniversalRpcTestsBase(HostOrServer hostOrServer) : base(hostOrServer)
+        {
+        }
+
+
+        protected override NetworkManagerInstatiationMode OnSetIntegrationTestMode()
+        {
+            return NetworkManagerInstatiationMode.AllTests;
+        }
+
+        protected override bool m_EnableTimeTravel => true;
+
+        protected override bool m_SetupIsACoroutine => false;
+        protected override bool m_TearDownIsACoroutine => false;
+
+        protected GameObject m_ServerObject;
+
+        protected override void OnCreatePlayerPrefab()
+        {
+            m_PlayerPrefab.AddComponent<UniversalRpcNetworkBehaviour>();
+        }
+
+        protected override void OnServerAndClientsCreated()
+        {
+            m_ServerObject = new GameObject { name = "Server Object" };
+            var networkObject = m_ServerObject.AddComponent<NetworkObject>();
+            m_ServerObject.AddComponent<UniversalRpcNetworkBehaviour>();
+            networkObject.NetworkManagerOwner = m_ServerNetworkManager;
+            NetcodeIntegrationTestHelpers.MakeNetworkObjectTestPrefab(networkObject);
+            m_ServerNetworkManager.AddNetworkPrefab(m_ServerObject);
+            foreach (var client in m_ClientNetworkManagers)
+            {
+                client.AddNetworkPrefab(m_ServerObject);
+            }
+        }
+
+        protected override void OnInlineTearDown()
+        {
+            Clear();
+        }
+
+        protected void Clear()
+        {
+            foreach (var obj in Object.FindObjectsByType<UniversalRpcNetworkBehaviour>(FindObjectsSortMode.None))
+            {
+                obj.Received = string.Empty;
+                obj.ReceivedParams = null;
+                obj.ReceivedFrom = ulong.MaxValue;
+            }
+        }
+
+        protected override void OnOneTimeTearDown()
+        {
+            Object.DestroyImmediate(m_ServerObject);
+        }
+
+        protected override void OnTimeTravelServerAndClientsConnected()
+        {
+            m_ServerObject.GetComponent<NetworkObject>().Spawn();
+            WaitForMessageReceivedWithTimeTravel<CreateObjectMessage>(m_ClientNetworkManagers.ToList());
+        }
+
+        protected UniversalRpcNetworkBehaviour GetPlayerObject(ulong ownerClientId, ulong onClient)
+        {
+            if (ownerClientId == NetworkManager.ServerClientId && !m_ServerNetworkManager.IsHost)
+            {
+                foreach (var obj in Object.FindObjectsByType<UniversalRpcNetworkBehaviour>(FindObjectsSortMode.None))
+                {
+                    if (obj.name.StartsWith("Server Object") && obj.OwnerClientId == ownerClientId && obj.NetworkManager.LocalClientId == onClient)
+                    {
+                        return obj;
+                    }
+                }
+            }
+
+            return m_PlayerNetworkObjects[onClient][ownerClientId].GetComponent<UniversalRpcNetworkBehaviour>();
+        }
+
+        protected void VerifyLocalReceived(ulong objectOwner, ulong sender, string name, bool verifyReceivedFrom)
+        {
+            var obj = GetPlayerObject(objectOwner, sender);
+            Assert.AreEqual(name, obj.Received);
+            Assert.IsNull(obj.ReceivedParams);
+            if (verifyReceivedFrom)
+            {
+                Assert.AreEqual(sender, obj.ReceivedFrom);
+            }
+        }
+
+        protected void VerifyLocalReceivedWithParams(ulong objectOwner, ulong sender, string name, int i, bool b, float f, string s)
+        {
+            var obj = GetPlayerObject(objectOwner, sender);
+            Assert.AreEqual(name, obj.Received);
+            Assert.IsNotNull(obj.ReceivedParams);
+            Assert.AreEqual(i, obj.ReceivedParams.Item1);
+            Assert.AreEqual(b, obj.ReceivedParams.Item2);
+            Assert.AreEqual(f, obj.ReceivedParams.Item3);
+            Assert.AreEqual(s, obj.ReceivedParams.Item4);
+        }
+
+        protected void VerifyNotReceived(ulong objectOwner, ulong[] receivedBy)
+        {
+            foreach (var client in receivedBy)
+            {
+                UniversalRpcNetworkBehaviour playerObject = GetPlayerObject(objectOwner, client);
+                Assert.AreEqual(string.Empty, playerObject.Received);
+                Assert.IsNull(playerObject.ReceivedParams);
+            }
+        }
+
+        protected void VerifyRemoteReceived(ulong objectOwner, ulong sender, string message, ulong[] receivedBy, bool verifyReceivedFrom, bool waitForMessages = true)
+        {
+            foreach (var client in receivedBy)
+            {
+                if (client == sender)
+                {
+                    VerifyLocalReceived(objectOwner, sender, message, verifyReceivedFrom);
+
+                    break;
+                }
+            }
+
+            if (waitForMessages)
+            {
+                var needsProxyMessage = false;
+                var needsServerRpcMessage = false;
+                if (sender != 0)
+                {
+                    foreach (var client in receivedBy)
+                    {
+                        if (client == sender)
+                        {
+                            continue;
+                        }
+
+                        if (client != 0)
+                        {
+                            needsProxyMessage = true;
+                        }
+                        else
+                        {
+                            needsServerRpcMessage = true;
+                        }
+                    }
+                }
+
+                if (needsProxyMessage)
+                {
+                    var messages = new List<Type> { typeof(ProxyMessage) };
+                    if (needsServerRpcMessage)
+                    {
+                        messages.Add(typeof(RpcMessage));
+                    }
+
+                    WaitForMessagesReceivedWithTimeTravel(messages, new[] { m_ServerNetworkManager }.ToList());
+                }
+
+                var managersThatNeedToWaitForRpc = new List<NetworkManager>();
+                if (needsServerRpcMessage && !needsProxyMessage)
+                {
+                    managersThatNeedToWaitForRpc.Add(m_ServerNetworkManager);
+                }
+
+                foreach (var client in receivedBy)
+                {
+                    if (client != sender && client != 0)
+                    {
+                        managersThatNeedToWaitForRpc.Add(m_ClientNetworkManagers[client - 1]);
+                    }
+                }
+
+                WaitForMessageReceivedWithTimeTravel<RpcMessage>(managersThatNeedToWaitForRpc);
+            }
+
+            foreach (var client in receivedBy)
+            {
+                UniversalRpcNetworkBehaviour playerObject = GetPlayerObject(objectOwner, client);
+                Assert.AreEqual(message, playerObject.Received);
+                Assert.IsNull(playerObject.ReceivedParams);
+                if (verifyReceivedFrom)
+                {
+                    Assert.AreEqual(sender, playerObject.ReceivedFrom);
+                }
+            }
+        }
+
+        protected void VerifyRemoteReceivedWithParams(ulong objectOwner, ulong sender, string message, ulong[] receivedBy, int i, bool b, float f, string s)
+        {
+            foreach (var client in receivedBy)
+            {
+                if (client == sender)
+                {
+                    VerifyLocalReceivedWithParams(objectOwner, sender, message, i, b, f, s);
+
+                    break;
+                }
+            }
+
+            var needsProxyMessage = false;
+            var needsServerRpcMessage = false;
+            if (sender != 0)
+            {
+                foreach (var client in receivedBy)
+                {
+                    if (client == sender)
+                    {
+                        continue;
+                    }
+
+                    if (client != 0)
+                    {
+                        needsProxyMessage = true;
+                    }
+                    else
+                    {
+                        needsServerRpcMessage = true;
+                    }
+                }
+            }
+
+            if (needsProxyMessage)
+            {
+                var messages = new List<Type> { typeof(ProxyMessage) };
+                if (needsServerRpcMessage)
+                {
+                    messages.Add(typeof(RpcMessage));
+                }
+
+                WaitForMessagesReceivedWithTimeTravel(messages, new[] { m_ServerNetworkManager }.ToList());
+            }
+
+            var managersThatNeedToWaitForRpc = new List<NetworkManager>();
+            if (needsServerRpcMessage && !needsProxyMessage)
+            {
+                managersThatNeedToWaitForRpc.Add(m_ServerNetworkManager);
+            }
+
+            foreach (var client in receivedBy)
+            {
+                if (client != sender && client != 0)
+                {
+                    managersThatNeedToWaitForRpc.Add(m_ClientNetworkManagers[client - 1]);
+                }
+            }
+
+            WaitForMessageReceivedWithTimeTravel<RpcMessage>(managersThatNeedToWaitForRpc);
+
+            foreach (var client in receivedBy)
+            {
+                UniversalRpcNetworkBehaviour playerObject = GetPlayerObject(objectOwner, client);
+                Assert.AreEqual(message, playerObject.Received);
+
+                Assert.IsNotNull(playerObject.ReceivedParams);
+                Assert.AreEqual(i, playerObject.ReceivedParams.Item1);
+                Assert.AreEqual(b, playerObject.ReceivedParams.Item2);
+                Assert.AreEqual(f, playerObject.ReceivedParams.Item3);
+                Assert.AreEqual(s, playerObject.ReceivedParams.Item4);
+            }
+        }
+
+        protected static ulong[] s_ClientIds = new[] { 0ul, 1ul, 2ul };
+
+        public void VerifySentToEveryone(ulong objectOwner, ulong sender, string methodName)
+        {
+            VerifyRemoteReceived(objectOwner, sender, methodName, s_ClientIds, false);
+        }
+
+        public void VerifySentToEveryoneWithReceivedFrom(ulong objectOwner, ulong sender, string methodName)
+        {
+            VerifyRemoteReceived(objectOwner, sender, methodName, s_ClientIds, true);
+        }
+
+        public void VerifySentToEveryoneWithParams(ulong objectOwner, ulong sender, string methodName, int i, bool b, float f, string s)
+        {
+            VerifyRemoteReceivedWithParams(objectOwner, sender, methodName, s_ClientIds, i, b, f, s);
+        }
+
+        public void VerifySentToId(ulong objectOwner, ulong sender, ulong receiver, string methodName, bool verifyReceivedFrom)
+        {
+            VerifyRemoteReceived(objectOwner, sender, methodName, new[] { receiver }, verifyReceivedFrom);
+            VerifyNotReceived(objectOwner, s_ClientIds.Where(c => c != receiver).ToArray());
+
+            // Pass some time to make sure that no other client ever receives this
+            TimeTravel(1f, 30);
+            VerifyNotReceived(objectOwner, s_ClientIds.Where(c => c != receiver).ToArray());
+        }
+
+        public void VerifySentToNotId(ulong objectOwner, ulong sender, ulong notReceiver, string methodName, bool verifyReceivedFrom)
+        {
+            VerifyNotReceived(objectOwner, new[] { notReceiver });
+            VerifyRemoteReceived(objectOwner, sender, methodName, s_ClientIds.Where(c => c != notReceiver).ToArray(), verifyReceivedFrom);
+            // Verify again after all the waiting is finished
+            VerifyNotReceived(objectOwner, new[] { notReceiver });
+        }
+
+        public void VerifySentToIdWithParams(ulong objectOwner, ulong sender, ulong receiver, string methodName, int i, bool b, float f, string s)
+        {
+            VerifyRemoteReceivedWithParams(objectOwner, sender, methodName, new[] { receiver }, i, b, f, s);
+            VerifyNotReceived(objectOwner, s_ClientIds.Where(c => c != receiver).ToArray());
+
+            // Pass some time to make sure that no other client ever receives this
+            TimeTravel(1f, 30);
+            VerifyNotReceived(objectOwner, s_ClientIds.Where(c => c != receiver).ToArray());
+        }
+
+        public void VerifySentToNotIdWithParams(ulong objectOwner, ulong sender, ulong notReceiver, string methodName, int i, bool b, float f, string s)
+        {
+            VerifyNotReceived(objectOwner, new[] { notReceiver });
+            VerifyRemoteReceivedWithParams(objectOwner, sender, methodName, s_ClientIds.Where(c => c != notReceiver).ToArray(), i, b, f, s);
+            // Verify again after all the waiting is finished
+            VerifyNotReceived(objectOwner, new[] { notReceiver });
+        }
+
+        public void VerifySentToOwner(ulong objectOwner, ulong sender, string methodName)
+        {
+            VerifySentToId(objectOwner, sender, objectOwner, methodName, false);
+        }
+
+        public void VerifySentToNotOwner(ulong objectOwner, ulong sender, string methodName)
+        {
+            VerifySentToNotId(objectOwner, sender, objectOwner, methodName, false);
+        }
+
+        public void VerifySentToServer(ulong objectOwner, ulong sender, string methodName)
+        {
+            VerifySentToId(objectOwner, sender, NetworkManager.ServerClientId, methodName, false);
+        }
+
+        public void VerifySentToNotServer(ulong objectOwner, ulong sender, string methodName)
+        {
+            VerifySentToNotId(objectOwner, sender, NetworkManager.ServerClientId, methodName, false);
+        }
+
+        public void VerifySentToClientsAndHost(ulong objectOwner, ulong sender, string methodName)
+        {
+            if (m_ServerNetworkManager.IsHost)
+            {
+                VerifySentToEveryone(objectOwner, sender, methodName);
+            }
+            else
+            {
+                VerifySentToNotServer(objectOwner, sender, methodName);
+            }
+        }
+
+        public void VerifySentToMe(ulong objectOwner, ulong sender, string methodName)
+        {
+            VerifySentToId(objectOwner, sender, sender, methodName, false);
+        }
+
+        public void VerifySentToNotMe(ulong objectOwner, ulong sender, string methodName)
+        {
+            VerifySentToNotId(objectOwner, sender, sender, methodName, false);
+        }
+
+        public void VerifySentToOwnerWithReceivedFrom(ulong objectOwner, ulong sender, string methodName)
+        {
+            VerifySentToId(objectOwner, sender, objectOwner, methodName, true);
+        }
+
+        public void VerifySentToNotOwnerWithReceivedFrom(ulong objectOwner, ulong sender, string methodName)
+        {
+            VerifySentToNotId(objectOwner, sender, objectOwner, methodName, true);
+        }
+
+        public void VerifySentToServerWithReceivedFrom(ulong objectOwner, ulong sender, string methodName)
+        {
+            VerifySentToId(objectOwner, sender, NetworkManager.ServerClientId, methodName, true);
+        }
+
+        public void VerifySentToNotServerWithReceivedFrom(ulong objectOwner, ulong sender, string methodName)
+        {
+            VerifySentToNotId(objectOwner, sender, NetworkManager.ServerClientId, methodName, true);
+        }
+
+        public void VerifySentToClientsAndHostWithReceivedFrom(ulong objectOwner, ulong sender, string methodName)
+        {
+            if (m_ServerNetworkManager.IsHost)
+            {
+                VerifySentToEveryoneWithReceivedFrom(objectOwner, sender, methodName);
+            }
+            else
+            {
+                VerifySentToNotServerWithReceivedFrom(objectOwner, sender, methodName);
+            }
+        }
+
+        public void VerifySentToMeWithReceivedFrom(ulong objectOwner, ulong sender, string methodName)
+        {
+            VerifySentToId(objectOwner, sender, sender, methodName, true);
+        }
+
+        public void VerifySentToNotMeWithReceivedFrom(ulong objectOwner, ulong sender, string methodName)
+        {
+            VerifySentToNotId(objectOwner, sender, sender, methodName, true);
+        }
+
+        public void VerifySentToOwnerWithParams(ulong objectOwner, ulong sender, string methodName, int i, bool b, float f, string s)
+        {
+            VerifySentToIdWithParams(objectOwner, sender, objectOwner, methodName, i, b, f, s);
+        }
+
+        public void VerifySentToNotOwnerWithParams(ulong objectOwner, ulong sender, string methodName, int i, bool b, float f, string s)
+        {
+            VerifySentToNotIdWithParams(objectOwner, sender, objectOwner, methodName, i, b, f, s);
+        }
+
+        public void VerifySentToServerWithParams(ulong objectOwner, ulong sender, string methodName, int i, bool b, float f, string s)
+        {
+            VerifySentToIdWithParams(objectOwner, sender, NetworkManager.ServerClientId, methodName, i, b, f, s);
+        }
+
+        public void VerifySentToNotServerWithParams(ulong objectOwner, ulong sender, string methodName, int i, bool b, float f, string s)
+        {
+            VerifySentToNotIdWithParams(objectOwner, sender, NetworkManager.ServerClientId, methodName, i, b, f, s);
+        }
+
+        public void VerifySentToClientsAndHostWithParams(ulong objectOwner, ulong sender, string methodName, int i, bool b, float f, string s)
+        {
+            if (m_ServerNetworkManager.IsHost)
+            {
+                VerifySentToEveryoneWithParams(objectOwner, sender, methodName, i, b, f, s);
+            }
+            else
+            {
+                VerifySentToNotServerWithParams(objectOwner, sender, methodName, i, b, f, s);
+            }
+        }
+
+        public void VerifySentToMeWithParams(ulong objectOwner, ulong sender, string methodName, int i, bool b, float f, string s)
+        {
+            VerifySentToIdWithParams(objectOwner, sender, sender, methodName, i, b, f, s);
+        }
+
+        public void VerifySentToNotMeWithParams(ulong objectOwner, ulong sender, string methodName, int i, bool b, float f, string s)
+        {
+            VerifySentToNotIdWithParams(objectOwner, sender, sender, methodName, i, b, f, s);
+        }
+
+        public void RethrowTargetInvocationException(Action action)
+        {
+            try
+            {
+                action.Invoke();
+            }
+            catch (TargetInvocationException e)
+            {
+                throw e.InnerException;
+            }
+        }
+    }
+
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    internal class UniversalRpcTestSendingNoOverride : UniversalRpcTestsBase
+    {
+        public UniversalRpcTestSendingNoOverride(HostOrServer hostOrServer) : base(hostOrServer)
+        {
+
+        }
+
+        [Test]
+        public void TestSendingNoOverride(
+            // Excludes SendTo.SpecifiedInParams
+            [Values(SendTo.Everyone, SendTo.Me, SendTo.Owner, SendTo.Server, SendTo.NotMe, SendTo.NotOwner, SendTo.NotServer, SendTo.ClientsAndHost)] SendTo sendTo,
+            [Values(0u, 1u, 2u)] ulong objectOwner,
+            [Values(0u, 1u, 2u)] ulong sender
+        )
+        {
+            var sendMethodName = $"DefaultTo{sendTo}Rpc";
+            var verifyMethodName = $"VerifySentTo{sendTo}";
+
+            var senderObject = GetPlayerObject(objectOwner, sender);
+            var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
+            sendMethod.Invoke(senderObject, new object[] { });
+
+            var verifyMethod = GetType().GetMethod(verifyMethodName);
+            verifyMethod.Invoke(this, new object[] { objectOwner, sender, sendMethodName });
+        }
+
+    }
+
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    internal class UniversalRpcTestSenderClientId : UniversalRpcTestsBase
+    {
+        public UniversalRpcTestSenderClientId(HostOrServer hostOrServer) : base(hostOrServer)
+        {
+
+        }
+
+        [Test]
+        public void TestSenderClientId(
+            // Excludes SendTo.SpecifiedInParams
+            [Values(SendTo.Everyone, SendTo.Me, SendTo.Owner, SendTo.Server, SendTo.NotMe, SendTo.NotOwner, SendTo.NotServer, SendTo.ClientsAndHost)] SendTo sendTo,
+            [Values(0u, 1u, 2u)] ulong objectOwner,
+            [Values(0u, 1u, 2u)] ulong sender
+        )
+        {
+            var sendMethodName = $"DefaultTo{sendTo}WithRpcParamsRpc";
+            var verifyMethodName = $"VerifySentTo{sendTo}WithReceivedFrom";
+
+            var senderObject = GetPlayerObject(objectOwner, sender);
+            var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
+            sendMethod.Invoke(senderObject, new object[] { new RpcParams() });
+
+            var verifyMethod = GetType().GetMethod(verifyMethodName);
+            verifyMethod.Invoke(this, new object[] { objectOwner, sender, sendMethodName });
+        }
+
+    }
+
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    internal class UniversalRpcTestSendingNoOverrideWithParams : UniversalRpcTestsBase
+    {
+        public UniversalRpcTestSendingNoOverrideWithParams(HostOrServer hostOrServer) : base(hostOrServer)
+        {
+
+        }
+
+        [Test]
+        public void TestSendingNoOverrideWithParams(
+            // Excludes SendTo.SpecifiedInParams
+            [Values(SendTo.Everyone, SendTo.Me, SendTo.Owner, SendTo.Server, SendTo.NotMe, SendTo.NotOwner, SendTo.NotServer, SendTo.ClientsAndHost)] SendTo sendTo,
+            [Values(0u, 1u, 2u)] ulong objectOwner,
+            [Values(0u, 1u, 2u)] ulong sender
+        )
+        {
+            var rand = new Random();
+            var i = rand.Next();
+            var f = (float)rand.NextDouble();
+            var b = rand.Next() % 2 == 1;
+            var s = "";
+            var numChars = rand.Next() % 5 + 5;
+            const string chars = "abcdefghijklmnopqrstuvwxycABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-=_+[]{}\\|;':\",./<>?";
+            for (var j = 0; j < numChars; ++j)
+            {
+                s += chars[rand.Next(chars.Length)];
+            }
+
+            var sendMethodName = $"DefaultTo{sendTo}WithParamsRpc";
+            var verifyMethodName = $"VerifySentTo{sendTo}WithParams";
+
+            var senderObject = GetPlayerObject(objectOwner, sender);
+            var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
+            sendMethod.Invoke(senderObject, new object[] { i, b, f, s });
+
+            var verifyMethod = GetType().GetMethod(verifyMethodName);
+            verifyMethod.Invoke(this, new object[] { objectOwner, sender, sendMethodName, i, b, f, s });
+        }
+
+    }
+
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    internal class UniversalRpcTestSendingNoOverrideWithParamsAndRpcParams : UniversalRpcTestsBase
+    {
+        public UniversalRpcTestSendingNoOverrideWithParamsAndRpcParams(HostOrServer hostOrServer) : base(hostOrServer)
+        {
+
+        }
+
+        [Test]
+        public void TestSendingNoOverrideWithParamsAndRpcParams(
+            // Excludes SendTo.SpecifiedInParams
+            [Values(SendTo.Everyone, SendTo.Me, SendTo.Owner, SendTo.Server, SendTo.NotMe, SendTo.NotOwner, SendTo.NotServer, SendTo.ClientsAndHost)] SendTo sendTo,
+            [Values(0u, 1u, 2u)] ulong objectOwner,
+            [Values(0u, 1u, 2u)] ulong sender
+        )
+        {
+            var rand = new Random();
+            var i = rand.Next();
+            var f = (float)rand.NextDouble();
+            var b = rand.Next() % 2 == 1;
+            var s = "";
+            var numChars = rand.Next() % 5 + 5;
+            const string chars = "abcdefghijklmnopqrstuvwxycABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-=_+[]{}\\|;':\",./<>?";
+            for (var j = 0; j < numChars; ++j)
+            {
+                s += chars[rand.Next(chars.Length)];
+            }
+
+            var sendMethodName = $"DefaultTo{sendTo}WithParamsAndRpcParamsRpc";
+            var verifyMethodName = $"VerifySentTo{sendTo}WithParams";
+
+            var senderObject = GetPlayerObject(objectOwner, sender);
+            var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
+            sendMethod.Invoke(senderObject, new object[] { i, b, f, s, new RpcParams() });
+
+            var verifyMethod = GetType().GetMethod(verifyMethodName);
+            verifyMethod.Invoke(this, new object[] { objectOwner, sender, sendMethodName, i, b, f, s });
+        }
+
+    }
+
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    internal class UniversalRpcTestRequireOwnership : UniversalRpcTestsBase
+    {
+        public UniversalRpcTestRequireOwnership(HostOrServer hostOrServer) : base(hostOrServer)
+        {
+
+        }
+
+        [Test]
+        public void TestRequireOwnership(
+            // Excludes SendTo.SpecifiedInParams
+            [Values(SendTo.Everyone, SendTo.Me, SendTo.Owner, SendTo.Server, SendTo.NotMe, SendTo.NotOwner, SendTo.NotServer, SendTo.ClientsAndHost)] SendTo sendTo,
+            [Values(0u, 1u, 2u)] ulong objectOwner,
+            [Values(0u, 1u, 2u)] ulong sender
+        )
+        {
+            var sendMethodName = $"DefaultTo{sendTo}RequireOwnershipRpc";
+
+            var senderObject = GetPlayerObject(objectOwner, sender);
+            var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
+            if (sender != objectOwner)
+            {
+                Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => sendMethod.Invoke(senderObject, new object[] { })));
+            }
+            else
+            {
+                var verifyMethodName = $"VerifySentTo{sendTo}";
+                sendMethod.Invoke(senderObject, new object[] { });
+
+                var verifyMethod = GetType().GetMethod(verifyMethodName);
+                verifyMethod.Invoke(this, new object[] { objectOwner, sender, sendMethodName });
+            }
+        }
+    }
+
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    internal class UniversalRpcTestDisallowedOverride : UniversalRpcTestsBase
+    {
+        public UniversalRpcTestDisallowedOverride(HostOrServer hostOrServer) : base(hostOrServer)
+        {
+
+        }
+
+        [Test]
+        public void TestDisallowedOverride(
+            // Excludes SendTo.SpecifiedInParams
+            [Values(SendTo.Everyone, SendTo.Me, SendTo.Owner, SendTo.Server, SendTo.NotMe, SendTo.NotOwner, SendTo.NotServer, SendTo.ClientsAndHost)] SendTo sendTo,
+            [Values(0u, 1u, 2u)] ulong objectOwner,
+            [Values(0u, 1u, 2u)] ulong sender)
+        {
+            var senderObject = GetPlayerObject(objectOwner, sender);
+            var methodName = $"DefaultTo{sendTo}WithRpcParamsRpc";
+            var method = senderObject.GetType().GetMethod(methodName);
+            Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => method.Invoke(senderObject, new object[] { (RpcParams)senderObject.RpcTarget.Everyone })));
+            Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => method.Invoke(senderObject, new object[] { (RpcParams)senderObject.RpcTarget.Owner })));
+            Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => method.Invoke(senderObject, new object[] { (RpcParams)senderObject.RpcTarget.NotOwner })));
+            Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => method.Invoke(senderObject, new object[] { (RpcParams)senderObject.RpcTarget.Server })));
+            Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => method.Invoke(senderObject, new object[] { (RpcParams)senderObject.RpcTarget.NotServer })));
+            Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => method.Invoke(senderObject, new object[] { (RpcParams)senderObject.RpcTarget.ClientsAndHost })));
+            Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => method.Invoke(senderObject, new object[] { (RpcParams)senderObject.RpcTarget.Me })));
+            Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => method.Invoke(senderObject, new object[] { (RpcParams)senderObject.RpcTarget.NotMe })));
+            Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => method.Invoke(senderObject, new object[] { (RpcParams)senderObject.RpcTarget.Single(0) })));
+            Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => method.Invoke(senderObject, new object[] { (RpcParams)senderObject.RpcTarget.Group(new[] { 0ul, 1ul, 2ul }) })));
+        }
+
+    }
+
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    internal class UniversalRpcTestSendingWithTargetOverride : UniversalRpcTestsBase
+    {
+        public UniversalRpcTestSendingWithTargetOverride(HostOrServer hostOrServer) : base(hostOrServer)
+        {
+
+        }
+
+        [Test]
+        public void TestSendingWithTargetOverride(
+            [Values] SendTo defaultSendTo,
+            [Values(SendTo.Everyone, SendTo.Me, SendTo.Owner, SendTo.Server, SendTo.NotMe, SendTo.NotOwner, SendTo.NotServer, SendTo.ClientsAndHost)] SendTo overrideSendTo,
+            [Values(0u, 1u, 2u)] ulong objectOwner,
+            [Values(0u, 1u, 2u)] ulong sender
+        )
+        {
+            var sendMethodName = $"DefaultTo{defaultSendTo}AllowOverrideRpc";
+            var targetField = typeof(RpcTarget).GetField(overrideSendTo.ToString());
+            var verifyMethodName = $"VerifySentTo{overrideSendTo}";
+
+            var senderObject = GetPlayerObject(objectOwner, sender);
+            var target = (BaseRpcTarget)targetField.GetValue(senderObject.RpcTarget);
+            var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
+            sendMethod.Invoke(senderObject, new object[] { (RpcParams)target });
+
+            var verifyMethod = GetType().GetMethod(verifyMethodName);
+            verifyMethod.Invoke(this, new object[] { objectOwner, sender, sendMethodName });
+        }
+
+
+    }
+
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    internal class UniversalRpcTestSendingWithSingleOverride : UniversalRpcTestsBase
+    {
+        public UniversalRpcTestSendingWithSingleOverride(HostOrServer hostOrServer) : base(hostOrServer)
+        {
+
+        }
+
+        [Test]
+        public void TestSendingWithSingleOverride(
+            [Values] SendTo defaultSendTo,
+            [Values(0u, 1u, 2u)] ulong recipient,
+            [Values(0u, 1u, 2u)] ulong objectOwner,
+            [Values(0u, 1u, 2u)] ulong sender
+        )
+        {
+            var sendMethodName = $"DefaultTo{defaultSendTo}AllowOverrideRpc";
+
+            var senderObject = GetPlayerObject(objectOwner, sender);
+            var target = senderObject.RpcTarget.Single(recipient);
+            var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
+            sendMethod.Invoke(senderObject, new object[] { (RpcParams)target });
+
+            VerifyRemoteReceived(objectOwner, sender, sendMethodName, new[] { recipient }, false);
+            VerifyNotReceived(objectOwner, s_ClientIds.Where(c => recipient != c).ToArray());
+
+            // Pass some time to make sure that no other client ever receives this
+            TimeTravel(1f, 30);
+            VerifyNotReceived(objectOwner, s_ClientIds.Where(c => recipient != c).ToArray());
+        }
+
+    }
+
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    internal class UniversalRpcTestSendingWithGroupOverride : UniversalRpcTestsBase
+    {
+        public UniversalRpcTestSendingWithGroupOverride(HostOrServer hostOrServer) : base(hostOrServer)
+        {
+
+        }
+
+        public static ulong[][] RecipientGroups = new[]
+        {
+            new[] { 0ul },
+            new[] { 1ul },
+            new[] { 0ul, 1ul },
+            new[] { 0ul, 1ul, 2ul }
+        };
+
+        [Test]
+        public void TestSendingWithGroupOverride(
+            [Values] SendTo defaultSendTo,
+            [ValueSource(nameof(RecipientGroups))] ulong[] recipient,
+            [Values(0u, 1u, 2u)] ulong objectOwner,
+            [Values(0u, 1u, 2u)] ulong sender
+        )
+        {
+            var sendMethodName = $"DefaultTo{defaultSendTo}AllowOverrideRpc";
+
+            var senderObject = GetPlayerObject(objectOwner, sender);
+            var target = senderObject.RpcTarget.Group(recipient);
+            var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
+            sendMethod.Invoke(senderObject, new object[] { (RpcParams)target });
+
+            VerifyRemoteReceived(objectOwner, sender, sendMethodName, s_ClientIds.Where(c => recipient.Contains(c)).ToArray(), false);
+            VerifyNotReceived(objectOwner, s_ClientIds.Where(c => !recipient.Contains(c)).ToArray());
+
+            // Pass some time to make sure that no other client ever receives this
+            TimeTravel(1f, 30);
+            VerifyNotReceived(objectOwner, s_ClientIds.Where(c => !recipient.Contains(c)).ToArray());
+        }
+
+    }
+
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    internal class UniversalRpcTestDefaultSendToSpecifiedInParamsSendingToServerAndOwner : UniversalRpcTestsBase
+    {
+        public UniversalRpcTestDefaultSendToSpecifiedInParamsSendingToServerAndOwner(HostOrServer hostOrServer) : base(hostOrServer)
+        {
+
+        }
+    }
+
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    internal class UniversalRpcTestDeferLocal : UniversalRpcTestsBase
+    {
+        public UniversalRpcTestDeferLocal(HostOrServer hostOrServer) : base(hostOrServer)
+        {
+
+        }
+
+        [Test]
+        // All the test cases that involve sends that will be delivered locally
+        [TestCase(SendTo.Everyone, 0u, 0u)]
+        [TestCase(SendTo.Everyone, 0u, 1u)]
+        [TestCase(SendTo.Everyone, 0u, 2u)]
+        [TestCase(SendTo.Everyone, 1u, 0u)]
+        [TestCase(SendTo.Everyone, 1u, 1u)]
+        [TestCase(SendTo.Everyone, 1u, 2u)]
+        [TestCase(SendTo.Everyone, 2u, 0u)]
+        [TestCase(SendTo.Everyone, 2u, 1u)]
+        [TestCase(SendTo.Everyone, 2u, 2u)]
+        [TestCase(SendTo.Me, 0u, 0u)]
+        [TestCase(SendTo.Me, 0u, 1u)]
+        [TestCase(SendTo.Me, 0u, 2u)]
+        [TestCase(SendTo.Me, 1u, 0u)]
+        [TestCase(SendTo.Me, 1u, 1u)]
+        [TestCase(SendTo.Me, 1u, 2u)]
+        [TestCase(SendTo.Me, 2u, 0u)]
+        [TestCase(SendTo.Me, 2u, 1u)]
+        [TestCase(SendTo.Me, 2u, 2u)]
+        [TestCase(SendTo.Owner, 0u, 0u)]
+        [TestCase(SendTo.Owner, 1u, 1u)]
+        [TestCase(SendTo.Owner, 2u, 2u)]
+        [TestCase(SendTo.Server, 0u, 0u)]
+        [TestCase(SendTo.Server, 1u, 0u)]
+        [TestCase(SendTo.Server, 2u, 0u)]
+        [TestCase(SendTo.NotOwner, 0u, 1u)]
+        [TestCase(SendTo.NotOwner, 0u, 2u)]
+        [TestCase(SendTo.NotOwner, 1u, 0u)]
+        [TestCase(SendTo.NotOwner, 1u, 2u)]
+        [TestCase(SendTo.NotOwner, 2u, 0u)]
+        [TestCase(SendTo.NotOwner, 2u, 1u)]
+        [TestCase(SendTo.NotServer, 0u, 1u)]
+        [TestCase(SendTo.NotServer, 0u, 2u)]
+        [TestCase(SendTo.NotServer, 1u, 1u)]
+        [TestCase(SendTo.NotServer, 1u, 2u)]
+        [TestCase(SendTo.NotServer, 2u, 1u)]
+        [TestCase(SendTo.NotServer, 2u, 2u)]
+        [TestCase(SendTo.ClientsAndHost, 0u, 0u)]
+        [TestCase(SendTo.ClientsAndHost, 0u, 1u)]
+        [TestCase(SendTo.ClientsAndHost, 0u, 2u)]
+        [TestCase(SendTo.ClientsAndHost, 1u, 0u)]
+        [TestCase(SendTo.ClientsAndHost, 1u, 1u)]
+        [TestCase(SendTo.ClientsAndHost, 1u, 2u)]
+        [TestCase(SendTo.ClientsAndHost, 2u, 0u)]
+        [TestCase(SendTo.ClientsAndHost, 2u, 1u)]
+        [TestCase(SendTo.ClientsAndHost, 2u, 2u)]
+        public void TestDeferLocal(
+            SendTo defaultSendTo,
+            ulong objectOwner,
+            ulong sender
+        )
+        {
+            if (defaultSendTo == SendTo.ClientsAndHost && sender == 0u && !m_ServerNetworkManager.IsHost)
+            {
+                // Not calling Assert.Ignore() because Unity will mark the whole block of tests as ignored
+                // Just consider this case a success...
+                return;
+            }
+            var sendMethodName = $"DefaultTo{defaultSendTo}DeferLocalRpc";
+            var verifyMethodName = $"VerifySentTo{defaultSendTo}";
+            var senderObject = GetPlayerObject(objectOwner, sender);
+            var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
+            sendMethod.Invoke(senderObject, new object[] { new RpcParams() });
+
+            VerifyNotReceived(objectOwner, new[] { sender });
+            // Should be received on the next frame
+            SimulateOneFrame();
+            VerifyLocalReceived(objectOwner, sender, sendMethodName, false);
+
+            var verifyMethod = GetType().GetMethod(verifyMethodName);
+            verifyMethod.Invoke(this, new object[] { objectOwner, sender, sendMethodName });
+        }
+
+        [Test]
+        // All the test cases that involve sends that will be delivered locally
+        [TestCase(SendTo.Everyone, 0u, 0u)]
+        [TestCase(SendTo.Everyone, 0u, 1u)]
+        [TestCase(SendTo.Everyone, 0u, 2u)]
+        [TestCase(SendTo.Everyone, 1u, 0u)]
+        [TestCase(SendTo.Everyone, 1u, 1u)]
+        [TestCase(SendTo.Everyone, 1u, 2u)]
+        [TestCase(SendTo.Everyone, 2u, 0u)]
+        [TestCase(SendTo.Everyone, 2u, 1u)]
+        [TestCase(SendTo.Everyone, 2u, 2u)]
+        [TestCase(SendTo.Me, 0u, 0u)]
+        [TestCase(SendTo.Me, 0u, 1u)]
+        [TestCase(SendTo.Me, 0u, 2u)]
+        [TestCase(SendTo.Me, 1u, 0u)]
+        [TestCase(SendTo.Me, 1u, 1u)]
+        [TestCase(SendTo.Me, 1u, 2u)]
+        [TestCase(SendTo.Me, 2u, 0u)]
+        [TestCase(SendTo.Me, 2u, 1u)]
+        [TestCase(SendTo.Me, 2u, 2u)]
+        [TestCase(SendTo.Owner, 0u, 0u)]
+        [TestCase(SendTo.Owner, 1u, 1u)]
+        [TestCase(SendTo.Owner, 2u, 2u)]
+        [TestCase(SendTo.Server, 0u, 0u)]
+        [TestCase(SendTo.Server, 1u, 0u)]
+        [TestCase(SendTo.Server, 2u, 0u)]
+        [TestCase(SendTo.NotOwner, 0u, 1u)]
+        [TestCase(SendTo.NotOwner, 0u, 2u)]
+        [TestCase(SendTo.NotOwner, 1u, 0u)]
+        [TestCase(SendTo.NotOwner, 1u, 2u)]
+        [TestCase(SendTo.NotOwner, 2u, 0u)]
+        [TestCase(SendTo.NotOwner, 2u, 1u)]
+        [TestCase(SendTo.NotServer, 0u, 1u)]
+        [TestCase(SendTo.NotServer, 0u, 2u)]
+        [TestCase(SendTo.NotServer, 1u, 1u)]
+        [TestCase(SendTo.NotServer, 1u, 2u)]
+        [TestCase(SendTo.NotServer, 2u, 1u)]
+        [TestCase(SendTo.NotServer, 2u, 2u)]
+        [TestCase(SendTo.ClientsAndHost, 0u, 0u)]
+        [TestCase(SendTo.ClientsAndHost, 0u, 1u)]
+        [TestCase(SendTo.ClientsAndHost, 0u, 2u)]
+        [TestCase(SendTo.ClientsAndHost, 1u, 0u)]
+        [TestCase(SendTo.ClientsAndHost, 1u, 1u)]
+        [TestCase(SendTo.ClientsAndHost, 1u, 2u)]
+        [TestCase(SendTo.ClientsAndHost, 2u, 0u)]
+        [TestCase(SendTo.ClientsAndHost, 2u, 1u)]
+        [TestCase(SendTo.ClientsAndHost, 2u, 2u)]
+        public void TestDeferLocalOverrideToTrue(
+            SendTo defaultSendTo,
+            ulong objectOwner,
+            ulong sender
+        )
+        {
+            if (defaultSendTo == SendTo.ClientsAndHost && sender == 0u && !m_ServerNetworkManager.IsHost)
+            {
+                // Not calling Assert.Ignore() because Unity will mark the whole block of tests as ignored
+                // Just consider this case a success...
+                return;
+            }
+            var sendMethodName = $"DefaultTo{defaultSendTo}WithRpcParamsRpc";
+            var verifyMethodName = $"VerifySentTo{defaultSendTo}";
+            var senderObject = GetPlayerObject(objectOwner, sender);
+            var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
+            sendMethod.Invoke(senderObject, new object[] { (RpcParams)LocalDeferMode.Defer });
+
+            VerifyNotReceived(objectOwner, new[] { sender });
+            // Should be received on the next frame
+            SimulateOneFrame();
+            VerifyLocalReceived(objectOwner, sender, sendMethodName, false);
+
+            var verifyMethod = GetType().GetMethod(verifyMethodName);
+            verifyMethod.Invoke(this, new object[] { objectOwner, sender, sendMethodName });
+        }
+
+        [Test]
+        // All the test cases that involve sends that will be delivered locally
+        [TestCase(SendTo.Everyone, 0u, 0u)]
+        [TestCase(SendTo.Everyone, 0u, 1u)]
+        [TestCase(SendTo.Everyone, 0u, 2u)]
+        [TestCase(SendTo.Everyone, 1u, 0u)]
+        [TestCase(SendTo.Everyone, 1u, 1u)]
+        [TestCase(SendTo.Everyone, 1u, 2u)]
+        [TestCase(SendTo.Everyone, 2u, 0u)]
+        [TestCase(SendTo.Everyone, 2u, 1u)]
+        [TestCase(SendTo.Everyone, 2u, 2u)]
+        [TestCase(SendTo.Me, 0u, 0u)]
+        [TestCase(SendTo.Me, 0u, 1u)]
+        [TestCase(SendTo.Me, 0u, 2u)]
+        [TestCase(SendTo.Me, 1u, 0u)]
+        [TestCase(SendTo.Me, 1u, 1u)]
+        [TestCase(SendTo.Me, 1u, 2u)]
+        [TestCase(SendTo.Me, 2u, 0u)]
+        [TestCase(SendTo.Me, 2u, 1u)]
+        [TestCase(SendTo.Me, 2u, 2u)]
+        [TestCase(SendTo.Owner, 0u, 0u)]
+        [TestCase(SendTo.Owner, 1u, 1u)]
+        [TestCase(SendTo.Owner, 2u, 2u)]
+        [TestCase(SendTo.Server, 0u, 0u)]
+        [TestCase(SendTo.Server, 1u, 0u)]
+        [TestCase(SendTo.Server, 2u, 0u)]
+        [TestCase(SendTo.NotOwner, 0u, 1u)]
+        [TestCase(SendTo.NotOwner, 0u, 2u)]
+        [TestCase(SendTo.NotOwner, 1u, 0u)]
+        [TestCase(SendTo.NotOwner, 1u, 2u)]
+        [TestCase(SendTo.NotOwner, 2u, 0u)]
+        [TestCase(SendTo.NotOwner, 2u, 1u)]
+        [TestCase(SendTo.NotServer, 0u, 1u)]
+        [TestCase(SendTo.NotServer, 0u, 2u)]
+        [TestCase(SendTo.NotServer, 1u, 1u)]
+        [TestCase(SendTo.NotServer, 1u, 2u)]
+        [TestCase(SendTo.NotServer, 2u, 1u)]
+        [TestCase(SendTo.NotServer, 2u, 2u)]
+        [TestCase(SendTo.ClientsAndHost, 0u, 0u)]
+        [TestCase(SendTo.ClientsAndHost, 0u, 1u)]
+        [TestCase(SendTo.ClientsAndHost, 0u, 2u)]
+        [TestCase(SendTo.ClientsAndHost, 1u, 0u)]
+        [TestCase(SendTo.ClientsAndHost, 1u, 1u)]
+        [TestCase(SendTo.ClientsAndHost, 1u, 2u)]
+        [TestCase(SendTo.ClientsAndHost, 2u, 0u)]
+        [TestCase(SendTo.ClientsAndHost, 2u, 1u)]
+        [TestCase(SendTo.ClientsAndHost, 2u, 2u)]
+        public void TestDeferLocalOverrideToFalse(
+            SendTo defaultSendTo,
+            ulong objectOwner,
+            ulong sender
+        )
+        {
+            if (defaultSendTo == SendTo.ClientsAndHost && sender == 0u && !m_ServerNetworkManager.IsHost)
+            {
+                // Not calling Assert.Ignore() because Unity will mark the whole block of tests as ignored
+                // Just consider this case a success...
+                return;
+            }
+            var sendMethodName = $"DefaultTo{defaultSendTo}DeferLocalRpc";
+            var verifyMethodName = $"VerifySentTo{defaultSendTo}";
+            var senderObject = GetPlayerObject(objectOwner, sender);
+            var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
+            sendMethod.Invoke(senderObject, new object[] { (RpcParams)LocalDeferMode.SendImmediate });
+
+            VerifyLocalReceived(objectOwner, sender, sendMethodName, false);
+
+            var verifyMethod = GetType().GetMethod(verifyMethodName);
+            verifyMethod.Invoke(this, new object[] { objectOwner, sender, sendMethodName });
+        }
+
+    }
+
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    internal class UniversalRpcTestMutualRecursion : UniversalRpcTestsBase
+    {
+        public UniversalRpcTestMutualRecursion(HostOrServer hostOrServer) : base(hostOrServer)
+        {
+
+        }
+
+        [Test]
+        public void TestMutualRecursion()
+        {
+            var serverObj = GetPlayerObject(NetworkManager.ServerClientId, NetworkManager.ServerClientId);
+
+            serverObj.MutualRecursionClientRpc();
+
+            var serverIdArray = new[] { NetworkManager.ServerClientId };
+            var clientIdArray = s_ClientIds.Where(c => c != NetworkManager.ServerClientId).ToArray();
+
+            var clientList = m_ClientNetworkManagers.ToList();
+            var serverList = new List<NetworkManager> { m_ServerNetworkManager };
+
+            VerifyNotReceived(NetworkManager.ServerClientId, s_ClientIds);
+
+            for (var i = 0; i < 10; ++i)
+            {
+                WaitForMessageReceivedWithTimeTravel<RpcMessage>(clientList);
+                VerifyRemoteReceived(NetworkManager.ServerClientId, NetworkManager.ServerClientId, nameof(UniversalRpcNetworkBehaviour.MutualRecursionClientRpc), clientIdArray, false, false);
+                VerifyNotReceived(NetworkManager.ServerClientId, serverIdArray);
+
+                Clear();
+
+                WaitForMessageReceivedWithTimeTravel<RpcMessage>(serverList);
+                VerifyRemoteReceived(NetworkManager.ServerClientId, NetworkManager.ServerClientId, nameof(UniversalRpcNetworkBehaviour.MutualRecursionServerRpc), serverIdArray, false, false);
+                VerifyNotReceived(NetworkManager.ServerClientId, clientIdArray);
+
+                Clear();
+            }
+            serverObj.Stop = true;
+            WaitForMessageReceivedWithTimeTravel<RpcMessage>(serverList);
+            Assert.IsFalse(serverObj.Stop);
+        }
+
+
+    }
+
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    internal class UniversalRpcTestSelfRecursion : UniversalRpcTestsBase
+    {
+        public UniversalRpcTestSelfRecursion(HostOrServer hostOrServer) : base(hostOrServer)
+        {
+
+        }
+
+        [Test]
+        public void TestSelfRecursion()
+        {
+            var serverObj = GetPlayerObject(NetworkManager.ServerClientId, NetworkManager.ServerClientId);
+
+            serverObj.SelfRecursiveRpc();
+
+            var serverIdArray = new[] { NetworkManager.ServerClientId };
+            var clientIdArray = s_ClientIds.Where(c => c != NetworkManager.ServerClientId).ToArray();
+
+            var clientList = m_ClientNetworkManagers.ToList();
+            var serverList = new List<NetworkManager> { m_ServerNetworkManager };
+
+            for (var i = 0; i < 10; ++i)
+            {
+                VerifyNotReceived(NetworkManager.ServerClientId, s_ClientIds);
+                SimulateOneFrame();
+                VerifyLocalReceived(NetworkManager.ServerClientId, NetworkManager.ServerClientId, nameof(UniversalRpcNetworkBehaviour.SelfRecursiveRpc), false);
+
+                Clear();
+            }
+
+            serverObj.Stop = true;
+            SimulateOneFrame();
+            Assert.IsFalse(serverObj.Stop);
+            VerifyNotReceived(NetworkManager.ServerClientId, s_ClientIds);
+        }
+
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
@@ -1270,7 +1270,10 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
                     arr.Dispose();
                     break;
                 case AllocationType.NativeList:
-                    var list = new NativeList<ulong>(recipient.Length, Allocator.Temp);
+                    // For some reason on 2020.3, calling list.AsArray() and passing that to the next function
+                    // causes Allocator.Temp allocations to become invalid somehow. This is not an issue on later
+                    // versions of Unity.
+                    var list = new NativeList<ulong>(recipient.Length, Allocator.TempJob);
                     foreach (var id in recipient)
                     {
                         list.Add(id);
@@ -1344,7 +1347,10 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
                     arr.Dispose();
                     break;
                 case AllocationType.NativeList:
-                    var list = new NativeList<ulong>(recipient.Length, Allocator.Temp);
+                    // For some reason on 2020.3, calling list.AsArray() and passing that to the next function
+                    // causes Allocator.Temp allocations to become invalid somehow. This is not an issue on later
+                    // versions of Unity.
+                    var list = new NativeList<ulong>(recipient.Length, Allocator.TempJob);
                     foreach (var id in recipient)
                     {
                         list.Add(id);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: af2b96a4f4d34fa798385b487fc5c97d
+timeCreated: 1698158457

--- a/testproject/Assets/Scripts/CommandLineHandler.cs
+++ b/testproject/Assets/Scripts/CommandLineHandler.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
-using UnityEngine;
-using UnityEngine.SceneManagement;
 using Unity.Netcode;
 using Unity.Netcode.Transports.UTP;
+using UnityEngine;
+using UnityEngine.SceneManagement;
 #if UNITY_UNET_PRESENT
 using Unity.Netcode.Transports.UNET;
 #endif

--- a/testproject/Assets/Scripts/ConnectionModeScript.cs
+++ b/testproject/Assets/Scripts/ConnectionModeScript.cs
@@ -62,10 +62,7 @@ public class ConnectionModeScript : MonoBehaviour
             {
                 if (NetworkManager.Singleton && !NetworkManager.Singleton.IsListening)
                 {
-                    if (m_ConnectionModeButtons != null)
-                    {
-                        m_ConnectionModeButtons.SetActive(false);
-                    }
+                    m_ConnectionModeButtons?.SetActive(false);
                     m_CommandLineProcessor.ProcessCommandLine();
                     break;
                 }
@@ -129,14 +126,8 @@ public class ConnectionModeScript : MonoBehaviour
         if (HasRelaySupport())
         {
             m_JoinCodeInput.SetActive(true);
-            if (m_ConnectionModeButtons != null)
-            {
-                m_ConnectionModeButtons.SetActive(false || AuthenticationService.Instance.IsSignedIn);
-            }
-            if (m_AuthenticationButtons != null)
-            {
-                m_AuthenticationButtons.SetActive(NetworkManager.Singleton && !NetworkManager.Singleton.IsListening && !AuthenticationService.Instance.IsSignedIn);
-            }
+            m_ConnectionModeButtons?.SetActive(false || AuthenticationService.Instance.IsSignedIn);
+            m_AuthenticationButtons?.SetActive(NetworkManager.Singleton && !NetworkManager.Singleton.IsListening && !AuthenticationService.Instance.IsSignedIn);
         }
     }
 
@@ -186,10 +177,7 @@ public class ConnectionModeScript : MonoBehaviour
     private IEnumerator StartRelayServer(Action postAllocationAction)
     {
 #if ENABLE_RELAY_SERVICE
-        if (m_ConnectionModeButtons != null)
-        {
-            m_ConnectionModeButtons.SetActive(false);
-        }
+        m_ConnectionModeButtons?.SetActive(false);
 
         var serverRelayUtilityTask = RelayUtility.AllocateRelayServerAndGetJoinCode(m_MaxConnections);
         while (!serverRelayUtilityTask.IsCompleted)
@@ -274,10 +262,7 @@ public class ConnectionModeScript : MonoBehaviour
             NetworkManager.Singleton.OnClientStopped += OnClientStopped;
         }
 
-        if (m_DisconnectClientButton != null)
-        {
-            m_DisconnectClientButton.SetActive(true);
-        }
+        m_DisconnectClientButton?.SetActive(true);
     }
 
     private void OnClientStopped(bool obj)

--- a/testproject/Assets/Tests/Manual/Scripts/StatsDisplay.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/StatsDisplay.cs
@@ -54,10 +54,7 @@ namespace TestProject.ManualTests
             }
             else
             {
-                if (m_ClientServerToggle != null)
-                {
-                    m_ClientServerToggle.SetActive(true);
-                }
+                m_ClientServerToggle?.SetActive(true);
                 UpdateButton();
             }
 

--- a/testproject/Assets/Tests/Runtime/MultiClientConnectionApproval.cs
+++ b/testproject/Assets/Tests/Runtime/MultiClientConnectionApproval.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using NUnit.Framework;
 using Unity.Netcode;

--- a/testproject/Assets/Tests/Runtime/RpcUserSerializableTypesTest.cs
+++ b/testproject/Assets/Tests/Runtime/RpcUserSerializableTypesTest.cs
@@ -333,6 +333,8 @@ namespace TestProject.RuntimeTests
                 yield return new WaitForSeconds(0.1f);
             }
 
+            Debug.Log($"clientMyObjCalled {clientMyObjCalled} && clientMySharedObjCalled {clientMySharedObjCalled} && clientMyObjPassedWithThisRefCalled {clientMyObjPassedWithThisRefCalled} && serverMyObjCalled {serverMyObjCalled} && serverMySharedObjCalled {serverMySharedObjCalled} && serverMyObjPassedWithThisRefCalled {serverMyObjPassedWithThisRefCalled} && serverIntListCalled {serverIntListCalled} && serverStrListCalled {serverStrListCalled}");
+
             // Verify the test passed
             Assert.False(timedOut);
 
@@ -1503,4 +1505,3 @@ namespace TestProject.RuntimeTests
 
     }
 }
-


### PR DESCRIPTION
The new attribute is more configurable at both compile time and runtime than the existing ClientRpc and ServerRpc attributes, and also includes support for clients sending to themselves, and for optionally delaying the invocation of local RPCs until the start of the next frame to enable mutually recursive client/server RPCs to function on a host the same as on other clients (as well as mutually recursive Owner/NotOwner RPCs and other similar patterns).

This attribute supersedes ClientRpc and ServerRpc and will be the new default recommendation for creating RPCs. ClientRpc and ServerRpc will eventually be deprecated in favor of the new [Rpc] attribute.

By necessity of the feature, this also adds `NetworkManager.PeerClientIds` to allow clients to know the IDs of other connected clients, as well as `NetworkManager.OnPeerConnectedCallback` and `NetworkManager.OnPeerDisconnectCallback` events that are fired when this list is updated via messages from the server.

resolves #2718
resolves #2615
resolves #2504
resolves #2465
resolves #2448
resolves #2331
resolves #2326

## Changelog

- Added: Added a new RPC attribute, which is simply `Rpc`. 
  - This is a generic attribute that can perform the functions of both Server and Client RPCs, as well as enabling client-to-client RPCs. Includes several default targets: `Server`, `NotServer`, `Owner`, `NotOwner`, `Me`, `NotMe`, `ClientsAndHost`, and `Everyone`. Runtime overrides are available for any of these targets, as well as for sending to a specific ID or groups of IDs.
  - This attribute also includes the ability to defer RPCs that are sent to the local process to the start of the next frame instead of executing them immediately, treating them as if they had gone across the network. The default behavior is to execute immediately.
  - This attribute effectively replaces `ServerRpc` and `ClientRpc`. `ServerRpc` and `ClientRpc` remain in their existing forms for backward compatibility, but `Rpc` will be the recommended and most supported option.
- Added: `NetworkManager.OnConnectionEvent` as a unified connection event callback to notify clients and servers of all client connections and disconnections within the session
- Added: `NetworkManager.ServerIsHost` and `NetworkBehaviour.ServerIsHost` to allow a client to tell if it is connected to a host or to a dedicated server
- Changed: `NetworkManager.ConnectedClientsIds` is now accessible on the client side and will contain the list of all clients in the session, including the host client if the server is operating in host mode 

## Testing and Documentation

- Includes unit tests.
- Includes integration tests.
- Includes documentation for previously-undocumented public API entry points.
