### PR TITLE
perf: Adjust maximum reliable resend timeout in UTP

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1230,13 +1230,12 @@ namespace Unity.Netcode.Transports.UTP
             // reliable delivery, we're better off with the increased window size compared to the
             // extra 4 bytes of header that this costs us.
             //
-            // We also increase the resend timeouts (even more if using Relay) since the default
-            // ones in UTP are very aggressive (optimized for latency and low bandwidth). With NGO,
-            // these are too low and we notice a lot of useless resends, especially if using Relay.
+            // We also increase the maximum resend timeout since the default one in UTP is very
+            // aggressive (optimized for latency and low bandwidth). With NGO, it's too low and
+            // we sometimes notice a lot of useless resends, especially if using Relay.
             m_NetworkSettings.WithReliableStageParameters(
                 windowSize: 64
 #if UTP_TRANSPORT_2_0_ABOVE
-                minimumResendTime: m_ProtocolType == ProtocolType.RelayUnityTransport ? 150 : 100,
                 maximumResendTime: m_ProtocolType == ProtocolType.RelayUnityTransport ? 750 : 500
 #endif
             );

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1229,7 +1229,17 @@ namespace Unity.Netcode.Transports.UTP
             // Bump the reliable window size to its maximum size of 64. Since NGO makes heavy use of
             // reliable delivery, we're better off with the increased window size compared to the
             // extra 4 bytes of header that this costs us.
-            m_NetworkSettings.WithReliableStageParameters(windowSize: 64);
+            //
+            // We also increase the resend timeouts (even more if using Relay) since the default
+            // ones in UTP are very aggressive (optimized for latency and low bandwidth). With NGO,
+            // these are too low and we notice a lot of useless resends, especially if using Relay.
+            m_NetworkSettings.WithReliableStageParameters(
+                windowSize: 64
+#if UTP_TRANSPORT_2_0_ABOVE
+                minimumResendTime: m_ProtocolType == ProtocolType.RelayUnityTransport ? 150 : 100,
+                maximumResendTime: m_ProtocolType == ProtocolType.RelayUnityTransport ? 750 : 500
+#endif
+            );
 
 #if !UTP_TRANSPORT_2_0_ABOVE && !UNITY_WEBGL
             m_NetworkSettings.WithBaselibNetworkInterfaceParameters(

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1232,7 +1232,8 @@ namespace Unity.Netcode.Transports.UTP
             //
             // We also increase the maximum resend timeout since the default one in UTP is very
             // aggressive (optimized for latency and low bandwidth). With NGO, it's too low and
-            // we sometimes notice a lot of useless resends, especially if using Relay.
+            // we sometimes notice a lot of useless resends, especially if using Relay. (We can
+            // only do this with UTP 2.0 because 1.X doesn't support that parameter.)
             m_NetworkSettings.WithReliableStageParameters(
                 windowSize: 64
 #if UTP_TRANSPORT_2_0_ABOVE


### PR DESCRIPTION
This PR increases the maximum resend timeout of UTP's reliable pipeline from 200 to 500 milliseconds (750 if using Relay). We've noticed that for bad connections and/or on servers that are heavily loaded (and thus take more time to process packets), the default maximum resend timeout could cause resends not because a packet was lost, but just because the RTT was high enough to be above the timeout. This causes wasted bandwidth, and for a server that is heavily loaded, will only compound the load problem since clients will keep resending traffic to it useless, which it will have to process.

Because UTP calculates the live RTT and uses that to determine resends, this change should not negatively impact performance for connections with good RTT. The minimum resend timeout (64 milliseconds) is also left unchanged.

## Changelog

N/A (Don't think it's worth mentioning in the changelog.)

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.