### PR TITLE
fix: Protect against error spams if connection state is messed up

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -995,6 +995,11 @@ namespace Unity.Netcode.Transports.UTP
 
         private void ExtractNetworkMetricsFromPipeline(NetworkPipeline pipeline, NetworkConnection networkConnection)
         {
+            if (m_Driver.GetConnectionState(networkConnection) != NetworkConnection.State.Connected)
+            {
+                return;
+            }
+
             //Don't need to dispose of the buffers, they are filled with data pointers.
             m_Driver.GetPipelineBuffers(pipeline,
 #if UTP_TRANSPORT_2_0_ABOVE


### PR DESCRIPTION
Add an extra check in `ExtractNetworkMetricsFromPipeline` to not extract anything if the connection is not alive in the transport. Normally that shouldn't happen since we only extract metrics for live connections. But if there's a mismatch between the state of a connection between NGO and UTP, then we could end up trying to extract metrics from a closed connection and that generates tons of exceptions. This PR protects against this.

## Changelog

N/A

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.
