### PR TITLE
fix: shutdown and shutdown notification issues [MTT-7791] [MTT-7540]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -21,6 +21,12 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where a client disconnected by a server-host would not receive a local notification. (#2789)
+- Fixed issue where a server-host could shutdown during a relay connection but periodically the transport disconnect message sent to any connected clients could be dropped. (#2789)
+- Fixed issue where a host could disconnect its local client but remain running as a server. (#2789)
+- Fixed issue where `OnClientDisconnectedCallback` was not being invoked under certain conditions. (#2789)
+- Fixed issue where `OnClientDisconnectedCallback` was always returning 0 as the client identifier. (#2789)
+- Fixed issue where if a host or server shutdown while a client owned NetworkObjects (other than the player) it would throw an exception.
 - Fixed issue where a teleport state could potentially be overridden by a previous unreliable delta state. (#2777)
 - Fixed issue where `NetworkTransform` was using the `NetworkManager.ServerTime.Tick` as opposed to `NetworkManager.NetworkTickSystem.ServerTime.Tick` during the authoritative side's tick update where it performed a delta state check. (#2777)
 - Fixed issue where a parented in-scene placed NetworkObject would be destroyed upon a client or server exiting a network session but not unloading the original scene in which the NetworkObject was placed. (#2737)
@@ -28,7 +34,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed issue where a `NetworkTransform` instance with interpolation enabled would result in wide visual motion gaps (stuttering) under above normal latency conditions and a 1-5% or higher packet are drop rate. (#2713)
 
 ### Changed
-
+- Changed the server or host shutdown so it will now perform a "soft shutdown" when `NetworkManager.Shutdown` is invoked. This will send a disconnect notification to all connected clients and the server-host will wait for all connected clients to disconnect or timeout after a 5 second period before completing the shutdown process. (#2789)
+- Changed `OnClientDisconnectedCallback` will now return the assigned client identifier on the local client side if the client was approved and assigned one prior to being disconnected. (#2789)
 - Changed `NetworkTransform.SetState` (and related methods) now are cumulative during a fractional tick period and sent on the next pending tick. (#2777)
 - `NetworkManager.ConnectedClientsIds` is now accessible on the client side and will contain the list of all clients in the session, including the host client if the server is operating in host mode (#2762)
 - Changed `NetworkSceneManager` to return a `SceneEventProgress` status and not throw exceptions for methods invoked when scene management is disabled and when a client attempts to access a `NetworkSceneManager` method by a client. (#2735)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -26,7 +26,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed issue where a host could disconnect its local client but remain running as a server. (#2789)
 - Fixed issue where `OnClientDisconnectedCallback` was not being invoked under certain conditions. (#2789)
 - Fixed issue where `OnClientDisconnectedCallback` was always returning 0 as the client identifier. (#2789)
-- Fixed issue where if a host or server shutdown while a client owned NetworkObjects (other than the player) it would throw an exception.
+- Fixed issue where if a host or server shutdown while a client owned NetworkObjects (other than the player) it would throw an exception. (#2789)
+- Fixed issue where setting values on a `NetworkVariable` or `NetworkList` within `OnNetworkDespawn` during a shutdown sequence would throw an exception. (#2789)
 - Fixed issue where a teleport state could potentially be overridden by a previous unreliable delta state. (#2777)
 - Fixed issue where `NetworkTransform` was using the `NetworkManager.ServerTime.Tick` as opposed to `NetworkManager.NetworkTickSystem.ServerTime.Tick` during the authoritative side's tick update where it performed a delta state check. (#2777)
 - Fixed issue where a parented in-scene placed NetworkObject would be destroyed upon a client or server exiting a network session but not unloading the original scene in which the NetworkObject was placed. (#2737)

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -833,8 +833,7 @@ namespace Unity.Netcode.Components
                     stateChangeDetected = true;
                     //Debug.Log($"[Cross-Fade] To-Hash: {nt.fullPathHash} | TI-Duration: ({tt.duration}) | TI-Norm: ({tt.normalizedTime}) | From-Hash: ({m_AnimationHash[layer]}) | SI-FPHash: ({st.fullPathHash}) | SI-Norm: ({st.normalizedTime})");
                 }
-                else
-                if (!tt.anyState && tt.fullPathHash != m_TransitionHash[layer])
+                else if (!tt.anyState && tt.fullPathHash != m_TransitionHash[layer])
                 {
                     // first time in this transition for this layer
                     m_TransitionHash[layer] = tt.fullPathHash;
@@ -1053,8 +1052,7 @@ namespace Unity.Netcode.Components
                         BytePacker.WriteValuePacked(writer, valueBool);
                     }
                 }
-                else
-                if (cacheValue.Type == AnimationParamEnumWrapper.AnimatorControllerParameterFloat)
+                else if (cacheValue.Type == AnimationParamEnumWrapper.AnimatorControllerParameterFloat)
                 {
                     var valueFloat = m_Animator.GetFloat(hash);
                     fixed (void* value = cacheValue.Value)

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -899,9 +899,8 @@ namespace Unity.Netcode
                 throw new Exception("[OnClientDisconnectFromServer] Was invoked by non-server instance!");
             }
 
-            // If we are shutting down and this is the server or host disconnecting, then ignore
-            // clean up as everything that needs to be destroyed will be during shutdown.
-            if (NetworkManager.ShutdownInProgress && clientId == NetworkManager.ServerClientId)
+            // If we are shutting down, then ignore clean up as everything that needs to be destroyed will be during shutdown.
+            if (NetworkManager.ShutdownInProgress)
             {
                 return;
             }

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -1080,16 +1080,9 @@ namespace Unity.Netcode
         /// </summary>
         internal void Shutdown()
         {
-            LocalClient.IsApproved = false;
-            LocalClient.IsConnected = false;
-            ConnectedClients.Clear();
-            ConnectedClientIds.Clear();
-            ConnectedClientsList.Clear();
+
             if (LocalClient.IsServer)
             {
-                // make sure all messages are flushed before transport disconnect clients
-                MessageManager?.ProcessSendQueues();
-
                 // Build a list of all client ids to be disconnected
                 var disconnectedIds = new HashSet<ulong>();
 
@@ -1125,6 +1118,9 @@ namespace Unity.Netcode
                 {
                     DisconnectRemoteClient(clientId);
                 }
+
+                // make sure all messages are flushed before transport disconnect clients
+                MessageManager?.ProcessSendQueues();
             }
             else if (NetworkManager != null && NetworkManager.IsListening && LocalClient.IsClient)
             {
@@ -1138,6 +1134,12 @@ namespace Unity.Netcode
                     Debug.LogException(ex);
                 }
             }
+
+            LocalClient.IsApproved = false;
+            LocalClient.IsConnected = false;
+            ConnectedClients.Clear();
+            ConnectedClientIds.Clear();
+            ConnectedClientsList.Clear();
 
             if (NetworkManager != null && NetworkManager.NetworkConfig?.NetworkTransport != null)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -899,8 +899,10 @@ namespace Unity.Netcode
                 throw new Exception("[OnClientDisconnectFromServer] Was invoked by non-server instance!");
             }
 
-            // If we are shutting down, then ignore clean up as everything that needs to be destroyed will be during shutdown.
-            if (NetworkManager.ShutdownInProgress)
+            // If we are shutting down and this is the server or host disconnecting, then ignore
+            // clean up as everything that needs to be destroyed will be during shutdown.
+
+            if (NetworkManager.ShutdownInProgress && clientId == NetworkManager.ServerClientId)
             {
                 return;
             }
@@ -924,6 +926,7 @@ namespace Unity.Netcode
                         }
                     }
                     else
+                    if (!NetworkManager.ShutdownInProgress)
                     {
                         playerObject.RemoveOwnership();
                     }
@@ -942,7 +945,7 @@ namespace Unity.Netcode
                 }
                 else
                 {
-                    // Handle changing ownership and prefab handlers                    
+                    // Handle changing ownership and prefab handlers
                     for (int i = clientOwnedObjects.Count - 1; i >= 0; i--)
                     {
                         var ownedObject = clientOwnedObjects[i];
@@ -960,6 +963,7 @@ namespace Unity.Netcode
                                 }
                             }
                             else
+                            if (!NetworkManager.ShutdownInProgress)
                             {
                                 ownedObject.RemoveOwnership();
                             }

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -1045,6 +1045,12 @@ namespace Unity.Netcode
                 throw new NotServerException($"Only server can disconnect remote clients. Please use `{nameof(Shutdown)}()` instead.");
             }
 
+            if (clientId == NetworkManager.ServerClientId)
+            {
+                Debug.LogWarning($"Disconnecting the local server-host client is not allowed. Use NetworkManager.Shutdown instead.");
+                return;
+            }
+
             if (!string.IsNullOrEmpty(reason))
             {
                 var disconnectReason = new DisconnectReasonMessage

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -993,9 +993,6 @@ namespace Unity.Netcode
                 ConnectedClientIds.Remove(clientId);
                 var message = new ClientDisconnectedMessage { ClientId = clientId };
                 MessageManager?.SendMessage(ref message, NetworkDelivery.ReliableFragmentedSequenced, ConnectedClientIds);
-
-                // Send the message immediately
-                MessageManager?.ProcessSendQueues();
             }
 
             // If the client ID transport map exists
@@ -1133,10 +1130,13 @@ namespace Unity.Netcode
                 {
                     DisconnectRemoteClient(clientId);
                 }
+
+                // make sure all messages are flushed before transport disconnects clients
+                MessageManager?.ProcessSendQueues();
             }
             else if (NetworkManager != null && NetworkManager.IsListening && LocalClient.IsClient)
             {
-                // make sure all messages are flushed before transport disconnect clients
+                // make sure all messages are flushed before disconnecting
                 MessageManager?.ProcessSendQueues();
 
                 // Client only, send disconnect and if transport throws and exception, log the exception and continue the shutdown sequence (or forever be shutting down)

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -934,8 +934,7 @@ namespace Unity.Netcode
                             NetworkManager.SpawnManager.DespawnObject(playerObject, true);
                         }
                     }
-                    else
-                    if (!NetworkManager.ShutdownInProgress)
+                    else if (!NetworkManager.ShutdownInProgress)
                     {
                         playerObject.RemoveOwnership();
                     }
@@ -971,8 +970,7 @@ namespace Unity.Netcode
                                     Object.Destroy(ownedObject.gameObject);
                                 }
                             }
-                            else
-                            if (!NetworkManager.ShutdownInProgress)
+                            else if (!NetworkManager.ShutdownInProgress)
                             {
                                 ownedObject.RemoveOwnership();
                             }

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -994,7 +994,10 @@ namespace Unity.Netcode
 
                 ConnectedClientIds.Remove(clientId);
                 var message = new ClientDisconnectedMessage { ClientId = clientId };
-                NetworkManager.MessageManager.SendMessage(ref message, NetworkDelivery.ReliableFragmentedSequenced, ConnectedClientIds);
+                MessageManager?.SendMessage(ref message, NetworkDelivery.ReliableFragmentedSequenced, ConnectedClientIds);
+
+                // Send the message immediately
+                MessageManager?.ProcessSendQueues();
             }
 
             // If the client ID transport map exists
@@ -1095,7 +1098,6 @@ namespace Unity.Netcode
         /// </summary>
         internal void Shutdown()
         {
-
             if (LocalClient.IsServer)
             {
                 // Build a list of all client ids to be disconnected
@@ -1133,12 +1135,12 @@ namespace Unity.Netcode
                 {
                     DisconnectRemoteClient(clientId);
                 }
-
-                // make sure all messages are flushed before transport disconnect clients
-                MessageManager?.ProcessSendQueues();
             }
             else if (NetworkManager != null && NetworkManager.IsListening && LocalClient.IsClient)
             {
+                // make sure all messages are flushed before transport disconnect clients
+                MessageManager?.ProcessSendQueues();
+
                 // Client only, send disconnect and if transport throws and exception, log the exception and continue the shutdown sequence (or forever be shutting down)
                 try
                 {

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
@@ -100,7 +100,16 @@ namespace Unity.Netcode
                                  "Are you modifying a NetworkVariable before the NetworkObject is spawned?");
                 return;
             }
-
+            if (m_NetworkBehaviour.NetworkManager.ShutdownInProgress)
+            {
+                if (m_NetworkBehaviour.NetworkManager.LogLevel <= LogLevel.Developer)
+                {
+                    Debug.LogWarning($"NetworkVariable is written to, but is happenging during the NetworkManager shutdown! " +
+                 "Are you modifying a NetworkVariable within a NetworkBehaviour.OnDestroy or NetworkBehaviour.OnDespawn method? " +
+                 "If so, avoid trying to set NetworkVariables during despawn or destroy.");
+                }
+                return;
+            }
             m_NetworkBehaviour.NetworkManager.BehaviourUpdater.AddForUpdate(m_NetworkBehaviour.NetworkObject);
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
@@ -104,7 +104,7 @@ namespace Unity.Netcode
             {
                 if (m_NetworkBehaviour.NetworkManager.LogLevel <= LogLevel.Developer)
                 {
-                    Debug.LogWarning($"NetworkVariable is written to, but is happenging during the NetworkManager shutdown! " +
+                    Debug.LogWarning($"NetworkVariable is written to during the NetworkManager shutdown! " +
                  "Are you modifying a NetworkVariable within a NetworkBehaviour.OnDestroy or NetworkBehaviour.OnDespawn method? " +
                  "If so, avoid trying to set NetworkVariables during despawn or destroy.");
                 }

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
@@ -105,8 +105,7 @@ namespace Unity.Netcode
                 if (m_NetworkBehaviour.NetworkManager.LogLevel <= LogLevel.Developer)
                 {
                     Debug.LogWarning($"NetworkVariable is written to during the NetworkManager shutdown! " +
-                 "Are you modifying a NetworkVariable within a NetworkBehaviour.OnDestroy or NetworkBehaviour.OnDespawn method? " +
-                 "If so, avoid trying to set NetworkVariables during despawn or destroy.");
+                 "Are you modifying a NetworkVariable within a NetworkBehaviour.OnDestroy or NetworkBehaviour.OnDespawn method?");
                 }
                 return;
             }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -2782,7 +2782,7 @@ namespace Unity.Netcode.RuntimeTests
 
         public override void OnNetworkDespawn()
         {
-            if (IsServer && m_IntList != null)
+            if (IsServer)
             {
                 m_IntNetworkVariable.Value = 5;
                 for (int i = 0; i < 10; i++)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -2769,4 +2769,71 @@ namespace Unity.Netcode.RuntimeTests
             Assert.IsFalse(s_GlobalTimeoutHelper.TimedOut, nameof(CheckTestObjectComponentValuesOnAll));
         }
     }
+
+    public class NetvarDespawnShutdown : NetworkBehaviour
+    {
+        private NetworkVariable<int> m_IntNetworkVariable = new NetworkVariable<int>();
+        private NetworkList<int> m_IntList;
+
+        private void Awake()
+        {
+            m_IntList = new NetworkList<int>();
+        }
+
+        public override void OnNetworkDespawn()
+        {
+            if (IsServer && m_IntList != null)
+            {
+                m_IntNetworkVariable.Value = 5;
+                for (int i = 0; i < 10; i++)
+                {
+                    m_IntList.Add(i);
+                }
+            }
+            base.OnNetworkDespawn();
+        }
+    }
+
+    /// <summary>
+    /// Validates that setting values for NetworkVariable or NetworkList during the
+    /// OnNetworkDespawn method will not cause an exception to occur.
+    /// </summary>
+    public class NetworkVariableModifyOnNetworkDespawn : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 1;
+
+        private GameObject m_TestPrefab;
+
+        protected override void OnServerAndClientsCreated()
+        {
+            m_TestPrefab = CreateNetworkObjectPrefab("NetVarDespawn");
+            m_TestPrefab.AddComponent<NetvarDespawnShutdown>();
+            base.OnServerAndClientsCreated();
+        }
+
+        private bool OnClientSpawnedTestPrefab(ulong networkObjectId)
+        {
+            var clientId = m_ClientNetworkManagers[0].LocalClientId;
+            if (!s_GlobalNetworkObjects.ContainsKey(clientId))
+            {
+                return false;
+            }
+
+            if (!s_GlobalNetworkObjects[clientId].ContainsKey(networkObjectId))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        [UnityTest]
+        public IEnumerator ModifyNetworkVariableOrListOnNetworkDespawn()
+        {
+            var instance = SpawnObject(m_TestPrefab, m_ServerNetworkManager);
+            yield return WaitForConditionOrTimeOut(() => OnClientSpawnedTestPrefab(instance.GetComponent<NetworkObject>().NetworkObjectId));
+            m_ServerNetworkManager.Shutdown();
+            // As long as no excetptions occur, the test passes.
+        }
+    }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/PeerDisconnectCallbackTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/PeerDisconnectCallbackTests.cs
@@ -176,9 +176,8 @@ namespace Unity.Netcode.RuntimeTests
                 }
             }
 
-            // If disconnected client-side, only server will receive it.
-            // If disconnected server-side, one for server, one for self
-            Assert.AreEqual(clientDisconnectType == ClientDisconnectType.ClientDisconnectsFromServer ? 1 : 2, m_ClientDisconnectCount);
+            // If disconnected, the server and the client that disconnected will be notified
+            Assert.AreEqual(2, m_ClientDisconnectCount);
             // Host receives peer disconnect, dedicated server does not
             Assert.AreEqual(m_UseHost ? 3 : 2, m_PeerDisconnectCount);
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/StopStartRuntimeTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/StopStartRuntimeTests.cs
@@ -1,7 +1,6 @@
 using System.Collections;
 using NUnit.Framework;
 using Unity.Netcode.TestHelpers.Runtime;
-using UnityEngine;
 using UnityEngine.TestTools;
 
 namespace Unity.Netcode.RuntimeTests

--- a/com.unity.netcode.gameobjects/Tests/Runtime/StopStartRuntimeTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/StopStartRuntimeTests.cs
@@ -16,15 +16,19 @@ namespace Unity.Netcode.RuntimeTests
             base.OnOneTimeSetup();
         }
 
+
+        private bool m_ServerStopped;
         [UnityTest]
         public IEnumerator WhenShuttingDownAndRestarting_SDKRestartsSuccessfullyAndStaysRunning()
         {
             // shutdown the server
+            m_ServerNetworkManager.OnServerStopped += OnServerStopped;
             m_ServerNetworkManager.Shutdown();
 
-            // wait 1 frame because shutdowns are delayed
-            var nextFrameNumber = Time.frameCount + 1;
-            yield return new WaitUntil(() => Time.frameCount >= nextFrameNumber);
+            // wait until the OnServerStopped is invoked
+            m_ServerStopped = false;
+            yield return WaitForConditionOrTimeOut(() => m_ServerStopped);
+            AssertOnTimeout("Timed out waiting for the server to stop!");
 
             // Verify the shutdown occurred
             Assert.IsFalse(m_ServerNetworkManager.IsServer);
@@ -45,15 +49,23 @@ namespace Unity.Netcode.RuntimeTests
             Assert.IsTrue(m_ServerNetworkManager.IsListening);
         }
 
+        private void OnServerStopped(bool obj)
+        {
+            m_ServerNetworkManager.OnServerStopped -= OnServerStopped;
+            m_ServerStopped = true;
+        }
+
         [UnityTest]
         public IEnumerator WhenShuttingDownTwiceAndRestarting_SDKRestartsSuccessfullyAndStaysRunning()
         {
             // shutdown the server
+            m_ServerNetworkManager.OnServerStopped += OnServerStopped;
             m_ServerNetworkManager.Shutdown();
 
-            // wait 1 frame because shutdowns are delayed
-            var nextFrameNumber = Time.frameCount + 1;
-            yield return new WaitUntil(() => Time.frameCount >= nextFrameNumber);
+            // wait until the OnServerStopped is invoked
+            m_ServerStopped = false;
+            yield return WaitForConditionOrTimeOut(() => m_ServerStopped);
+            AssertOnTimeout("Timed out waiting for the server to stop!");
 
             // Verify the shutdown occurred
             Assert.IsFalse(m_ServerNetworkManager.IsServer);

--- a/testproject/Assets/Scripts/ConnectionModeScript.cs
+++ b/testproject/Assets/Scripts/ConnectionModeScript.cs
@@ -256,18 +256,21 @@ public class ConnectionModeScript : MonoBehaviour
     {
         NetworkManager.Singleton.StartClient();
         OnNotifyConnectionEventClient?.Invoke();
-        if (m_ConnectionModeButtons != null)
+        if (m_ConnectionModeButtons)
         {
             m_ConnectionModeButtons.SetActive(false);
             NetworkManager.Singleton.OnClientStopped += OnClientStopped;
         }
 
-        m_DisconnectClientButton?.SetActive(true);
+        if (m_DisconnectClientButton)
+        {
+            m_DisconnectClientButton.SetActive(true);
+        }
     }
 
     private void OnClientStopped(bool obj)
     {
-        if (m_ConnectionModeButtons != null)
+        if (m_ConnectionModeButtons)
         {
             NetworkManager.Singleton.OnClientStopped -= OnClientStopped;
             m_ConnectionModeButtons.SetActive(true);

--- a/testproject/Assets/Scripts/ExitButtonScript.cs
+++ b/testproject/Assets/Scripts/ExitButtonScript.cs
@@ -7,14 +7,68 @@ public class ExitButtonScript : MonoBehaviour
     [SerializeField]
     private MenuReference m_SceneMenuToLoad;
 
+    [SerializeField]
+    private bool m_DestroyNetworkManagerOnExit = true;
+
+    private void Start()
+    {
+        if (!NetworkManager.Singleton)
+        {
+            return;
+        }
+
+        NetworkManager.Singleton.OnServerStopped += OnNetworkManagerStopped;
+        NetworkManager.Singleton.OnClientStopped += OnNetworkManagerStopped;
+
+        NetworkManager.Singleton.OnServerStarted += OnNetworkManagerStarted;
+        NetworkManager.Singleton.OnClientStarted += OnNetworkManagerStarted;
+    }
+
+    private void OnNetworkManagerStarted()
+    {
+        NetworkManager.Singleton.OnClientDisconnectCallback -= OnClientDisconnectCallback;
+        NetworkManager.Singleton.OnClientDisconnectCallback += OnClientDisconnectCallback;
+    }
+
+    private void OnClientDisconnectCallback(ulong clientId)
+    {
+        var disconnectedReason = "Disconnected from session.";
+        if (NetworkManager.Singleton && !string.IsNullOrEmpty(NetworkManager.Singleton.DisconnectReason))
+        {
+            disconnectedReason = $"{NetworkManager.Singleton.DisconnectReason}";
+        }
+        Debug.Log($"[Client-{clientId}] {disconnectedReason}");
+    }
+
     /// <summary>
     /// A very basic way to exit back to the first scene in the build settings
     /// </summary>
     public void OnExitScene()
     {
-        if (NetworkManager.Singleton)
+        if (!NetworkManager.Singleton)
         {
-            NetworkManager.Singleton.Shutdown();
+            LoadExitScene();
+            return;
+        }
+
+        if (NetworkManager.Singleton.IsListening)
+        {
+            if (!NetworkManager.Singleton.ShutdownInProgress)
+            {
+
+                NetworkManager.Singleton.Shutdown();
+            }
+        }
+        else
+        {
+            LoadExitScene();
+        }
+    }
+
+    private void LoadExitScene()
+    {
+        if (m_DestroyNetworkManagerOnExit)
+        {
             Destroy(NetworkManager.Singleton.gameObject);
         }
 
@@ -26,6 +80,12 @@ public class ExitButtonScript : MonoBehaviour
         {
             SceneManager.LoadSceneAsync(0, LoadSceneMode.Single);
         }
+    }
 
+    private void OnNetworkManagerStopped(bool obj)
+    {
+        NetworkManager.Singleton.OnServerStopped -= OnNetworkManagerStopped;
+        NetworkManager.Singleton.OnClientStopped -= OnNetworkManagerStopped;
+        LoadExitScene();
     }
 }

--- a/testproject/Assets/Tests/Manual/InSceneObjectParentingTests/ChildObjectScript.cs
+++ b/testproject/Assets/Tests/Manual/InSceneObjectParentingTests/ChildObjectScript.cs
@@ -71,8 +71,7 @@ namespace TestProject.ManualTests
                 transform.localRotation = m_OriginalLocalRotation;
                 transform.localScale = m_OriginalLocalScale;
             }
-            else
-            if (parentNetworkObject == null && m_LastParent)
+            else if (parentNetworkObject == null && m_LastParent)
             {
                 // This example will drop the object at the current world position
                 transform.position = m_LastParent.transform.position;

--- a/testproject/Assets/Tests/Manual/Scripts/StatsDisplay.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/StatsDisplay.cs
@@ -54,7 +54,10 @@ namespace TestProject.ManualTests
             }
             else
             {
-                m_ClientServerToggle?.SetActive(true);
+                if (m_ClientServerToggle)
+                {
+                    m_ClientServerToggle.SetActive(false);
+                }
                 UpdateButton();
             }
 


### PR DESCRIPTION
This PR includes several fixes to the NetworkManager shutdown sequence where:

- A client disconnected by a server-host would not receive a notification
- A server-host could shutdown during a relay connection but periodically the transport disconnect message to any connected clients could be dropped.
- A host could disconnect its local client but remain running as a server
- OnClientDisconnectedCallback was not being invoked under certain conditions when disconnected.
- OnClientDisconnectedCallback was not returning the assigned client identifier on the client-side when invoked.
- If a host or server shutdown while a client owned NetworkObjects (other than the player) it would throw an exception.
- If you modify a NetworkVariable or NetworkList during a NetworkManager shutdown an exception was thrown.

[MTT-7791](https://jira.unity3d.com/browse/MTT-7791)
[MTT-7540](https://jira.unity3d.com/browse/MTT-7540)

fix: #2759
fix: #2705
fix: #2699
fix: #2389
fix: #2064
fix: #1880

## Changelog

- Fixed: Issue where a client disconnected by a server-host would not receive a local notification.
- Fixed: Issue where a server-host could shutdown during a relay connection but periodically the transport disconnect message sent to any connected clients could be dropped.
- Fixed: Issue where a host could disconnect its local client but remain running as a server.
- Fixed: Issue where `OnClientDisconnectedCallback` was not being invoked under certain conditions.
- Fixed: Issue where `OnClientDisconnectedCallback` was always returning 0 as the client identifier.
- Fixed: Issue where if a host or server shutdown while a client owned NetworkObjects (other than the player) it would throw an exception.
- Fixed: Issue where setting values on a `NetworkVariable` or `NetworkList` within `OnNetworkDespawn` during a shutdown sequence would throw an exception.
- Changed: The server or host shutdown so it will now perform a "soft shutdown" when `NetworkManager.Shutdown` is invoked. This will send a disconnect notification to all connected clients and the server-host will wait for all connected clients to disconnect or timeout after a 5 second period before completing the shutdown process.
- Changed: `OnClientDisconnectedCallback` will now return the assigned client identifier on the local client side if the client was approved and assigned one prior to being disconnected.


## Testing and Documentation

- Includes integration test updates.
- Updates to public documentation: [PR-1149](https://github.com/Unity-Technologies/com.unity.multiplayer.docs/pull/1149)

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
