### PR TITLE
fix: NetworkTransform half float synch

### DIFF
--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -1857,6 +1857,7 @@ namespace Unity.Netcode.Components
 
                         networkState.NetworkDeltaPosition = m_HalfPositionState;
 
+                        // If ownership offset is greater or we are doing an axial synchronization then synchronize the base position 
                         if ((m_HalfFloatTargetTickOwnership > m_CachedNetworkManager.ServerTime.Tick || isAxisSync) && !networkState.IsTeleportingNextFrame)
                         {
                             networkState.SynchronizeBaseHalfFloat = true;

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -1857,7 +1857,7 @@ namespace Unity.Netcode.Components
 
                         networkState.NetworkDeltaPosition = m_HalfPositionState;
 
-                        if (m_HalfFloatTargetTickOwnership > m_CachedNetworkManager.ServerTime.Tick && !networkState.IsTeleportingNextFrame)
+                        if ((m_HalfFloatTargetTickOwnership > m_CachedNetworkManager.ServerTime.Tick || isAxisSync) && !networkState.IsTeleportingNextFrame)
                         {
                             networkState.SynchronizeBaseHalfFloat = true;
                         }


### PR DESCRIPTION
Fixes the issue found when running through the play test where when UseUnreliableDeltas was enabled and a NetworkTransform was using half float precision the NetworkDeltaPosition was not synchronizing the base position during an axial frame synch.

## Changelog
NA

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
