### PR TITLE
fix: handle null or empty named message registration [MTT-7771]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+- Fixed issue where NetworkTransform could potentially attempt to "unregister" a named message prior to it being registered. (#2807)
+
+### Changed
+
+- Changed `CustomMessageManager` so it no longer attempts to register or "unregister" a null or empty string and will log an error if this condition occurs. (#2807)
+
+
 ## [1.8.0] - 2023-12-12
 
 ### Added

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -2763,7 +2763,7 @@ namespace Unity.Netcode.Components
         public override void OnNetworkDespawn()
         {
             // During destroy, use NetworkBehaviour.NetworkManager as opposed to m_CachedNetworkManager
-            if (!NetworkManager.ShutdownInProgress && NetworkManager.CustomMessagingManager != null)
+            if (!NetworkManager.ShutdownInProgress && NetworkManager.CustomMessagingManager != null && !string.IsNullOrEmpty(m_MessageName))
             {
                 NetworkManager.CustomMessagingManager.UnregisterNamedMessageHandler(m_MessageName);
             }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/CustomMessageManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/CustomMessageManager.cs
@@ -202,7 +202,7 @@ namespace Unity.Netcode
         {
             if (string.IsNullOrEmpty(name))
             {
-                if (m_NetworkManager.LogLevel <= LogLevel.Normal)
+                if (m_NetworkManager.LogLevel <= LogLevel.Error)
                 {
                     Debug.LogError($"[{nameof(CustomMessagingManager.RegisterNamedMessageHandler)}] Cannot register a named message of type null or empty!");
                 }
@@ -226,9 +226,9 @@ namespace Unity.Netcode
         {
             if (string.IsNullOrEmpty(name))
             {
-                if (m_NetworkManager.LogLevel <= LogLevel.Developer)
+                if (m_NetworkManager.LogLevel <= LogLevel.Error)
                 {
-                    Debug.LogWarning($"[{nameof(CustomMessagingManager.UnregisterNamedMessageHandler)}] Cannot unregister a named message of type null or empty!");
+                    Debug.LogError($"[{nameof(CustomMessagingManager.UnregisterNamedMessageHandler)}] Cannot unregister a named message of type null or empty!");
                 }
                 return;
             }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/CustomMessageManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/CustomMessageManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Unity.Collections;
+using UnityEngine;
 
 namespace Unity.Netcode
 {
@@ -199,6 +200,14 @@ namespace Unity.Netcode
         /// <param name="callback">The callback to run when a named message is received.</param>
         public void RegisterNamedMessageHandler(string name, HandleNamedMessageDelegate callback)
         {
+            if (string.IsNullOrEmpty(name))
+            {
+                if (m_NetworkManager.LogLevel <= LogLevel.Normal)
+                {
+                    Debug.LogError($"[{nameof(CustomMessagingManager.RegisterNamedMessageHandler)}] Cannot register a named message of type null or empty!");
+                }
+                return;
+            }
             var hash32 = XXHash.Hash32(name);
             var hash64 = XXHash.Hash64(name);
 
@@ -215,6 +224,15 @@ namespace Unity.Netcode
         /// <param name="name">The name of the message.</param>
         public void UnregisterNamedMessageHandler(string name)
         {
+            if (string.IsNullOrEmpty(name))
+            {
+                if (m_NetworkManager.LogLevel <= LogLevel.Developer)
+                {
+                    Debug.LogWarning($"[{nameof(CustomMessagingManager.UnregisterNamedMessageHandler)}] Cannot unregister a named message of type null or empty!");
+                }
+                return;
+            }
+
             var hash32 = XXHash.Hash32(name);
             var hash64 = XXHash.Hash64(name);
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Messaging/NamedMessageTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Messaging/NamedMessageTests.cs
@@ -86,6 +86,24 @@ namespace Unity.Netcode.RuntimeTests
             Assert.AreEqual(m_ServerNetworkManager.LocalClientId, receivedMessageSender);
         }
 
+        private void MockNamedMessageCallback(ulong sender, FastBufferReader reader)
+        {
+
+        }
+
+        [Test]
+        public void NullOrEmptyNamedMessageDoesNotThrowException()
+        {
+            LogAssert.Expect(UnityEngine.LogType.Error, $"[{nameof(CustomMessagingManager.RegisterNamedMessageHandler)}] Cannot register a named message of type null or empty!");
+            m_ServerNetworkManager.CustomMessagingManager.RegisterNamedMessageHandler(string.Empty, MockNamedMessageCallback);
+            LogAssert.Expect(UnityEngine.LogType.Error, $"[{nameof(CustomMessagingManager.RegisterNamedMessageHandler)}] Cannot register a named message of type null or empty!");
+            m_ServerNetworkManager.CustomMessagingManager.RegisterNamedMessageHandler(null, MockNamedMessageCallback);
+            LogAssert.Expect(UnityEngine.LogType.Error, $"[{nameof(CustomMessagingManager.UnregisterNamedMessageHandler)}] Cannot unregister a named message of type null or empty!");            
+            m_ServerNetworkManager.CustomMessagingManager.UnregisterNamedMessageHandler(string.Empty);
+            LogAssert.Expect(UnityEngine.LogType.Error, $"[{nameof(CustomMessagingManager.UnregisterNamedMessageHandler)}] Cannot unregister a named message of type null or empty!");
+            m_ServerNetworkManager.CustomMessagingManager.UnregisterNamedMessageHandler(null);
+        }
+
         [UnityTest]
         public IEnumerator NamedMessageIsReceivedOnMultipleClientsWithContent()
         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Messaging/NamedMessageTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Messaging/NamedMessageTests.cs
@@ -98,7 +98,7 @@ namespace Unity.Netcode.RuntimeTests
             m_ServerNetworkManager.CustomMessagingManager.RegisterNamedMessageHandler(string.Empty, MockNamedMessageCallback);
             LogAssert.Expect(UnityEngine.LogType.Error, $"[{nameof(CustomMessagingManager.RegisterNamedMessageHandler)}] Cannot register a named message of type null or empty!");
             m_ServerNetworkManager.CustomMessagingManager.RegisterNamedMessageHandler(null, MockNamedMessageCallback);
-            LogAssert.Expect(UnityEngine.LogType.Error, $"[{nameof(CustomMessagingManager.UnregisterNamedMessageHandler)}] Cannot unregister a named message of type null or empty!");            
+            LogAssert.Expect(UnityEngine.LogType.Error, $"[{nameof(CustomMessagingManager.UnregisterNamedMessageHandler)}] Cannot unregister a named message of type null or empty!");
             m_ServerNetworkManager.CustomMessagingManager.UnregisterNamedMessageHandler(string.Empty);
             LogAssert.Expect(UnityEngine.LogType.Error, $"[{nameof(CustomMessagingManager.UnregisterNamedMessageHandler)}] Cannot unregister a named message of type null or empty!");
             m_ServerNetworkManager.CustomMessagingManager.UnregisterNamedMessageHandler(null);


### PR DESCRIPTION
This catches the case where trying to register or "unregister" a null or empty string will log an error and not throw an exception.
This also resolves the issue on the `NetworkTransform` side where, under certain conditions, it was possible for `NetworkTransform` to attempt to "unregister" its named message before it had been assigned.

[MTT-7771](https://jira.unity3d.com/browse/MTT-7771)

fix: #2772

## Changelog
- Changed: `CustomMessageManager` will no longer attempt to register or "unregister" a null or empty string and will log an error if this condition occurs.
- Fixed: Issue where `NetworkTransform` could potentially attempt to "unregister" a named message prior to it being registered.

## Testing and Documentation

- Includes unit test.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
