### PR TITLE
chore: migrate NetworkTransform away from using named messages over to NetworkTransformMessage [MTT-7535]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+### Changed
+
+- Changed `NetworkTransform` to now use `NetworkTransformMessage` as opposed to named messages for NetworkTransformState updates. (#2810)
+
 ## [1.8.0] - 2023-12-12
 
 ### Added

--- a/com.unity.netcode.gameobjects/Components/Messages.meta
+++ b/com.unity.netcode.gameobjects/Components/Messages.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a9db1d18fa0117f4da5e8e65386b894a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.netcode.gameobjects/Components/Messages/NetworkTransformMessage.cs
+++ b/com.unity.netcode.gameobjects/Components/Messages/NetworkTransformMessage.cs
@@ -1,0 +1,114 @@
+using UnityEngine;
+using Unity.Netcode.Components;
+
+namespace Unity.Netcode
+{
+    /// <summary>
+    /// NetworkTransform State Update Message
+    /// </summary>
+    internal struct NetworkTransformMessage : INetworkMessage, INetworkSerializeByMemcpy
+    {
+        public int Version => 0;
+        public ulong NetworkObjectId;
+        public int NetworkBehaviourId;
+        public NetworkTransform.NetworkTransformState State;
+
+        private NetworkTransform m_ReceiverNetworkTransform;
+        private FastBufferReader m_CurrentReader;
+
+        private unsafe void CopyPayload(ref FastBufferWriter writer)
+        {
+            writer.WriteBytesSafe(m_CurrentReader.GetUnsafePtrAtCurrentPosition(), m_CurrentReader.Length - m_CurrentReader.Position);
+        }
+
+        public void Serialize(FastBufferWriter writer, int targetVersion)
+        {
+            if (m_CurrentReader.IsInitialized)
+            {
+                CopyPayload(ref writer);
+            }
+            else
+            {
+                BytePacker.WriteValueBitPacked(writer, NetworkObjectId);
+                BytePacker.WriteValueBitPacked(writer, NetworkBehaviourId);
+                writer.WriteNetworkSerializable(State);
+            }
+        }
+
+        public bool Deserialize(FastBufferReader reader, ref NetworkContext context, int receivedMessageVersion)
+        {
+            var networkManager = context.SystemOwner as NetworkManager;
+            if (networkManager == null)
+            {
+                Debug.LogError($"[{nameof(NetworkTransformMessage)}] System owner context was not of type {nameof(NetworkManager)}!");
+                return false;
+            }
+            var currentPosition = reader.Position;
+            ByteUnpacker.ReadValueBitPacked(reader, out NetworkObjectId);
+            if (!networkManager.SpawnManager.SpawnedObjects.ContainsKey(NetworkObjectId))
+            {
+                networkManager.DeferredMessageManager.DeferMessage(IDeferredNetworkMessageManager.TriggerType.OnSpawn, NetworkObjectId, reader, ref context);
+                return false;
+            }
+            // Get the behaviour index
+            ByteUnpacker.ReadValueBitPacked(reader, out NetworkBehaviourId);
+
+            // Deserialize the state
+            reader.ReadNetworkSerializable(out State);
+
+            var networkObject = networkManager.SpawnManager.SpawnedObjects[NetworkObjectId];
+
+            // Get the target NetworkTransform
+            m_ReceiverNetworkTransform = networkObject.ChildNetworkBehaviours[NetworkBehaviourId] as NetworkTransform;
+
+            var isServerAuthoritative = m_ReceiverNetworkTransform.IsServerAuthoritative();
+            var ownerAuthoritativeServerSide = !isServerAuthoritative && networkManager.IsServer;
+            if (ownerAuthoritativeServerSide)
+            {
+                var ownerClientId = networkObject.OwnerClientId;
+                if (ownerClientId == NetworkManager.ServerClientId)
+                {
+                    // Ownership must have changed, ignore any additional pending messages that might have
+                    // come from a previous owner client.
+                    return true;
+                }
+
+                var networkDelivery = State.IsReliableStateUpdate() ? NetworkDelivery.ReliableSequenced : NetworkDelivery.UnreliableSequenced;
+
+                // Forward the state update if there are any remote clients to foward it to
+                if (networkManager.ConnectionManager.ConnectedClientsList.Count > (networkManager.IsHost ? 2 : 1))
+                {
+                    var currentMessage = this;
+                    // Create a new reader that replicates this message
+                    currentMessage.m_CurrentReader = new FastBufferReader(reader, Collections.Allocator.Temp);
+                    // Rewind the new reader to the beginning of the message's payload
+                    currentMessage.m_CurrentReader.Seek(currentPosition);
+                    // Forward the message to all connected clients that are observers of the associated NetworkObject
+                    var clientCount = networkManager.ConnectionManager.ConnectedClientsList.Count;
+                    for (int i = 0; i < clientCount; i++)
+                    {
+                        var clientId = networkManager.ConnectionManager.ConnectedClientsList[i].ClientId;
+                        if (NetworkManager.ServerClientId == clientId || (!isServerAuthoritative && clientId == ownerClientId) || !networkObject.Observers.Contains(clientId))
+                        {
+                            continue;
+                        }
+                        networkManager.MessageManager.SendMessage(ref currentMessage, networkDelivery, clientId);
+                    }
+                    // Dispose of the reader used for forwarding
+                    currentMessage.m_CurrentReader.Dispose();
+                }
+            }
+            return true;
+        }
+
+        public void Handle(ref NetworkContext context)
+        {
+            if (m_ReceiverNetworkTransform == null)
+            {
+                Debug.LogError($"[{nameof(NetworkTransformMessage)}][Dropped] Reciever {nameof(NetworkTransform)} was not set!");
+                return;
+            }
+            m_ReceiverNetworkTransform.TransformStateUpdate(ref State);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Components/Messages/NetworkTransformMessage.cs
+++ b/com.unity.netcode.gameobjects/Components/Messages/NetworkTransformMessage.cs
@@ -78,9 +78,11 @@ namespace Unity.Netcode
                 // Forward the state update if there are any remote clients to foward it to
                 if (networkManager.ConnectionManager.ConnectedClientsList.Count > (networkManager.IsHost ? 2 : 1))
                 {
+                    // This is only to copy the existing and already serialized struct for forwarding purposes only.
+                    // This will not include any changes made to this struct at this particular stage of processing the message.
                     var currentMessage = this;
                     // Create a new reader that replicates this message
-                    currentMessage.m_CurrentReader = new FastBufferReader(reader, Collections.Allocator.Temp);
+                    currentMessage.m_CurrentReader = new FastBufferReader(reader, Collections.Allocator.None);
                     // Rewind the new reader to the beginning of the message's payload
                     currentMessage.m_CurrentReader.Seek(currentPosition);
                     // Forward the message to all connected clients that are observers of the associated NetworkObject

--- a/com.unity.netcode.gameobjects/Components/Messages/NetworkTransformMessage.cs
+++ b/com.unity.netcode.gameobjects/Components/Messages/NetworkTransformMessage.cs
@@ -6,7 +6,7 @@ namespace Unity.Netcode
     /// <summary>
     /// NetworkTransform State Update Message
     /// </summary>
-    internal struct NetworkTransformMessage : INetworkMessage, INetworkSerializeByMemcpy
+    internal struct NetworkTransformMessage : INetworkMessage
     {
         public int Version => 0;
         public ulong NetworkObjectId;

--- a/com.unity.netcode.gameobjects/Components/Messages/NetworkTransformMessage.cs
+++ b/com.unity.netcode.gameobjects/Components/Messages/NetworkTransformMessage.cs
@@ -1,5 +1,5 @@
-using UnityEngine;
 using Unity.Netcode.Components;
+using UnityEngine;
 
 namespace Unity.Netcode
 {

--- a/com.unity.netcode.gameobjects/Components/Messages/NetworkTransformMessage.cs.meta
+++ b/com.unity.netcode.gameobjects/Components/Messages/NetworkTransformMessage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dcfc8ac43fef97e42adb19b998d70c37
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using Unity.Collections;
 using Unity.Mathematics;
 using UnityEngine;
 

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/CodeGenHelpers.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/CodeGenHelpers.cs
@@ -21,6 +21,7 @@ namespace Unity.Netcode.Editor.CodeGen
         public const string NetcodeModuleName = "Unity.Netcode.Runtime.dll";
 
         public const string RuntimeAssemblyName = "Unity.Netcode.Runtime";
+        public const string ComponentsAssemblyName = "Unity.Netcode.Components";
 
         public static readonly string NetworkBehaviour_FullName = typeof(NetworkBehaviour).FullName;
         public static readonly string INetworkMessage_FullName = typeof(INetworkMessage).FullName;

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/INetworkMessageILPP.cs
@@ -17,7 +17,7 @@ namespace Unity.Netcode.Editor.CodeGen
     {
         public override ILPPInterface GetInstance() => this;
 
-        public override bool WillProcess(ICompiledAssembly compiledAssembly) => compiledAssembly.Name == CodeGenHelpers.RuntimeAssemblyName;
+        public override bool WillProcess(ICompiledAssembly compiledAssembly) => compiledAssembly.Name == CodeGenHelpers.RuntimeAssemblyName || compiledAssembly.Name == CodeGenHelpers.ComponentsAssemblyName;
 
         private readonly List<DiagnosticMessage> m_Diagnostics = new List<DiagnosticMessage>();
 


### PR DESCRIPTION
This PR implements an internal NetworkTransformMessage that NetworkTransform will now use as opposed to using named messages. For future feature compatibility purposes.

[MTT-7535](https://jira.unity3d.com/browse/MTT-7535)

## Changelog

- Changed: `NetworkTransform` now uses `NetworkTransformMessage` as opposed to named messages for `NetworkTransformState` updates.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

