### PR TITLE
fix: host not generating its own local client disconnect notification

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,7 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where the host was not invoking OnClientDisconnected for its own local client when internally shutting down. (#2822)
+- Fixed issue where the host was not invoking OnClientDisconnectCallback for its own local client when internally shutting down. (#2822)
 - Fixed issue where NetworkTransform could potentially attempt to "unregister" a named message prior to it being registered. (#2807)
 - Fixed issue where in-scene placed `NetworkObject`s with complex nested children `NetworkObject`s (more than one child in depth) would not synchronize properly if WorldPositionStays was set to true. (#2796)
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,7 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where the host was not invoking OnClientDisconnectCallback for its own local client when internally shutting down. (#2822)
+- Fixed issue where the host was not invoking `OnClientDisconnectCallback` for its own local client when internally shutting down. (#2822)
 - Fixed issue where NetworkTransform could potentially attempt to "unregister" a named message prior to it being registered. (#2807)
 - Fixed issue where in-scene placed `NetworkObject`s with complex nested children `NetworkObject`s (more than one child in depth) would not synchronize properly if WorldPositionStays was set to true. (#2796)
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where the host was not invoking OnClientDisconnected for its own local client when internally shutting down. (#2822)
 - Fixed issue where NetworkTransform could potentially attempt to "unregister" a named message prior to it being registered. (#2807)
 - Fixed issue where in-scene placed `NetworkObject`s with complex nested children `NetworkObject`s (more than one child in depth) would not synchronize properly if WorldPositionStays was set to true. (#2796)
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1185,6 +1185,12 @@ namespace Unity.Netcode
             IsListening = false;
             m_ShuttingDown = false;
 
+            // Generate a local notification that the host client is disconnected
+            if (IsHost)
+            {
+                ConnectionManager.InvokeOnClientDisconnectCallback(LocalClientId);
+            }
+
             if (ConnectionManager.LocalClient.IsClient)
             {
                 // If we were a client, we want to know if we were a host

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -534,7 +534,10 @@ namespace Unity.Netcode.TestHelpers.Runtime
         protected IEnumerator StopOneClient(NetworkManager networkManager, bool destroy = false)
         {
             NetcodeIntegrationTestHelpers.StopOneClient(networkManager, destroy);
-            AddRemoveNetworkManager(networkManager, false);
+            if (destroy)
+            {
+                AddRemoveNetworkManager(networkManager, false);
+            }
             yield return WaitForConditionOrTimeOut(() => !networkManager.IsConnectedClient);
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DisconnectTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DisconnectTests.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using Unity.Netcode.TestHelpers.Runtime;
@@ -37,7 +38,10 @@ namespace Unity.Netcode.RuntimeTests
         protected override int NumberOfClients => 1;
 
         private OwnerPersistence m_OwnerPersistence;
+        private ClientDisconnectType m_ClientDisconnectType;
         private bool m_ClientDisconnected;
+        private Dictionary<NetworkManager, ConnectionEventData> m_DisconnectedEvent = new Dictionary<NetworkManager, ConnectionEventData>();
+        private ulong m_DisconnectEventClientId;
         private ulong m_TransportClientId;
         private ulong m_ClientId;
 
@@ -89,6 +93,16 @@ namespace Unity.Netcode.RuntimeTests
             m_ClientDisconnected = true;
         }
 
+        private void OnConnectionEvent(NetworkManager networkManager, ConnectionEventData connectionEventData)
+        {
+            if (connectionEventData.EventType != ConnectionEvent.ClientDisconnected)
+            {
+                return;
+            }
+
+            m_DisconnectedEvent.Add(networkManager, connectionEventData);
+        }
+
         /// <summary>
         /// Conditional check to assure the transport to client (and vice versa) mappings are cleaned up
         /// </summary>
@@ -126,6 +140,7 @@ namespace Unity.Netcode.RuntimeTests
         public IEnumerator ClientPlayerDisconnected([Values] ClientDisconnectType clientDisconnectType)
         {
             m_ClientId = m_ClientNetworkManagers[0].LocalClientId;
+            m_ClientDisconnectType = clientDisconnectType;
 
             var serverSideClientPlayer = m_ServerNetworkManager.ConnectionManager.ConnectedClients[m_ClientId].PlayerObject;
 
@@ -134,17 +149,38 @@ namespace Unity.Netcode.RuntimeTests
             if (clientDisconnectType == ClientDisconnectType.ServerDisconnectsClient)
             {
                 m_ClientNetworkManagers[0].OnClientDisconnectCallback += OnClientDisconnectCallback;
+                m_ClientNetworkManagers[0].OnConnectionEvent += OnConnectionEvent;
+                m_ServerNetworkManager.OnConnectionEvent += OnConnectionEvent;
                 m_ServerNetworkManager.DisconnectClient(m_ClientId);
             }
             else
             {
                 m_ServerNetworkManager.OnClientDisconnectCallback += OnClientDisconnectCallback;
+                m_ServerNetworkManager.OnConnectionEvent += OnConnectionEvent;
+                m_ClientNetworkManagers[0].OnConnectionEvent += OnConnectionEvent;
 
                 yield return StopOneClient(m_ClientNetworkManagers[0]);
             }
 
             yield return WaitForConditionOrTimeOut(() => m_ClientDisconnected);
             AssertOnTimeout("Timed out waiting for client to disconnect!");
+
+            if (clientDisconnectType == ClientDisconnectType.ServerDisconnectsClient)
+            {
+                Assert.IsTrue(m_DisconnectedEvent.ContainsKey(m_ServerNetworkManager), $"Could not find the server {nameof(NetworkManager)} disconnect event entry!");
+                Assert.IsTrue(m_DisconnectedEvent[m_ServerNetworkManager].ClientId == m_ClientId, $"Expected ClientID {m_ClientId} but found ClientID {m_DisconnectedEvent[m_ServerNetworkManager].ClientId} for the server {nameof(NetworkManager)} disconnect event entry!");
+                Assert.IsTrue(m_DisconnectedEvent.ContainsKey(m_ClientNetworkManagers[0]), $"Could not find the client {nameof(NetworkManager)} disconnect event entry!");
+                Assert.IsTrue(m_DisconnectedEvent[m_ClientNetworkManagers[0]].ClientId == m_ClientId, $"Expected ClientID {m_ClientId} but found ClientID {m_DisconnectedEvent[m_ServerNetworkManager].ClientId} for the client {nameof(NetworkManager)} disconnect event entry!");
+                // Unregister for this event otherwise it will be invoked during teardown
+                m_ServerNetworkManager.OnConnectionEvent -= OnConnectionEvent;
+            }
+            else
+            {
+                Assert.IsTrue(m_DisconnectedEvent.ContainsKey(m_ServerNetworkManager), $"Could not find the server {nameof(NetworkManager)} disconnect event entry!");
+                Assert.IsTrue(m_DisconnectedEvent[m_ServerNetworkManager].ClientId == m_ClientId, $"Expected ClientID {m_ClientId} but found ClientID {m_DisconnectedEvent[m_ServerNetworkManager].ClientId} for the server {nameof(NetworkManager)} disconnect event entry!");
+                Assert.IsTrue(m_DisconnectedEvent.ContainsKey(m_ClientNetworkManagers[0]), $"Could not find the client {nameof(NetworkManager)} disconnect event entry!");
+                Assert.IsTrue(m_DisconnectedEvent[m_ClientNetworkManagers[0]].ClientId == m_ClientId, $"Expected ClientID {m_ClientId} but found ClientID {m_DisconnectedEvent[m_ServerNetworkManager].ClientId} for the client {nameof(NetworkManager)} disconnect event entry!");
+            }
 
             if (m_OwnerPersistence == OwnerPersistence.DestroyWithOwner)
             {
@@ -166,11 +202,15 @@ namespace Unity.Netcode.RuntimeTests
             // Only test when the test run is the client disconnecting from the server (otherwise the server will be shutdown already)
             if (clientDisconnectType == ClientDisconnectType.ClientDisconnectsFromServer)
             {
+                m_DisconnectedEvent.Clear();
                 m_ClientDisconnected = false;
                 m_ServerNetworkManager.Shutdown();
 
                 yield return WaitForConditionOrTimeOut(() => m_ClientDisconnected);
                 AssertOnTimeout("Timed out waiting for host-client to generate disconnect message!");
+
+                Assert.IsTrue(m_DisconnectedEvent.ContainsKey(m_ServerNetworkManager), $"Could not find the server {nameof(NetworkManager)} disconnect event entry!");
+                Assert.IsTrue(m_DisconnectedEvent[m_ServerNetworkManager].ClientId == NetworkManager.ServerClientId, $"Expected ClientID {m_ClientId} but found ClientID {m_DisconnectedEvent[m_ServerNetworkManager].ClientId} for the server {nameof(NetworkManager)} disconnect event entry!");
             }
         }
     }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DisconnectTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DisconnectTests.cs
@@ -161,6 +161,17 @@ namespace Unity.Netcode.RuntimeTests
 
             yield return WaitForConditionOrTimeOut(TransportIdCleanedUp);
             AssertOnTimeout("Timed out waiting for transport and client id mappings to be cleaned up!");
+
+            // Validate the host-client generates a OnClientDisconnected event when it shutsdown.
+            // Only test when the test run is the client disconnecting from the server (otherwise the server will be shutdown already)
+            if (clientDisconnectType == ClientDisconnectType.ClientDisconnectsFromServer)
+            {
+                m_ClientDisconnected = false;
+                m_ServerNetworkManager.Shutdown();
+
+                yield return WaitForConditionOrTimeOut(() => m_ClientDisconnected);
+                AssertOnTimeout("Timed out waiting for host-client to generate disconnect message!");
+            }
         }
     }
 }

--- a/testproject/Assets/Tests/Runtime/SenderIdTests.cs
+++ b/testproject/Assets/Tests/Runtime/SenderIdTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using NUnit.Framework;
 using Unity.Collections;
 using Unity.Netcode;
@@ -89,36 +90,34 @@ namespace TestProject.RuntimeTests
             Assert.IsTrue(secondReceived);
         }
 
+
+        private List<ulong> m_ClientsDisconnected = new List<ulong>();
+        private ulong m_ClientToValidateDisconnected;
+
+        private bool ValidateClientId()
+        {
+            return m_ClientsDisconnected.Contains(m_ClientToValidateDisconnected);
+        }
+       
+        private void OnClientDisconnected(ulong clientId)
+        {
+            m_ClientsDisconnected.Add(clientId);
+        }
+
         [UnityTest]
         public IEnumerator WhenClientDisconnectsFromServer_ClientIdIsCorrect()
         {
-            var firstClientId = FirstClient.LocalClientId;
-            bool received = false;
-            void firstCallback(ulong id)
-            {
-                Assert.AreEqual(firstClientId, id);
-                received = true;
-            }
-            m_ServerNetworkManager.OnClientDisconnectCallback += firstCallback;
+            m_ClientsDisconnected.Clear();
+            m_ServerNetworkManager.OnClientDisconnectCallback += OnClientDisconnected;
+            m_ClientToValidateDisconnected = m_ClientNetworkManagers[0].LocalClientId;
             FirstClient.Shutdown();
+            yield return WaitForConditionOrTimeOut(ValidateClientId);
+            AssertOnTimeout($"Timed out waiting for the server to receive Client-{m_ClientToValidateDisconnected} disconnect event!");
 
-            yield return new WaitForSeconds(0.2f);
-
-            Assert.IsTrue(received);
-            var secondClientId = SecondClient.LocalClientId;
-            received = false;
-
-            m_ServerNetworkManager.OnClientDisconnectCallback -= firstCallback;
-            m_ServerNetworkManager.OnClientDisconnectCallback += id =>
-            {
-                Assert.AreEqual(secondClientId, id);
-                received = true;
-            };
+            m_ClientToValidateDisconnected = m_ClientNetworkManagers[1].LocalClientId;
             SecondClient.Shutdown();
-
-            yield return new WaitForSeconds(0.2f);
-
-            Assert.IsTrue(received);
+            yield return WaitForConditionOrTimeOut(ValidateClientId);
+            AssertOnTimeout($"Timed out waiting for the server to receive Client-{m_ClientToValidateDisconnected} disconnect event!");
         }
     }
 }

--- a/testproject/Assets/Tests/Runtime/SenderIdTests.cs
+++ b/testproject/Assets/Tests/Runtime/SenderIdTests.cs
@@ -98,7 +98,7 @@ namespace TestProject.RuntimeTests
         {
             return m_ClientsDisconnected.Contains(m_ClientToValidateDisconnected);
         }
-       
+
         private void OnClientDisconnected(ulong clientId)
         {
             m_ClientsDisconnected.Add(clientId);


### PR DESCRIPTION
This fix assures a host will invoke `OnClientDisconnectCallback` for its local client when it is internally shutting down.

fix: #2789

## Changelog

- Fixed: Issue where the host was not invoking `OnClientDisconnectCallback` for its own local client when internally shutting down.

## Testing and Documentation

- Includes integration test update.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
