### PR TITLE
fix: Fixed compile error using IL2CPP builds with new [Rpc] attribute

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
+## [1.8.1] - 2024-02-05
+
+### Fixed
+
+- Fixed a compile error when compiling for IL2CPP targets when using the new `[Rpc]` attribute. (#2824)
+
 ## [1.8.0] - 2023-12-12
 
 ### Added

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -822,7 +822,7 @@ namespace Unity.Netcode.Editor.CodeGen
                         break;
                 }
             }
-            m_UniversalRpcParams_TypeRef = moduleDefinition.ImportReference(rpcParamsTypeDef);
+            m_UniversalRpcParams_TypeRef = moduleDefinition.ImportReference(universalRpcParamsTypeDef);
             foreach (var fieldDef in rpcParamsTypeDef.Fields)
             {
                 switch (fieldDef.Name)

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -2,7 +2,7 @@
     "name": "com.unity.netcode.gameobjects",
     "displayName": "Netcode for GameObjects",
     "description": "Netcode for GameObjects is a high-level netcode SDK that provides networking capabilities to GameObject/MonoBehaviour workflows within Unity and sits on top of underlying transport layer.",
-    "version": "1.8.0",
+    "version": "1.8.1",
     "unity": "2021.3",
     "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",


### PR DESCRIPTION
fixes #2817 

## Changelog

- Fixed: Fixed a compile error when compiling for IL2CPP targets when using the new `[Rpc]` attribute.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.
