### PR TITLE
feat: allows `NetworkObjectReference`s and `NetworkBehaviourReference`s to be null

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Serialization/NetworkBehaviourReference.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/NetworkBehaviourReference.cs
@@ -11,6 +11,7 @@ namespace Unity.Netcode
     {
         private NetworkObjectReference m_NetworkObjectReference;
         private ushort m_NetworkBehaviourId;
+        private static ulong nullId = ulong.MaxValue;
 
         /// <summary>
         /// Creates a new instance of the <see cref="NetworkBehaviourReference{T}"/> struct.
@@ -21,7 +22,9 @@ namespace Unity.Netcode
         {
             if (networkBehaviour == null)
             {
-                throw new ArgumentNullException(nameof(networkBehaviour));
+                m_NetworkObjectReference = new NetworkObjectReference((NetworkObject)null);
+                m_NetworkBehaviourId = nullId;
+                return;
             }
             if (networkBehaviour.NetworkObject == null)
             {
@@ -60,6 +63,8 @@ namespace Unity.Netcode
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static NetworkBehaviour GetInternal(NetworkBehaviourReference networkBehaviourRef, NetworkManager networkManager = null)
         {
+            if (m_NetworkBehaviourId == nullId)
+                return null;
             if (networkBehaviourRef.m_NetworkObjectReference.TryGet(out NetworkObject networkObject, networkManager))
             {
                 return networkObject.GetNetworkBehaviourAtOrderIndex(networkBehaviourRef.m_NetworkBehaviourId);

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/NetworkObjectReference.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/NetworkObjectReference.cs
@@ -10,6 +10,7 @@ namespace Unity.Netcode
     public struct NetworkObjectReference : INetworkSerializable, IEquatable<NetworkObjectReference>
     {
         private ulong m_NetworkObjectId;
+        private static ulong nullId = ulong.MaxValue;
 
         /// <summary>
         /// The <see cref="NetworkObject.NetworkObjectId"/> of the referenced <see cref="NetworkObject"/>.
@@ -24,13 +25,13 @@ namespace Unity.Netcode
         /// Creates a new instance of the <see cref="NetworkObjectReference"/> struct.
         /// </summary>
         /// <param name="networkObject">The <see cref="NetworkObject"/> to reference.</param>
-        /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
         public NetworkObjectReference(NetworkObject networkObject)
         {
             if (networkObject == null)
             {
-                throw new ArgumentNullException(nameof(networkObject));
+                m_NetworkObjectId = nullId;
+                return;
             }
 
             if (networkObject.IsSpawned == false)
@@ -45,16 +46,20 @@ namespace Unity.Netcode
         /// Creates a new instance of the <see cref="NetworkObjectReference"/> struct.
         /// </summary>
         /// <param name="gameObject">The GameObject from which the <see cref="NetworkObject"/> component will be referenced.</param>
-        /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
         public NetworkObjectReference(GameObject gameObject)
         {
             if (gameObject == null)
             {
-                throw new ArgumentNullException(nameof(gameObject));
+                m_NetworkObjectId = nullId;
+                return;
             }
 
-            var networkObject = gameObject.GetComponent<NetworkObject>() ?? throw new ArgumentException($"Cannot create {nameof(NetworkObjectReference)} from {nameof(GameObject)} without a {nameof(NetworkObject)} component.");
+            var networkObject = gameObject.GetComponent<NetworkObject>();
+            if (networkObject == null)
+            {
+                throw new ArgumentException($"Cannot create {nameof(NetworkObjectReference)} from {nameof(GameObject)} without a {nameof(NetworkObject)} component.");
+            }
             if (networkObject.IsSpawned == false)
             {
                 throw new ArgumentException($"{nameof(NetworkObjectReference)} can only be created from spawned {nameof(NetworkObject)}s.");
@@ -80,10 +85,12 @@ namespace Unity.Netcode
         /// </summary>
         /// <param name="networkObjectRef">The reference.</param>
         /// <param name="networkManager">The networkmanager. Uses <see cref="NetworkManager.Singleton"/> to resolve if null.</param>
-        /// <returns>The resolves <see cref="NetworkObject"/>. Returns null if the networkobject was not found</returns>
+        /// <returns>The resolved <see cref="NetworkObject"/>. Returns null if the networkobject was not found</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static NetworkObject Resolve(NetworkObjectReference networkObjectRef, NetworkManager networkManager = null)
         {
+            if (networkObjectRef.m_NetworkObjectId == nullId)
+                return null;
             networkManager = networkManager ?? NetworkManager.Singleton;
             networkManager.SpawnManager.SpawnedObjects.TryGetValue(networkObjectRef.m_NetworkObjectId, out NetworkObject networkObject);
 


### PR DESCRIPTION
Allows `NetworkObjectReference`s and `NetworkBehaviourReference`s to be null

This PR implements this request: https://forum.unity.com/threads/networkobjectreference-cant-be-null-though-that-seems-like-a-perfectly-valid-use-case.1373304/ which has its own issues https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/2346 and https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/1693

This PR adds support for `NetworkObjectReference` and `NetworkBehaviourReference` to be null. References in C# are allowed to be null, this should also be supported in these primitives. It's common, even in networked communication, to have to pass a null value to a function denoting the absence of something.

The `nullId` used to represent `null` is `ulong.MaxValue` = ~1.8e19, which seems to be large enough to avoid collision with normal use cases or special cases requiring further validation.

## Changelog

- Added: support for `NetworkObjectReference` and `NetworkBehaviourReference` to be null, which in turn also allows passing null GameObjects or Behaviours to remote calls.

## Testing and Documentation

- No tests have been added.
