### PR TITLE
fix: NetworkTransformEditor error, when physics2D enabled, but physics disabled

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/NetworkTransformEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkTransformEditor.cs
@@ -150,9 +150,10 @@ namespace Unity.Netcode.Editor
             }
             EditorGUILayout.PropertyField(m_UseHalfFloatPrecision);
 
-#if COM_UNITY_MODULES_PHYSICS
             // if rigidbody is present but network rigidbody is not present
             var go = ((NetworkTransform)target).gameObject;
+
+#if COM_UNITY_MODULES_PHYSICS
             if (go.TryGetComponent<Rigidbody>(out _) && go.TryGetComponent<NetworkRigidbody>(out _) == false)
             {
                 EditorGUILayout.HelpBox("This GameObject contains a Rigidbody but no NetworkRigidbody.\n" +


### PR DESCRIPTION
Fixing `Library\PackageCache\com.unity.netcode.gameobjects@1.7.1\Editor\NetworkTransformEditor.cs(160,17): error CS0103: The name 'go' does not exist in the current context` when "physics" disabled in built-in packages, but "physics2D" enabled

## Changelog

- Fixed: declaration and initialization of "go" gameObject moved out of "physics" scope.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.