### PR TITLE
fix: Avoid duplicate RPC invocation on host

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotMeRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotMeRpcTarget.cs
@@ -49,6 +49,10 @@ namespace Unity.Netcode
                     {
                         continue;
                     }
+                    if (clientId == NetworkManager.ServerClientId)
+                    {
+                        continue;
+                    }
                     m_GroupSendTarget.Add(clientId);
                 }
             }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotOwnerRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotOwnerRpcTarget.cs
@@ -40,6 +40,10 @@ namespace Unity.Netcode
                     {
                         continue;
                     }
+                    if (clientId == NetworkManager.ServerClientId)
+                    {
+                        continue;
+                    }
                     if (clientId == behaviour.NetworkManager.LocalClientId)
                     {
                         m_LocalSendRpcTarget.Send(behaviour, ref message, delivery, rpcParams);
@@ -54,6 +58,10 @@ namespace Unity.Netcode
                 foreach (var clientId in m_NetworkManager.ConnectedClientsIds)
                 {
                     if (clientId == behaviour.OwnerClientId)
+                    {
+                        continue;
+                    }
+                    if (clientId == NetworkManager.ServerClientId)
                     {
                         continue;
                     }


### PR DESCRIPTION
Host acts as both client and server.
Both the client target and the server target points to same instance This results in two invocations on the host which is not expected Checking that the server is host and skipping the RpcTarget invocation we avoid this situation

[Host executes "Rpc NotMe" twice with each call (1.8.0)](https://jira.unity3d.com/browse/MTT-8142)

## Changelog

- Fixed: Avoid duplicate RPC invocation on host

## Testing and Documentation

- Expanded test coverage to include invocation count in RPC test suite