### PR TITLE
fix: Freeze rigidbody on Awake and interpolate based on ownership

### DIFF
--- a/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
@@ -29,15 +29,25 @@ namespace Unity.Netcode.Components
             m_NetworkTransform = GetComponent<NetworkTransform>();
             m_IsServerAuthoritative = m_NetworkTransform.IsServerAuthoritative();
 
+            SetupRigidBody();
+        }
+
+        /// <summary>
+        /// If the current <see cref="NetworkTransform"/> has authority,
+        /// then use the <see cref="RigidBody"/> interpolation strategy,
+        /// if the <see cref="NetworkTransform"/> is handling interpolation,
+        /// set interpolation to none on the <see cref="RigidBody"/>
+        /// <br/>
+        /// Turn off physics for the rigid body until spawned, otherwise
+        /// clients can run fixed update before the first
+        /// full <see cref="NetworkTransform"/> update
+        /// </summary>
+        private void SetupRigidBody()
+        {
             m_Rigidbody = GetComponent<Rigidbody>();
             m_OriginalInterpolation = m_Rigidbody.interpolation;
 
-            // Set interpolation to none if NetworkTransform is handling interpolation, otherwise it sets it to the original value
-            m_Rigidbody.interpolation = m_NetworkTransform.Interpolate ? RigidbodyInterpolation.None : m_OriginalInterpolation;
-
-            // Turn off physics for the rigid body until spawned, otherwise
-            // clients can run fixed update before the first full
-            // NetworkTransform update
+            m_Rigidbody.interpolation = m_IsAuthority ? m_OriginalInterpolation : (m_NetworkTransform.Interpolate ? RigidbodyInterpolation.None : m_OriginalInterpolation);
             m_Rigidbody.isKinematic = true;
         }
 

--- a/com.unity.netcode.gameobjects/Components/NetworkRigidbody2D.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkRigidbody2D.cs
@@ -30,6 +30,11 @@ namespace Unity.Netcode.Components
         {
             m_Rigidbody = GetComponent<Rigidbody2D>();
             m_NetworkTransform = GetComponent<NetworkTransform>();
+
+            // Turn off physics for the rigid body until spawned, otherwise
+            // clients can run fixed update before the first full
+            // NetworkTransform update
+            m_Rigidbody.isKinematic = true;
         }
 
         private void FixedUpdate()


### PR DESCRIPTION
NetworkRigidbody is not checking for NetworkTransform.Interpolate value on ownership loss as it does on Awake, so it assumes that the NetworkTransform will treat the interpolation even if NetworkTransform.Interpolate is false.

NetworkRigibody sets kinematic on a NetworkObject's Rigidbody before it is spawned (on Awake) to prevent the transform from being changed before knowing the actual ownership of the object. NetworkRigidbody2D follows the same pattern

## Changelog

- Fixed: [GH-2836] NetworkRigidbody is not checking for NetworkTransform.Interpolate value on ownership change 
- Fixed: [GH-2835] NetworkRigidbody2D not freezing object on Awake as NetworkRigidbody does