### PR TITLE
fix: NetworkTransform synchronize position when half float precision is enabled

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,7 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where NetworkTransform could not properly synchronize its base position when using half float precision.
+- Fixed issue where `NetworkTransform` could not properly synchronize its base position when using half float precision. (#2845)
 - Fixed issue where the host was not invoking `OnClientDisconnectCallback` for its own local client when internally shutting down. (#2822)
 - Fixed issue where NetworkTransform could potentially attempt to "unregister" a named message prior to it being registered. (#2807)
 - Fixed issue where in-scene placed `NetworkObject`s with complex nested children `NetworkObject`s (more than one child in depth) would not synchronize properly if WorldPositionStays was set to true. (#2796)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where NetworkTransform could not properly synchronize its base position when using half float precision.
 - Fixed issue where the host was not invoking `OnClientDisconnectCallback` for its own local client when internally shutting down. (#2822)
 - Fixed issue where NetworkTransform could potentially attempt to "unregister" a named message prior to it being registered. (#2807)
 - Fixed issue where in-scene placed `NetworkObject`s with complex nested children `NetworkObject`s (more than one child in depth) would not synchronize properly if WorldPositionStays was set to true. (#2796)
@@ -20,6 +21,13 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 - Changed `NetworkTransform` to now use `NetworkTransformMessage` as opposed to named messages for NetworkTransformState updates. (#2810)
 - Changed `CustomMessageManager` so it no longer attempts to register or "unregister" a null or empty string and will log an error if this condition occurs. (#2807)
+
+## [1.8.1] - 2024-02-05
+
+### Fixed
+
+- Fixed a compile error when compiling for IL2CPP targets when using the new `[Rpc]` attribute. (#2824)
+
 
 ## [1.8.0] - 2023-12-12
 

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -1424,6 +1424,7 @@ namespace Unity.Netcode.Components
         /// <param name="targetClientId">the clientId being synchronized (both reading and writing)</param>
         protected override void OnSynchronize<T>(ref BufferSerializer<T> serializer)
         {
+            m_CachedNetworkManager = NetworkManager;
             var targetClientId = m_TargetIdBeingSynchronized;
             var synchronizationState = new NetworkTransformState()
             {
@@ -2750,6 +2751,11 @@ namespace Unity.Netcode.Components
             m_CachedNetworkManager = NetworkManager;
 
             Initialize();
+
+            if (CanCommitToTransform && UseHalfFloatPrecision)
+            {
+                SetState(GetSpaceRelativePosition(), GetSpaceRelativeRotation(), GetScale(), false);
+            }
         }
 
         /// <inheritdoc/>

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformPacketLossTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformPacketLossTests.cs
@@ -54,15 +54,21 @@ namespace Unity.Netcode.RuntimeTests
             // We don't assert on timeout here because we want to log this information during PostAllChildrenLocalTransformValuesMatch
             yield return WaitForConditionOrTimeOut(() => AllInstancesKeptLocalTransformValues(useSubChild));
             var success = true;
-            m_InfoMessage.AppendLine($"[{checkType}][{useSubChild}] Timed out waiting for all children to have the correct local space values:\n");
             if (s_GlobalTimeoutHelper.TimedOut)
             {
                 var waitForMs = new WaitForSeconds(0.001f);
                 // If we timed out, then wait for a full range of ticks to assure all data has been synchronized before declaring this a failed test.
                 for (int j = 0; j < m_ServerNetworkManager.NetworkConfig.TickRate; j++)
                 {
+                    m_InfoMessage.Clear();
+                    m_InfoMessage.AppendLine($"[{checkType}][{useSubChild}] Timed out waiting for all children to have the correct local space values:\n");
                     var instances = useSubChild ? ChildObjectComponent.SubInstances : ChildObjectComponent.Instances;
                     success = PostAllChildrenLocalTransformValuesMatch(useSubChild);
+                    // If we pass, then exit loop
+                    if (success)
+                    {
+                        break;
+                    }
                     yield return waitForMs;
                 }
             }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -1210,7 +1210,7 @@ namespace Unity.Netcode.RuntimeTests
 
         private void TestValueTypeNativeArray<T>(NativeArray<T> testValue, NativeArray<T> changedValue) where T : unmanaged
         {
-            Debug.Log($"Changing {ArrayStr(testValue)} to {ArrayStr(changedValue)}");
+            VerboseDebug($"Changing {ArrayStr(testValue)} to {ArrayStr(changedValue)}");
             var serverVariable = new NetworkVariable<NativeArray<T>>(testValue);
             var clientVariable = new NetworkVariable<NativeArray<T>>(new NativeArray<T>(1, Allocator.Persistent));
             using var writer = new FastBufferWriter(1024, Allocator.Temp, int.MaxValue);
@@ -1277,7 +1277,7 @@ namespace Unity.Netcode.RuntimeTests
 
         private void TestList<T>(List<T> testValue, List<T> changedValue)
         {
-            Debug.Log($"Changing {ListStr(testValue)} to {ListStr(changedValue)}");
+            VerboseDebug($"Changing {ListStr(testValue)} to {ListStr(changedValue)}");
             var serverVariable = new NetworkVariable<List<T>>(testValue);
             var inPlaceList = new List<T>();
             var clientVariable = new NetworkVariable<List<T>>(inPlaceList);
@@ -1341,7 +1341,7 @@ namespace Unity.Netcode.RuntimeTests
 
         private void TestHashSet<T>(HashSet<T> testValue, HashSet<T> changedValue) where T : IEquatable<T>
         {
-            Debug.Log($"Changing {HashSetStr(testValue)} to {HashSetStr(changedValue)}");
+            VerboseDebug($"Changing {HashSetStr(testValue)} to {HashSetStr(changedValue)}");
             var serverVariable = new NetworkVariable<HashSet<T>>(testValue);
             var inPlaceList = new HashSet<T>();
             var clientVariable = new NetworkVariable<HashSet<T>>(inPlaceList);
@@ -1409,7 +1409,7 @@ namespace Unity.Netcode.RuntimeTests
         private void TestDictionary<TKey, TVal>(Dictionary<TKey, TVal> testValue, Dictionary<TKey, TVal> changedValue)
             where TKey : IEquatable<TKey>
         {
-            Debug.Log($"Changing {DictionaryStr(testValue)} to {DictionaryStr(changedValue)}");
+            VerboseDebug($"Changing {DictionaryStr(testValue)} to {DictionaryStr(changedValue)}");
             var serverVariable = new NetworkVariable<Dictionary<TKey, TVal>>(testValue);
             var inPlaceList = new Dictionary<TKey, TVal>();
             var clientVariable = new NetworkVariable<Dictionary<TKey, TVal>>(inPlaceList);
@@ -1480,7 +1480,7 @@ namespace Unity.Netcode.RuntimeTests
 
         private void TestValueTypeNativeList<T>(NativeList<T> testValue, NativeList<T> changedValue) where T : unmanaged
         {
-            Debug.Log($"Changing {NativeListStr(testValue)} to {NativeListStr(changedValue)}");
+            VerboseDebug($"Changing {NativeListStr(testValue)} to {NativeListStr(changedValue)}");
             var serverVariable = new NetworkVariable<NativeList<T>>(testValue);
             var inPlaceList = new NativeList<T>(1, Allocator.Temp);
             var clientVariable = new NetworkVariable<NativeList<T>>(inPlaceList);
@@ -1548,7 +1548,7 @@ namespace Unity.Netcode.RuntimeTests
 
         private void TestValueTypeNativeHashSet<T>(NativeHashSet<T> testValue, NativeHashSet<T> changedValue) where T : unmanaged, IEquatable<T>
         {
-            Debug.Log($"Changing {NativeHashSetStr(testValue)} to {NativeHashSetStr(changedValue)}");
+            VerboseDebug($"Changing {NativeHashSetStr(testValue)} to {NativeHashSetStr(changedValue)}");
             var serverVariable = new NetworkVariable<NativeHashSet<T>>(testValue);
             var inPlaceList = new NativeHashSet<T>(1, Allocator.Temp);
             var clientVariable = new NetworkVariable<NativeHashSet<T>>(inPlaceList);
@@ -1623,7 +1623,7 @@ namespace Unity.Netcode.RuntimeTests
             where TKey : unmanaged, IEquatable<TKey>
             where TVal : unmanaged
         {
-            Debug.Log($"Changing {NativeHashMapStr(testValue)} to {NativeHashMapStr(changedValue)}");
+            VerboseDebug($"Changing {NativeHashMapStr(testValue)} to {NativeHashMapStr(changedValue)}");
             var serverVariable = new NetworkVariable<NativeHashMap<TKey, TVal>>(testValue);
             var inPlaceList = new NativeHashMap<TKey, TVal>(1, Allocator.Temp);
             var clientVariable = new NetworkVariable<NativeHashMap<TKey, TVal>>(inPlaceList);
@@ -2166,10 +2166,10 @@ namespace Unity.Netcode.RuntimeTests
                 changed2[originalSize + i] = item;
             }
 
-            Debug.Log($"Original: {ArrayStr(original)}");
-            Debug.Log($"Changed: {ArrayStr(changed)}");
-            Debug.Log($"Original2: {ArrayStr(original2)}");
-            Debug.Log($"Changed2: {ArrayStr(changed2)}");
+            VerboseDebug($"Original: {ArrayStr(original)}");
+            VerboseDebug($"Changed: {ArrayStr(changed)}");
+            VerboseDebug($"Original2: {ArrayStr(original2)}");
+            VerboseDebug($"Changed2: {ArrayStr(changed2)}");
             return (original, original2, changed, changed2);
         }
 
@@ -2461,10 +2461,10 @@ namespace Unity.Netcode.RuntimeTests
 
             }
 
-            Debug.Log($"Original: {ListStr(original)}");
-            Debug.Log($"Changed: {ListStr(changed)}");
-            Debug.Log($"Original2: {ListStr(original2)}");
-            Debug.Log($"Changed2: {ListStr(changed2)}");
+            VerboseDebug($"Original: {ListStr(original)}");
+            VerboseDebug($"Changed: {ListStr(changed)}");
+            VerboseDebug($"Original2: {ListStr(original2)}");
+            VerboseDebug($"Changed2: {ListStr(changed2)}");
             return (original, original2, changed, changed2);
         }
 
@@ -2528,10 +2528,10 @@ namespace Unity.Netcode.RuntimeTests
                 changed2.Add(item);
             }
 
-            Debug.Log($"Original: {HashSetStr(original)}");
-            Debug.Log($"Changed: {HashSetStr(changed)}");
-            Debug.Log($"Original2: {HashSetStr(original2)}");
-            Debug.Log($"Changed2: {HashSetStr(changed2)}");
+            VerboseDebug($"Original: {HashSetStr(original)}");
+            VerboseDebug($"Changed: {HashSetStr(changed)}");
+            VerboseDebug($"Original2: {HashSetStr(original2)}");
+            VerboseDebug($"Changed2: {HashSetStr(changed2)}");
             return (original, original2, changed, changed2);
         }
 
@@ -2619,10 +2619,10 @@ namespace Unity.Netcode.RuntimeTests
                 changed2.Add(key, val);
             }
 
-            Debug.Log($"Original: {DictionaryStr(original)}");
-            Debug.Log($"Changed: {DictionaryStr(changed)}");
-            Debug.Log($"Original2: {DictionaryStr(original2)}");
-            Debug.Log($"Changed2: {DictionaryStr(changed2)}");
+            VerboseDebug($"Original: {DictionaryStr(original)}");
+            VerboseDebug($"Changed: {DictionaryStr(changed)}");
+            VerboseDebug($"Original2: {DictionaryStr(original2)}");
+            VerboseDebug($"Changed2: {DictionaryStr(changed2)}");
             return (original, original2, changed, changed2);
         }
 
@@ -3908,10 +3908,10 @@ namespace Unity.Netcode.RuntimeTests
 
             }
 
-            Debug.Log($"Original: {NativeListStr(original)}");
-            Debug.Log($"Changed: {NativeListStr(changed)}");
-            Debug.Log($"Original2: {NativeListStr(original2)}");
-            Debug.Log($"Changed2: {NativeListStr(changed2)}");
+            VerboseDebug($"Original: {NativeListStr(original)}");
+            VerboseDebug($"Changed: {NativeListStr(changed)}");
+            VerboseDebug($"Original2: {NativeListStr(original2)}");
+            VerboseDebug($"Changed2: {NativeListStr(changed2)}");
             return (original, original2, changed, changed2);
         }
 
@@ -3975,10 +3975,10 @@ namespace Unity.Netcode.RuntimeTests
                 changed2.Add(item);
             }
 
-            Debug.Log($"Original: {NativeHashSetStr(original)}");
-            Debug.Log($"Changed: {NativeHashSetStr(changed)}");
-            Debug.Log($"Original2: {NativeHashSetStr(original2)}");
-            Debug.Log($"Changed2: {NativeHashSetStr(changed2)}");
+            VerboseDebug($"Original: {NativeHashSetStr(original)}");
+            VerboseDebug($"Changed: {NativeHashSetStr(changed)}");
+            VerboseDebug($"Original2: {NativeHashSetStr(original2)}");
+            VerboseDebug($"Changed2: {NativeHashSetStr(changed2)}");
             return (original, original2, changed, changed2);
         }
 
@@ -4067,10 +4067,10 @@ namespace Unity.Netcode.RuntimeTests
                 changed2.Add(key, val);
             }
 
-            Debug.Log($"Original: {NativeHashMapStr(original)}");
-            Debug.Log($"Changed: {NativeHashMapStr(changed)}");
-            Debug.Log($"Original2: {NativeHashMapStr(original2)}");
-            Debug.Log($"Changed2: {NativeHashMapStr(changed2)}");
+            VerboseDebug($"Original: {NativeHashMapStr(original)}");
+            VerboseDebug($"Changed: {NativeHashMapStr(changed)}");
+            VerboseDebug($"Original2: {NativeHashMapStr(original2)}");
+            VerboseDebug($"Changed2: {NativeHashMapStr(changed2)}");
             return (original, original2, changed, changed2);
         }
 


### PR DESCRIPTION
Resolves an issue discovered internally where under certain conditions the base position used when half float precision is enabled could not get properly synchronized.

## Changelog

- Fixed: Issue where `NetworkTransform` could not properly synchronize its base position when using half float precision.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.


