### PR TITLE
chore: add develop 2.0.0 to triggers and conventional pr

### DIFF
--- a/.github/workflows/autoupdate.yaml
+++ b/.github/workflows/autoupdate.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - develop
+      - develop-2.0.0
 jobs:
   autoupdate:
     name: auto-update

--- a/.github/workflows/autoupdate.yaml
+++ b/.github/workflows/autoupdate.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - develop-2.0.0
 jobs:
   autoupdate:
     name: auto-update

--- a/.github/workflows/autoupdate.yaml
+++ b/.github/workflows/autoupdate.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - develop
+      - "develop-2.0.0"
 jobs:
   autoupdate:
     name: auto-update

--- a/.github/workflows/autoupdate.yaml
+++ b/.github/workflows/autoupdate.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - develop
-      - "develop-2.0.0"
+      - develop-2.0.0
 jobs:
   autoupdate:
     name: auto-update

--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches:
     - develop
-
+    - develop-2.0.0
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"

--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
     - develop
+    - develop-2.0.0
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     branches:
     - develop
-    - develop-2.0.0
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -62,6 +62,7 @@ pull_request_trigger:
         only:
           - "master"
           - "develop"
+          - "develop-2.0.0"
           - "/release\/.*/"
           
 # Currently, we need to have a trigger to updated badges

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -62,7 +62,6 @@ pull_request_trigger:
         only:
           - "master"
           - "develop"
-          - "develop-2.0.0"
           - "/release\/.*/"
           
 # Currently, we need to have a trigger to updated badges


### PR DESCRIPTION
Adding NGO v2.0,0 develop branch to conventional prs and triggers.
This will be the working develop branch for 2.0 related changes  until NGO v2.0.0's first release at which time (or prior to) we will determine if we want to merge everything into develop and remove the develop-2.0.0 branch.

## Changelog
NA

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
