### PR TITLE
Use slough artifactory in CI Part 2

### DIFF
--- a/.yamato/mobile-build-and-test.yml
+++ b/.yamato/mobile-build-and-test.yml
@@ -12,7 +12,7 @@ build_{{ project.name }}_tests_{{ editor }}_android:
       flavor: b1.xlarge
   commands:
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
-    - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
+    - curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
     - python .yamato/disable-burst-if-requested.py --project-path testproject --platform Android
     - unity-downloader-cli -u {{ editor }} -c editor -c Android -w --fast
     - |
@@ -51,7 +51,7 @@ build_{{ project.name }}_tests_{{ editor }}_iOS:
   commands:
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - unity-downloader-cli -u {{ editor }} -c editor -c iOS -w --fast
-    - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+    - curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
     - chmod +x ./utr
     - export UTR_VERSION=0.12.0
     - ./utr --artifacts_path=artifacts --timeout=1800 --testproject={{ project.name }} --editor-location=.Editor --suite=playmode --platform=iOS --build-only --player-save-path=build/players --extra-editor-arg=-batchmode --extra-editor-arg=-nographics --testfilter=Unity.Netcode.RuntimeTests
@@ -88,7 +88,7 @@ run_{{ project.name }}_tests_{{ editor }}_iOS:
     - .yamato/mobile-build-and-test.yml#build_{{ project.name }}_tests_{{ editor }}_iOS
   commands:
     # Download standalone UnityTestRunner
-    - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+    - curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
     # Give UTR execution permissions
     - chmod +x ./utr
     # Run the test build on the device
@@ -127,7 +127,7 @@ run_{{ project.name }}_tests_{{ editor }}_android:
   dependencies:
     - .yamato/mobile-build-and-test.yml#build_{{ project.name }}_tests_{{ editor }}_android
   commands:
-    - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
+    - curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
     - |
        set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
        start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%

--- a/.yamato/multiprocess-project-tests.yml
+++ b/.yamato/multiprocess-project-tests.yml
@@ -15,7 +15,7 @@ singlenode_multiprocess_test_testproject_{{ editor }}_{{ platform.name }}:
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
 {% if editor != "trunk" %}
     - unity-downloader-cli -u {{ editor }} -c editor -w --fast
-    - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr{% if platform.name == "win" %}.bat --output utr.bat{% endif %}{% if platform.name != "win" %} --output utr && chmod +x ./utr{% endif %}
+    - curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr{% if platform.name == "win" %}.bat --output utr.bat{% endif %}{% if platform.name != "win" %} --output utr && chmod +x ./utr{% endif %}
     - {{ platform.editorpath }} -projectpath testproject -batchmode -quit -nographics -logfile BuildMultiprocessTestPlayer.log -executeMethod Unity.Netcode.MultiprocessRuntimeTests.BuildMultiprocessTestPlayer.BuildRelease
 {% if platform.name == "mac" %}    -  sudo codesign --force --deep --sign - ./testproject/Builds/MultiprocessTests/MultiprocessTestPlayer.app{% endif %}
     - {{ platform.utr }} --suite=playmode --testproject=testproject --editor-location=.Editor --testfilter=Unity.Netcode.MultiprocessRuntimeTests --extra-editor-arg=-bypassIgnoreUTR

--- a/.yamato/standalone-project-tests.yml
+++ b/.yamato/standalone-project-tests.yml
@@ -16,7 +16,7 @@ standalone_tests_{{ project.name }}_{{ backend }}_{{ editor }}_{{ platform.name 
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
-    - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr{% if platform.name == "win" %}.bat{% endif %} --output utr{% if platform.name == "win" %}.bat{% endif %}
+    - curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr{% if platform.name == "win" %}.bat{% endif %} --output utr{% if platform.name == "win" %}.bat{% endif %}
 {% if platform.name != "win" %}
     - chmod +x ./utr
 {% endif %}

--- a/.yamato/webgl-build.yml
+++ b/.yamato/webgl-build.yml
@@ -12,7 +12,7 @@ build_{{ project.name }}_tests_{{ editor }}_webgl:
       flavor: b1.xlarge
   commands:
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
-    - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
+    - curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
     - python .yamato/disable-burst-if-requested.py --project-path testproject --platform WebGL
     - unity-downloader-cli -u {{ editor }} -c editor -c webgl -c il2cpp -w --fast
     - |


### PR DESCRIPTION
There's an ongoing incident in [#incident-2024-03-25-1](https://unity.enterprise.slack.com/archives/C06R0T5V18E) that is causing timeouts for IT Artifactory. 

This PR is part of a series of updates where we try to reduce the load on artifactory as well as lowering the risk of Yamato jobs timing out by relying on it less.

Slough artifactory is useful because it is an artifactory instance in the same datacenter as the vms the Yamato jobs run on.


This PR specifically addresses:
* UTR script downloads from IT artifactory have been replaced with slough artifactory.


This PR is auto generated so the results is probably pretty dumb. 


If something looks strange then please help it along by correcting anything that is incorrect or missing.

[_Created by Sourcegraph batch change `henrikp/utr-slough-artifactory`._](https://sourcegraph.ds.unity3d.com/users/henrikp/batch-changes/utr-slough-artifactory)