### PR TITLE
chore: migrate 2830 allow null references in NetworkBehaviourReference and NetworkObjectReference

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -32,7 +32,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
-- Changed `NetworkObjectReference` and `NetworkBehaviourReference` can handle null references. (#2874)
+- Changed `NetworkObjectReference` and `NetworkBehaviourReference` to allow null references when constructing and serializing. (#2874)
 - Changed `NetworkAnimator` no longer requires the `Animator` component to exist on the same `GameObject`. (#2872)
 - Changed `NetworkTransform` to now use `NetworkTransformMessage` as opposed to named messages for NetworkTransformState updates. (#2810)
 - Changed `CustomMessageManager` so it no longer attempts to register or "unregister" a null or empty string and will log an error if this condition occurs. (#2807)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -32,6 +32,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+- Changed `NetworkObjectReference` and `NetworkBehaviourReference` can handle null references. (#2874)
 - Changed `NetworkAnimator` no longer requires the `Animator` component to exist on the same `GameObject`. (#2872)
 - Changed `NetworkTransform` to now use `NetworkTransformMessage` as opposed to named messages for NetworkTransformState updates. (#2810)
 - Changed `CustomMessageManager` so it no longer attempts to register or "unregister" a null or empty string and will log an error if this condition occurs. (#2807)

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/NetworkBehaviourReference.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/NetworkBehaviourReference.cs
@@ -11,7 +11,7 @@ namespace Unity.Netcode
     {
         private NetworkObjectReference m_NetworkObjectReference;
         private ushort m_NetworkBehaviourId;
-        private static ulong nullId = ulong.MaxValue;
+        private static ushort s_NullId = ushort.MaxValue;
 
         /// <summary>
         /// Creates a new instance of the <see cref="NetworkBehaviourReference{T}"/> struct.
@@ -23,7 +23,7 @@ namespace Unity.Netcode
             if (networkBehaviour == null)
             {
                 m_NetworkObjectReference = new NetworkObjectReference((NetworkObject)null);
-                m_NetworkBehaviourId = nullId;
+                m_NetworkBehaviourId = s_NullId;
                 return;
             }
             if (networkBehaviour.NetworkObject == null)
@@ -63,8 +63,10 @@ namespace Unity.Netcode
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static NetworkBehaviour GetInternal(NetworkBehaviourReference networkBehaviourRef, NetworkManager networkManager = null)
         {
-            if (m_NetworkBehaviourId == nullId)
+            if (networkBehaviourRef.m_NetworkBehaviourId == s_NullId)
+            {
                 return null;
+            }
             if (networkBehaviourRef.m_NetworkObjectReference.TryGet(out NetworkObject networkObject, networkManager))
             {
                 return networkObject.GetNetworkBehaviourAtOrderIndex(networkBehaviourRef.m_NetworkBehaviourId);

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/NetworkBehaviourReference.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/NetworkBehaviourReference.cs
@@ -11,6 +11,7 @@ namespace Unity.Netcode
     {
         private NetworkObjectReference m_NetworkObjectReference;
         private ushort m_NetworkBehaviourId;
+        private static ulong nullId = ulong.MaxValue;
 
         /// <summary>
         /// Creates a new instance of the <see cref="NetworkBehaviourReference{T}"/> struct.
@@ -21,7 +22,9 @@ namespace Unity.Netcode
         {
             if (networkBehaviour == null)
             {
-                throw new ArgumentNullException(nameof(networkBehaviour));
+                m_NetworkObjectReference = new NetworkObjectReference((NetworkObject)null);
+                m_NetworkBehaviourId = nullId;
+                return;
             }
             if (networkBehaviour.NetworkObject == null)
             {
@@ -60,6 +63,8 @@ namespace Unity.Netcode
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static NetworkBehaviour GetInternal(NetworkBehaviourReference networkBehaviourRef, NetworkManager networkManager = null)
         {
+            if (m_NetworkBehaviourId == nullId)
+                return null;
             if (networkBehaviourRef.m_NetworkObjectReference.TryGet(out NetworkObject networkObject, networkManager))
             {
                 return networkObject.GetNetworkBehaviourAtOrderIndex(networkBehaviourRef.m_NetworkBehaviourId);

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/NetworkObjectReference.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/NetworkObjectReference.cs
@@ -10,7 +10,7 @@ namespace Unity.Netcode
     public struct NetworkObjectReference : INetworkSerializable, IEquatable<NetworkObjectReference>
     {
         private ulong m_NetworkObjectId;
-        private static ulong nullId = ulong.MaxValue;
+        private static ulong s_NullId = ulong.MaxValue;
 
         /// <summary>
         /// The <see cref="NetworkObject.NetworkObjectId"/> of the referenced <see cref="NetworkObject"/>.
@@ -30,7 +30,7 @@ namespace Unity.Netcode
         {
             if (networkObject == null)
             {
-                m_NetworkObjectId = nullId;
+                m_NetworkObjectId = s_NullId;
                 return;
             }
 
@@ -51,12 +51,12 @@ namespace Unity.Netcode
         {
             if (gameObject == null)
             {
-                m_NetworkObjectId = nullId;
+                m_NetworkObjectId = s_NullId;
                 return;
             }
 
             var networkObject = gameObject.GetComponent<NetworkObject>();
-            if (networkObject == null)
+            if (!networkObject)
             {
                 throw new ArgumentException($"Cannot create {nameof(NetworkObjectReference)} from {nameof(GameObject)} without a {nameof(NetworkObject)} component.");
             }
@@ -89,8 +89,10 @@ namespace Unity.Netcode
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static NetworkObject Resolve(NetworkObjectReference networkObjectRef, NetworkManager networkManager = null)
         {
-            if (networkObjectRef.m_NetworkObjectId == nullId)
+            if (networkObjectRef.m_NetworkObjectId == s_NullId)
+            {
                 return null;
+            }
             networkManager = networkManager ?? NetworkManager.Singleton;
             networkManager.SpawnManager.SpawnedObjects.TryGetValue(networkObjectRef.m_NetworkObjectId, out NetworkObject networkObject);
 

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/NetworkObjectReference.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/NetworkObjectReference.cs
@@ -10,6 +10,7 @@ namespace Unity.Netcode
     public struct NetworkObjectReference : INetworkSerializable, IEquatable<NetworkObjectReference>
     {
         private ulong m_NetworkObjectId;
+        private static ulong nullId = ulong.MaxValue;
 
         /// <summary>
         /// The <see cref="NetworkObject.NetworkObjectId"/> of the referenced <see cref="NetworkObject"/>.
@@ -24,13 +25,13 @@ namespace Unity.Netcode
         /// Creates a new instance of the <see cref="NetworkObjectReference"/> struct.
         /// </summary>
         /// <param name="networkObject">The <see cref="NetworkObject"/> to reference.</param>
-        /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
         public NetworkObjectReference(NetworkObject networkObject)
         {
             if (networkObject == null)
             {
-                throw new ArgumentNullException(nameof(networkObject));
+                m_NetworkObjectId = nullId;
+                return;
             }
 
             if (networkObject.IsSpawned == false)
@@ -45,16 +46,20 @@ namespace Unity.Netcode
         /// Creates a new instance of the <see cref="NetworkObjectReference"/> struct.
         /// </summary>
         /// <param name="gameObject">The GameObject from which the <see cref="NetworkObject"/> component will be referenced.</param>
-        /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
         public NetworkObjectReference(GameObject gameObject)
         {
             if (gameObject == null)
             {
-                throw new ArgumentNullException(nameof(gameObject));
+                m_NetworkObjectId = nullId;
+                return;
             }
 
-            var networkObject = gameObject.GetComponent<NetworkObject>() ?? throw new ArgumentException($"Cannot create {nameof(NetworkObjectReference)} from {nameof(GameObject)} without a {nameof(NetworkObject)} component.");
+            var networkObject = gameObject.GetComponent<NetworkObject>();
+            if (networkObject == null)
+            {
+                throw new ArgumentException($"Cannot create {nameof(NetworkObjectReference)} from {nameof(GameObject)} without a {nameof(NetworkObject)} component.");
+            }
             if (networkObject.IsSpawned == false)
             {
                 throw new ArgumentException($"{nameof(NetworkObjectReference)} can only be created from spawned {nameof(NetworkObject)}s.");
@@ -80,10 +85,12 @@ namespace Unity.Netcode
         /// </summary>
         /// <param name="networkObjectRef">The reference.</param>
         /// <param name="networkManager">The networkmanager. Uses <see cref="NetworkManager.Singleton"/> to resolve if null.</param>
-        /// <returns>The resolves <see cref="NetworkObject"/>. Returns null if the networkobject was not found</returns>
+        /// <returns>The resolved <see cref="NetworkObject"/>. Returns null if the networkobject was not found</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static NetworkObject Resolve(NetworkObjectReference networkObjectRef, NetworkManager networkManager = null)
         {
+            if (networkObjectRef.m_NetworkObjectId == nullId)
+                return null;
             networkManager = networkManager ?? NetworkManager.Singleton;
             networkManager.SpawnManager.SpawnedObjects.TryGetValue(networkObjectRef.m_NetworkObjectId, out NetworkObject networkObject);
 


### PR DESCRIPTION
This PR migrates #2830 to the public repository.

## Changelog

- Changed: `NetworkObjectReference` and `NetworkBehaviourReference` to allow null references when constructing and serializing.

## Testing and Documentation

- Includes integration tests.
- No documentation changes or additions were necessary.

