### PR TITLE
fix: universal rpc test timeout

### DIFF
--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -1,5 +1,5 @@
-validation_editor: 2021.3
-mobile_validation_editor: 2021.3
+validation_editor: 2022.3
+mobile_validation_editor: 2022.3
 
 # Platforms that will be tested. The first entry in this array will also
 # be used for validation
@@ -42,10 +42,7 @@ projects:
       - name: com.unity.netcode.gameobjects
         path: com.unity.netcode.gameobjects
     test_editors:
-      - 2021.3
-      - 2022.2
-      - 2023.1
-      - trunk
+      - 2022.3
   - name: minimalproject
     path: minimalproject
     validate: false
@@ -55,24 +52,21 @@ projects:
       - name: com.unity.netcode.gameobjects
         path: com.unity.netcode.gameobjects
     test_editors:
-      - 2021.3
+      - 2022.3
   - name: testproject-tools-integration
     path: testproject-tools-integration
     validate: false
     publish: false
     has_tests: true
     test_editors:
-      - 2021.3
-      - 2022.2
-      - trunk
+      - 2022.3
 
 # Package dependencies
 dependencies: 
   - name: com.unity.transport
     version: 2.0.0-pre.2
     test_editors:
-      - 2022.2
-      - trunk
+      - 2022.3
 
 # Scripting backends used by Standalone Playmode Tests
 scripting_backends: 

--- a/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
@@ -222,7 +222,7 @@ namespace Unity.Netcode.Editor
         private void DrawTransportField()
         {
 #if RELAY_INTEGRATION_AVAILABLE
-            var useRelay = EditorPrefs.GetBool(k_UseEasyRelayIntegrationKey, false);
+            var useRelay = EditorPrefs.GetBool(m_UseEasyRelayIntegrationKey, false);
 #else
             var useRelay = false;
 #endif
@@ -257,7 +257,7 @@ namespace Unity.Netcode.Editor
         }
 
 #if RELAY_INTEGRATION_AVAILABLE
-        private readonly string k_UseEasyRelayIntegrationKey = "NetworkManagerUI_UseRelay_" + Application.dataPath.GetHashCode();
+        private readonly string m_UseEasyRelayIntegrationKey = "NetworkManagerUI_UseRelay_" + Application.dataPath.GetHashCode();
         private string m_JoinCode = "";
         private string m_StartConnectionError = null;
         private string m_Region = "";
@@ -272,7 +272,7 @@ namespace Unity.Netcode.Editor
 
 #if RELAY_INTEGRATION_AVAILABLE
             // use editor prefs to persist the setting when entering / leaving play mode / exiting Unity
-            var useRelay = EditorPrefs.GetBool(k_UseEasyRelayIntegrationKey, false);
+            var useRelay = EditorPrefs.GetBool(m_UseEasyRelayIntegrationKey, false);
             GUILayout.BeginHorizontal();
             useRelay = GUILayout.Toggle(useRelay, "Try Relay in the Editor");
 
@@ -284,7 +284,7 @@ namespace Unity.Netcode.Editor
             }
             GUILayout.EndHorizontal();
 
-            EditorPrefs.SetBool(k_UseEasyRelayIntegrationKey, useRelay);
+            EditorPrefs.SetBool(m_UseEasyRelayIntegrationKey, useRelay);
             if (useRelay && !Application.isPlaying && !CloudProjectSettings.projectBound)
             {
                 EditorGUILayout.HelpBox("To use relay, you need to setup your project in the Project Settings in the Services section.", MessageType.Warning);

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageCorruptionTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageCorruptionTests.cs
@@ -92,7 +92,7 @@ namespace Unity.Netcode.EditorTests
                     case TypeOfCorruption.CorruptBytes:
                         {
                             batchData.Seek(batchData.Length - 4);
-                            for (int i = 0;i < 4; i++)
+                            for (int i = 0; i < 4; i++)
                             {
                                 var currentByte = batchData.GetUnsafePtr()[i];
                                 batchData.WriteByteSafe((byte)(currentByte == 0 ? 1 : 0));

--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageCorruptionTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageCorruptionTests.cs
@@ -90,11 +90,16 @@ namespace Unity.Netcode.EditorTests
                             break;
                         }
                     case TypeOfCorruption.CorruptBytes:
-                        batchData.Seek(batchData.Length - 2);
-                        var currentByte = batchData.GetUnsafePtr()[0];
-                        batchData.WriteByteSafe((byte)(currentByte == 0 ? 1 : 0));
-                        MessageQueue.Add(batchData.ToArray());
-                        break;
+                        {
+                            batchData.Seek(batchData.Length - 4);
+                            for (int i = 0;i < 4; i++)
+                            {
+                                var currentByte = batchData.GetUnsafePtr()[i];
+                                batchData.WriteByteSafe((byte)(currentByte == 0 ? 1 : 0));
+                                MessageQueue.Add(batchData.ToArray());
+                            }
+                            break;
+                        }
                     case TypeOfCorruption.Truncated:
                         batchData.Truncate(batchData.Length - 1);
                         MessageQueue.Add(batchData.ToArray());

--- a/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
@@ -1285,6 +1285,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             List
         }
 
+        [Timeout(360000)]
         [UnityTest]
         public IEnumerator TestSendingWithGroupOverride()
         {
@@ -1378,6 +1379,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             List
         }
 
+        [Timeout(360000)]
         [UnityTest]
         public IEnumerator TestSendingWithGroupNotOverride()
         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
@@ -1285,6 +1285,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             List
         }
 
+        // Extending timeout since the added yield return causes this test to commonly timeout
         [Timeout(360000)]
         [UnityTest]
         public IEnumerator TestSendingWithGroupOverride()
@@ -1379,6 +1380,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             List
         }
 
+        // Extending timeout since the added yield return causes this test to commonly timeout
         [Timeout(360000)]
         [UnityTest]
         public IEnumerator TestSendingWithGroupNotOverride()

--- a/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
@@ -1286,24 +1286,30 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
         }
 
         // Extending timeout since the added yield return causes this test to commonly timeout
-        [Timeout(360000)]
+        [Timeout(600000)]
         [UnityTest]
         public IEnumerator TestSendingWithGroupOverride()
         {
+            var waitFor = new WaitForFixedUpdate();
             foreach (var defaultSendTo in Enum.GetValues(typeof(SendTo)))
             {
+                m_EnableVerboseDebug = true;
+                VerboseDebug($"Processing: {defaultSendTo}");
+                m_EnableVerboseDebug = false;
+
                 foreach (var recipient in RecipientGroups)
                 {
                     for (ulong objectOwner = 0u; objectOwner <= 2u; ++objectOwner)
                     {
                         for (ulong sender = 0u; sender <= 2u; ++sender)
                         {
+                            yield return waitFor;
                             foreach (var allocationType in Enum.GetValues(typeof(AllocationType)))
                             {
-                                if (++YieldCheck % YieldCycleCount == 0)
-                                {
-                                    yield return null;
-                                }
+                                //if (++YieldCheck % YieldCycleCount == 0)
+                                //{
+                                //    yield return null;
+                                //}
                                 OnInlineSetup();
                                 var sendMethodName = $"DefaultTo{defaultSendTo}AllowOverrideRpc";
 
@@ -1381,24 +1387,31 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
         }
 
         // Extending timeout since the added yield return causes this test to commonly timeout
-        [Timeout(360000)]
+        [Timeout(600000)]
         [UnityTest]
         public IEnumerator TestSendingWithGroupNotOverride()
         {
+            var waitFor = new WaitForFixedUpdate();
             foreach (var defaultSendTo in Enum.GetValues(typeof(SendTo)))
             {
+                m_EnableVerboseDebug = true;
+                VerboseDebug($"Processing: {defaultSendTo}");
+                m_EnableVerboseDebug = false;
                 foreach (var recipient in RecipientGroups)
                 {
                     for (ulong objectOwner = 0u; objectOwner <= 2u; ++objectOwner)
                     {
                         for (ulong sender = 0u; sender <= 2u; ++sender)
                         {
+                            yield return waitFor;
+
                             foreach (var allocationType in Enum.GetValues(typeof(AllocationType)))
                             {
-                                if (++YieldCheck % YieldCycleCount == 0)
-                                {
-                                    yield return null;
-                                }
+                                //if (++YieldCheck % YieldCycleCount == 0)
+                                //{
+                                //    yield return waitFor;
+                                //}
+
                                 OnInlineSetup();
                                 var sendMethodName = $"DefaultTo{defaultSendTo}AllowOverrideRpc";
 


### PR DESCRIPTION
Extending timeout since the added yield return causes this test to commonly timeout
(DO NOT MERGE)

## Changelog

NA

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
