### PR TITLE
fix: Scene network objects are destroyed when cancelling client conne…

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -855,7 +855,7 @@ namespace Unity.Netcode
                         // Leave destruction up to the handler
                         NetworkManager.PrefabHandler.HandleNetworkPrefabDestroy(networkObjects[i]);
                     }
-                    else
+                    else if (networkObjects[i].IsSpawned)
                     {
                         // If it is an in-scene placed NetworkObject then just despawn and let it be destroyed when the scene
                         // is unloaded. Otherwise, despawn and destroy it.


### PR DESCRIPTION
…ction

Those objects aren't spawned when cancelling the connection leading to destroying those objects from the scene when they should not.

Fixes: #2917 regression from 7ab9947

As described in the issue, when cancelling a client connection the network scene objects are destroyed.
This fixes the issue, however it might not be the **correct** fix, I do not know the project's code really well!

## Changelog

- Fixed: Scene network objects are not destroyed anymore when the client cancels the connection to a server.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.