### PR TITLE
chore: add second part of session restore

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
@@ -242,16 +242,13 @@ namespace Unity.Netcode
                     {
                         // Spawn any in-scene placed NetworkObjects
                         networkManager.SpawnManager.ServerSpawnSceneObjectsOnStartSweep();
-                    }
 
-                    // Spawn the local player of the session owner
-                    if (networkManager.AutoSpawnPlayerPrefabClientSide)
-                    {
-                        networkManager.ConnectionManager.CreateAndSpawnPlayer(OwnerClientId);
-                    }
+                        // Spawn the local player of the session owner
+                        if (networkManager.AutoSpawnPlayerPrefabClientSide)
+                        {
+                            networkManager.ConnectionManager.CreateAndSpawnPlayer(OwnerClientId);
+                        }
 
-                    if (!IsRestoredSession)
-                    {
                         // Synchronize the service with the initial session owner's loaded scenes and spawned objects
                         networkManager.SceneManager.SynchronizeNetworkObjects(NetworkManager.ServerClientId);
                     }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
@@ -236,6 +236,8 @@ namespace Unity.Netcode
                     // Mark the client being connected
                     networkManager.IsConnectedClient = true;
 
+                    networkManager.SceneManager.IsRestoringSession = IsRestoredSession;
+
                     if (!IsRestoredSession)
                     {
                         // Spawn any in-scene placed NetworkObjects

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
@@ -236,16 +236,23 @@ namespace Unity.Netcode
                     // Mark the client being connected
                     networkManager.IsConnectedClient = true;
 
-                    // Spawn any in-scene placed NetworkObjects
-                    networkManager.SpawnManager.ServerSpawnSceneObjectsOnStartSweep();
+                    if (!IsRestoredSession)
+                    {
+                        // Spawn any in-scene placed NetworkObjects
+                        networkManager.SpawnManager.ServerSpawnSceneObjectsOnStartSweep();
+                    }
 
                     // Spawn the local player of the session owner
                     if (networkManager.AutoSpawnPlayerPrefabClientSide)
                     {
                         networkManager.ConnectionManager.CreateAndSpawnPlayer(OwnerClientId);
                     }
-                    // Synchronize the service with the initial session owner's loaded scenes and spawned objects
-                    networkManager.SceneManager.SynchronizeNetworkObjects(NetworkManager.ServerClientId);
+
+                    if (!IsRestoredSession)
+                    {
+                        // Synchronize the service with the initial session owner's loaded scenes and spawned objects
+                        networkManager.SceneManager.SynchronizeNetworkObjects(NetworkManager.ServerClientId);
+                    }
                 }
             }
             ConnectedClientIds.Dispose();

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -444,6 +444,7 @@ namespace Unity.Netcode
         internal Dictionary<int, int> ServerSceneHandleToClientSceneHandle = new Dictionary<int, int>();
         internal Dictionary<int, int> ClientSceneHandleToServerSceneHandle = new Dictionary<int, int>();
 
+        internal bool IsRestoringSession;
         /// <summary>
         /// Add the client to server (and vice versa) scene handle lookup.
         /// Add the client-side handle to scene entry in the HandleToScene table.
@@ -454,8 +455,8 @@ namespace Unity.Netcode
             if (!ServerSceneHandleToClientSceneHandle.ContainsKey(serverHandle))
             {
                 ServerSceneHandleToClientSceneHandle.Add(serverHandle, clientHandle);
-            }
-            else
+            }            
+            else if (!IsRestoringSession)
             {
                 return false;
             }
@@ -464,7 +465,7 @@ namespace Unity.Netcode
             {
                 ClientSceneHandleToServerSceneHandle.Add(clientHandle, serverHandle);
             }
-            else
+            else if (!IsRestoringSession)
             {
                 return false;
             }
@@ -2428,6 +2429,11 @@ namespace Unity.Netcode
                             foreach (var networkObject in NetworkManager.SpawnManager.SpawnedObjectsList)
                             {
                                 networkObject.InternalNetworkSessionSynchronized();
+                            }
+
+                            if (NetworkManager.CurrentSessionOwner == NetworkManager.LocalClientId && IsRestoringSession)
+                            {
+                                IsRestoringSession = false;
                             }
 
                             EndSceneEvent(sceneEventId);

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
@@ -378,7 +378,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
         {
             // If VerifySceneBeforeLoading is not already set, then go ahead and set it so the host/server
             // will not try to synchronize clients to the TestRunner scene.  We only need to do this for the server.
-            if (networkManager.IsServer && networkManager.SceneManager.VerifySceneBeforeLoading == null)
+            // All clients in distributed authority mode, should have this registered (since any one client can become the session owner).
+            if ((networkManager.IsServer && networkManager.SceneManager.VerifySceneBeforeLoading == null) || networkManager.DistributedAuthorityMode)
             {
                 networkManager.SceneManager.VerifySceneBeforeLoading = VerifySceneIsValidForClientsToLoad;
 


### PR DESCRIPTION
This update includes some final changes to handle session restoration with scene management enabled.

- Session owner does not run through in-scene placed NetworkObject spawning if, upon connection approval, a session is being restored. This is because the service will be sending a synchronization event to the session owner to restore it to where the last known session states.
- Session owner now sends all scene events to the service target id to assure when no clients are connected it keeps track of the session states.
- For distributed authority integration tests, all clients register for the NetworkSceneManager.VerifySceneBeforeLoading to prevent from loading the InitTestScene multiple times.


[MPSNGM-250](https://jira.unity3d.com/browse/MPSNGM-250)


## Changelog

NA

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.


<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
