### PR TITLE
fix: unreliable deltas half float synch jitter

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -16,6 +16,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where `NetworkDeltaPosition` would "jitter" periodically if both unreliable delta state updates and half-floats were used together.
 - Fixed issue where `NetworkRigidbody2D` would not properly change body type based on the instance's authority when spawned. (#2916)
 - Fixed issue where a `NetworkObject` component's associated `NetworkBehaviour` components would not be detected if scene loading is disabled in the editor and the currently loaded scene has in-scene placed `NetworkObject`s. (#2906)
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -16,7 +16,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where `NetworkDeltaPosition` would "jitter" periodically if both unreliable delta state updates and half-floats were used together.
+- Fixed issue where `NetworkDeltaPosition` would "jitter" periodically if both unreliable delta state updates and half-floats were used together. (#2922)
 - Fixed issue where `NetworkRigidbody2D` would not properly change body type based on the instance's authority when spawned. (#2916)
 - Fixed issue where a `NetworkObject` component's associated `NetworkBehaviour` components would not be detected if scene loading is disabled in the editor and the currently loaded scene has in-scene placed `NetworkObject`s. (#2906)
 

--- a/com.unity.netcode.gameobjects/Components/NetworkDeltaPosition.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkDeltaPosition.cs
@@ -31,8 +31,7 @@ namespace Unity.Netcode.Components
         /// The serialization implementation of <see cref="INetworkSerializable"/>
         /// </summary>
         public void NetworkSerialize<T>(BufferSerializer<T> serializer) where T : IReaderWriter
-        {
-            HalfVector3.NetworkSerialize(serializer);
+        {            
             if (!SynchronizeBase)
             {
                 HalfVector3.NetworkSerialize(serializer);

--- a/com.unity.netcode.gameobjects/Components/NetworkDeltaPosition.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkDeltaPosition.cs
@@ -33,8 +33,13 @@ namespace Unity.Netcode.Components
         public void NetworkSerialize<T>(BufferSerializer<T> serializer) where T : IReaderWriter
         {
             HalfVector3.NetworkSerialize(serializer);
-            if (SynchronizeBase)
+            if (!SynchronizeBase)
             {
+                HalfVector3.NetworkSerialize(serializer);
+            }
+            else
+            {
+                serializer.SerializeValue(ref DeltaPosition);
                 serializer.SerializeValue(ref CurrentBasePosition);
             }
         }

--- a/com.unity.netcode.gameobjects/Components/NetworkDeltaPosition.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkDeltaPosition.cs
@@ -31,7 +31,7 @@ namespace Unity.Netcode.Components
         /// The serialization implementation of <see cref="INetworkSerializable"/>
         /// </summary>
         public void NetworkSerialize<T>(BufferSerializer<T> serializer) where T : IReaderWriter
-        {            
+        {
             if (!SynchronizeBase)
             {
                 HalfVector3.NetworkSerialize(serializer);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformBase.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformBase.cs
@@ -751,11 +751,29 @@ namespace Unity.Netcode.RuntimeTests
             base.OnAuthorityPushTransformState(ref networkTransformState);
         }
 
+        public bool AuthorityMove;
+        public Vector3 DirectionToMove;
+        public float MoveSpeed;
+
+        protected override void Update()
+        {
+            if (CanCommitToTransform && AuthorityMove)
+            {
+                transform.position += DirectionToMove * MoveSpeed * Time.deltaTime;
+            }
+            base.Update();
+        }
+
+
+        public delegate void NonAuthorityReceivedTransformStateDelegateHandler(ref NetworkTransformState networkTransformState);
+
+        public event NonAuthorityReceivedTransformStateDelegateHandler NonAuthorityReceivedTransformState;
 
         public bool StateUpdated { get; internal set; }
         protected override void OnNetworkTransformStateUpdated(ref NetworkTransformState oldState, ref NetworkTransformState newState)
         {
             StateUpdated = true;
+            NonAuthorityReceivedTransformState?.Invoke(ref newState);
             base.OnNetworkTransformStateUpdated(ref oldState, ref newState);
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformGeneral.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformGeneral.cs
@@ -310,5 +310,64 @@ namespace Unity.Netcode.RuntimeTests
             Assert.True(Approximately(newScale, m_AuthoritativeTransform.transform.localScale), "Authoritative scale does not match!");
             Assert.True(Approximately(newScale, m_NonAuthoritativeTransform.transform.localScale), "Non-Authoritative scale does not match!");
         }
+
+        /// <summary>
+        /// Validates that the unreliable frame synchronization is correct on the
+        /// non-authority side when using half float precision.
+        /// </summary>
+        [Test]
+        public void UnreliableHalfPrecisionTest([Values] Interpolation interpolation)
+        {
+            var interpolate = interpolation != Interpolation.EnableInterpolate;
+            m_AuthoritativeTransform.Interpolate = interpolate;
+            m_NonAuthoritativeTransform.Interpolate = interpolate;
+            m_AuthoritativeTransform.UseHalfFloatPrecision = true;
+            m_NonAuthoritativeTransform.UseHalfFloatPrecision = true;
+            m_AuthoritativeTransform.UseUnreliableDeltas = true;
+            m_NonAuthoritativeTransform.UseUnreliableDeltas = true;
+            m_AuthoritativeTransform.AuthorityPushedTransformState += AuthorityPushedTransformState;
+            m_NonAuthoritativeTransform.NonAuthorityReceivedTransformState += NonAuthorityReceivedTransformState;
+            m_AuthoritativeTransform.MoveSpeed = 6.325f;
+            m_AuthoritativeTransform.AuthorityMove = true;
+            m_AuthoritativeTransform.DirectionToMove = GetRandomVector3(-1.0f, 1.0f);
+
+            // Iterate several times so the authority moves around enough where we get 10 frame synchs to compare against.
+            for (int i = 0; i < 10; i++)
+            {
+                m_AuthorityFrameSync = false;
+                m_NonAuthorityFrameSync = false;
+                VerboseDebug($"Starting with authority ({m_AuthoritativeTransform.transform.position}) and nonauthority({m_NonAuthoritativeTransform.transform.position})");
+                var success = WaitForConditionOrTimeOutWithTimeTravel(() => m_AuthorityFrameSync && m_NonAuthorityFrameSync, 320);
+                Assert.True(success, $"Timed out waiting for authority or nonauthority frame state synchronization!");
+                VerboseDebug($"Comparing authority ({m_AuthorityPosition}) with nonauthority({m_NonAuthorityPosition})");
+                Assert.True(Approximately(m_AuthorityPosition, m_NonAuthorityPosition), $"Non-Authoritative position {m_AuthorityPosition} does not match authortative position {m_NonAuthorityPosition}!");
+            }
+
+            m_AuthoritativeTransform.AuthorityMove = false;
+            m_AuthoritativeTransform.AuthorityPushedTransformState -= AuthorityPushedTransformState;
+            m_NonAuthoritativeTransform.NonAuthorityReceivedTransformState -= NonAuthorityReceivedTransformState;
+        }
+
+        private bool m_AuthorityFrameSync;
+        private Vector3 m_AuthorityPosition;
+        private bool m_NonAuthorityFrameSync;
+        private Vector3 m_NonAuthorityPosition;
+        private void AuthorityPushedTransformState(ref NetworkTransform.NetworkTransformState networkTransformState)
+        {
+            if (networkTransformState.UnreliableFrameSync)
+            {
+                m_AuthorityPosition = m_AuthoritativeTransform.GetSpaceRelativePosition();
+                m_AuthorityFrameSync = true;
+            }
+        }
+
+        private void NonAuthorityReceivedTransformState(ref NetworkTransform.NetworkTransformState networkTransformState)
+        {
+            if (networkTransformState.UnreliableFrameSync)
+            {
+                m_NonAuthorityPosition = networkTransformState.NetworkDeltaPosition.GetFullPosition();
+                m_NonAuthorityFrameSync = true;
+            }
+        }
     }
 }


### PR DESCRIPTION
This fixes an issue where using NetworkDeltaPosition & unreliable deltas together would result in a periodic (but constant) jitter.

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->

<!-- Add RFC link here if applicable. -->

## Changelog

- Fixed: Issue where `NetworkDeltaPosition` would "jitter" periodically if both unreliable delta state updates and half-floats were used together.

## Testing and Documentation

- Includes integration test `NetworkTransformGeneral.UnreliableHalfPrecisionTest`.
- No documentation changes or additions were necessary.


<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
