### PR TITLE
fix: In-scene placed NetworkObjects getting destroyed if early disconnect (up-port)

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -16,7 +16,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where in-scene placed NetworkObjects could be destroyed if a client disconnects early and/or before approval.
+- Fixed issue where in-scene placed NetworkObjects could be destroyed if a client disconnects early and/or before approval. (#2924)
 - Fixed issue where a `NetworkObject` component's associated `NetworkBehaviour` components would not be detected if scene loading is disabled in the editor and the currently loaded scene has in-scene placed `NetworkObject`s. (#2912)
 - Fixed issue where an in-scene placed `NetworkObject` with `NetworkTransform` that is also parented under a `GameObject` would not properly synchronize when the parent `GameObject` had a world space position other than 0,0,0. (#2898)
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -16,6 +16,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where in-scene placed NetworkObjects could be destroyed if a client disconnects early and/or before approval.
 - Fixed issue where a `NetworkObject` component's associated `NetworkBehaviour` components would not be detected if scene loading is disabled in the editor and the currently loaded scene has in-scene placed `NetworkObject`s. (#2912)
 - Fixed issue where an in-scene placed `NetworkObject` with `NetworkTransform` that is also parented under a `GameObject` would not properly synchronize when the parent `GameObject` had a world space position other than 0,0,0. (#2898)
 

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1245,7 +1245,7 @@ namespace Unity.Netcode
                     {
                         // If it is an in-scene placed NetworkObject then just despawn and let it be destroyed when the scene
                         // is unloaded. Otherwise, despawn and destroy it.
-                        var shouldDestroy = !(networkObjects[i].IsSceneObject != null && networkObjects[i].IsSceneObject.Value);
+                        var shouldDestroy = !(networkObjects[i].IsSceneObject == null || (networkObjects[i].IsSceneObject != null && networkObjects[i].IsSceneObject.Value));
 
                         // If we are going to destroy this NetworkObject, check for any in-scene placed children that need to be removed
                         if (shouldDestroy)

--- a/testproject/Assets/Tests/Manual/InSceneObjectParentingTests/InSceneParentChildHandler.cs
+++ b/testproject/Assets/Tests/Manual/InSceneObjectParentingTests/InSceneParentChildHandler.cs
@@ -132,7 +132,7 @@ namespace TestProject.ManualTests
 
         public void DeparentAllChildren(bool worldPositionStays = true)
         {
-            if (IsRootParent && CheckForAuthority())
+            if (IsRootParent && HasAuthority)
             {
                 var lastChild = GetLastChild(transform);
                 if (lastChild != null)
@@ -163,7 +163,7 @@ namespace TestProject.ManualTests
 
         public void ReParentAllChildren(bool worldPositionStays = true)
         {
-            if (IsRootParent && CheckForAuthority())
+            if (IsRootParent && HasAuthority)
             {
                 ParentChild(m_Child, worldPositionStays);
             }
@@ -171,7 +171,7 @@ namespace TestProject.ManualTests
 
         public override void OnNetworkSpawn()
         {
-            if (CheckForAuthority())
+            if (HasAuthority)
             {
                 LogMessage($"[{NetworkObjectId}] Pos = ({m_TargetLocalPosition}) | Rotation ({m_TargetLocalRotation}) | Scale ({m_TargetLocalScale})");
                 if (AddNetworkTransform)
@@ -206,7 +206,7 @@ namespace TestProject.ManualTests
 
         public void DeparentSetValuesAndReparent()
         {
-            if (IsRootParent && CheckForAuthority())
+            if (IsRootParent && HasAuthority)
             {
                 // Back to back de-parenting and re-parenting
                 s_GenerateRandomValues = true;
@@ -222,7 +222,7 @@ namespace TestProject.ManualTests
         /// </summary>
         public override void OnNetworkObjectParentChanged(NetworkObject parentNetworkObject)
         {
-            if (!CheckForAuthority() || !IsSpawned || parentNetworkObject != null || !s_GenerateRandomValues)
+            if (!HasAuthority || !IsSpawned || parentNetworkObject != null || !s_GenerateRandomValues)
             {
                 return;
             }
@@ -242,7 +242,7 @@ namespace TestProject.ManualTests
 
         private void LateUpdate()
         {
-            if (!IsSpawned || !CheckForAuthority() || NetworkManagerTestDisabler.IsIntegrationTest)
+            if (!IsSpawned || !HasAuthority || NetworkManagerTestDisabler.IsIntegrationTest)
             {
                 return;
             }

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/InScenePlacedNetworkObjectTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/InScenePlacedNetworkObjectTests.cs
@@ -578,4 +578,51 @@ namespace TestProject.RuntimeTests
         }
 
     }
+
+    internal class InScenePlacedNetworkObjectClientTests : NetcodeIntegrationTest
+    {
+        private const string k_SceneToLoad = "InSceneNetworkObject";
+
+        protected override int NumberOfClients => 0;
+
+        private Scene m_Scene;
+
+        protected override IEnumerator OnSetup()
+        {
+            SceneManager.sceneLoaded += SceneManager_sceneLoaded;
+            SceneManager.LoadScene(k_SceneToLoad, LoadSceneMode.Additive);
+            return base.OnSetup();
+        }
+
+        private void SceneManager_sceneLoaded(Scene scene, LoadSceneMode loadSceneMode)
+        {
+            if (scene.name == k_SceneToLoad && loadSceneMode == LoadSceneMode.Additive)
+            {
+                m_Scene = scene;
+                SceneManager.sceneLoaded -= SceneManager_sceneLoaded;
+            }
+        }
+
+        protected override IEnumerator OnTearDown()
+        {
+            if (m_Scene.isLoaded)
+            {
+                SceneManager.UnloadSceneAsync(m_Scene);
+            }
+            return base.OnTearDown();
+        }
+
+        [UnityTest]
+        public IEnumerator DespawnAndDestroyNetworkObjects()
+        {
+            // Simulate a client disconnecting early by just invoking DespawnAndDestroyNetworkObjects to assure
+            // this method does not destroy in-scene placed NetworkObjects.
+            m_ServerNetworkManager.SpawnManager.DespawnAndDestroyNetworkObjects();
+
+            yield return s_DefaultWaitForTick;
+
+            var insceneObject = GameObject.Find("InSceneObject");
+            Assert.IsNotNull(insceneObject, $"Could not find the in-scene placed {nameof(NetworkObject)}: InSceneObject!");
+        }
+    }
 }


### PR DESCRIPTION
This is an up-port of fix #2923 


## Changelog

- Fixed: Issue where in-scene placed NetworkObjects could be destroyed if a client disconnects early and/or before approval.


## Testing and Documentation

- Added `InScenePlacedNetworkObjectClientTests.DespawnAndDestroyNetworkObjects` integration test.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
