### PR TITLE
feat: expose the UTP connect

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -138,11 +138,6 @@ namespace Unity.Netcode.Transports.UTP
         public const int InitialMaxPayloadSize = 6 * 1024;
 
         /// <summary>
-        /// Payload to send along with a new connection
-        /// </summary>
-        public NativeArray<byte> ConnectPayload = new(0, Allocator.Temp);
-
-        /// <summary>
         /// The default maximum send queue size
         /// </summary>
         [Obsolete("MaxSendQueueSize is now determined dynamically (can still be set programmatically using the MaxSendQueueSize property). This initial value is not used anymore.", false)]
@@ -431,10 +426,11 @@ namespace Unity.Netcode.Transports.UTP
         internal static event Action<int> TransportDisposed;
         internal NetworkDriver NetworkDriver => m_Driver;
 
+        protected NetworkDriver m_Driver;
+
         private PacketLossCache m_PacketLossCache = new PacketLossCache();
 
         private State m_State = State.Disconnected;
-        private NetworkDriver m_Driver;
         private NetworkSettings m_NetworkSettings;
         private ulong m_ServerClientId;
 
@@ -559,10 +555,15 @@ namespace Unity.Netcode.Transports.UTP
                 return false;
             }
 
-            var serverConnection = m_Driver.Connect(serverEndpoint, ConnectPayload);
+            var serverConnection = Connect(serverEndpoint);
             m_ServerClientId = ParseClientId(serverConnection);
 
             return true;
+        }
+
+        protected virtual NetworkConnection Connect(NetworkEndpoint serverEndpoint)
+        {
+            return m_Driver.Connect(serverEndpoint);
         }
 
         private bool ServerBindAndListen(NetworkEndpoint endPoint)

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -813,7 +813,7 @@ namespace Unity.Netcode.Transports.UTP
 
         private bool AcceptConnection()
         {
-            var connection = m_Driver.Accept(out var payload);
+            var connection = m_Driver.Accept();
 
             if (connection == default)
             {
@@ -822,7 +822,7 @@ namespace Unity.Netcode.Transports.UTP
 
             InvokeOnTransportEvent(NetcodeNetworkEvent.Connect,
                 ParseClientId(connection),
-                new ArraySegment<byte>(payload.ToArray()),
+                default,
                 m_RealTimeProvider.RealTimeSinceStartup);
 
             return true;

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -812,7 +812,7 @@ namespace Unity.Netcode.Transports.UTP
 
         private bool AcceptConnection()
         {
-            var connection = m_Driver.Accept();
+            var connection = m_Driver.Accept(out var payload);
 
             if (connection == default)
             {
@@ -821,7 +821,7 @@ namespace Unity.Netcode.Transports.UTP
 
             InvokeOnTransportEvent(NetcodeNetworkEvent.Connect,
                 ParseClientId(connection),
-                default,
+                new ArraySegment<byte>(payload.ToArray()),
                 m_RealTimeProvider.RealTimeSinceStartup);
 
             return true;

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -140,7 +140,7 @@ namespace Unity.Netcode.Transports.UTP
         /// <summary>
         /// Payload to send along with a new connection
         /// </summary>
-        public NativeArray<byte> ConnectPayload = new (0, Allocator.Temp);
+        public NativeArray<byte> ConnectPayload = new(0, Allocator.Temp);
 
         /// <summary>
         /// The default maximum send queue size

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -138,6 +138,11 @@ namespace Unity.Netcode.Transports.UTP
         public const int InitialMaxPayloadSize = 6 * 1024;
 
         /// <summary>
+        /// Payload to send along with a new connection
+        /// </summary>
+        public NativeArray<byte> ConnectPayload = new (0, Allocator.Temp);
+
+        /// <summary>
         /// The default maximum send queue size
         /// </summary>
         [Obsolete("MaxSendQueueSize is now determined dynamically (can still be set programmatically using the MaxSendQueueSize property). This initial value is not used anymore.", false)]
@@ -554,7 +559,7 @@ namespace Unity.Netcode.Transports.UTP
                 return false;
             }
 
-            var serverConnection = m_Driver.Connect(serverEndpoint);
+            var serverConnection = m_Driver.Connect(serverEndpoint, ConnectPayload);
             m_ServerClientId = ParseClientId(serverConnection);
 
             return true;


### PR DESCRIPTION
Expose the UTP Connect override. So that services using the payload can adjust the flow as needed. 

## Changelog

- Added: Expose the UTP Connect transport method. 

## Testing and Documentation

- No tests have been added.

