### PR TITLE
chore: removing unreleased section in changelog

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
-## [Unreleased]
-
 ## [2.0.0-exp.3] - 2024-05-30
 
 ### Added


### PR DESCRIPTION
Removing unreleased section in changelog. It was causing a failure in package promotion CI job: https://unity-ci.cds.internal.unity3d.com/job/37864928/dependency-graph

## Changelog
- Removed/Deprecated/Changed: Removed "Unreleased" section

## Testing and Documentation

- No tests have been added.