### PR TITLE
fix: client side disconnect incorrect client count on host-server side [MTTB-135]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -15,6 +15,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue with the client count not being correct on the host or server side when a client disconnects itself from a session.
+- Fixed issue with the host trying to send itself a message that it has connected when first starting up.
 - Fixed issue where in-scene placed NetworkObjects could be destroyed if a client disconnects early and/or before approval. (#2923)
 - Fixed issue where `NetworkDeltaPosition` would "jitter" periodically if both unreliable delta state updates and half-floats were used together. (#2922)
 - Fixed issue where `NetworkRigidbody2D` would not properly change body type based on the instance's authority when spawned. (#2916)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -15,8 +15,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue with the client count not being correct on the host or server side when a client disconnects itself from a session.
-- Fixed issue with the host trying to send itself a message that it has connected when first starting up.
+- Fixed issue with the client count not being correct on the host or server side when a client disconnects itself from a session. (#2941)
+- Fixed issue with the host trying to send itself a message that it has connected when first starting up. (#2941)
 - Fixed issue where in-scene placed NetworkObjects could be destroyed if a client disconnects early and/or before approval. (#2923)
 - Fixed issue where `NetworkDeltaPosition` would "jitter" periodically if both unreliable delta state updates and half-floats were used together. (#2922)
 - Fixed issue where `NetworkRigidbody2D` would not properly change body type based on the instance's authority when spawned. (#2916)

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -104,9 +104,11 @@ namespace Unity.Netcode
                     {
                         continue;
                     }
-
-                    peerClientIds[idx] = peerId;
-                    ++idx;
+                    if (peerClientIds.Length > idx)
+                    {
+                        peerClientIds[idx] = peerId;
+                        ++idx;
+                    }
                 }
 
                 try
@@ -915,7 +917,7 @@ namespace Unity.Netcode
                 var message = new ClientConnectedMessage { ClientId = clientId };
                 NetworkManager.MessageManager.SendMessage(ref message, NetworkDelivery.ReliableFragmentedSequenced, ConnectedClientIds);
             }
-            
+
             return networkClient;
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -908,13 +908,14 @@ namespace Unity.Netcode
 
             ConnectedClients.Add(clientId, networkClient);
             ConnectedClientsList.Add(networkClient);
+            ConnectedClientIds.Add(clientId);
             // Host should not send this message to itself
-            if (NetworkManager.LocalClientId != NetworkManager.ServerClientId)
+            if (clientId != NetworkManager.ServerClientId)
             {
                 var message = new ClientConnectedMessage { ClientId = clientId };
                 NetworkManager.MessageManager.SendMessage(ref message, NetworkDelivery.ReliableFragmentedSequenced, ConnectedClientIds);
             }
-            ConnectedClientIds.Add(clientId);
+            
             return networkClient;
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApprovalTimeoutTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApprovalTimeoutTests.cs
@@ -81,7 +81,7 @@ namespace Unity.Netcode.RuntimeTests
         public IEnumerator ValidateApprovalTimeout()
         {
             // Delay for half of the wait period
-            yield return new WaitForSeconds(k_TestTimeoutPeriod * 0.5f);
+            yield return new WaitForSeconds(k_TestTimeoutPeriod * 0.25f);
 
             // Verify we haven't received the time out message yet
             NetcodeLogAssert.LogWasNotReceived(LogType.Log, m_ExpectedLogMessage);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DisconnectTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DisconnectTests.cs
@@ -182,6 +182,9 @@ namespace Unity.Netcode.RuntimeTests
                 Assert.IsTrue(m_DisconnectedEvent[m_ServerNetworkManager].ClientId == m_ClientId, $"Expected ClientID {m_ClientId} but found ClientID {m_DisconnectedEvent[m_ServerNetworkManager].ClientId} for the server {nameof(NetworkManager)} disconnect event entry!");
                 Assert.IsTrue(m_DisconnectedEvent.ContainsKey(clientManager), $"Could not find the client {nameof(NetworkManager)} disconnect event entry!");
                 Assert.IsTrue(m_DisconnectedEvent[clientManager].ClientId == m_ClientId, $"Expected ClientID {m_ClientId} but found ClientID {m_DisconnectedEvent[m_ServerNetworkManager].ClientId} for the client {nameof(NetworkManager)} disconnect event entry!");
+                Assert.IsTrue(m_ServerNetworkManager.ConnectedClientsIds.Count == 1, $"Expected connected client identifiers count to be 1 but it was {m_ServerNetworkManager.ConnectedClientsIds.Count}!");
+                Assert.IsTrue(m_ServerNetworkManager.ConnectedClients.Count == 1, $"Expected connected client identifiers count to be 1 but it was {m_ServerNetworkManager.ConnectedClients.Count}!");
+                Assert.IsTrue(m_ServerNetworkManager.ConnectedClientsList.Count == 1, $"Expected connected client identifiers count to be 1 but it was {m_ServerNetworkManager.ConnectedClientsList.Count}!");
             }
 
             if (m_OwnerPersistence == OwnerPersistence.DestroyWithOwner)


### PR DESCRIPTION
This resolves the issue with the client count not being correct on the host or server side when a client disconnects itself from a session.
This also resolves the issue with the host trying to send itself a message that it has connected when first starting up.

[MTTB-135](https://jira.unity3d.com/browse/MTTB-135)

fix: #2927

## Changelog

- Fixed: Issue with the client count not being correct on the host or server side when a client disconnects itself from a session.
- Fixed: Issue with the host trying to send itself a message that it has connected when first starting up.

## Testing and Documentation

- Includes integration test update.
- No documentation changes or additions were necessary.


<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
