### PR TITLE
fix: new message versioning starting after session owner message

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -8,6 +8,10 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed issue where SessionOwner message was being treated as a new entry for the new message indexing when it should have been ordinally sorted with the legacy message indices.
+
 ## [2.0.0-exp.4] - 2024-05-31
 
 ### Added

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,7 +10,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where SessionOwner message was being treated as a new entry for the new message indexing when it should have been ordinally sorted with the legacy message indices.
+- Fixed issue where SessionOwner message was being treated as a new entry for the new message indexing when it should have been ordinally sorted with the legacy message indices. (#2942)
 
 ## [2.0.0-exp.4] - 2024-05-31
 

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/ILPPMessageProvider.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/ILPPMessageProvider.cs
@@ -44,9 +44,9 @@ namespace Unity.Netcode
             SceneEvent = 17,
             ServerLog = 18,
             ServerRpc = 19,
-            TimeSync = 20,
-            Unnamed = 21,
-            SessionOwner = 22
+            SessionOwner = 20,
+            TimeSync = 21,
+            Unnamed = 22,
         }
 
 


### PR DESCRIPTION
Fixing session owner and time synchronization issue by including the session owner message in the legacy ordinally sorted message indices ordering.

[MTTB-129](https://jira.unity3d.com/browse/MTTB-129)

## Changelog

- Fixed: Issue where SessionOwner message was being treated as a new entry for the new message indexing when it should have been ordinally sorted with the legacy message indices.


## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
