### PR TITLE
chore: Ensure lengths are always written as uint

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferWriter.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferWriter.cs
@@ -959,7 +959,7 @@ namespace Unity.Netcode
             {
                 throw new InvalidCastException("Cannot write negative length");
             }
-            WriteLengthSafe((uint) length);
+            WriteLengthSafe((uint)length);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
<!-- Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. Delete bullet points below that don't apply, and update the changelog section as appropriate. -->
In order to unserialize and manage network variables on CMB, we need to know the type of values being serialized inside C#. This PR adds some helper logic to ensure that lengths are getting serialized with a consistent type.

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->
[MPSNGM-274](https://jira.unity3d.com/browse/MPSNGM-274)

<!-- Add RFC link here if applicable. -->

## Changelog

- Ensure that the length of items is always serialized as a uint.
- Add a check before casting for safe reading and writing.

## Testing and Documentation

- All existing tests are passing