### PR TITLE
refactor: Ensure lengths are always written as uints

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -8,9 +8,16 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ## [Unreleased]
 
+### Added
+
+
 ### Fixed
 
 - Fixed issue where SessionOwner message was being treated as a new entry for the new message indexing when it should have been ordinally sorted with the legacy message indices. (#2942)
+
+### Changed
+- Changed `FastBufferReader` and `FastBufferWriter` so that they always ensure the length of items serialized is always serialized as an `uint` and added a check before casting for safe reading and writing.(#2946)
+
 
 ## [2.0.0-exp.4] - 2024-05-31
 


### PR DESCRIPTION
<!-- Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. Delete bullet points below that don't apply, and update the changelog section as appropriate. -->
In order to unserialize and manage network variables on CMB, we need to know the type of values being serialized inside C#. This PR adds some helper logic to ensure that lengths are getting serialized with a consistent type.

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->
[MPSNGM-274](https://jira.unity3d.com/browse/MPSNGM-274)

<!-- Add RFC link here if applicable. -->

## Changelog

- Changed: `FastBufferReader` and `FastBufferWriter` so that they always ensure the length of items serialized is always serialized as an `uint` and added a check before casting for safe reading and writing.

## Testing and Documentation

- No tests have been updated or added.
- No documentation updates were required.