### PR TITLE
fix: Added support for byte on NetworkVariable through codegen

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -15,6 +15,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where internal delta serialization could not have a byte serializer defined when serializing deltas for other types. Added `[GenerateSerializationForType(typeof(byte))]` to both the `NetworkVariable` and `AnticipatedNetworkVariable` classes to assure a byte serializer is defined. (#2953)
 - Fixed issue with the client count not being correct on the host or server side when a client disconnects itself from a session. (#2941)
 - Fixed issue with the host trying to send itself a message that it has connected when first starting up. (#2941)
 - Fixed issue where in-scene placed NetworkObjects could be destroyed if a client disconnects early and/or before approval. (#2923)

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/AnticipatedNetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/AnticipatedNetworkVariable.cs
@@ -51,6 +51,7 @@ namespace Unity.Netcode
 #pragma warning restore IDE0001
     [Serializable]
     [GenerateSerializationForGenericParameter(0)]
+    [GenerateSerializationForType(typeof(byte))]
     public class AnticipatedNetworkVariable<T> : NetworkVariableBase
     {
         [SerializeField]

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -9,6 +9,7 @@ namespace Unity.Netcode
     /// <typeparam name="T">the unmanaged type for <see cref="NetworkVariable{T}"/> </typeparam>
     [Serializable]
     [GenerateSerializationForGenericParameter(0)]
+    [GenerateSerializationForType(typeof(byte))]
     public class NetworkVariable<T> : NetworkVariableBase
     {
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableSerialization.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableSerialization.cs
@@ -717,7 +717,7 @@ namespace Unity.Netcode
                 writer.WriteValueSafe(value);
                 return;
             }
-            writer.WriteByte(0);
+            writer.WriteValueSafe(0);
             BytePacker.WriteValuePacked(writer, value.Length);
             writer.WriteValueSafe(changes);
             unsafe
@@ -766,7 +766,7 @@ namespace Unity.Netcode
                 {
                     if (changes.IsSet(i))
                     {
-                        reader.ReadByte(out ptr[i]);
+                        reader.ReadByteSafe(out ptr[i]);
                     }
                 }
             }

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableSerialization.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableSerialization.cs
@@ -717,7 +717,7 @@ namespace Unity.Netcode
                 writer.WriteValueSafe(value);
                 return;
             }
-            writer.WriteValueSafe(0);
+            writer.WriteByteSafe(0);
             BytePacker.WriteValuePacked(writer, value.Length);
             writer.WriteValueSafe(changes);
             unsafe


### PR DESCRIPTION
the codegen wasn't picking byte  - it's because a variable of a type other than `NetworkVariable<byte>` (such as `NetworkVariable<FixedString32Bytes>`) is serializing a byte value as part of its delta serialization. Delta serialization was added in NGO 1.9, which is why it doesn't happen in previous versions. This code assumes the existence of a byte serializer, but if the user doesn't have a NetworkVariable<byte> in their code, the byte serializer won't be initialized by the codegen pass.

fix: #2920 

## Changelog

- Fixed:  Issue where internal delta serialization could not have a byte serializer defined when serializing deltas for other types. Added `[GenerateSerializationForType(typeof(byte))]` to both the `NetworkVariable` and `AnticipatedNetworkVariable` classes to assure a byte serializer is defined.

## Testing and Documentation
    
- No tests were added or updated.
- No documentation changes or additions were necessary.