### PR TITLE
fix: rotation not being 1.0 issue using rigid body for motion

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkRigidBodyBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkRigidBodyBase.cs
@@ -336,6 +336,7 @@ namespace Unity.Netcode.Components
             }
         }
 
+        private Vector4 m_QuaternionCheck = Vector4.zero;
         /// <summary>
         /// Rotatates the Rigidbody towards a specified rotation
         /// </summary>
@@ -353,6 +354,17 @@ namespace Unity.Netcode.Components
             }
             else
             {
+                // Evidently we need to check to make sure the quaternion is a perfect
+                // magnitude of 1.0f when applying the rotation to a rigid body.
+                m_QuaternionCheck.x = rotation.x;
+                m_QuaternionCheck.y = rotation.y;
+                m_QuaternionCheck.z = rotation.z;
+                m_QuaternionCheck.w = rotation.w;
+                // If the magnitude is greater than 1.0f (even by a very small fractional value), then normalize the quaternion
+                if (m_QuaternionCheck.magnitude != 1.0f)
+                {
+                    rotation.Normalize();
+                }
                 m_Rigidbody.MoveRotation(rotation);
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkRigidBodyBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkRigidBodyBase.cs
@@ -336,7 +336,9 @@ namespace Unity.Netcode.Components
             }
         }
 
+        // Used for Rigidbody only (see info on normalized below)
         private Vector4 m_QuaternionCheck = Vector4.zero;
+
         /// <summary>
         /// Rotatates the Rigidbody towards a specified rotation
         /// </summary>


### PR DESCRIPTION
Fixes the issue where a quaternion could not precisely be equal to 1.0f after updating Euler values.

## Changelog

NA

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
