### PR TITLE
feat: up-port of network variable traits, anticipation, serialized null references, and removal of animator component requirement

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -29,6 +29,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+- Changed `NetworkAnimator` no longer requires the `Animator` component to exist on the same `GameObject`. (#2957)
+- Changed `NetworkObjectReference` and `NetworkBehaviourReference` to allow null references when constructing and serializing. (#2957)
 - Changed the client's owned objects is now returned (`NetworkClient` and `NetworkSpawnManager`) as an array as opposed to a list for performance purposes. (#2948)
 - Changed `NetworkTransfrom.TryCommitTransformToServer` to be internal as it will be removed by the final 2.0.0 release. (#2948)
 - Changed `NetworkTransformEditor.OnEnable` to a virtual method to be able to customize a `NetworkTransform` derived class by creating a derived editor control from `NetworkTransformEditor`. (#2948)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,10 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
-## [2.0.0-pre.1] - 2024-06-17
+## [2.0.0-pre.2] - 2024-06-17
 
 ### Added
 
+- Added `AnticipatedNetworkVariable<T>`, which adds support for client anticipation of `NetworkVariable` values, allowing for more responsive gameplay. (#2957)
+- Added `AnticipatedNetworkTransform`, which adds support for client anticipation of NetworkTransforms. (#2957)
+- Added `NetworkVariableBase.ExceedsDirtinessThreshold` to allow network variables to throttle updates by only sending updates when the difference between the current and previous values exceeds a threshold. (This is exposed in `NetworkVariable<T>` with the callback `NetworkVariable<T>.CheckExceedsDirtinessThreshold`). (#2957)
+- Added `NetworkVariableUpdateTraits`, which add additional throttling support: `MinSecondsBetweenUpdates` will prevent the `NetworkVariable` from sending updates more often than the specified time period (even if it exceeds the dirtiness threshold), while `MaxSecondsBetweenUpdates` will force a dirty `NetworkVariable` to send an update after the specified time period even if it has not yet exceeded the dirtiness threshold. (#2957)
+- Added virtual method `NetworkVariableBase.OnInitialize` which can be used by `NetworkVariable` subclasses to add initialization code. (#2957)
+- Added `NetworkTime.TickWithPartial`, which represents the current tick as a double that includes the fractional/partial tick value. (#2957)
+- Added `NetworkTickSystem.AnticipationTick`, which can be helpful with implementation of client anticipation. This value represents the tick the current local client was at at the beginning of the most recent network round trip, which enables it to correlate server update ticks with the client tick that may have triggered them. (#2957)
 - Added event `NetworkManager.OnSessionOwnerPromoted` that is invoked when a new session owner promotion occurs. (#2948)
 - Added `NetworkRigidBodyBase.GetLinearVelocity` and `NetworkRigidBodyBase.SetLinearVelocity` convenience/helper methods. (#2948)
 - Added `NetworkRigidBodyBase.GetAngularVelocity` and `NetworkRigidBodyBase.SetAngularVelocity` convenience/helper methods. (#2948)

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -409,6 +409,7 @@ namespace Unity.Netcode.Editor.CodeGen
                     }
                     else
                     {
+                        m_Diagnostics.AddError($"{type}: Managed type in NetworkVariable must implement IEquatable<{type}>");
                         equalityMethod = new GenericInstanceMethod(m_NetworkVariableSerializationTypes_InitializeEqualityChecker_ManagedClassEquals_MethodRef);
                     }
 

--- a/com.unity.netcode.gameobjects/Editor/NetworkTransformEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkTransformEditor.cs
@@ -148,7 +148,7 @@ namespace Unity.Netcode.Editor
             if (!networkTransform.HideInterpolateValue)
             {
                 EditorGUILayout.PropertyField(m_InterpolateProperty);
-            }            
+            }
             EditorGUILayout.PropertyField(m_SlerpPosition);
             EditorGUILayout.PropertyField(m_UseQuaternionSynchronization);
             if (m_UseQuaternionSynchronization.boolValue)

--- a/com.unity.netcode.gameobjects/Editor/NetworkTransformEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkTransformEditor.cs
@@ -66,6 +66,7 @@ namespace Unity.Netcode.Editor
         /// <inheritdoc/>
         public override void OnInspectorGUI()
         {
+            var networkTransform = target as NetworkTransform;
             EditorGUILayout.LabelField("Axis to Synchronize", EditorStyles.boldLabel);
             {
                 GUILayout.BeginHorizontal();
@@ -144,7 +145,10 @@ namespace Unity.Netcode.Editor
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Configurations", EditorStyles.boldLabel);
             EditorGUILayout.PropertyField(m_InLocalSpaceProperty);
-            EditorGUILayout.PropertyField(m_InterpolateProperty);
+            if (!networkTransform.HideInterpolateValue)
+            {
+                EditorGUILayout.PropertyField(m_InterpolateProperty);
+            }            
             EditorGUILayout.PropertyField(m_SlerpPosition);
             EditorGUILayout.PropertyField(m_UseQuaternionSynchronization);
             if (m_UseQuaternionSynchronization.boolValue)

--- a/com.unity.netcode.gameobjects/Runtime/Components/AnticipatedNetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/AnticipatedNetworkTransform.cs
@@ -1,0 +1,504 @@
+using Unity.Mathematics;
+using UnityEngine;
+
+namespace Unity.Netcode.Components
+{
+
+#pragma warning disable IDE0001
+    /// <summary>
+    /// A subclass of <see cref="NetworkTransform"/> that supports basic client anticipation - the client
+    /// can set a value on the belief that the server will update it to reflect the same value in a future update
+    /// (i.e., as the result of an RPC call). This value can then be adjusted as new updates from the server come in,
+    /// in three basic modes:
+    ///
+    /// <list type="bullet">
+    ///
+    /// <item><b>Snap:</b> In this mode (with <see cref="StaleDataHandling"/> set to
+    /// <see cref="StaleDataHandling.Ignore"/> and no <see cref="NetworkBehaviour.OnReanticipate"/> callback),
+    /// the moment a more up-to-date value is received from the authority, it will simply replace the anticipated value,
+    /// resulting in a "snap" to the new value if it is different from the anticipated value.</item>
+    ///
+    /// <item><b>Smooth:</b> In this mode (with <see cref="StaleDataHandling"/> set to
+    /// <see cref="Netcode.StaleDataHandling.Ignore"/> and an <see cref="NetworkBehaviour.OnReanticipate"/> callback that calls
+    /// <see cref="Smooth"/> from the anticipated value to the authority value with an appropriate
+    /// <see cref="Mathf.Lerp"/>-style smooth function), when a more up-to-date value is received from the authority,
+    /// it will interpolate over time from an incorrect anticipated value to the correct authoritative value.</item>
+    ///
+    /// <item><b>Constant Reanticipation:</b> In this mode (with <see cref="StaleDataHandling"/> set to
+    /// <see cref="Netcode.StaleDataHandling.Reanticipate"/> and an <see cref="NetworkBehaviour.OnReanticipate"/> that calculates a
+    /// new anticipated value based on the current authoritative value), when a more up-to-date value is received from
+    /// the authority, user code calculates a new anticipated value, possibly calling <see cref="Smooth"/> to interpolate
+    /// between the previous anticipation and the new anticipation. This is useful for values that change frequently and
+    /// need to constantly be re-evaluated, as opposed to values that change only in response to user action and simply
+    /// need a one-time anticipation when the user performs that action.</item>
+    ///
+    /// </list>
+    ///
+    /// Note that these three modes may be combined. For example, if an <see cref="NetworkBehaviour.OnReanticipate"/> callback
+    /// does not call either <see cref="Smooth"/> or one of the Anticipate methods, the result will be a snap to the
+    /// authoritative value, enabling for a callback that may conditionally call <see cref="Smooth"/> when the
+    /// difference between the anticipated and authoritative values is within some threshold, but fall back to
+    /// snap behavior if the difference is too large.
+    /// </summary>
+#pragma warning restore IDE0001
+    [DisallowMultipleComponent]
+    [AddComponentMenu("Netcode/Anticipated Network Transform")]
+    public class AnticipatedNetworkTransform : NetworkTransform
+    {
+
+#if UNITY_EDITOR
+        internal override bool HideInterpolateValue => true;
+#endif
+
+        public struct TransformState
+        {
+            public Vector3 Position;
+            public Quaternion Rotation;
+            public Vector3 Scale;
+        }
+
+        private TransformState m_AuthoritativeTransform = new TransformState();
+        private TransformState m_AnticipatedTransform = new TransformState();
+        private TransformState m_PreviousAnticipatedTransform = new TransformState();
+        private ulong m_LastAnticipaionCounter;
+        private double m_LastAnticipationTime;
+        private ulong m_LastAuthorityUpdateCounter;
+
+        private TransformState m_SmoothFrom;
+        private TransformState m_SmoothTo;
+        private float m_SmoothDuration;
+        private float m_CurrentSmoothTime;
+
+        private bool m_OutstandingAuthorityChange = false;
+
+#if UNITY_EDITOR
+        private void Reset()
+        {
+            // Anticipation + smoothing is a form of interpolation, and adding NetworkTransform's buffered interpolation
+            // makes the anticipation get weird, so we default it to false.
+            Interpolate = false;
+        }
+#endif
+
+#pragma warning disable IDE0001
+        /// <summary>
+        /// Defines what the behavior should be if we receive a value from the server with an earlier associated
+        /// time value than the anticipation time value.
+        /// <br/><br/>
+        /// If this is <see cref="Netcode.StaleDataHandling.Ignore"/>, the stale data will be ignored and the authoritative
+        /// value will not replace the anticipated value until the anticipation time is reached. <see cref="OnAuthoritativeValueChanged"/>
+        /// and <see cref="OnReanticipate"/> will also not be invoked for this stale data.
+        /// <br/><br/>
+        /// If this is <see cref="Netcode.StaleDataHandling.Reanticipate"/>, the stale data will replace the anticipated data and
+        /// <see cref="OnAuthoritativeValueChanged"/> and <see cref="OnReanticipate"/> will be invoked.
+        /// In this case, the authoritativeTime value passed to <see cref="OnReanticipate"/> will be lower than
+        /// the anticipationTime value, and that callback can be used to calculate a new anticipated value.
+        /// </summary>
+#pragma warning restore IDE0001
+        public StaleDataHandling StaleDataHandling = StaleDataHandling.Reanticipate;
+
+        /// <summary>
+        /// Contains the current state of this transform on the server side.
+        /// Note that, on the server side, this gets updated at the end of the frame, and will not immediately reflect
+        /// changes to the transform.
+        /// </summary>
+        public TransformState AuthoritativeState => m_AuthoritativeTransform;
+
+        /// <summary>
+        /// Contains the current anticipated state, which will match the values of this object's
+        /// actual <see cref="MonoBehaviour.transform"/>. When a server
+        /// update arrives, this value will be overwritten by the new
+        /// server value (unless stale data handling is set to "Ignore"
+        /// and the update is determined to be stale). This value will
+        /// be duplicated in <see cref="PreviousAnticipatedState"/>, which
+        /// will NOT be overwritten in server updates.
+        /// </summary>
+        public TransformState AnticipatedState => m_AnticipatedTransform;
+
+        /// <summary>
+        /// Indicates whether this transform currently needs
+        /// reanticipation. If this is true, the anticipated value
+        /// has been overwritten by the authoritative value from the
+        /// server; the previous anticipated value is stored in <see cref="PreviousAnticipatedState"/>
+        /// </summary>
+        public bool ShouldReanticipate
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Holds the most recent anticipated state, whatever was
+        /// most recently set using the Anticipate methods. Unlike
+        /// <see cref="AnticipatedState"/>, this does not get overwritten
+        /// when a server update arrives.
+        /// </summary>
+        public TransformState PreviousAnticipatedState => m_PreviousAnticipatedTransform;
+
+        /// <summary>
+        /// Anticipate that, at the end of one round trip to the server, this transform will be in the given
+        /// <see cref="newPosition"/>
+        /// </summary>
+        /// <param name="newPosition"></param>
+        public void AnticipateMove(Vector3 newPosition)
+        {
+            if (NetworkManager.ShutdownInProgress || !NetworkManager.IsListening)
+            {
+                return;
+            }
+            transform.position = newPosition;
+            m_AnticipatedTransform.Position = newPosition;
+            if (CanCommitToTransform)
+            {
+                m_AuthoritativeTransform.Position = newPosition;
+            }
+
+            m_PreviousAnticipatedTransform = m_AnticipatedTransform;
+
+            m_LastAnticipaionCounter = NetworkManager.AnticipationSystem.AnticipationCounter;
+            m_LastAnticipationTime = NetworkManager.LocalTime.Time;
+
+            m_SmoothDuration = 0;
+            m_CurrentSmoothTime = 0;
+        }
+
+        /// <summary>
+        /// Anticipate that, at the end of one round trip to the server, this transform will have the given
+        /// <see cref="newRotation"/>
+        /// </summary>
+        /// <param name="newRotation"></param>
+        public void AnticipateRotate(Quaternion newRotation)
+        {
+            if (NetworkManager.ShutdownInProgress || !NetworkManager.IsListening)
+            {
+                return;
+            }
+            transform.rotation = newRotation;
+            m_AnticipatedTransform.Rotation = newRotation;
+            if (CanCommitToTransform)
+            {
+                m_AuthoritativeTransform.Rotation = newRotation;
+            }
+
+            m_PreviousAnticipatedTransform = m_AnticipatedTransform;
+
+            m_LastAnticipaionCounter = NetworkManager.AnticipationSystem.AnticipationCounter;
+            m_LastAnticipationTime = NetworkManager.LocalTime.Time;
+
+            m_SmoothDuration = 0;
+            m_CurrentSmoothTime = 0;
+        }
+
+        /// <summary>
+        /// Anticipate that, at the end of one round trip to the server, this transform will have the given
+        /// <see cref="newScale"/>
+        /// </summary>
+        /// <param name="newScale"></param>
+        public void AnticipateScale(Vector3 newScale)
+        {
+            if (NetworkManager.ShutdownInProgress || !NetworkManager.IsListening)
+            {
+                return;
+            }
+            transform.localScale = newScale;
+            m_AnticipatedTransform.Scale = newScale;
+            if (CanCommitToTransform)
+            {
+                m_AuthoritativeTransform.Scale = newScale;
+            }
+
+            m_PreviousAnticipatedTransform = m_AnticipatedTransform;
+
+            m_LastAnticipaionCounter = NetworkManager.AnticipationSystem.AnticipationCounter;
+            m_LastAnticipationTime = NetworkManager.LocalTime.Time;
+
+            m_SmoothDuration = 0;
+            m_CurrentSmoothTime = 0;
+        }
+
+        /// <summary>
+        /// Anticipate that, at the end of one round trip to the server, the transform will have the given
+        /// <see cref="newState"/>
+        /// </summary>
+        /// <param name="newState"></param>
+        public void AnticipateState(TransformState newState)
+        {
+            if (NetworkManager.ShutdownInProgress || !NetworkManager.IsListening)
+            {
+                return;
+            }
+            var transform_ = transform;
+            transform_.position = newState.Position;
+            transform_.rotation = newState.Rotation;
+            transform_.localScale = newState.Scale;
+            m_AnticipatedTransform = newState;
+            if (CanCommitToTransform)
+            {
+                m_AuthoritativeTransform = newState;
+            }
+
+            m_PreviousAnticipatedTransform = m_AnticipatedTransform;
+
+            m_LastAnticipaionCounter = NetworkManager.AnticipationSystem.AnticipationCounter;
+            m_LastAnticipationTime = NetworkManager.LocalTime.Time;
+
+            m_SmoothDuration = 0;
+            m_CurrentSmoothTime = 0;
+        }
+
+        public override void OnUpdate()
+        {
+            // If not spawned or this instance has authority, exit early
+            if (!IsSpawned)
+            {
+                return;
+            }
+            // Do not call the base class implementation...
+            // AnticipatedNetworkTransform applies its authoritative state immediately rather than waiting for update
+            // This is because AnticipatedNetworkTransforms may need to reference each other in reanticipating
+            // and we will want all reanticipation done before anything else wants to reference the transform in
+            // OnUpdate()
+            //base.Update();
+
+            if (m_CurrentSmoothTime < m_SmoothDuration)
+            {
+                m_CurrentSmoothTime += NetworkManager.RealTimeProvider.DeltaTime;
+                var transform_ = transform;
+                var pct = math.min(m_CurrentSmoothTime / m_SmoothDuration, 1f);
+
+                m_AnticipatedTransform = new TransformState
+                {
+                    Position = Vector3.Lerp(m_SmoothFrom.Position, m_SmoothTo.Position, pct),
+                    Rotation = Quaternion.Slerp(m_SmoothFrom.Rotation, m_SmoothTo.Rotation, pct),
+                    Scale = Vector3.Lerp(m_SmoothFrom.Scale, m_SmoothTo.Scale, pct)
+                };
+                m_PreviousAnticipatedTransform = m_AnticipatedTransform;
+                if (!CanCommitToTransform)
+                {
+                    transform_.position = m_AnticipatedTransform.Position;
+                    transform_.localScale = m_AnticipatedTransform.Scale;
+                    transform_.rotation = m_AnticipatedTransform.Rotation;
+                }
+            }
+        }
+
+        internal class AnticipatedObject : IAnticipationEventReceiver, IAnticipatedObject
+        {
+            public AnticipatedNetworkTransform Transform;
+
+
+            public void SetupForRender()
+            {
+                if (Transform.CanCommitToTransform)
+                {
+                    var transform_ = Transform.transform;
+                    Transform.m_AuthoritativeTransform = new TransformState
+                    {
+                        Position = transform_.position,
+                        Rotation = transform_.rotation,
+                        Scale = transform_.localScale
+                    };
+                    if (Transform.m_CurrentSmoothTime >= Transform.m_SmoothDuration)
+                    {
+                        // If we've had a call to Smooth() we'll continue interpolating.
+                        // Otherwise we'll go ahead and make the visual and actual locations
+                        // match.
+                        Transform.m_AnticipatedTransform = Transform.m_AuthoritativeTransform;
+                    }
+
+                    transform_.position = Transform.m_AnticipatedTransform.Position;
+                    transform_.rotation = Transform.m_AnticipatedTransform.Rotation;
+                    transform_.localScale = Transform.m_AnticipatedTransform.Scale;
+                }
+            }
+
+            public void SetupForUpdate()
+            {
+                if (Transform.CanCommitToTransform)
+                {
+                    var transform_ = Transform.transform;
+                    transform_.position = Transform.m_AuthoritativeTransform.Position;
+                    transform_.rotation = Transform.m_AuthoritativeTransform.Rotation;
+                    transform_.localScale = Transform.m_AuthoritativeTransform.Scale;
+                }
+            }
+
+            public void Update()
+            {
+                // No need to do this, it's handled by NetworkBehaviour.Update
+            }
+
+            public void ResetAnticipation()
+            {
+                Transform.ShouldReanticipate = false;
+            }
+
+            public NetworkObject OwnerObject => Transform.NetworkObject;
+        }
+
+        private AnticipatedObject m_AnticipatedObject = null;
+
+        private void ResetAnticipatedState()
+        {
+            var transform_ = transform;
+            m_AuthoritativeTransform = new TransformState
+            {
+                Position = transform_.position,
+                Rotation = transform_.rotation,
+                Scale = transform_.localScale
+            };
+            m_AnticipatedTransform = m_AuthoritativeTransform;
+            m_PreviousAnticipatedTransform = m_AnticipatedTransform;
+
+            m_SmoothDuration = 0;
+            m_CurrentSmoothTime = 0;
+        }
+
+        protected override void OnSynchronize<T>(ref BufferSerializer<T> serializer)
+        {
+            base.OnSynchronize(ref serializer);
+            if (!CanCommitToTransform)
+            {
+                m_OutstandingAuthorityChange = true;
+                ApplyAuthoritativeState();
+                ResetAnticipatedState();
+            }
+        }
+
+        public override void OnNetworkSpawn()
+        {
+            base.OnNetworkSpawn();
+            m_OutstandingAuthorityChange = true;
+            ApplyAuthoritativeState();
+            ResetAnticipatedState();
+
+            m_AnticipatedObject = new AnticipatedObject { Transform = this };
+            NetworkManager.AnticipationSystem.RegisterForAnticipationEvents(m_AnticipatedObject);
+            NetworkManager.AnticipationSystem.AllAnticipatedObjects.Add(m_AnticipatedObject);
+        }
+
+        public override void OnNetworkDespawn()
+        {
+            if (m_AnticipatedObject != null)
+            {
+                NetworkManager.AnticipationSystem.DeregisterForAnticipationEvents(m_AnticipatedObject);
+                NetworkManager.AnticipationSystem.AllAnticipatedObjects.Remove(m_AnticipatedObject);
+                NetworkManager.AnticipationSystem.ObjectsToReanticipate.Remove(m_AnticipatedObject);
+                m_AnticipatedObject = null;
+            }
+            ResetAnticipatedState();
+
+            base.OnNetworkDespawn();
+        }
+
+        public override void OnDestroy()
+        {
+            if (m_AnticipatedObject != null)
+            {
+                NetworkManager.AnticipationSystem.DeregisterForAnticipationEvents(m_AnticipatedObject);
+                NetworkManager.AnticipationSystem.AllAnticipatedObjects.Remove(m_AnticipatedObject);
+                NetworkManager.AnticipationSystem.ObjectsToReanticipate.Remove(m_AnticipatedObject);
+                m_AnticipatedObject = null;
+            }
+
+            base.OnDestroy();
+        }
+
+        /// <summary>
+        /// Interpolate between the transform represented by <see cref="from"/> to the transform represented by
+        /// <see cref="to"/> over <see cref="durationSeconds"/> of real time. The duration uses
+        /// <see cref="Time.deltaTime"/>, so it is affected by <see cref="Time.timeScale"/>.
+        /// </summary>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        /// <param name="durationSeconds"></param>
+        public void Smooth(TransformState from, TransformState to, float durationSeconds)
+        {
+            var transform_ = transform;
+            if (durationSeconds <= 0)
+            {
+                m_AnticipatedTransform = to;
+                m_PreviousAnticipatedTransform = m_AnticipatedTransform;
+                transform_.position = to.Position;
+                transform_.rotation = to.Rotation;
+                transform_.localScale = to.Scale;
+                m_SmoothDuration = 0;
+                m_CurrentSmoothTime = 0;
+                return;
+            }
+            m_AnticipatedTransform = from;
+            m_PreviousAnticipatedTransform = m_AnticipatedTransform;
+
+            if (!CanCommitToTransform)
+            {
+                transform_.position = from.Position;
+                transform_.rotation = from.Rotation;
+                transform_.localScale = from.Scale;
+            }
+
+            m_SmoothFrom = from;
+            m_SmoothTo = to;
+            m_SmoothDuration = durationSeconds;
+            m_CurrentSmoothTime = 0;
+        }
+
+        protected override void OnBeforeUpdateTransformState()
+        {
+            // this is called when new data comes from the server
+            m_LastAuthorityUpdateCounter = NetworkManager.AnticipationSystem.LastAnticipationAck;
+            m_OutstandingAuthorityChange = true;
+        }
+
+        protected override void OnNetworkTransformStateUpdated(ref NetworkTransformState oldState, ref NetworkTransformState newState)
+        {
+            base.OnNetworkTransformStateUpdated(ref oldState, ref newState);
+            ApplyAuthoritativeState();
+        }
+
+        protected override void OnTransformUpdated()
+        {
+            if (CanCommitToTransform || m_AnticipatedObject == null)
+            {
+                return;
+            }
+            // this is called pretty much every frame and will change the transform
+            // If we've overridden the transform with an anticipated state, we need to be able to change it back
+            // to the anticipated state (while updating the authority state accordingly) or else
+            // mark this transform for reanticipation
+            var transform_ = transform;
+
+            var previousAnticipatedTransform = m_AnticipatedTransform;
+
+            // Update authority state to catch any possible interpolation data
+            m_AuthoritativeTransform.Position = transform_.position;
+            m_AuthoritativeTransform.Rotation = transform_.rotation;
+            m_AuthoritativeTransform.Scale = transform_.localScale;
+
+            if (!m_OutstandingAuthorityChange)
+            {
+                // Keep the anticipated value unchanged, we have no updates from the server at all.
+                transform_.position = previousAnticipatedTransform.Position;
+                transform_.localScale = previousAnticipatedTransform.Scale;
+                transform_.rotation = previousAnticipatedTransform.Rotation;
+                return;
+            }
+
+            if (StaleDataHandling == StaleDataHandling.Ignore && m_LastAnticipaionCounter > m_LastAuthorityUpdateCounter)
+            {
+                // Keep the anticipated value unchanged because it is more recent than the authoritative one.
+                transform_.position = previousAnticipatedTransform.Position;
+                transform_.localScale = previousAnticipatedTransform.Scale;
+                transform_.rotation = previousAnticipatedTransform.Rotation;
+                return;
+            }
+
+            m_SmoothDuration = 0;
+            m_CurrentSmoothTime = 0;
+            m_OutstandingAuthorityChange = false;
+            m_AnticipatedTransform = m_AuthoritativeTransform;
+
+            ShouldReanticipate = true;
+            NetworkManager.AnticipationSystem.ObjectsToReanticipate.Add(m_AnticipatedObject);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Components/AnticipatedNetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/AnticipatedNetworkTransform.cs
@@ -61,7 +61,6 @@ namespace Unity.Netcode.Components
         private TransformState m_AnticipatedTransform = new TransformState();
         private TransformState m_PreviousAnticipatedTransform = new TransformState();
         private ulong m_LastAnticipaionCounter;
-        private double m_LastAnticipationTime;
         private ulong m_LastAuthorityUpdateCounter;
 
         private TransformState m_SmoothFrom;
@@ -156,7 +155,6 @@ namespace Unity.Netcode.Components
             m_PreviousAnticipatedTransform = m_AnticipatedTransform;
 
             m_LastAnticipaionCounter = NetworkManager.AnticipationSystem.AnticipationCounter;
-            m_LastAnticipationTime = NetworkManager.LocalTime.Time;
 
             m_SmoothDuration = 0;
             m_CurrentSmoothTime = 0;
@@ -183,7 +181,6 @@ namespace Unity.Netcode.Components
             m_PreviousAnticipatedTransform = m_AnticipatedTransform;
 
             m_LastAnticipaionCounter = NetworkManager.AnticipationSystem.AnticipationCounter;
-            m_LastAnticipationTime = NetworkManager.LocalTime.Time;
 
             m_SmoothDuration = 0;
             m_CurrentSmoothTime = 0;
@@ -210,7 +207,6 @@ namespace Unity.Netcode.Components
             m_PreviousAnticipatedTransform = m_AnticipatedTransform;
 
             m_LastAnticipaionCounter = NetworkManager.AnticipationSystem.AnticipationCounter;
-            m_LastAnticipationTime = NetworkManager.LocalTime.Time;
 
             m_SmoothDuration = 0;
             m_CurrentSmoothTime = 0;
@@ -238,9 +234,6 @@ namespace Unity.Netcode.Components
             }
 
             m_PreviousAnticipatedTransform = m_AnticipatedTransform;
-
-            m_LastAnticipaionCounter = NetworkManager.AnticipationSystem.AnticipationCounter;
-            m_LastAnticipationTime = NetworkManager.LocalTime.Time;
 
             m_SmoothDuration = 0;
             m_CurrentSmoothTime = 0;
@@ -325,7 +318,7 @@ namespace Unity.Netcode.Components
 
             public void Update()
             {
-                // No need to do this, it's handled by NetworkBehaviour.Update
+                // No need to do this, it's handled by NetworkTransform.OnUpdate
             }
 
             public void ResetAnticipation()

--- a/com.unity.netcode.gameobjects/Runtime/Components/AnticipatedNetworkTransform.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Components/AnticipatedNetworkTransform.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5abfce83aadd948498d4990c645a017b

--- a/com.unity.netcode.gameobjects/Runtime/Components/Messages.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Messages.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: a9db1d18fa0117f4da5e8e65386b894a
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
@@ -186,7 +186,6 @@ namespace Unity.Netcode.Components
     /// NetworkAnimator enables remote synchronization of <see cref="UnityEngine.Animator"/> state for on network objects.
     /// </summary>
     [AddComponentMenu("Netcode/Network Animator")]
-    [RequireComponent(typeof(Animator))]
     public class NetworkAnimator : NetworkBehaviour, ISerializationCallbackReceiver
     {
         [Serializable]

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
@@ -17,6 +17,11 @@ namespace Unity.Netcode.Components
     [AddComponentMenu("Netcode/Network Transform")]
     public class NetworkTransform : NetworkBehaviour
     {
+
+#if UNITY_EDITOR
+        internal virtual bool HideInterpolateValue => false;
+#endif
+
         #region NETWORK TRANSFORM STATE
         /// <summary>
         /// Data structure used to synchronize the <see cref="NetworkTransform"/>
@@ -2184,10 +2189,15 @@ namespace Unity.Netcode.Components
 
         internal bool LogMotion;
 
+        protected virtual void OnTransformUpdated()
+        {
+
+        }
+
         /// <summary>
         /// Applies the authoritative state to the transform
         /// </summary>
-        private void ApplyAuthoritativeState()
+        protected internal void ApplyAuthoritativeState()
         {
 #if COM_UNITY_MODULES_PHYSICS
             // TODO: Make this an authority flag
@@ -2391,6 +2401,7 @@ namespace Unity.Netcode.Components
                 }
                 transform.localScale = m_CurrentScale;
             }
+            OnTransformUpdated();
         }
 
         /// <summary>
@@ -2602,6 +2613,8 @@ namespace Unity.Netcode.Components
             {
                 AddLogEntry(ref newState, NetworkObject.OwnerClientId);
             }
+
+            OnTransformUpdated();
         }
 
         /// <summary>
@@ -2769,6 +2782,11 @@ namespace Unity.Netcode.Components
 
         }
 
+        protected virtual void OnBeforeUpdateTransformState()
+        {
+
+        }
+
         internal bool LogStateUpdate;
         /// <summary>
         /// Only non-authoritative instances should invoke this method
@@ -2809,6 +2827,10 @@ namespace Unity.Netcode.Components
                 }
                 Debug.Log(builder);
             }
+
+            // Notification prior to applying a state update
+            OnBeforeUpdateTransformState();
+
             // Apply the new state
             ApplyUpdatedState(newState);
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
@@ -11,6 +11,7 @@ namespace Unity.Netcode
         private NetworkManager m_NetworkManager;
         private NetworkConnectionManager m_ConnectionManager;
         private HashSet<NetworkObject> m_DirtyNetworkObjects = new HashSet<NetworkObject>();
+        private HashSet<NetworkObject> m_PendingDirtyNetworkObjects = new HashSet<NetworkObject>();
 
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
         private ProfilerMarker m_NetworkBehaviourUpdate = new ProfilerMarker($"{nameof(NetworkBehaviour)}.{nameof(NetworkBehaviourUpdate)}");
@@ -18,7 +19,7 @@ namespace Unity.Netcode
 
         internal void AddForUpdate(NetworkObject networkObject)
         {
-            m_DirtyNetworkObjects.Add(networkObject);
+            m_PendingDirtyNetworkObjects.Add(networkObject);
         }
 
         internal void NetworkBehaviourUpdate()
@@ -28,6 +29,9 @@ namespace Unity.Netcode
 #endif
             try
             {
+                m_DirtyNetworkObjects.UnionWith(m_PendingDirtyNetworkObjects);
+                m_PendingDirtyNetworkObjects.Clear();
+
                 // NetworkObject references can become null, when hidden or despawned. Once NUll, there is no point
                 // trying to process them, even if they were previously marked as dirty.
                 m_DirtyNetworkObjects.RemoveWhere((sobj) => sobj == null);

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -253,8 +253,10 @@ namespace Unity.Netcode
 
                         DeferredMessageManager.ProcessTriggers(IDeferredNetworkMessageManager.TriggerType.OnNextFrame, 0);
 
+                        AnticipationSystem.SetupForUpdate();
                         MessageManager.ProcessIncomingMessageQueue();
                         MessageManager.CleanupDisconnectedClients();
+                        AnticipationSystem.ProcessReanticipation();
                     }
                     break;
 #if COM_UNITY_MODULES_PHYSICS
@@ -273,6 +275,7 @@ namespace Unity.Netcode
                 case NetworkUpdateStage.PreUpdate:
                     {
                         NetworkTimeSystem.UpdateTime();
+                        AnticipationSystem.Update();
                     }
                     break;
                 case NetworkUpdateStage.PreLateUpdate:
@@ -285,6 +288,12 @@ namespace Unity.Netcode
                                 networkTransformEntry.Value.OnUpdate();
                             }
                         }
+                    }
+                    break;
+                case NetworkUpdateStage.PostScriptLateUpdate:
+                    {
+                        AnticipationSystem.Sync();
+                        AnticipationSystem.SetupForRender();
                     }
                     break;
                 case NetworkUpdateStage.PostLateUpdate:
@@ -524,6 +533,25 @@ namespace Unity.Netcode
         {
             add => ConnectionManager.OnTransportFailure += value;
             remove => ConnectionManager.OnTransportFailure -= value;
+        }
+
+        public delegate void ReanticipateDelegate(double lastRoundTripTime);
+
+        /// <summary>
+        /// This callback is called after all individual OnReanticipate calls on AnticipatedNetworkVariable
+        /// and AnticipatedNetworkTransform values have been invoked. The first parameter is a hash set of
+        /// all the variables that have been changed on this frame (you can detect a particular variable by
+        /// checking if the set contains it), while the second parameter is a set of all anticipated network
+        /// transforms that have been changed. Both are passed as their base class type.
+        ///
+        /// The third parameter is the local time corresponding to the current authoritative server state
+        /// (i.e., to determine the amount of time that needs to be re-simulated, you will use
+        /// NetworkManager.LocalTime.Time - authorityTime).
+        /// </summary>
+        public event ReanticipateDelegate OnReanticipate
+        {
+            add => AnticipationSystem.OnReanticipate += value;
+            remove => AnticipationSystem.OnReanticipate -= value;
         }
 
         /// <summary>
@@ -769,6 +797,8 @@ namespace Unity.Netcode
         /// Accessor property for the <see cref="NetworkTickSystem"/> of the NetworkManager.
         /// </summary>
         public NetworkTickSystem NetworkTickSystem { get; private set; }
+
+        internal AnticipationSystem AnticipationSystem { get; private set; }
 
         /// <summary>
         /// Used for time mocking in tests
@@ -1078,6 +1108,7 @@ namespace Unity.Netcode
             this.RegisterNetworkUpdate(NetworkUpdateStage.FixedUpdate);
 #endif
             this.RegisterNetworkUpdate(NetworkUpdateStage.PreUpdate);
+            this.RegisterNetworkUpdate(NetworkUpdateStage.PostScriptLateUpdate);
             this.RegisterNetworkUpdate(NetworkUpdateStage.PreLateUpdate);
             this.RegisterNetworkUpdate(NetworkUpdateStage.PostLateUpdate);
 
@@ -1117,6 +1148,7 @@ namespace Unity.Netcode
             // The remaining systems can then be initialized
             NetworkTimeSystem = server ? NetworkTimeSystem.ServerTimeSystem() : new NetworkTimeSystem(1.0 / NetworkConfig.TickRate);
             NetworkTickSystem = NetworkTimeSystem.Initialize(this);
+            AnticipationSystem = new AnticipationSystem(this);
 
             // Create spawn manager instance
             SpawnManager = new NetworkSpawnManager(this);

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkUpdateLoop.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkUpdateLoop.cs
@@ -54,6 +54,12 @@ namespace Unity.Netcode
         /// </summary>
         PreLateUpdate = 6,
         /// <summary>
+        /// Updated after Monobehaviour.LateUpdate, but BEFORE rendering
+        /// </summary>
+        // Yes, these numbers are out of order due to backward compatibility requirements.
+        // The enum values are listed in the order they will be called.
+        PostScriptLateUpdate = 8,
+        /// <summary>
         /// Updated after the Monobehaviour.LateUpdate for all components is invoked
         /// </summary>
         PostLateUpdate = 7
@@ -258,6 +264,18 @@ namespace Unity.Netcode
             }
         }
 
+        internal struct NetworkPostScriptLateUpdate
+        {
+            public static PlayerLoopSystem CreateLoopSystem()
+            {
+                return new PlayerLoopSystem
+                {
+                    type = typeof(NetworkPostScriptLateUpdate),
+                    updateDelegate = () => RunNetworkUpdateStage(NetworkUpdateStage.PostScriptLateUpdate)
+                };
+            }
+        }
+
         internal struct NetworkPostLateUpdate
         {
             public static PlayerLoopSystem CreateLoopSystem()
@@ -399,6 +417,7 @@ namespace Unity.Netcode
                 else if (currentSystem.type == typeof(PreLateUpdate))
                 {
                     TryAddLoopSystem(ref currentSystem, NetworkPreLateUpdate.CreateLoopSystem(), typeof(PreLateUpdate.ScriptRunBehaviourLateUpdate), LoopSystemPosition.Before);
+                    TryAddLoopSystem(ref currentSystem, NetworkPostScriptLateUpdate.CreateLoopSystem(), typeof(PreLateUpdate.ScriptRunBehaviourLateUpdate), LoopSystemPosition.After);
                 }
                 else if (currentSystem.type == typeof(PostLateUpdate))
                 {
@@ -440,6 +459,7 @@ namespace Unity.Netcode
                 else if (currentSystem.type == typeof(PreLateUpdate))
                 {
                     TryRemoveLoopSystem(ref currentSystem, typeof(NetworkPreLateUpdate));
+                    TryRemoveLoopSystem(ref currentSystem, typeof(NetworkPostScriptLateUpdate));
                 }
                 else if (currentSystem.type == typeof(PostLateUpdate))
                 {

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/ILPPMessageProvider.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/ILPPMessageProvider.cs
@@ -47,6 +47,8 @@ namespace Unity.Netcode
             SessionOwner = 20,
             TimeSync = 21,
             Unnamed = 22,
+            AnticipationCounterSyncPingMessage = 23,
+            AnticipationCounterSyncPongMessage = 24,
         }
 
 
@@ -103,7 +105,9 @@ namespace Unity.Netcode
                 { typeof(ServerRpcMessage), NetworkMessageTypes.ServerRpc },
                 { typeof(TimeSyncMessage), NetworkMessageTypes.TimeSync },
                 { typeof(UnnamedMessage), NetworkMessageTypes.Unnamed },
-                { typeof(SessionOwnerMessage), NetworkMessageTypes.SessionOwner }
+                { typeof(SessionOwnerMessage), NetworkMessageTypes.SessionOwner },
+                { typeof(AnticipationCounterSyncPingMessage), NetworkMessageTypes.AnticipationCounterSyncPingMessage},
+                { typeof(AnticipationCounterSyncPongMessage), NetworkMessageTypes.AnticipationCounterSyncPongMessage},
             };
 
             // Assure the type to lookup table count and NetworkMessageType enum count matches (i.e. to catch human error when adding new messages)

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/AnticipationCounterSyncPingMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/AnticipationCounterSyncPingMessage.cs
@@ -1,0 +1,70 @@
+namespace Unity.Netcode
+{
+    internal struct AnticipationCounterSyncPingMessage : INetworkMessage
+    {
+        public int Version => 0;
+
+        public ulong Counter;
+        public double Time;
+
+        public void Serialize(FastBufferWriter writer, int targetVersion)
+        {
+            BytePacker.WriteValuePacked(writer, Counter);
+            writer.WriteValueSafe(Time);
+        }
+
+        public bool Deserialize(FastBufferReader reader, ref NetworkContext context, int receivedMessageVersion)
+        {
+            var networkManager = (NetworkManager)context.SystemOwner;
+            if (!networkManager.IsServer)
+            {
+                return false;
+            }
+            ByteUnpacker.ReadValuePacked(reader, out Counter);
+            reader.ReadValueSafe(out Time);
+            return true;
+        }
+
+        public void Handle(ref NetworkContext context)
+        {
+            var networkManager = (NetworkManager)context.SystemOwner;
+            if (networkManager.IsListening && !networkManager.ShutdownInProgress && networkManager.ConnectedClients.ContainsKey(context.SenderId))
+            {
+                var message = new AnticipationCounterSyncPongMessage { Counter = Counter, Time = Time };
+                networkManager.MessageManager.SendMessage(ref message, NetworkDelivery.Reliable, context.SenderId);
+            }
+        }
+    }
+    internal struct AnticipationCounterSyncPongMessage : INetworkMessage
+    {
+        public int Version => 0;
+
+        public ulong Counter;
+        public double Time;
+
+        public void Serialize(FastBufferWriter writer, int targetVersion)
+        {
+            BytePacker.WriteValuePacked(writer, Counter);
+            writer.WriteValueSafe(Time);
+        }
+
+        public bool Deserialize(FastBufferReader reader, ref NetworkContext context, int receivedMessageVersion)
+        {
+            var networkManager = (NetworkManager)context.SystemOwner;
+            if (!networkManager.IsClient)
+            {
+                return false;
+            }
+            ByteUnpacker.ReadValuePacked(reader, out Counter);
+            reader.ReadValueSafe(out Time);
+            return true;
+        }
+
+        public void Handle(ref NetworkContext context)
+        {
+            var networkManager = (NetworkManager)context.SystemOwner;
+            networkManager.AnticipationSystem.LastAnticipationAck = Counter;
+            networkManager.AnticipationSystem.LastAnticipationAckTime = Time;
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/AnticipationCounterSyncPingMessage.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/AnticipationCounterSyncPingMessage.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b7d5c92979ad7e646a078aaf058b53a9

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkVariableDeltaMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkVariableDeltaMessage.cs
@@ -69,7 +69,8 @@ namespace Unity.Netcode
                 var networkVariable = NetworkBehaviour.NetworkVariableFields[i];
                 var shouldWrite = networkVariable.IsDirty() &&
                     networkVariable.CanClientRead(TargetClientId) &&
-                    (networkManager.IsServer || networkVariable.CanClientWrite(networkManager.LocalClientId));
+                    (networkManager.IsServer || networkVariable.CanClientWrite(networkManager.LocalClientId)) &&
+                    networkVariable.CanSend();
 
                 // Prevent the server from writing to the client that owns a given NetworkVariable
                 // Allowing the write would send an old value to the client and cause jitter

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/AnticipatedNetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/AnticipatedNetworkVariable.cs
@@ -1,0 +1,392 @@
+using System;
+using Unity.Mathematics;
+using UnityEngine;
+
+namespace Unity.Netcode
+{
+
+    public enum StaleDataHandling
+    {
+        Ignore,
+        Reanticipate
+    }
+
+#pragma warning disable IDE0001
+    /// <summary>
+    /// A variable that can be synchronized over the network.
+    /// This version supports basic client anticipation - the client can set a value on the belief that the server
+    /// will update it to reflect the same value in a future update (i.e., as the result of an RPC call).
+    /// This value can then be adjusted as new updates from the server come in, in three basic modes:
+    ///
+    /// <list type="bullet">
+    ///
+    /// <item><b>Snap:</b> In this mode (with <see cref="StaleDataHandling"/> set to
+    /// <see cref="Netcode.StaleDataHandling.Ignore"/> and no <see cref="NetworkBehaviour.OnReanticipate"/> callback),
+    /// the moment a more up-to-date value is received from the authority, it will simply replace the anticipated value,
+    /// resulting in a "snap" to the new value if it is different from the anticipated value.</item>
+    ///
+    /// <item><b>Smooth:</b> In this mode (with <see cref="StaleDataHandling"/> set to
+    /// <see cref="Netcode.StaleDataHandling.Ignore"/> and an <see cref="NetworkBehaviour.OnReanticipate"/> callback that calls
+    /// <see cref="Smooth"/> from the anticipated value to the authority value with an appropriate
+    /// <see cref="Mathf.Lerp"/>-style smooth function), when a more up-to-date value is received from the authority,
+    /// it will interpolate over time from an incorrect anticipated value to the correct authoritative value.</item>
+    ///
+    /// <item><b>Constant Reanticipation:</b> In this mode (with <see cref="StaleDataHandling"/> set to
+    /// <see cref="Netcode.StaleDataHandling.Reanticipate"/> and an <see cref="NetworkBehaviour.OnReanticipate"/> that calculates a
+    /// new anticipated value based on the current authoritative value), when a more up-to-date value is received from
+    /// the authority, user code calculates a new anticipated value, possibly calling <see cref="Smooth"/> to interpolate
+    /// between the previous anticipation and the new anticipation. This is useful for values that change frequently and
+    /// need to constantly be re-evaluated, as opposed to values that change only in response to user action and simply
+    /// need a one-time anticipation when the user performs that action.</item>
+    ///
+    /// </list>
+    ///
+    /// Note that these three modes may be combined. For example, if an <see cref="NetworkBehaviour.OnReanticipate"/> callback
+    /// does not call either <see cref="Smooth"/> or <see cref="Anticipate"/>, the result will be a snap to the
+    /// authoritative value, enabling for a callback that may conditionally call <see cref="Smooth"/> when the
+    /// difference between the anticipated and authoritative values is within some threshold, but fall back to
+    /// snap behavior if the difference is too large.
+    /// </summary>
+    /// <typeparam name="T">the unmanaged type for <see cref="NetworkVariable{T}"/> </typeparam>
+#pragma warning restore IDE0001
+    [Serializable]
+    [GenerateSerializationForGenericParameter(0)]
+    public class AnticipatedNetworkVariable<T> : NetworkVariableBase
+    {
+        [SerializeField]
+        private NetworkVariable<T> m_AuthoritativeValue;
+        private T m_AnticipatedValue;
+        private T m_PreviousAnticipatedValue;
+        private ulong m_LastAuthorityUpdateCounter = 0;
+        private ulong m_LastAnticipationCounter = 0;
+        private bool m_IsDisposed = false;
+        private bool m_SettingAuthoritativeValue = false;
+
+        private T m_SmoothFrom;
+        private T m_SmoothTo;
+        private float m_SmoothDuration;
+        private float m_CurrentSmoothTime;
+        private bool m_HasSmoothValues;
+
+#pragma warning disable IDE0001
+        /// <summary>
+        /// Defines what the behavior should be if we receive a value from the server with an earlier associated
+        /// time value than the anticipation time value.
+        /// <br/><br/>
+        /// If this is <see cref="Netcode.StaleDataHandling.Ignore"/>, the stale data will be ignored and the authoritative
+        /// value will not replace the anticipated value until the anticipation time is reached. <see cref="OnAuthoritativeValueChanged"/>
+        /// and <see cref="NetworkBehaviour.OnReanticipate"/> will also not be invoked for this stale data.
+        /// <br/><br/>
+        /// If this is <see cref="Netcode.StaleDataHandling.Reanticipate"/>, the stale data will replace the anticipated data and
+        /// <see cref="OnAuthoritativeValueChanged"/> and <see cref="NetworkBehaviour.OnReanticipate"/> will be invoked.
+        /// In this case, the authoritativeTime value passed to <see cref="NetworkBehaviour.OnReanticipate"/> will be lower than
+        /// the anticipationTime value, and that callback can be used to calculate a new anticipated value.
+        /// </summary>
+#pragma warning restore IDE0001
+        public StaleDataHandling StaleDataHandling;
+
+        public delegate void OnAuthoritativeValueChangedDelegate(AnticipatedNetworkVariable<T> variable, in T previousValue, in T newValue);
+
+        /// <summary>
+        /// Invoked any time the authoritative value changes, even when the data is stale or has been changed locally.
+        /// </summary>
+        public OnAuthoritativeValueChangedDelegate OnAuthoritativeValueChanged = null;
+
+        /// <summary>
+        /// Determines if the difference between the last serialized value and the current value is large enough
+        /// to serialize it again.
+        /// </summary>
+        public event NetworkVariable<T>.CheckExceedsDirtinessThresholdDelegate CheckExceedsDirtinessThreshold
+        {
+            add => m_AuthoritativeValue.CheckExceedsDirtinessThreshold += value;
+            remove => m_AuthoritativeValue.CheckExceedsDirtinessThreshold -= value;
+        }
+
+        private class AnticipatedObject : IAnticipatedObject
+        {
+            public AnticipatedNetworkVariable<T> Variable;
+
+            public void Update()
+            {
+                Variable.Update();
+            }
+
+            public void ResetAnticipation()
+            {
+                Variable.ShouldReanticipate = false;
+            }
+
+            public NetworkObject OwnerObject => Variable.m_NetworkBehaviour.NetworkObject;
+        }
+
+        private AnticipatedObject m_AnticipatedObject;
+
+        public override void OnInitialize()
+        {
+            m_AuthoritativeValue.Initialize(m_NetworkBehaviour);
+            NetworkVariableSerialization<T>.Duplicate(m_AuthoritativeValue.Value, ref m_AnticipatedValue);
+            NetworkVariableSerialization<T>.Duplicate(m_AnticipatedValue, ref m_PreviousAnticipatedValue);
+            if (m_NetworkBehaviour != null && m_NetworkBehaviour.NetworkManager != null && m_NetworkBehaviour.NetworkManager.AnticipationSystem != null)
+            {
+                m_AnticipatedObject = new AnticipatedObject { Variable = this };
+                m_NetworkBehaviour.NetworkManager.AnticipationSystem.AllAnticipatedObjects.Add(m_AnticipatedObject);
+            }
+        }
+
+        public override bool ExceedsDirtinessThreshold()
+        {
+            return m_AuthoritativeValue.ExceedsDirtinessThreshold();
+        }
+
+        /// <summary>
+        /// Retrieves the current value for the variable.
+        /// This is the "display value" for this variable, and is affected by <see cref="Anticipate"/> and
+        /// <see cref="Smooth"/>, as well as by updates from the authority, depending on <see cref="StaleDataHandling"/>
+        /// and the behavior of any <see cref="NetworkBehaviour.OnReanticipate"/> callbacks.
+        /// <br /><br />
+        /// When a server update arrives, this value will be overwritten
+        /// by the new server value (unless stale data handling is set
+        /// to "Ignore" and the update is determined to be stale).
+        /// This value will be duplicated in
+        /// <see cref="PreviousAnticipatedValue"/>, which
+        /// will NOT be overwritten in server updates.
+        /// </summary>
+        public T Value => m_AnticipatedValue;
+
+        /// <summary>
+        /// Indicates whether this variable currently needs
+        /// reanticipation. If this is true, the anticipated value
+        /// has been overwritten by the authoritative value from the
+        /// server; the previous anticipated value is stored in <see cref="PreviousAnticipatedState"/>
+        /// </summary>
+        public bool ShouldReanticipate
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Holds the most recent anticipated value, whatever was
+        /// most recently set using <see cref="Anticipate"/>. Unlike
+        /// <see cref="Value"/>, this does not get overwritten
+        /// when a server update arrives.
+        /// </summary>
+        public T PreviousAnticipatedValue => m_PreviousAnticipatedValue;
+
+        /// <summary>
+        /// Sets the current value of the variable on the expectation that the authority will set the variable
+        /// to the same value within one network round trip (i.e., in response to an RPC).
+        /// </summary>
+        /// <param name="value"></param>
+        public void Anticipate(T value)
+        {
+            if (m_NetworkBehaviour.NetworkManager.ShutdownInProgress || !m_NetworkBehaviour.NetworkManager.IsListening)
+            {
+                return;
+            }
+            m_SmoothDuration = 0;
+            m_CurrentSmoothTime = 0;
+            m_LastAnticipationCounter = m_NetworkBehaviour.NetworkManager.AnticipationSystem.AnticipationCounter;
+            m_AnticipatedValue = value;
+            NetworkVariableSerialization<T>.Duplicate(m_AnticipatedValue, ref m_PreviousAnticipatedValue);
+            if (CanClientWrite(m_NetworkBehaviour.NetworkManager.LocalClientId))
+            {
+                AuthoritativeValue = value;
+            }
+        }
+
+#pragma warning disable IDE0001
+        /// <summary>
+        /// Retrieves or sets the underlying authoritative value.
+        /// Note that only a client or server with write permissions to this variable may set this value.
+        /// When this variable has been anticipated, this value will alawys return the most recent authoritative
+        /// state, which is updated even if <see cref="StaleDataHandling"/> is <see cref="Netcode.StaleDataHandling.Ignore"/>.
+        /// </summary>
+#pragma warning restore IDE0001
+        public T AuthoritativeValue
+        {
+            get => m_AuthoritativeValue.Value;
+            set
+            {
+                m_SettingAuthoritativeValue = true;
+                try
+                {
+                    m_AuthoritativeValue.Value = value;
+                    m_AnticipatedValue = value;
+                    NetworkVariableSerialization<T>.Duplicate(m_AnticipatedValue, ref m_PreviousAnticipatedValue);
+                }
+                finally
+                {
+                    m_SettingAuthoritativeValue = false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// A function to interpolate between two values based on a percentage.
+        /// See <see cref="Mathf.Lerp"/>, <see cref="Vector3.Lerp"/>, <see cref="Vector3.Slerp"/>, and so on
+        /// for examples.
+        /// </summary>
+        public delegate T SmoothDelegate(T authoritativeValue, T anticipatedValue, float amount);
+
+        private SmoothDelegate m_SmoothDelegate = null;
+
+        public AnticipatedNetworkVariable(T value = default,
+            StaleDataHandling staleDataHandling = StaleDataHandling.Ignore)
+            : base()
+        {
+            StaleDataHandling = staleDataHandling;
+            m_AuthoritativeValue = new NetworkVariable<T>(value)
+            {
+                OnValueChanged = OnValueChangedInternal
+            };
+        }
+
+        public void Update()
+        {
+            if (m_CurrentSmoothTime < m_SmoothDuration)
+            {
+                m_CurrentSmoothTime += m_NetworkBehaviour.NetworkManager.RealTimeProvider.DeltaTime;
+                var pct = math.min(m_CurrentSmoothTime / m_SmoothDuration, 1f);
+                m_AnticipatedValue = m_SmoothDelegate(m_SmoothFrom, m_SmoothTo, pct);
+                NetworkVariableSerialization<T>.Duplicate(m_AnticipatedValue, ref m_PreviousAnticipatedValue);
+            }
+        }
+
+        public override void Dispose()
+        {
+            if (m_IsDisposed)
+            {
+                return;
+            }
+
+            if (m_NetworkBehaviour != null && m_NetworkBehaviour.NetworkManager != null && m_NetworkBehaviour.NetworkManager.AnticipationSystem != null)
+            {
+                if (m_AnticipatedObject != null)
+                {
+                    m_NetworkBehaviour.NetworkManager.AnticipationSystem.AllAnticipatedObjects.Remove(m_AnticipatedObject);
+                    m_NetworkBehaviour.NetworkManager.AnticipationSystem.ObjectsToReanticipate.Remove(m_AnticipatedObject);
+                    m_AnticipatedObject = null;
+                }
+            }
+
+            m_IsDisposed = true;
+
+            m_AuthoritativeValue.Dispose();
+            if (m_AnticipatedValue is IDisposable anticipatedValueDisposable)
+            {
+                anticipatedValueDisposable.Dispose();
+            }
+
+            m_AnticipatedValue = default;
+            if (m_PreviousAnticipatedValue is IDisposable previousValueDisposable)
+            {
+                previousValueDisposable.Dispose();
+                m_PreviousAnticipatedValue = default;
+            }
+
+            if (m_HasSmoothValues)
+            {
+                if (m_SmoothFrom is IDisposable smoothFromDisposable)
+                {
+                    smoothFromDisposable.Dispose();
+                    m_SmoothFrom = default;
+                }
+                if (m_SmoothTo is IDisposable smoothToDisposable)
+                {
+                    smoothToDisposable.Dispose();
+                    m_SmoothTo = default;
+                }
+
+                m_HasSmoothValues = false;
+            }
+        }
+
+        ~AnticipatedNetworkVariable()
+        {
+            Dispose();
+        }
+
+        private void OnValueChangedInternal(T previousValue, T newValue)
+        {
+            if (!m_SettingAuthoritativeValue)
+            {
+                m_LastAuthorityUpdateCounter = m_NetworkBehaviour.NetworkManager.AnticipationSystem.LastAnticipationAck;
+                if (StaleDataHandling == StaleDataHandling.Ignore && m_LastAnticipationCounter > m_LastAuthorityUpdateCounter)
+                {
+                    // Keep the anticipated value unchanged because it is more recent than the authoritative one.
+                    return;
+                }
+
+
+                ShouldReanticipate = true;
+                m_NetworkBehaviour.NetworkManager.AnticipationSystem.ObjectsToReanticipate.Add(m_AnticipatedObject);
+            }
+
+            NetworkVariableSerialization<T>.Duplicate(AuthoritativeValue, ref m_AnticipatedValue);
+
+            m_SmoothDuration = 0;
+            m_CurrentSmoothTime = 0;
+            OnAuthoritativeValueChanged?.Invoke(this, previousValue, newValue);
+        }
+
+        /// <summary>
+        /// Interpolate this variable from <see cref="from"/> to <see cref="to"/> over <see cref="durationSeconds"/> of
+        /// real time. The duration uses <see cref="Time.deltaTime"/>, so it is affected by <see cref="Time.timeScale"/>.
+        /// </summary>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        /// <param name="durationSeconds"></param>
+        /// <param name="how"></param>
+        public void Smooth(in T from, in T to, float durationSeconds, SmoothDelegate how)
+        {
+            if (durationSeconds <= 0)
+            {
+                NetworkVariableSerialization<T>.Duplicate(to, ref m_AnticipatedValue);
+                m_SmoothDuration = 0;
+                m_CurrentSmoothTime = 0;
+                m_SmoothDelegate = null;
+                return;
+            }
+            NetworkVariableSerialization<T>.Duplicate(from, ref m_AnticipatedValue);
+            NetworkVariableSerialization<T>.Duplicate(from, ref m_SmoothFrom);
+            NetworkVariableSerialization<T>.Duplicate(to, ref m_SmoothTo);
+            m_SmoothDuration = durationSeconds;
+            m_CurrentSmoothTime = 0;
+            m_SmoothDelegate = how;
+            m_HasSmoothValues = true;
+        }
+
+        public override bool IsDirty()
+        {
+            return m_AuthoritativeValue.IsDirty();
+        }
+
+        public override void ResetDirty()
+        {
+            m_AuthoritativeValue.ResetDirty();
+        }
+
+        public override void WriteDelta(FastBufferWriter writer)
+        {
+            m_AuthoritativeValue.WriteDelta(writer);
+        }
+
+        public override void WriteField(FastBufferWriter writer)
+        {
+            m_AuthoritativeValue.WriteField(writer);
+        }
+
+        public override void ReadField(FastBufferReader reader)
+        {
+            m_AuthoritativeValue.ReadField(reader);
+            NetworkVariableSerialization<T>.Duplicate(m_AuthoritativeValue.Value, ref m_AnticipatedValue);
+            NetworkVariableSerialization<T>.Duplicate(m_AnticipatedValue, ref m_PreviousAnticipatedValue);
+        }
+
+        public override void ReadDelta(FastBufferReader reader, bool keepDirtyDelta)
+        {
+            m_AuthoritativeValue.ReadDelta(reader, keepDirtyDelta);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/AnticipatedNetworkVariable.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/AnticipatedNetworkVariable.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fc9fd5701bee8534a971eb9f49178e21

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -21,6 +21,29 @@ namespace Unity.Netcode
         /// The callback to be invoked when the value gets changed
         /// </summary>
         public OnValueChangedDelegate OnValueChanged;
+
+        public delegate bool CheckExceedsDirtinessThresholdDelegate(in T previousValue, in T newValue);
+
+        public CheckExceedsDirtinessThresholdDelegate CheckExceedsDirtinessThreshold;
+
+        public override bool ExceedsDirtinessThreshold()
+        {
+            if (CheckExceedsDirtinessThreshold != null && m_HasPreviousValue)
+            {
+                return CheckExceedsDirtinessThreshold(m_PreviousValue, m_InternalValue);
+            }
+
+            return true;
+        }
+
+        public override void OnInitialize()
+        {
+            base.OnInitialize();
+
+            m_HasPreviousValue = true;
+            NetworkVariableSerialization<T>.Duplicate(m_InternalValue, ref m_PreviousValue);
+        }
+
         internal override NetworkVariableType Type => NetworkVariableType.Value;
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
@@ -3,11 +3,26 @@ using UnityEngine;
 
 namespace Unity.Netcode
 {
+    public struct NetworkVariableUpdateTraits
+    {
+        [Tooltip("The minimum amount of time that must pass between sending updates. If this amount of time has not passed since the last update, dirtiness will be ignored.")]
+        public float MinSecondsBetweenUpdates;
+
+        [Tooltip("The maximum amount of time that a variable can be dirty without sending an update. If this amount of time has passed since the last update, an update will be sent even if the dirtiness threshold has not been met.")]
+        public float MaxSecondsBetweenUpdates;
+    }
+
     /// <summary>
     /// Interface for network value containers
     /// </summary>
     public abstract class NetworkVariableBase : IDisposable
     {
+        [SerializeField]
+        internal NetworkVariableUpdateTraits UpdateTraits = default;
+
+        [NonSerialized]
+        internal double LastUpdateSent;
+
         /// <summary>
         /// The delivery type (QoS) to send data with
         /// </summary>
@@ -52,7 +67,42 @@ namespace Unity.Netcode
                 m_InternalNetworkManager = m_NetworkBehaviour.NetworkObject?.NetworkManager;
                 // When in distributed authority mode, there is no such thing as server write permissions
                 InternalWritePerm = m_InternalNetworkManager.DistributedAuthorityMode ? NetworkVariableWritePermission.Owner : InternalWritePerm;
+
+                if (m_NetworkBehaviour.NetworkManager.NetworkTimeSystem != null)
+                {
+                    UpdateLastSentTime();
+                }
             }
+
+            OnInitialize();
+        }
+
+        /// <summary>
+        /// Called on initialization
+        /// </summary>
+        public virtual void OnInitialize()
+        {
+
+        }
+
+        /// <summary>
+        /// Sets the update traits for this network variable to determine how frequently it will send updates.
+        /// </summary>
+        /// <param name="traits"></param>
+        public void SetUpdateTraits(NetworkVariableUpdateTraits traits)
+        {
+            UpdateTraits = traits;
+        }
+
+        /// <summary>
+        /// Check whether or not this variable has changed significantly enough to send an update.
+        /// If not, no update will be sent even if the variable is dirty, unless the time since last update exceeds
+        /// the <see cref="UpdateTraits"/>' <see cref="NetworkVariableUpdateTraits.MaxSecondsBetweenUpdates"/>.
+        /// </summary>
+        /// <returns></returns>
+        public virtual bool ExceedsDirtinessThreshold()
+        {
+            return true;
         }
 
         /// <summary>
@@ -125,6 +175,25 @@ namespace Unity.Netcode
             }
         }
 
+        internal bool CanSend()
+        {
+            var timeSinceLastUpdate = m_NetworkBehaviour.NetworkManager.NetworkTimeSystem.LocalTime - LastUpdateSent;
+            return
+                (
+                    UpdateTraits.MaxSecondsBetweenUpdates > 0 &&
+                    timeSinceLastUpdate >= UpdateTraits.MaxSecondsBetweenUpdates
+                ) ||
+                (
+                    timeSinceLastUpdate >= UpdateTraits.MinSecondsBetweenUpdates &&
+                    ExceedsDirtinessThreshold()
+                );
+        }
+
+        internal void UpdateLastSentTime()
+        {
+            LastUpdateSent = m_NetworkBehaviour.NetworkManager.NetworkTimeSystem.LocalTime;
+        }
+
         internal static bool IgnoreInitializeWarning;
 
         protected void MarkNetworkBehaviourDirty()
@@ -147,6 +216,17 @@ namespace Unity.Netcode
                 }
                 return;
             }
+
+            if (!m_NetworkBehaviour.NetworkManager.IsListening)
+            {
+                if (m_NetworkBehaviour.NetworkManager.LogLevel <= LogLevel.Developer)
+                {
+                    Debug.LogWarning($"NetworkVariable is written to after the NetworkManager has already shutdown! " +
+                     "Are you modifying a NetworkVariable within a NetworkBehaviour.OnDestroy or NetworkBehaviour.OnDespawn method?");
+                }
+                return;
+            }
+
             m_NetworkBehaviour.NetworkManager.BehaviourUpdater?.AddForUpdate(m_NetworkBehaviour.NetworkObject);
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/NetworkBehaviourReference.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/NetworkBehaviourReference.cs
@@ -11,6 +11,8 @@ namespace Unity.Netcode
     {
         private NetworkObjectReference m_NetworkObjectReference;
         private ushort m_NetworkBehaviourId;
+        private static ushort s_NullId = ushort.MaxValue;
+
 
         /// <summary>
         /// Creates a new instance of the <see cref="NetworkBehaviourReference{T}"/> struct.
@@ -21,7 +23,9 @@ namespace Unity.Netcode
         {
             if (networkBehaviour == null)
             {
-                throw new ArgumentNullException(nameof(networkBehaviour));
+                m_NetworkObjectReference = new NetworkObjectReference((NetworkObject)null);
+                m_NetworkBehaviourId = s_NullId;
+                return;
             }
             if (networkBehaviour.NetworkObject == null)
             {
@@ -60,6 +64,11 @@ namespace Unity.Netcode
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static NetworkBehaviour GetInternal(NetworkBehaviourReference networkBehaviourRef, NetworkManager networkManager = null)
         {
+            if (networkBehaviourRef.m_NetworkBehaviourId == s_NullId)
+            {
+                return null;
+            }
+
             if (networkBehaviourRef.m_NetworkObjectReference.TryGet(out NetworkObject networkObject, networkManager))
             {
                 return networkObject.GetNetworkBehaviourAtOrderIndex(networkBehaviourRef.m_NetworkBehaviourId);

--- a/com.unity.netcode.gameobjects/Runtime/Timing/AnticipationSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Timing/AnticipationSystem.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+
+namespace Unity.Netcode
+{
+    internal interface IAnticipationEventReceiver
+    {
+        public void SetupForUpdate();
+        public void SetupForRender();
+    }
+
+    internal interface IAnticipatedObject
+    {
+        public void Update();
+        public void ResetAnticipation();
+        public NetworkObject OwnerObject { get; }
+    }
+
+    internal class AnticipationSystem
+    {
+        internal ulong LastAnticipationAck;
+        internal double LastAnticipationAckTime;
+
+        internal HashSet<IAnticipatedObject> AllAnticipatedObjects = new HashSet<IAnticipatedObject>();
+
+        internal ulong AnticipationCounter;
+
+        private NetworkManager m_NetworkManager;
+
+        public HashSet<IAnticipatedObject> ObjectsToReanticipate = new HashSet<IAnticipatedObject>();
+
+        public AnticipationSystem(NetworkManager manager)
+        {
+            m_NetworkManager = manager;
+        }
+
+        public event NetworkManager.ReanticipateDelegate OnReanticipate;
+
+        private HashSet<IAnticipationEventReceiver> m_AnticipationEventReceivers = new HashSet<IAnticipationEventReceiver>();
+
+        public void RegisterForAnticipationEvents(IAnticipationEventReceiver receiver)
+        {
+            m_AnticipationEventReceivers.Add(receiver);
+        }
+        public void DeregisterForAnticipationEvents(IAnticipationEventReceiver receiver)
+        {
+            m_AnticipationEventReceivers.Remove(receiver);
+        }
+
+        public void SetupForUpdate()
+        {
+            foreach (var receiver in m_AnticipationEventReceivers)
+            {
+                receiver.SetupForUpdate();
+            }
+        }
+
+        public void SetupForRender()
+        {
+            foreach (var receiver in m_AnticipationEventReceivers)
+            {
+                receiver.SetupForRender();
+            }
+        }
+
+        public void ProcessReanticipation()
+        {
+            var lastRoundTripTime = m_NetworkManager.LocalTime.Time - LastAnticipationAckTime;
+            foreach (var item in ObjectsToReanticipate)
+            {
+                foreach (var behaviour in item.OwnerObject.ChildNetworkBehaviours)
+                {
+                    behaviour.OnReanticipate(lastRoundTripTime);
+                }
+                item.ResetAnticipation();
+            }
+
+            ObjectsToReanticipate.Clear();
+            OnReanticipate?.Invoke(lastRoundTripTime);
+        }
+
+        public void Update()
+        {
+            foreach (var item in AllAnticipatedObjects)
+            {
+                item.Update();
+            }
+        }
+
+        public void Sync()
+        {
+            if (AllAnticipatedObjects.Count != 0 && !m_NetworkManager.ShutdownInProgress && !m_NetworkManager.ConnectionManager.LocalClient.IsServer && m_NetworkManager.ConnectionManager.LocalClient.IsConnected)
+            {
+                var message = new AnticipationCounterSyncPingMessage { Counter = AnticipationCounter, Time = m_NetworkManager.LocalTime.Time };
+                m_NetworkManager.MessageManager.SendMessage(ref message, NetworkDelivery.Reliable, NetworkManager.ServerClientId);
+            }
+
+            ++AnticipationCounter;
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Timing/AnticipationSystem.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Timing/AnticipationSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4a75eccede7ecf1408f61dd55c338e06

--- a/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTime.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTime.cs
@@ -25,6 +25,11 @@ namespace Unity.Netcode
         public double TickOffset => m_CachedTickOffset;
 
         /// <summary>
+        /// Gets the tick, including partial tick value passed since it started.
+        /// </summary>
+        public double TickWithPartial => Tick + (TickOffset / m_TickInterval);
+
+        /// <summary>
         /// Gets the current time. This is a non fixed time value and similar to <see cref="Time.time"/>.
         /// </summary>
         public double Time => m_TimeSec;

--- a/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTimeSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Timing/NetworkTimeSystem.cs
@@ -5,7 +5,9 @@ namespace Unity.Netcode
 {
     /// <summary>
     /// <see cref="NetworkTimeSystem"/> is a standalone system which can be used to run a network time simulation.
-    /// The network time system maintains both a local and a server time. The local time is based on
+    /// The network time system maintains both a local and a server time. The local time is based on the server time
+    /// as last received from the server plus an offset based on the current RTT - in other words, it is a best-guess
+    /// effort at predicting what the server tick will be when a given network action is processed on the server.
     /// </summary>
     public class NetworkTimeSystem
     {

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/MockTransport.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/MockTransport.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Random = UnityEngine.Random;
 
 namespace Unity.Netcode.TestHelpers.Runtime
 {
@@ -10,6 +11,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             public ulong FromClientId;
             public ArraySegment<byte> Payload;
             public NetworkEvent Event;
+            public float AvailableTime;
         }
 
         private static Dictionary<ulong, Queue<MessageData>> s_MessageQueue = new Dictionary<ulong, Queue<MessageData>>();
@@ -18,21 +20,38 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
         public static ulong HighTransportId = 0;
         public ulong TransportId = 0;
+        public float SimulatedLatencySeconds;
+        public float PacketDropRate;
+        public float LatencyJitter;
 
         public NetworkManager NetworkManager;
 
         public override void Send(ulong clientId, ArraySegment<byte> payload, NetworkDelivery networkDelivery)
         {
+            if (Random.Range(0, 1) < PacketDropRate)
+            {
+                return;
+            }
             var copy = new byte[payload.Array.Length];
             Array.Copy(payload.Array, copy, payload.Array.Length);
-            s_MessageQueue[clientId].Enqueue(new MessageData { FromClientId = TransportId, Payload = new ArraySegment<byte>(copy, payload.Offset, payload.Count), Event = NetworkEvent.Data });
+            s_MessageQueue[clientId].Enqueue(new MessageData { FromClientId = TransportId, Payload = new ArraySegment<byte>(copy, payload.Offset, payload.Count), Event = NetworkEvent.Data, AvailableTime =
+                NetworkManager.RealTimeProvider.UnscaledTime + SimulatedLatencySeconds + Random.Range(-LatencyJitter, LatencyJitter) });
         }
 
         public override NetworkEvent PollEvent(out ulong clientId, out ArraySegment<byte> payload, out float receiveTime)
         {
             if (s_MessageQueue[TransportId].Count > 0)
             {
-                var data = s_MessageQueue[TransportId].Dequeue();
+                var data = s_MessageQueue[TransportId].Peek();
+                if (data.AvailableTime > NetworkManager.RealTimeProvider.UnscaledTime)
+                {
+                    clientId = 0;
+                    payload = new ArraySegment<byte>();
+                    receiveTime = 0;
+                    return NetworkEvent.Nothing;
+                }
+
+                s_MessageQueue[TransportId].Dequeue();
                 clientId = data.FromClientId;
                 payload = data.Payload;
                 receiveTime = NetworkManager.RealTimeProvider.RealTimeSinceStartup;
@@ -89,6 +108,20 @@ namespace Unity.Netcode.TestHelpers.Runtime
         public override void Initialize(NetworkManager networkManager = null)
         {
             NetworkManager = networkManager;
+        }
+
+        public static void Reset()
+        {
+            s_MessageQueue.Clear();
+            HighTransportId = 0;
+        }
+
+        public static void ClearQueues()
+        {
+            foreach (var kvp in s_MessageQueue)
+            {
+                kvp.Value.Clear();
+            }
         }
     }
 }

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/MockTransport.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/MockTransport.cs
@@ -34,8 +34,14 @@ namespace Unity.Netcode.TestHelpers.Runtime
             }
             var copy = new byte[payload.Array.Length];
             Array.Copy(payload.Array, copy, payload.Array.Length);
-            s_MessageQueue[clientId].Enqueue(new MessageData { FromClientId = TransportId, Payload = new ArraySegment<byte>(copy, payload.Offset, payload.Count), Event = NetworkEvent.Data, AvailableTime =
-                NetworkManager.RealTimeProvider.UnscaledTime + SimulatedLatencySeconds + Random.Range(-LatencyJitter, LatencyJitter) });
+            s_MessageQueue[clientId].Enqueue(new MessageData
+            {
+                FromClientId = TransportId,
+                Payload = new ArraySegment<byte>(copy, payload.Offset, payload.Count),
+                Event = NetworkEvent.Data,
+                AvailableTime =
+                NetworkManager.RealTimeProvider.UnscaledTime + SimulatedLatencySeconds + Random.Range(-LatencyJitter, LatencyJitter)
+            });
         }
 
         public override NetworkEvent PollEvent(out ulong clientId, out ArraySegment<byte> payload, out float receiveTime)

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -337,6 +337,15 @@ namespace Unity.Netcode.TestHelpers.Runtime
             NetcodeLogAssert = new NetcodeLogAssert();
             if (m_EnableTimeTravel)
             {
+                if (m_NetworkManagerInstatiationMode == NetworkManagerInstatiationMode.AllTests)
+                {
+                    MockTransport.ClearQueues();
+                }
+                else
+                {
+                    MockTransport.Reset();
+                }
+
                 // Setup the frames per tick for time travel advance to next tick
                 ConfigureFramesPerTick();
             }
@@ -634,6 +643,33 @@ namespace Unity.Netcode.TestHelpers.Runtime
             NetcodeIntegrationTestHelpers.StopOneClient(networkManager, destroy);
             AddRemoveNetworkManager(networkManager, false);
             Assert.True(WaitForConditionOrTimeOutWithTimeTravel(() => !networkManager.IsConnectedClient));
+        }
+
+        protected void SetTimeTravelSimulatedLatency(float latencySeconds)
+        {
+            ((MockTransport)m_ServerNetworkManager.NetworkConfig.NetworkTransport).SimulatedLatencySeconds = latencySeconds;
+            foreach (var client in m_ClientNetworkManagers)
+            {
+                ((MockTransport)client.NetworkConfig.NetworkTransport).SimulatedLatencySeconds = latencySeconds;
+            }
+        }
+
+        protected void SetTimeTravelSimulatedDropRate(float dropRatePercent)
+        {
+            ((MockTransport)m_ServerNetworkManager.NetworkConfig.NetworkTransport).PacketDropRate = dropRatePercent;
+            foreach (var client in m_ClientNetworkManagers)
+            {
+                ((MockTransport)client.NetworkConfig.NetworkTransport).PacketDropRate = dropRatePercent;
+            }
+        }
+
+        protected void SetTimeTravelSimulatedLatencyJitter(float jitterSeconds)
+        {
+            ((MockTransport)m_ServerNetworkManager.NetworkConfig.NetworkTransport).LatencyJitter = jitterSeconds;
+            foreach (var client in m_ClientNetworkManagers)
+            {
+                ((MockTransport)client.NetworkConfig.NetworkTransport).LatencyJitter = jitterSeconds;
+            }
         }
 
         /// <summary>
@@ -1880,8 +1916,21 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// </summary>
         public static void SimulateOneFrame()
         {
-            foreach (NetworkUpdateStage stage in Enum.GetValues(typeof(NetworkUpdateStage)))
+            foreach (NetworkUpdateStage updateStage in Enum.GetValues(typeof(NetworkUpdateStage)))
             {
+                var stage = updateStage;
+                // These two are out of order numerically due to backward compatibility
+                // requirements. We have to swap them to maintain correct execution
+                // order.
+                if (stage == NetworkUpdateStage.PostScriptLateUpdate)
+                {
+                    stage = NetworkUpdateStage.PostLateUpdate;
+                }
+                else if (stage == NetworkUpdateStage.PostLateUpdate)
+                {
+                    stage = NetworkUpdateStage.PostScriptLateUpdate;
+                }
+
                 NetworkUpdateLoop.RunNetworkUpdateStage(stage);
                 string methodName = string.Empty;
                 switch (stage)
@@ -1900,13 +1949,18 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 if (!string.IsNullOrEmpty(methodName))
                 {
 #if UNITY_2023_1_OR_NEWER
-                    foreach (var behaviour in Object.FindObjectsByType<NetworkBehaviour>(FindObjectsSortMode.InstanceID))
+                    foreach (var obj in Object.FindObjectsByType<NetworkObject>(FindObjectsSortMode.InstanceID))
 #else
-                    foreach (var behaviour in Object.FindObjectsOfType<NetworkBehaviour>())
+                    foreach (var obj in Object.FindObjectsOfType<NetworkObject>())
 #endif
                     {
-                        var method = behaviour.GetType().GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-                        method?.Invoke(behaviour, new object[] { });
+                        var method = obj.GetType().GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                        method?.Invoke(obj, new object[] { });
+                        foreach (var behaviour in obj.ChildNetworkBehaviours)
+                        {
+                            var behaviourMethod = behaviour.GetType().GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                            behaviourMethod?.Invoke(behaviour, new object[] { });
+                        }
                     }
                 }
             }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerEventsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerEventsTests.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
 using UnityEngine.TestTools;
+using Object = UnityEngine.Object;
 
 namespace Unity.Netcode.RuntimeTests
 {
@@ -35,7 +36,7 @@ namespace Unity.Netcode.RuntimeTests
 
             m_ServerManager.OnServerStopped += onServerStopped;
             m_ServerManager.Shutdown();
-            UnityEngine.Object.DestroyImmediate(gameObject);
+            Object.DestroyImmediate(gameObject);
 
             yield return WaitUntilManagerShutsdown();
 
@@ -92,7 +93,7 @@ namespace Unity.Netcode.RuntimeTests
             m_ServerManager.OnServerStopped += onServerStopped;
             m_ServerManager.OnClientStopped += onClientStopped;
             m_ServerManager.Shutdown();
-            UnityEngine.Object.DestroyImmediate(gameObject);
+            Object.DestroyImmediate(gameObject);
 
             yield return WaitUntilManagerShutsdown();
 
@@ -228,6 +229,18 @@ namespace Unity.Netcode.RuntimeTests
         public virtual IEnumerator Teardown()
         {
             NetcodeIntegrationTestHelpers.Destroy();
+            if (m_ServerManager != null)
+            {
+                m_ServerManager.ShutdownInternal();
+                Object.DestroyImmediate(m_ServerManager);
+                m_ServerManager = null;
+            }
+            if (m_ClientManager != null)
+            {
+                m_ClientManager.ShutdownInternal();
+                Object.DestroyImmediate(m_ClientManager);
+                m_ClientManager = null;
+            }
             yield return null;
         }
     }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransformAnticipationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransformAnticipationTests.cs
@@ -1,0 +1,521 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Unity.Netcode.Components;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    internal class NetworkTransformAnticipationComponent : NetworkBehaviour
+    {
+        [Rpc(SendTo.Server)]
+        public void MoveRpc(Vector3 newPosition)
+        {
+            transform.position = newPosition;
+        }
+
+        [Rpc(SendTo.Server)]
+        public void ScaleRpc(Vector3 newScale)
+        {
+            transform.localScale = newScale;
+        }
+
+        [Rpc(SendTo.Server)]
+        public void RotateRpc(Quaternion newRotation)
+        {
+            transform.rotation = newRotation;
+        }
+
+        public bool ShouldSmooth = false;
+        public bool ShouldMove = false;
+
+        public override void OnReanticipate(double lastRoundTripTime)
+        {
+            var transform_ = GetComponent<AnticipatedNetworkTransform>();
+            if (transform_.ShouldReanticipate)
+            {
+                if (ShouldSmooth)
+                {
+                    transform_.Smooth(transform_.PreviousAnticipatedState, transform_.AuthoritativeState, 1);
+                }
+
+                if (ShouldMove)
+                {
+                    transform_.AnticipateMove(transform_.AuthoritativeState.Position + new Vector3(0, 5, 0));
+
+                }
+            }
+        }
+    }
+
+    internal class NetworkTransformAnticipationTests : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 2;
+
+        protected override bool m_EnableTimeTravel => true;
+        protected override bool m_SetupIsACoroutine => false;
+        protected override bool m_TearDownIsACoroutine => false;
+
+        protected override void OnPlayerPrefabGameObjectCreated()
+        {
+            m_PlayerPrefab.AddComponent<AnticipatedNetworkTransform>();
+            m_PlayerPrefab.AddComponent<NetworkTransformAnticipationComponent>();
+        }
+
+        protected override void OnTimeTravelServerAndClientsConnected()
+        {
+            var serverComponent = GetServerComponent();
+            var testComponent = GetTestComponent();
+            var otherClientComponent = GetOtherClientComponent();
+
+            serverComponent.transform.position = Vector3.zero;
+            serverComponent.transform.localScale = Vector3.one;
+            serverComponent.transform.rotation = Quaternion.LookRotation(Vector3.forward);
+            testComponent.transform.position = Vector3.zero;
+            testComponent.transform.localScale = Vector3.one;
+            testComponent.transform.rotation = Quaternion.LookRotation(Vector3.forward);
+            otherClientComponent.transform.position = Vector3.zero;
+            otherClientComponent.transform.localScale = Vector3.one;
+            otherClientComponent.transform.rotation = Quaternion.LookRotation(Vector3.forward);
+        }
+
+        public AnticipatedNetworkTransform GetTestComponent()
+        {
+            return m_ClientNetworkManagers[0].LocalClient.PlayerObject.GetComponent<AnticipatedNetworkTransform>();
+        }
+
+        public AnticipatedNetworkTransform GetServerComponent()
+        {
+            foreach (var obj in Object.FindObjectsByType<AnticipatedNetworkTransform>(FindObjectsSortMode.None))
+            {
+                if (obj.NetworkManager == m_ServerNetworkManager && obj.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId)
+                {
+                    return obj;
+                }
+            }
+
+            return null;
+        }
+
+        public AnticipatedNetworkTransform GetOtherClientComponent()
+        {
+            foreach (var obj in Object.FindObjectsByType<AnticipatedNetworkTransform>(FindObjectsSortMode.None))
+            {
+                if (obj.NetworkManager == m_ClientNetworkManagers[1] && obj.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId)
+                {
+                    return obj;
+                }
+            }
+
+            return null;
+        }
+
+        [Test]
+        public void WhenAnticipating_ValueChangesImmediately()
+        {
+            var testComponent = GetTestComponent();
+
+            testComponent.AnticipateMove(new Vector3(0, 1, 2));
+            testComponent.AnticipateScale(new Vector3(1, 2, 3));
+            testComponent.AnticipateRotate(Quaternion.LookRotation(new Vector3(2, 3, 4)));
+
+            Assert.AreEqual(new Vector3(0, 1, 2), testComponent.transform.position);
+            Assert.AreEqual(new Vector3(1, 2, 3), testComponent.transform.localScale);
+            Assert.AreEqual(Quaternion.LookRotation(new Vector3(2, 3, 4)), testComponent.transform.rotation);
+
+            Assert.AreEqual(new Vector3(0, 1, 2), testComponent.AnticipatedState.Position);
+            Assert.AreEqual(new Vector3(1, 2, 3), testComponent.AnticipatedState.Scale);
+            Assert.AreEqual(Quaternion.LookRotation(new Vector3(2, 3, 4)), testComponent.AnticipatedState.Rotation);
+
+        }
+
+        [Test]
+        public void WhenAnticipating_AuthoritativeValueDoesNotChange()
+        {
+            var testComponent = GetTestComponent();
+
+            var startPosition = testComponent.transform.position;
+            var startScale = testComponent.transform.localScale;
+            var startRotation = testComponent.transform.rotation;
+
+            testComponent.AnticipateMove(new Vector3(0, 1, 2));
+            testComponent.AnticipateScale(new Vector3(1, 2, 3));
+            testComponent.AnticipateRotate(Quaternion.LookRotation(new Vector3(2, 3, 4)));
+
+            Assert.AreEqual(startPosition, testComponent.AuthoritativeState.Position);
+            Assert.AreEqual(startScale, testComponent.AuthoritativeState.Scale);
+            Assert.AreEqual(startRotation, testComponent.AuthoritativeState.Rotation);
+        }
+
+        [Test]
+        public void WhenAnticipating_ServerDoesNotChange()
+        {
+            var testComponent = GetTestComponent();
+
+            var startPosition = testComponent.transform.position;
+            var startScale = testComponent.transform.localScale;
+            var startRotation = testComponent.transform.rotation;
+
+            testComponent.AnticipateMove(new Vector3(0, 1, 2));
+            testComponent.AnticipateScale(new Vector3(1, 2, 3));
+            testComponent.AnticipateRotate(Quaternion.LookRotation(new Vector3(2, 3, 4)));
+
+            var serverComponent = GetServerComponent();
+
+            Assert.AreEqual(startPosition, serverComponent.AuthoritativeState.Position);
+            Assert.AreEqual(startScale, serverComponent.AuthoritativeState.Scale);
+            Assert.AreEqual(startRotation, serverComponent.AuthoritativeState.Rotation);
+            Assert.AreEqual(startPosition, serverComponent.AnticipatedState.Position);
+            Assert.AreEqual(startScale, serverComponent.AnticipatedState.Scale);
+            Assert.AreEqual(startRotation, serverComponent.AnticipatedState.Rotation);
+
+            TimeTravel(2, 120);
+
+            Assert.AreEqual(startPosition, serverComponent.AuthoritativeState.Position);
+            Assert.AreEqual(startScale, serverComponent.AuthoritativeState.Scale);
+            Assert.AreEqual(startRotation, serverComponent.AuthoritativeState.Rotation);
+            Assert.AreEqual(startPosition, serverComponent.AnticipatedState.Position);
+            Assert.AreEqual(startScale, serverComponent.AnticipatedState.Scale);
+            Assert.AreEqual(startRotation, serverComponent.AnticipatedState.Rotation);
+        }
+
+        [Test]
+        public void WhenAnticipating_OtherClientDoesNotChange()
+        {
+            var testComponent = GetTestComponent();
+
+            var startPosition = testComponent.transform.position;
+            var startScale = testComponent.transform.localScale;
+            var startRotation = testComponent.transform.rotation;
+
+            testComponent.AnticipateMove(new Vector3(0, 1, 2));
+            testComponent.AnticipateScale(new Vector3(1, 2, 3));
+            testComponent.AnticipateRotate(Quaternion.LookRotation(new Vector3(2, 3, 4)));
+
+            var otherClientComponent = GetOtherClientComponent();
+
+            Assert.AreEqual(startPosition, otherClientComponent.AuthoritativeState.Position);
+            Assert.AreEqual(startScale, otherClientComponent.AuthoritativeState.Scale);
+            Assert.AreEqual(startRotation, otherClientComponent.AuthoritativeState.Rotation);
+            Assert.AreEqual(startPosition, otherClientComponent.AnticipatedState.Position);
+            Assert.AreEqual(startScale, otherClientComponent.AnticipatedState.Scale);
+            Assert.AreEqual(startRotation, otherClientComponent.AnticipatedState.Rotation);
+
+            TimeTravel(2, 120);
+
+            Assert.AreEqual(startPosition, otherClientComponent.AuthoritativeState.Position);
+            Assert.AreEqual(startScale, otherClientComponent.AuthoritativeState.Scale);
+            Assert.AreEqual(startRotation, otherClientComponent.AuthoritativeState.Rotation);
+            Assert.AreEqual(startPosition, otherClientComponent.AnticipatedState.Position);
+            Assert.AreEqual(startScale, otherClientComponent.AnticipatedState.Scale);
+            Assert.AreEqual(startRotation, otherClientComponent.AnticipatedState.Rotation);
+        }
+
+        [Test]
+        public void WhenServerChangesSnapValue_ValuesAreUpdated()
+        {
+            var testComponent = GetTestComponent();
+            var serverComponent = GetServerComponent();
+            serverComponent.Interpolate = false;
+
+            testComponent.AnticipateMove(new Vector3(0, 1, 2));
+            testComponent.AnticipateScale(new Vector3(1, 2, 3));
+            testComponent.AnticipateRotate(Quaternion.LookRotation(new Vector3(2, 3, 4)));
+
+            var rpcComponent = testComponent.GetComponent<NetworkTransformAnticipationComponent>();
+            rpcComponent.MoveRpc(new Vector3(2, 3, 4));
+
+            WaitForMessageReceivedWithTimeTravel<RpcMessage>(new List<NetworkManager> { m_ServerNetworkManager });
+            var otherClientComponent = GetOtherClientComponent();
+
+            WaitForConditionOrTimeOutWithTimeTravel(() => testComponent.AuthoritativeState.Position == serverComponent.transform.position && otherClientComponent.AuthoritativeState.Position == serverComponent.transform.position);
+
+            Assert.AreEqual(serverComponent.transform.position, testComponent.transform.position);
+            Assert.AreEqual(serverComponent.transform.position, testComponent.AnticipatedState.Position);
+            Assert.AreEqual(serverComponent.transform.position, testComponent.AuthoritativeState.Position);
+
+            Assert.AreEqual(serverComponent.transform.position, otherClientComponent.transform.position);
+            Assert.AreEqual(serverComponent.transform.position, otherClientComponent.AnticipatedState.Position);
+            Assert.AreEqual(serverComponent.transform.position, otherClientComponent.AuthoritativeState.Position);
+        }
+
+        public void AssertQuaternionsAreEquivalent(Quaternion a, Quaternion b)
+        {
+            var aAngles = a.eulerAngles;
+            var bAngles = b.eulerAngles;
+            Assert.AreEqual(aAngles.x, bAngles.x, 0.001, $"Quaternions were not equal. Expected: {a}, but was {b}");
+            Assert.AreEqual(aAngles.y, bAngles.y, 0.001, $"Quaternions were not equal. Expected: {a}, but was {b}");
+            Assert.AreEqual(aAngles.z, bAngles.z, 0.001, $"Quaternions were not equal. Expected: {a}, but was {b}");
+        }
+        public void AssertVectorsAreEquivalent(Vector3 a, Vector3 b)
+        {
+            Assert.AreEqual(a.x, b.x, 0.001, $"Vectors were not equal. Expected: {a}, but was {b}");
+            Assert.AreEqual(a.y, b.y, 0.001, $"Vectors were not equal. Expected: {a}, but was {b}");
+            Assert.AreEqual(a.z, b.z, 0.001, $"Vectors were not equal. Expected: {a}, but was {b}");
+        }
+
+        [Test]
+        public void WhenServerChangesSmoothValue_ValuesAreLerped()
+        {
+            var testComponent = GetTestComponent();
+            var otherClientComponent = GetOtherClientComponent();
+
+            testComponent.StaleDataHandling = StaleDataHandling.Ignore;
+            otherClientComponent.StaleDataHandling = StaleDataHandling.Ignore;
+
+            var serverComponent = GetServerComponent();
+            serverComponent.Interpolate = false;
+
+            testComponent.GetComponent<NetworkTransformAnticipationComponent>().ShouldSmooth = true;
+            otherClientComponent.GetComponent<NetworkTransformAnticipationComponent>().ShouldSmooth = true;
+
+            var startPosition = testComponent.transform.position;
+            var startScale = testComponent.transform.localScale;
+            var startRotation = testComponent.transform.rotation;
+            var anticipePosition = new Vector3(0, 1, 2);
+            var anticipeScale = new Vector3(1, 2, 3);
+            var anticipeRotation = Quaternion.LookRotation(new Vector3(2, 3, 4));
+            var serverSetPosition = new Vector3(3, 4, 5);
+            var serverSetScale = new Vector3(4, 5, 6);
+            var serverSetRotation = Quaternion.LookRotation(new Vector3(5, 6, 7));
+
+            testComponent.AnticipateMove(anticipePosition);
+            testComponent.AnticipateScale(anticipeScale);
+            testComponent.AnticipateRotate(anticipeRotation);
+
+            var rpcComponent = testComponent.GetComponent<NetworkTransformAnticipationComponent>();
+            rpcComponent.MoveRpc(serverSetPosition);
+            rpcComponent.RotateRpc(serverSetRotation);
+            rpcComponent.ScaleRpc(serverSetScale);
+
+            WaitForMessagesReceivedWithTimeTravel(new List<Type>
+            {
+                typeof(RpcMessage),
+                typeof(RpcMessage),
+                typeof(RpcMessage),
+            }, new List<NetworkManager> { m_ServerNetworkManager });
+
+            WaitForMessageReceivedWithTimeTravel<NetworkTransformMessage>(m_ClientNetworkManagers.ToList());
+
+            var percentChanged = 1f / 60f;
+
+            AssertVectorsAreEquivalent(Vector3.Lerp(anticipePosition, serverSetPosition, percentChanged), testComponent.transform.position);
+            AssertVectorsAreEquivalent(Vector3.Lerp(anticipeScale, serverSetScale, percentChanged), testComponent.transform.localScale);
+            AssertQuaternionsAreEquivalent(Quaternion.Slerp(anticipeRotation, serverSetRotation, percentChanged), testComponent.transform.rotation);
+
+            AssertVectorsAreEquivalent(Vector3.Lerp(anticipePosition, serverSetPosition, percentChanged), testComponent.AnticipatedState.Position);
+            AssertVectorsAreEquivalent(Vector3.Lerp(anticipeScale, serverSetScale, percentChanged), testComponent.AnticipatedState.Scale);
+            AssertQuaternionsAreEquivalent(Quaternion.Slerp(anticipeRotation, serverSetRotation, percentChanged), testComponent.AnticipatedState.Rotation);
+
+            AssertVectorsAreEquivalent(serverSetPosition, testComponent.AuthoritativeState.Position);
+            AssertVectorsAreEquivalent(serverSetScale, testComponent.AuthoritativeState.Scale);
+            AssertQuaternionsAreEquivalent(serverSetRotation, testComponent.AuthoritativeState.Rotation);
+
+            AssertVectorsAreEquivalent(Vector3.Lerp(startPosition, serverSetPosition, percentChanged), otherClientComponent.transform.position);
+            AssertVectorsAreEquivalent(Vector3.Lerp(startScale, serverSetScale, percentChanged), otherClientComponent.transform.localScale);
+            AssertQuaternionsAreEquivalent(Quaternion.Slerp(startRotation, serverSetRotation, percentChanged), otherClientComponent.transform.rotation);
+
+            AssertVectorsAreEquivalent(Vector3.Lerp(startPosition, serverSetPosition, percentChanged), otherClientComponent.AnticipatedState.Position);
+            AssertVectorsAreEquivalent(Vector3.Lerp(startScale, serverSetScale, percentChanged), otherClientComponent.AnticipatedState.Scale);
+            AssertQuaternionsAreEquivalent(Quaternion.Slerp(startRotation, serverSetRotation, percentChanged), otherClientComponent.AnticipatedState.Rotation);
+
+            AssertVectorsAreEquivalent(serverSetPosition, otherClientComponent.AuthoritativeState.Position);
+            AssertVectorsAreEquivalent(serverSetScale, otherClientComponent.AuthoritativeState.Scale);
+            AssertQuaternionsAreEquivalent(serverSetRotation, otherClientComponent.AuthoritativeState.Rotation);
+
+            for (var i = 1; i < 60; ++i)
+            {
+                TimeTravel(1f / 60f, 1);
+                percentChanged = 1f / 60f * (i + 1);
+
+                AssertVectorsAreEquivalent(Vector3.Lerp(anticipePosition, serverSetPosition, percentChanged), testComponent.transform.position);
+                AssertVectorsAreEquivalent(Vector3.Lerp(anticipeScale, serverSetScale, percentChanged), testComponent.transform.localScale);
+                AssertQuaternionsAreEquivalent(Quaternion.Slerp(anticipeRotation, serverSetRotation, percentChanged), testComponent.transform.rotation);
+
+                AssertVectorsAreEquivalent(Vector3.Lerp(anticipePosition, serverSetPosition, percentChanged), testComponent.AnticipatedState.Position);
+                AssertVectorsAreEquivalent(Vector3.Lerp(anticipeScale, serverSetScale, percentChanged), testComponent.AnticipatedState.Scale);
+                AssertQuaternionsAreEquivalent(Quaternion.Slerp(anticipeRotation, serverSetRotation, percentChanged), testComponent.AnticipatedState.Rotation);
+
+                AssertVectorsAreEquivalent(serverSetPosition, testComponent.AuthoritativeState.Position);
+                AssertVectorsAreEquivalent(serverSetScale, testComponent.AuthoritativeState.Scale);
+                AssertQuaternionsAreEquivalent(serverSetRotation, testComponent.AuthoritativeState.Rotation);
+
+                AssertVectorsAreEquivalent(Vector3.Lerp(startPosition, serverSetPosition, percentChanged), otherClientComponent.transform.position);
+                AssertVectorsAreEquivalent(Vector3.Lerp(startScale, serverSetScale, percentChanged), otherClientComponent.transform.localScale);
+                AssertQuaternionsAreEquivalent(Quaternion.Slerp(startRotation, serverSetRotation, percentChanged), otherClientComponent.transform.rotation);
+
+                AssertVectorsAreEquivalent(Vector3.Lerp(startPosition, serverSetPosition, percentChanged), otherClientComponent.AnticipatedState.Position);
+                AssertVectorsAreEquivalent(Vector3.Lerp(startScale, serverSetScale, percentChanged), otherClientComponent.AnticipatedState.Scale);
+                AssertQuaternionsAreEquivalent(Quaternion.Slerp(startRotation, serverSetRotation, percentChanged), otherClientComponent.AnticipatedState.Rotation);
+
+                AssertVectorsAreEquivalent(serverSetPosition, otherClientComponent.AuthoritativeState.Position);
+                AssertVectorsAreEquivalent(serverSetScale, otherClientComponent.AuthoritativeState.Scale);
+                AssertQuaternionsAreEquivalent(serverSetRotation, otherClientComponent.AuthoritativeState.Rotation);
+            }
+            TimeTravel(1f / 60f, 1);
+
+            AssertVectorsAreEquivalent(serverSetPosition, testComponent.transform.position);
+            AssertVectorsAreEquivalent(serverSetScale, testComponent.transform.localScale);
+            AssertQuaternionsAreEquivalent(serverSetRotation, testComponent.transform.rotation);
+
+            AssertVectorsAreEquivalent(serverSetPosition, testComponent.AnticipatedState.Position);
+            AssertVectorsAreEquivalent(serverSetScale, testComponent.AnticipatedState.Scale);
+            AssertQuaternionsAreEquivalent(serverSetRotation, testComponent.AnticipatedState.Rotation);
+
+            AssertVectorsAreEquivalent(serverSetPosition, testComponent.AuthoritativeState.Position);
+            AssertVectorsAreEquivalent(serverSetScale, testComponent.AuthoritativeState.Scale);
+            AssertQuaternionsAreEquivalent(serverSetRotation, testComponent.AuthoritativeState.Rotation);
+
+            AssertVectorsAreEquivalent(serverSetPosition, otherClientComponent.transform.position);
+            AssertVectorsAreEquivalent(serverSetScale, otherClientComponent.transform.localScale);
+            AssertQuaternionsAreEquivalent(serverSetRotation, otherClientComponent.transform.rotation);
+
+            AssertVectorsAreEquivalent(serverSetPosition, otherClientComponent.AnticipatedState.Position);
+            AssertVectorsAreEquivalent(serverSetScale, otherClientComponent.AnticipatedState.Scale);
+            AssertQuaternionsAreEquivalent(serverSetRotation, otherClientComponent.AnticipatedState.Rotation);
+
+            AssertVectorsAreEquivalent(serverSetPosition, otherClientComponent.AuthoritativeState.Position);
+            AssertVectorsAreEquivalent(serverSetScale, otherClientComponent.AuthoritativeState.Scale);
+            AssertQuaternionsAreEquivalent(serverSetRotation, otherClientComponent.AuthoritativeState.Rotation);
+        }
+
+        [Test]
+        public void WhenServerChangesReanticipeValue_ValuesAreReanticiped()
+        {
+            var testComponent = GetTestComponent();
+            var otherClientComponent = GetOtherClientComponent();
+
+            testComponent.GetComponent<NetworkTransformAnticipationComponent>().ShouldMove = true;
+            otherClientComponent.GetComponent<NetworkTransformAnticipationComponent>().ShouldMove = true;
+
+            var serverComponent = GetServerComponent();
+            serverComponent.Interpolate = false;
+            serverComponent.transform.position = new Vector3(0, 1, 2);
+            var rpcComponent = testComponent.GetComponent<NetworkTransformAnticipationComponent>();
+            rpcComponent.MoveRpc(new Vector3(0, 1, 2));
+
+            WaitForMessageReceivedWithTimeTravel<RpcMessage>(new List<NetworkManager> { m_ServerNetworkManager });
+
+            WaitForMessageReceivedWithTimeTravel<NetworkTransformMessage>(m_ClientNetworkManagers.ToList());
+
+            Assert.AreEqual(new Vector3(0, 6, 2), testComponent.transform.position);
+            Assert.AreEqual(new Vector3(0, 6, 2), testComponent.AnticipatedState.Position);
+            Assert.AreEqual(new Vector3(0, 1, 2), testComponent.AuthoritativeState.Position);
+
+            Assert.AreEqual(new Vector3(0, 6, 2), otherClientComponent.transform.position);
+            Assert.AreEqual(new Vector3(0, 6, 2), otherClientComponent.AnticipatedState.Position);
+            Assert.AreEqual(new Vector3(0, 1, 2), otherClientComponent.AuthoritativeState.Position);
+        }
+
+        [Test]
+        public void WhenStaleDataArrivesToIgnoreVariable_ItIsIgnored([Values(10u, 30u, 60u)] uint tickRate, [Values(0u, 1u, 2u)] uint skipFrames)
+        {
+            m_ServerNetworkManager.NetworkConfig.TickRate = tickRate;
+            m_ServerNetworkManager.NetworkTickSystem.TickRate = tickRate;
+
+            for (var i = 0; i < skipFrames; ++i)
+            {
+                TimeTravel(1 / 60f, 1);
+            }
+
+            var serverComponent = GetServerComponent();
+            serverComponent.Interpolate = false;
+
+            var testComponent = GetTestComponent();
+            testComponent.StaleDataHandling = StaleDataHandling.Ignore;
+            testComponent.Interpolate = false;
+
+            var otherClientComponent = GetOtherClientComponent();
+            otherClientComponent.StaleDataHandling = StaleDataHandling.Ignore;
+            otherClientComponent.Interpolate = false;
+
+            var rpcComponent = testComponent.GetComponent<NetworkTransformAnticipationComponent>();
+            rpcComponent.MoveRpc(new Vector3(1, 2, 3));
+
+            WaitForMessageReceivedWithTimeTravel<RpcMessage>(new List<NetworkManager> { m_ServerNetworkManager });
+
+            testComponent.AnticipateMove(new Vector3(0, 5, 0));
+            rpcComponent.MoveRpc(new Vector3(4, 5, 6));
+
+            // Depending on tick rate, one of these two things will happen.
+            // The assertions are different based on this... either the tick rate is slow enough that the second RPC is received
+            // before the next update and we move to 4, 5, 6, or the tick rate is fast enough that the next update is sent out
+            // before the RPC is received and we get the update for the move to 1, 2, 3. Both are valid, what we want to assert
+            // here is that the anticipated state never becomes 1, 2, 3.
+            WaitForConditionOrTimeOutWithTimeTravel(() => testComponent.AuthoritativeState.Position == new Vector3(1, 2, 3) || testComponent.AuthoritativeState.Position == new Vector3(4, 5, 6));
+
+            if (testComponent.AnticipatedState.Position == new Vector3(4, 5, 6))
+            {
+                // Anticiped client received this data for a time earlier than its anticipation, and should have prioritized the anticiped value
+                Assert.AreEqual(new Vector3(4, 5, 6), testComponent.transform.position);
+                Assert.AreEqual(new Vector3(4, 5, 6), testComponent.AnticipatedState.Position);
+                // However, the authoritative value still gets updated
+                Assert.AreEqual(new Vector3(4, 5, 6), testComponent.AuthoritativeState.Position);
+
+                // Other client got the server value and had made no anticipation, so it applies it to the anticiped value as well.
+                Assert.AreEqual(new Vector3(4, 5, 6), otherClientComponent.transform.position);
+                Assert.AreEqual(new Vector3(4, 5, 6), otherClientComponent.AnticipatedState.Position);
+                Assert.AreEqual(new Vector3(4, 5, 6), otherClientComponent.AuthoritativeState.Position);
+            }
+            else
+            {
+                // Anticiped client received this data for a time earlier than its anticipation, and should have prioritized the anticiped value
+                Assert.AreEqual(new Vector3(0, 5, 0), testComponent.transform.position);
+                Assert.AreEqual(new Vector3(0, 5, 0), testComponent.AnticipatedState.Position);
+                // However, the authoritative value still gets updated
+                Assert.AreEqual(new Vector3(1, 2, 3), testComponent.AuthoritativeState.Position);
+
+                // Other client got the server value and had made no anticipation, so it applies it to the anticiped value as well.
+                Assert.AreEqual(new Vector3(1, 2, 3), otherClientComponent.transform.position);
+                Assert.AreEqual(new Vector3(1, 2, 3), otherClientComponent.AnticipatedState.Position);
+                Assert.AreEqual(new Vector3(1, 2, 3), otherClientComponent.AuthoritativeState.Position);
+            }
+        }
+
+
+        [Test]
+        public void WhenNonStaleDataArrivesToIgnoreVariable_ItIsNotIgnored([Values(10u, 30u, 60u)] uint tickRate, [Values(0u, 1u, 2u)] uint skipFrames)
+        {
+            m_ServerNetworkManager.NetworkConfig.TickRate = tickRate;
+            m_ServerNetworkManager.NetworkTickSystem.TickRate = tickRate;
+
+            for (var i = 0; i < skipFrames; ++i)
+            {
+                TimeTravel(1 / 60f, 1);
+            }
+
+            var serverComponent = GetServerComponent();
+            serverComponent.Interpolate = false;
+
+            var testComponent = GetTestComponent();
+            testComponent.StaleDataHandling = StaleDataHandling.Ignore;
+            testComponent.Interpolate = false;
+
+            var otherClientComponent = GetOtherClientComponent();
+            otherClientComponent.StaleDataHandling = StaleDataHandling.Ignore;
+            otherClientComponent.Interpolate = false;
+
+            testComponent.AnticipateMove(new Vector3(0, 5, 0));
+            var rpcComponent = testComponent.GetComponent<NetworkTransformAnticipationComponent>();
+            rpcComponent.MoveRpc(new Vector3(1, 2, 3));
+
+            WaitForMessageReceivedWithTimeTravel<RpcMessage>(new List<NetworkManager> { m_ServerNetworkManager });
+
+            WaitForConditionOrTimeOutWithTimeTravel(() => testComponent.AuthoritativeState.Position == serverComponent.transform.position && otherClientComponent.AuthoritativeState.Position == serverComponent.transform.position);
+
+            // Anticiped client received this data for a time earlier than its anticipation, and should have prioritized the anticiped value
+            Assert.AreEqual(new Vector3(1, 2, 3), testComponent.transform.position);
+            Assert.AreEqual(new Vector3(1, 2, 3), testComponent.AnticipatedState.Position);
+            // However, the authoritative value still gets updated
+            Assert.AreEqual(new Vector3(1, 2, 3), testComponent.AuthoritativeState.Position);
+
+            // Other client got the server value and had made no anticipation, so it applies it to the anticiped value as well.
+            Assert.AreEqual(new Vector3(1, 2, 3), otherClientComponent.transform.position);
+            Assert.AreEqual(new Vector3(1, 2, 3), otherClientComponent.AnticipatedState.Position);
+            Assert.AreEqual(new Vector3(1, 2, 3), otherClientComponent.AuthoritativeState.Position);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransformAnticipationTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransformAnticipationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ceb074b080c27184a9f669cd68355955

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableAnticipationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableAnticipationTests.cs
@@ -1,0 +1,420 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    internal class NetworkVariableAnticipationComponent : NetworkBehaviour
+    {
+        public AnticipatedNetworkVariable<int> SnapOnAnticipationFailVariable = new AnticipatedNetworkVariable<int>(0, StaleDataHandling.Ignore);
+        public AnticipatedNetworkVariable<float> SmoothOnAnticipationFailVariable = new AnticipatedNetworkVariable<float>(0, StaleDataHandling.Reanticipate);
+        public AnticipatedNetworkVariable<float> ReanticipateOnAnticipationFailVariable = new AnticipatedNetworkVariable<float>(0, StaleDataHandling.Reanticipate);
+
+        public override void OnReanticipate(double lastRoundTripTime)
+        {
+            if (SmoothOnAnticipationFailVariable.ShouldReanticipate)
+            {
+                if (Mathf.Abs(SmoothOnAnticipationFailVariable.AuthoritativeValue - SmoothOnAnticipationFailVariable.PreviousAnticipatedValue) > Mathf.Epsilon)
+                {
+                    SmoothOnAnticipationFailVariable.Smooth(SmoothOnAnticipationFailVariable.PreviousAnticipatedValue, SmoothOnAnticipationFailVariable.AuthoritativeValue, 1, Mathf.Lerp);
+                }
+            }
+
+            if (ReanticipateOnAnticipationFailVariable.ShouldReanticipate)
+            {
+                // Would love to test some stuff about anticipation based on time, but that is difficult to test accurately.
+                // This reanticipating variable will just always anticipate a value 5 higher than the server value.
+                ReanticipateOnAnticipationFailVariable.Anticipate(ReanticipateOnAnticipationFailVariable.AuthoritativeValue + 5);
+            }
+        }
+
+        public bool SnapRpcResponseReceived = false;
+
+        [Rpc(SendTo.Server)]
+        public void SetSnapValueRpc(int i, RpcParams rpcParams = default)
+        {
+            SnapOnAnticipationFailVariable.AuthoritativeValue = i;
+            SetSnapValueResponseRpc(RpcTarget.Single(rpcParams.Receive.SenderClientId, RpcTargetUse.Temp));
+        }
+
+        [Rpc(SendTo.SpecifiedInParams)]
+        public void SetSnapValueResponseRpc(RpcParams rpcParams)
+        {
+            SnapRpcResponseReceived = true;
+        }
+
+        [Rpc(SendTo.Server)]
+        public void SetSmoothValueRpc(float f)
+        {
+            SmoothOnAnticipationFailVariable.AuthoritativeValue = f;
+        }
+
+        [Rpc(SendTo.Server)]
+        public void SetReanticipateValueRpc(float f)
+        {
+            ReanticipateOnAnticipationFailVariable.AuthoritativeValue = f;
+        }
+    }
+
+    internal class NetworkVariableAnticipationTests : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 2;
+
+        protected override bool m_EnableTimeTravel => true;
+        protected override bool m_SetupIsACoroutine => false;
+        protected override bool m_TearDownIsACoroutine => false;
+
+        protected override void OnPlayerPrefabGameObjectCreated()
+        {
+            m_PlayerPrefab.AddComponent<NetworkVariableAnticipationComponent>();
+        }
+
+        public NetworkVariableAnticipationComponent GetTestComponent()
+        {
+            return m_ClientNetworkManagers[0].LocalClient.PlayerObject.GetComponent<NetworkVariableAnticipationComponent>();
+        }
+
+        public NetworkVariableAnticipationComponent GetServerComponent()
+        {
+            foreach (var obj in Object.FindObjectsByType<NetworkVariableAnticipationComponent>(FindObjectsSortMode.None))
+            {
+                if (obj.NetworkManager == m_ServerNetworkManager && obj.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId)
+                {
+                    return obj;
+                }
+            }
+
+            return null;
+        }
+
+        public NetworkVariableAnticipationComponent GetOtherClientComponent()
+        {
+            foreach (var obj in Object.FindObjectsByType<NetworkVariableAnticipationComponent>(FindObjectsSortMode.None))
+            {
+                if (obj.NetworkManager == m_ClientNetworkManagers[1] && obj.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId)
+                {
+                    return obj;
+                }
+            }
+
+            return null;
+        }
+
+        [Test]
+        public void WhenAnticipating_ValueChangesImmediately()
+        {
+            var testComponent = GetTestComponent();
+
+            testComponent.SnapOnAnticipationFailVariable.Anticipate(10);
+            testComponent.SmoothOnAnticipationFailVariable.Anticipate(15);
+            testComponent.ReanticipateOnAnticipationFailVariable.Anticipate(20);
+
+            Assert.AreEqual(10, testComponent.SnapOnAnticipationFailVariable.Value);
+            Assert.AreEqual(15, testComponent.SmoothOnAnticipationFailVariable.Value);
+            Assert.AreEqual(20, testComponent.ReanticipateOnAnticipationFailVariable.Value);
+        }
+
+        [Test]
+        public void WhenAnticipating_AuthoritativeValueDoesNotChange()
+        {
+            var testComponent = GetTestComponent();
+
+            testComponent.SnapOnAnticipationFailVariable.Anticipate(10);
+            testComponent.SmoothOnAnticipationFailVariable.Anticipate(15);
+            testComponent.ReanticipateOnAnticipationFailVariable.Anticipate(20);
+
+            Assert.AreEqual(0, testComponent.SnapOnAnticipationFailVariable.AuthoritativeValue);
+            Assert.AreEqual(0, testComponent.SmoothOnAnticipationFailVariable.AuthoritativeValue);
+            Assert.AreEqual(0, testComponent.ReanticipateOnAnticipationFailVariable.AuthoritativeValue);
+        }
+
+        [Test]
+        public void WhenAnticipating_ServerDoesNotChange()
+        {
+            var testComponent = GetTestComponent();
+
+            testComponent.SnapOnAnticipationFailVariable.Anticipate(10);
+            testComponent.SmoothOnAnticipationFailVariable.Anticipate(15);
+            testComponent.ReanticipateOnAnticipationFailVariable.Anticipate(20);
+
+            var serverComponent = GetServerComponent();
+
+            Assert.AreEqual(0, serverComponent.SnapOnAnticipationFailVariable.AuthoritativeValue);
+            Assert.AreEqual(0, serverComponent.SmoothOnAnticipationFailVariable.AuthoritativeValue);
+            Assert.AreEqual(0, serverComponent.ReanticipateOnAnticipationFailVariable.AuthoritativeValue);
+            Assert.AreEqual(0, serverComponent.SnapOnAnticipationFailVariable.Value);
+            Assert.AreEqual(0, serverComponent.SmoothOnAnticipationFailVariable.Value);
+            Assert.AreEqual(0, serverComponent.ReanticipateOnAnticipationFailVariable.Value);
+
+            TimeTravel(2, 120);
+
+            Assert.AreEqual(0, serverComponent.SnapOnAnticipationFailVariable.AuthoritativeValue);
+            Assert.AreEqual(0, serverComponent.SmoothOnAnticipationFailVariable.AuthoritativeValue);
+            Assert.AreEqual(0, serverComponent.ReanticipateOnAnticipationFailVariable.AuthoritativeValue);
+            Assert.AreEqual(0, serverComponent.SnapOnAnticipationFailVariable.Value);
+            Assert.AreEqual(0, serverComponent.SmoothOnAnticipationFailVariable.Value);
+            Assert.AreEqual(0, serverComponent.ReanticipateOnAnticipationFailVariable.Value);
+        }
+
+        [Test]
+        public void WhenAnticipating_OtherClientDoesNotChange()
+        {
+            var testComponent = GetTestComponent();
+
+            testComponent.SnapOnAnticipationFailVariable.Anticipate(10);
+            testComponent.SmoothOnAnticipationFailVariable.Anticipate(15);
+            testComponent.ReanticipateOnAnticipationFailVariable.Anticipate(20);
+
+            var otherClientComponent = GetOtherClientComponent();
+
+            Assert.AreEqual(0, otherClientComponent.SnapOnAnticipationFailVariable.AuthoritativeValue);
+            Assert.AreEqual(0, otherClientComponent.SmoothOnAnticipationFailVariable.AuthoritativeValue);
+            Assert.AreEqual(0, otherClientComponent.ReanticipateOnAnticipationFailVariable.AuthoritativeValue);
+            Assert.AreEqual(0, otherClientComponent.SnapOnAnticipationFailVariable.Value);
+            Assert.AreEqual(0, otherClientComponent.SmoothOnAnticipationFailVariable.Value);
+            Assert.AreEqual(0, otherClientComponent.ReanticipateOnAnticipationFailVariable.Value);
+
+            TimeTravel(2, 120);
+
+            Assert.AreEqual(0, otherClientComponent.SnapOnAnticipationFailVariable.AuthoritativeValue);
+            Assert.AreEqual(0, otherClientComponent.SmoothOnAnticipationFailVariable.AuthoritativeValue);
+            Assert.AreEqual(0, otherClientComponent.ReanticipateOnAnticipationFailVariable.AuthoritativeValue);
+            Assert.AreEqual(0, otherClientComponent.SnapOnAnticipationFailVariable.Value);
+            Assert.AreEqual(0, otherClientComponent.SmoothOnAnticipationFailVariable.Value);
+            Assert.AreEqual(0, otherClientComponent.ReanticipateOnAnticipationFailVariable.Value);
+        }
+
+        [Test]
+        public void WhenServerChangesSnapValue_ValuesAreUpdated()
+        {
+            var testComponent = GetTestComponent();
+
+            testComponent.SnapOnAnticipationFailVariable.Anticipate(10);
+
+            Assert.AreEqual(10, testComponent.SnapOnAnticipationFailVariable.Value);
+            Assert.AreEqual(0, testComponent.SnapOnAnticipationFailVariable.AuthoritativeValue);
+
+            testComponent.SetSnapValueRpc(10);
+
+            WaitForMessageReceivedWithTimeTravel<RpcMessage>(
+                new List<NetworkManager> { m_ServerNetworkManager }
+            );
+
+            var serverComponent = GetServerComponent();
+            Assert.AreEqual(10, serverComponent.SnapOnAnticipationFailVariable.Value);
+            Assert.AreEqual(10, serverComponent.SnapOnAnticipationFailVariable.AuthoritativeValue);
+
+            var otherClientComponent = GetOtherClientComponent();
+            Assert.AreEqual(0, otherClientComponent.SnapOnAnticipationFailVariable.Value);
+            Assert.AreEqual(0, otherClientComponent.SnapOnAnticipationFailVariable.AuthoritativeValue);
+
+            WaitForMessageReceivedWithTimeTravel<NetworkVariableDeltaMessage>(m_ClientNetworkManagers.ToList());
+
+            Assert.AreEqual(10, testComponent.SnapOnAnticipationFailVariable.Value);
+            Assert.AreEqual(10, testComponent.SnapOnAnticipationFailVariable.AuthoritativeValue);
+
+            Assert.AreEqual(10, otherClientComponent.SnapOnAnticipationFailVariable.Value);
+            Assert.AreEqual(10, otherClientComponent.SnapOnAnticipationFailVariable.AuthoritativeValue);
+        }
+
+        [Test]
+        public void WhenServerChangesSmoothValue_ValuesAreLerped()
+        {
+            var testComponent = GetTestComponent();
+
+            testComponent.SmoothOnAnticipationFailVariable.Anticipate(15);
+
+            Assert.AreEqual(15, testComponent.SmoothOnAnticipationFailVariable.Value, Mathf.Epsilon);
+            Assert.AreEqual(0, testComponent.SmoothOnAnticipationFailVariable.AuthoritativeValue, Mathf.Epsilon);
+
+            // Set to a different value to simulate a anticipation failure - will lerp between the anticipated value
+            // and the actual one
+            testComponent.SetSmoothValueRpc(20);
+
+            WaitForMessageReceivedWithTimeTravel<RpcMessage>(
+                new List<NetworkManager> { m_ServerNetworkManager }
+            );
+
+            var serverComponent = GetServerComponent();
+            Assert.AreEqual(20, serverComponent.SmoothOnAnticipationFailVariable.Value, Mathf.Epsilon);
+            Assert.AreEqual(20, serverComponent.SmoothOnAnticipationFailVariable.AuthoritativeValue, Mathf.Epsilon);
+
+            var otherClientComponent = GetOtherClientComponent();
+            Assert.AreEqual(0, otherClientComponent.SmoothOnAnticipationFailVariable.Value, Mathf.Epsilon);
+            Assert.AreEqual(0, otherClientComponent.SmoothOnAnticipationFailVariable.AuthoritativeValue, Mathf.Epsilon);
+
+            WaitForMessageReceivedWithTimeTravel<NetworkVariableDeltaMessage>(m_ClientNetworkManagers.ToList());
+
+            Assert.AreEqual(15 + 1f / 60f * 5, testComponent.SmoothOnAnticipationFailVariable.Value, Mathf.Epsilon);
+            Assert.AreEqual(20, testComponent.SmoothOnAnticipationFailVariable.AuthoritativeValue, Mathf.Epsilon);
+
+            Assert.AreEqual(0 + 1f / 60f * 20, otherClientComponent.SmoothOnAnticipationFailVariable.Value, Mathf.Epsilon);
+            Assert.AreEqual(20, otherClientComponent.SmoothOnAnticipationFailVariable.AuthoritativeValue, Mathf.Epsilon);
+
+            for (var i = 1; i < 60; ++i)
+            {
+                TimeTravel(1f / 60f, 1);
+
+                Assert.AreEqual(15 + 1f / 60f * 5 * (i + 1), testComponent.SmoothOnAnticipationFailVariable.Value, 0.00001);
+                Assert.AreEqual(20, testComponent.SmoothOnAnticipationFailVariable.AuthoritativeValue, Mathf.Epsilon);
+
+                Assert.AreEqual(0 + 1f / 60f * 20 * (i + 1), otherClientComponent.SmoothOnAnticipationFailVariable.Value, 0.00001);
+                Assert.AreEqual(20, otherClientComponent.SmoothOnAnticipationFailVariable.AuthoritativeValue, Mathf.Epsilon);
+            }
+            TimeTravel(1f / 60f, 1);
+            Assert.AreEqual(20, testComponent.SmoothOnAnticipationFailVariable.Value, Mathf.Epsilon);
+            Assert.AreEqual(20, otherClientComponent.SmoothOnAnticipationFailVariable.Value, Mathf.Epsilon);
+        }
+
+        [Test]
+        public void WhenServerChangesReanticipateValue_ValuesAreReanticipated()
+        {
+            var testComponent = GetTestComponent();
+
+            testComponent.ReanticipateOnAnticipationFailVariable.Anticipate(15);
+
+            Assert.AreEqual(15, testComponent.ReanticipateOnAnticipationFailVariable.Value, Mathf.Epsilon);
+            Assert.AreEqual(0, testComponent.ReanticipateOnAnticipationFailVariable.AuthoritativeValue, Mathf.Epsilon);
+
+            // Set to a different value to simulate a anticipation failure - will lerp between the anticipated value
+            // and the actual one
+            testComponent.SetReanticipateValueRpc(20);
+
+            WaitForMessageReceivedWithTimeTravel<RpcMessage>(
+                new List<NetworkManager> { m_ServerNetworkManager }
+            );
+
+            var serverComponent = GetServerComponent();
+            Assert.AreEqual(20, serverComponent.ReanticipateOnAnticipationFailVariable.Value, Mathf.Epsilon);
+            Assert.AreEqual(20, serverComponent.ReanticipateOnAnticipationFailVariable.AuthoritativeValue, Mathf.Epsilon);
+
+            var otherClientComponent = GetOtherClientComponent();
+            Assert.AreEqual(0, otherClientComponent.ReanticipateOnAnticipationFailVariable.Value, Mathf.Epsilon);
+            Assert.AreEqual(0, otherClientComponent.ReanticipateOnAnticipationFailVariable.AuthoritativeValue, Mathf.Epsilon);
+
+            WaitForMessageReceivedWithTimeTravel<NetworkVariableDeltaMessage>(m_ClientNetworkManagers.ToList());
+
+            Assert.AreEqual(25, testComponent.ReanticipateOnAnticipationFailVariable.Value, Mathf.Epsilon);
+            Assert.AreEqual(20, testComponent.ReanticipateOnAnticipationFailVariable.AuthoritativeValue, Mathf.Epsilon);
+
+            Assert.AreEqual(25, otherClientComponent.ReanticipateOnAnticipationFailVariable.Value, Mathf.Epsilon);
+            Assert.AreEqual(20, otherClientComponent.ReanticipateOnAnticipationFailVariable.AuthoritativeValue, Mathf.Epsilon);
+        }
+
+        [Test]
+        public void WhenNonStaleDataArrivesToIgnoreVariable_ItIsNotIgnored([Values(10u, 30u, 60u)] uint tickRate, [Values(0u, 1u, 2u)] uint skipFrames)
+        {
+            m_ServerNetworkManager.NetworkConfig.TickRate = tickRate;
+            m_ServerNetworkManager.NetworkTickSystem.TickRate = tickRate;
+
+            for (var i = 0; i < skipFrames; ++i)
+            {
+                TimeTravel(1 / 60f, 1);
+            }
+            var testComponent = GetTestComponent();
+            testComponent.SnapOnAnticipationFailVariable.Anticipate(10);
+
+            Assert.AreEqual(10, testComponent.SnapOnAnticipationFailVariable.Value);
+            Assert.AreEqual(0, testComponent.SnapOnAnticipationFailVariable.AuthoritativeValue);
+            testComponent.SetSnapValueRpc(20);
+            WaitForMessageReceivedWithTimeTravel<RpcMessage>(new List<NetworkManager> { m_ServerNetworkManager });
+
+            var serverComponent = GetServerComponent();
+
+            Assert.AreEqual(20, serverComponent.SnapOnAnticipationFailVariable.Value);
+            Assert.AreEqual(20, serverComponent.SnapOnAnticipationFailVariable.AuthoritativeValue);
+
+            WaitForMessageReceivedWithTimeTravel<NetworkVariableDeltaMessage>(m_ClientNetworkManagers.ToList());
+
+            // Both values get updated
+            Assert.AreEqual(20, testComponent.SnapOnAnticipationFailVariable.Value);
+            Assert.AreEqual(20, testComponent.SnapOnAnticipationFailVariable.AuthoritativeValue);
+
+            // Other client got the server value and had made no anticipation, so it applies it to the anticipated value as well.
+            var otherClientComponent = GetOtherClientComponent();
+            Assert.AreEqual(20, otherClientComponent.SnapOnAnticipationFailVariable.Value);
+            Assert.AreEqual(20, otherClientComponent.SnapOnAnticipationFailVariable.AuthoritativeValue);
+        }
+
+        [Test]
+        public void WhenStaleDataArrivesToIgnoreVariable_ItIsIgnored([Values(10u, 30u, 60u)] uint tickRate, [Values(0u, 1u, 2u)] uint skipFrames)
+        {
+            m_ServerNetworkManager.NetworkConfig.TickRate = tickRate;
+            m_ServerNetworkManager.NetworkTickSystem.TickRate = tickRate;
+
+            for (var i = 0; i < skipFrames; ++i)
+            {
+                TimeTravel(1 / 60f, 1);
+            }
+            var testComponent = GetTestComponent();
+            testComponent.SnapOnAnticipationFailVariable.Anticipate(10);
+
+            Assert.AreEqual(10, testComponent.SnapOnAnticipationFailVariable.Value);
+            Assert.AreEqual(0, testComponent.SnapOnAnticipationFailVariable.AuthoritativeValue);
+
+            testComponent.SetSnapValueRpc(30);
+
+            var serverComponent = GetServerComponent();
+            serverComponent.SnapOnAnticipationFailVariable.AuthoritativeValue = 20;
+
+            Assert.AreEqual(20, serverComponent.SnapOnAnticipationFailVariable.Value);
+            Assert.AreEqual(20, serverComponent.SnapOnAnticipationFailVariable.AuthoritativeValue);
+
+            WaitForMessageReceivedWithTimeTravel<NetworkVariableDeltaMessage>(m_ClientNetworkManagers.ToList());
+
+            if (testComponent.SnapRpcResponseReceived)
+            {
+                // In this case the tick rate is slow enough that the RPC was received and processed, so we check that.
+                Assert.AreEqual(30, testComponent.SnapOnAnticipationFailVariable.Value);
+                Assert.AreEqual(30, testComponent.SnapOnAnticipationFailVariable.AuthoritativeValue);
+
+                var otherClientComponent = GetOtherClientComponent();
+                Assert.AreEqual(30, otherClientComponent.SnapOnAnticipationFailVariable.Value);
+                Assert.AreEqual(30, otherClientComponent.SnapOnAnticipationFailVariable.AuthoritativeValue);
+            }
+            else
+            {
+                // In this case, we got an update before the RPC was processed, so we should have ignored it.
+                // Anticipated client received this data for a tick earlier than its anticipation, and should have prioritized the anticipated value
+                Assert.AreEqual(10, testComponent.SnapOnAnticipationFailVariable.Value);
+                // However, the authoritative value still gets updated
+                Assert.AreEqual(20, testComponent.SnapOnAnticipationFailVariable.AuthoritativeValue);
+
+                // Other client got the server value and had made no anticipation, so it applies it to the anticipated value as well.
+                var otherClientComponent = GetOtherClientComponent();
+                Assert.AreEqual(20, otherClientComponent.SnapOnAnticipationFailVariable.Value);
+                Assert.AreEqual(20, otherClientComponent.SnapOnAnticipationFailVariable.AuthoritativeValue);
+            }
+        }
+
+        [Test]
+        public void WhenStaleDataArrivesToReanticipatedVariable_ItIsAppliedAndReanticipated()
+        {
+            var testComponent = GetTestComponent();
+            testComponent.ReanticipateOnAnticipationFailVariable.Anticipate(10);
+
+            Assert.AreEqual(10, testComponent.ReanticipateOnAnticipationFailVariable.Value);
+            Assert.AreEqual(0, testComponent.ReanticipateOnAnticipationFailVariable.AuthoritativeValue);
+
+            var serverComponent = GetServerComponent();
+            serverComponent.ReanticipateOnAnticipationFailVariable.AuthoritativeValue = 20;
+
+            Assert.AreEqual(20, serverComponent.ReanticipateOnAnticipationFailVariable.Value);
+            Assert.AreEqual(20, serverComponent.ReanticipateOnAnticipationFailVariable.AuthoritativeValue);
+
+            WaitForMessageReceivedWithTimeTravel<NetworkVariableDeltaMessage>(m_ClientNetworkManagers.ToList());
+
+            Assert.AreEqual(25, testComponent.ReanticipateOnAnticipationFailVariable.Value);
+            // However, the authoritative value still gets updated
+            Assert.AreEqual(20, testComponent.ReanticipateOnAnticipationFailVariable.AuthoritativeValue);
+
+            // Other client got the server value and had made no anticipation, so it applies it to the anticipated value as well.
+            var otherClientComponent = GetOtherClientComponent();
+            Assert.AreEqual(25, otherClientComponent.ReanticipateOnAnticipationFailVariable.Value);
+            Assert.AreEqual(20, otherClientComponent.ReanticipateOnAnticipationFailVariable.AuthoritativeValue);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableAnticipationTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableAnticipationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 74e627a9d18dcd04e9c56ab2539a6593

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTests.cs
@@ -386,9 +386,12 @@ namespace Unity.Netcode.RuntimeTests
 
     // Used just to create a NetworkVariable in the templated NetworkBehaviour type that isn't referenced anywhere else
     // Please do not reference this class anywhere else!
-    internal class TestClass_ReferencedOnlyByTemplateNetworkBehavourType : TestClass
+    internal class TestClass_ReferencedOnlyByTemplateNetworkBehaviourType : TestClass, IEquatable<TestClass_ReferencedOnlyByTemplateNetworkBehaviourType>
     {
-
+        public bool Equals(TestClass_ReferencedOnlyByTemplateNetworkBehaviourType other)
+        {
+            return Equals((TestClass)other);
+        }
     }
 
     internal class NetworkVariableTest : NetworkBehaviour
@@ -921,7 +924,7 @@ namespace Unity.Netcode.RuntimeTests
                        m_Player1OnClient1.GetComponent<ClassHavingNetworkBehaviour2>().TheVar.Value.SomeInt == m_Player1OnServer.GetComponent<ClassHavingNetworkBehaviour2>().TheVar.Value.SomeInt;
             }
 
-            m_Player1OnServer.GetComponent<ClassHavingNetworkBehaviour2>().TheVar.Value = new TestClass_ReferencedOnlyByTemplateNetworkBehavourType { SomeInt = k_TestUInt, SomeBool = false };
+            m_Player1OnServer.GetComponent<ClassHavingNetworkBehaviour2>().TheVar.Value = new TestClass_ReferencedOnlyByTemplateNetworkBehaviourType { SomeInt = k_TestUInt, SomeBool = false };
             m_Player1OnServer.GetComponent<ClassHavingNetworkBehaviour2>().TheVar.SetDirty(true);
 
             // Wait for the client-side to notify it is finished initializing and spawning.

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTestsHelperTypes.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTestsHelperTypes.cs
@@ -903,7 +903,7 @@ namespace Unity.Netcode.RuntimeTests
     }
 
     // Please do not reference TestClass_ReferencedOnlyByTemplateNetworkBehavourType anywhere other than here!
-    internal class ClassHavingNetworkBehaviour2 : TemplateNetworkBehaviourType<TestClass_ReferencedOnlyByTemplateNetworkBehavourType>
+    internal class ClassHavingNetworkBehaviour2 : TemplateNetworkBehaviourType<TestClass_ReferencedOnlyByTemplateNetworkBehaviourType>
     {
 
     }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTraitsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTraitsTests.cs
@@ -1,0 +1,138 @@
+using NUnit.Framework;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    internal class NetworkVariableTraitsComponent : NetworkBehaviour
+    {
+        public NetworkVariable<float> TheVariable = new NetworkVariable<float>();
+    }
+
+    internal class NetworkVariableTraitsTests : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 2;
+
+        protected override bool m_EnableTimeTravel => true;
+        protected override bool m_SetupIsACoroutine => false;
+        protected override bool m_TearDownIsACoroutine => false;
+
+        protected override void OnPlayerPrefabGameObjectCreated()
+        {
+            m_PlayerPrefab.AddComponent<NetworkVariableTraitsComponent>();
+        }
+
+        public NetworkVariableTraitsComponent GetTestComponent()
+        {
+            return m_ClientNetworkManagers[0].LocalClient.PlayerObject.GetComponent<NetworkVariableTraitsComponent>();
+        }
+
+        public NetworkVariableTraitsComponent GetServerComponent()
+        {
+            foreach (var obj in Object.FindObjectsByType<NetworkVariableTraitsComponent>(FindObjectsSortMode.None))
+            {
+                if (obj.NetworkManager == m_ServerNetworkManager && obj.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId)
+                {
+                    return obj;
+                }
+            }
+
+            return null;
+        }
+
+        [Test]
+        public void WhenNewValueIsLessThanThreshold_VariableIsNotSerialized()
+        {
+            var serverComponent = GetServerComponent();
+            var testComponent = GetTestComponent();
+            serverComponent.TheVariable.CheckExceedsDirtinessThreshold = (in float value, in float newValue) => Mathf.Abs(newValue - value) >= 0.1;
+
+            serverComponent.TheVariable.Value = 0.05f;
+
+            TimeTravel(2, 120);
+
+            Assert.AreEqual(0.05f, serverComponent.TheVariable.Value); ;
+            Assert.AreEqual(0, testComponent.TheVariable.Value); ;
+        }
+        [Test]
+        public void WhenNewValueIsGreaterThanThreshold_VariableIsSerialized()
+        {
+            var serverComponent = GetServerComponent();
+            var testComponent = GetTestComponent();
+            serverComponent.TheVariable.CheckExceedsDirtinessThreshold = (in float value, in float newValue) => Mathf.Abs(newValue - value) >= 0.1;
+
+            serverComponent.TheVariable.Value = 0.15f;
+
+            TimeTravel(2, 120);
+
+            Assert.AreEqual(0.15f, serverComponent.TheVariable.Value); ;
+            Assert.AreEqual(0.15f, testComponent.TheVariable.Value); ;
+        }
+
+        [Test]
+        public void WhenNewValueIsLessThanThresholdButMaxTimeHasPassed_VariableIsSerialized()
+        {
+            var serverComponent = GetServerComponent();
+            var testComponent = GetTestComponent();
+            serverComponent.TheVariable.CheckExceedsDirtinessThreshold = (in float value, in float newValue) => Mathf.Abs(newValue - value) >= 0.1;
+            serverComponent.TheVariable.SetUpdateTraits(new NetworkVariableUpdateTraits { MaxSecondsBetweenUpdates = 2 });
+            serverComponent.TheVariable.LastUpdateSent = m_ServerNetworkManager.NetworkTimeSystem.LocalTime;
+
+            serverComponent.TheVariable.Value = 0.05f;
+
+            TimeTravel(1 / 60f * 119, 119);
+
+            Assert.AreEqual(0.05f, serverComponent.TheVariable.Value); ;
+            Assert.AreEqual(0, testComponent.TheVariable.Value); ;
+
+            TimeTravel(1 / 60f * 4, 4);
+
+            Assert.AreEqual(0.05f, serverComponent.TheVariable.Value); ;
+            Assert.AreEqual(0.05f, testComponent.TheVariable.Value); ;
+        }
+
+        [Test]
+        public void WhenNewValueIsGreaterThanThresholdButMinTimeHasNotPassed_VariableIsNotSerialized()
+        {
+            var serverComponent = GetServerComponent();
+            var testComponent = GetTestComponent();
+            serverComponent.TheVariable.CheckExceedsDirtinessThreshold = (in float value, in float newValue) => Mathf.Abs(newValue - value) >= 0.1;
+            serverComponent.TheVariable.SetUpdateTraits(new NetworkVariableUpdateTraits { MinSecondsBetweenUpdates = 2 });
+            serverComponent.TheVariable.LastUpdateSent = m_ServerNetworkManager.NetworkTimeSystem.LocalTime;
+
+            serverComponent.TheVariable.Value = 0.15f;
+
+            TimeTravel(1 / 60f * 119, 119);
+
+            Assert.AreEqual(0.15f, serverComponent.TheVariable.Value); ;
+            Assert.AreEqual(0, testComponent.TheVariable.Value); ;
+
+            TimeTravel(1 / 60f * 4, 4);
+
+            Assert.AreEqual(0.15f, serverComponent.TheVariable.Value); ;
+            Assert.AreEqual(0.15f, testComponent.TheVariable.Value); ;
+        }
+
+        [Test]
+        public void WhenNoThresholdIsSetButMinTimeHasNotPassed_VariableIsNotSerialized()
+        {
+            var serverComponent = GetServerComponent();
+            var testComponent = GetTestComponent();
+            serverComponent.TheVariable.SetUpdateTraits(new NetworkVariableUpdateTraits { MinSecondsBetweenUpdates = 2 });
+            serverComponent.TheVariable.LastUpdateSent = m_ServerNetworkManager.NetworkTimeSystem.LocalTime;
+
+            serverComponent.TheVariable.Value = 0.15f;
+
+            TimeTravel(1 / 60f * 119, 119);
+
+            Assert.AreEqual(0.15f, serverComponent.TheVariable.Value); ;
+            Assert.AreEqual(0, testComponent.TheVariable.Value); ;
+
+            TimeTravel(1 / 60f * 4, 4);
+
+            Assert.AreEqual(0.15f, serverComponent.TheVariable.Value); ;
+            Assert.AreEqual(0.15f, testComponent.TheVariable.Value); ;
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTraitsTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTraitsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 49f46ca2b4327464498a7465891647bb

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableUserSerializableTypesTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableUserSerializableTypesTests.cs
@@ -112,6 +112,16 @@ namespace Unity.Netcode.RuntimeTests
         protected override IEnumerator OnSetup()
         {
             WorkingUserNetworkVariableComponentBase.Reset();
+
+            UserNetworkVariableSerialization<MyTypeOne>.WriteValue = null;
+            UserNetworkVariableSerialization<MyTypeOne>.ReadValue = null;
+            UserNetworkVariableSerialization<MyTypeOne>.DuplicateValue = null;
+            UserNetworkVariableSerialization<MyTypeTwo>.WriteValue = null;
+            UserNetworkVariableSerialization<MyTypeTwo>.ReadValue = null;
+            UserNetworkVariableSerialization<MyTypeTwo>.DuplicateValue = null;
+            UserNetworkVariableSerialization<MyTypeThree>.WriteValue = null;
+            UserNetworkVariableSerialization<MyTypeThree>.ReadValue = null;
+            UserNetworkVariableSerialization<MyTypeThree>.DuplicateValue = null;
             return base.OnSetup();
         }
 
@@ -217,5 +227,37 @@ namespace Unity.Netcode.RuntimeTests
                 }
             );
         }
+
+        protected override IEnumerator OnTearDown()
+        {
+            // These have to get set to SOMETHING, otherwise we will get an exception thrown because Object.Destroy()
+            // calls __initializeNetworkVariables, and the network variable initialization attempts to call FallbackSerializer<T>,
+            // which throws an exception if any of these values are null. They don't have to DO anything, they just have to
+            // be non-null to keep the test from failing during teardown.
+            // None of this is related to what's being tested above, and in reality, these values being null is an invalid
+            // use case. But one of the tests is explicitly testing that invalid use case, and the values are being set
+            // to null in OnSetup to ensure test isolation. This wouldn't be a situation a user would have to think about
+            // in a real world use case.
+            UserNetworkVariableSerialization<MyTypeOne>.WriteValue = (FastBufferWriter writer, in MyTypeOne value) => { };
+            UserNetworkVariableSerialization<MyTypeOne>.ReadValue = (FastBufferReader reader, out MyTypeOne value) => { value = new MyTypeOne(); };
+            UserNetworkVariableSerialization<MyTypeOne>.DuplicateValue = (in MyTypeOne value, ref MyTypeOne duplicatedValue) =>
+            {
+                duplicatedValue = value;
+            };
+            UserNetworkVariableSerialization<MyTypeTwo>.WriteValue = (FastBufferWriter writer, in MyTypeTwo value) => { };
+            UserNetworkVariableSerialization<MyTypeTwo>.ReadValue = (FastBufferReader reader, out MyTypeTwo value) => { value = new MyTypeTwo(); };
+            UserNetworkVariableSerialization<MyTypeTwo>.DuplicateValue = (in MyTypeTwo value, ref MyTypeTwo duplicatedValue) =>
+            {
+                duplicatedValue = value;
+            };
+            UserNetworkVariableSerialization<MyTypeThree>.WriteValue = (FastBufferWriter writer, in MyTypeThree value) => { };
+            UserNetworkVariableSerialization<MyTypeThree>.ReadValue = (FastBufferReader reader, out MyTypeThree value) => { value = new MyTypeThree(); };
+            UserNetworkVariableSerialization<MyTypeThree>.DuplicateValue = (in MyTypeThree value, ref MyTypeThree duplicatedValue) =>
+            {
+                duplicatedValue = value;
+            };
+            return base.OnTearDown();
+        }
     }
 }
+

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/NetworkBehaviourReferenceTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/NetworkBehaviourReferenceTests.cs
@@ -17,6 +17,8 @@ namespace Unity.Netcode.RuntimeTests
     {
         private class TestNetworkBehaviour : NetworkBehaviour
         {
+            public static bool ReceivedRPC;
+
             public NetworkVariable<NetworkBehaviourReference> TestVariable = new NetworkVariable<NetworkBehaviourReference>();
 
             public TestNetworkBehaviour RpcReceivedBehaviour;
@@ -25,6 +27,7 @@ namespace Unity.Netcode.RuntimeTests
             public void SendReferenceServerRpc(NetworkBehaviourReference value)
             {
                 RpcReceivedBehaviour = (TestNetworkBehaviour)value;
+                ReceivedRPC = true;
             }
         }
 
@@ -57,8 +60,43 @@ namespace Unity.Netcode.RuntimeTests
             Assert.AreEqual(testNetworkBehaviour, testNetworkBehaviour.RpcReceivedBehaviour);
         }
 
+        [UnityTest]
+        public IEnumerator TestSerializeNull([Values] bool initializeWithNull)
+        {
+            TestNetworkBehaviour.ReceivedRPC = false;
+            using var networkObjectContext = UnityObjectContext.CreateNetworkObject();
+            var testNetworkBehaviour = networkObjectContext.Object.gameObject.AddComponent<TestNetworkBehaviour>();
+            networkObjectContext.Object.Spawn();
 
+            using var otherObjectContext = UnityObjectContext.CreateNetworkObject();
+            otherObjectContext.Object.Spawn();
 
+            // If not initializing with null, then use the default constructor with no assigned NetworkBehaviour
+            if (!initializeWithNull)
+            {
+                testNetworkBehaviour.SendReferenceServerRpc(new NetworkBehaviourReference());
+            }
+            else // Otherwise, initialize and pass in null as the reference
+            {
+                testNetworkBehaviour.SendReferenceServerRpc(new NetworkBehaviourReference(null));
+            }
+
+            // wait for rpc completion
+            float t = 0;
+            while (!TestNetworkBehaviour.ReceivedRPC)
+            {
+                t += Time.deltaTime;
+                if (t > 5f)
+                {
+                    new AssertionException("RPC with NetworkBehaviour reference hasn't been received");
+                }
+
+                yield return null;
+            }
+
+            // validate
+            Assert.AreEqual(null, testNetworkBehaviour.RpcReceivedBehaviour);
+        }
 
         [UnityTest]
         public IEnumerator TestRpcImplicitNetworkBehaviour()
@@ -128,15 +166,6 @@ namespace Unity.Netcode.RuntimeTests
             Assert.Throws<ArgumentException>(() =>
             {
                 NetworkBehaviourReference outReference = component;
-            });
-        }
-
-        [Test]
-        public void FailSerializeNullBehaviour()
-        {
-            Assert.Throws<ArgumentNullException>(() =>
-            {
-                NetworkBehaviourReference outReference = null;
             });
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/NetworkObjectReferenceTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/NetworkObjectReferenceTests.cs
@@ -30,6 +30,7 @@ namespace Unity.Netcode.RuntimeTests
             [ServerRpc]
             public void SendReferenceServerRpc(NetworkObjectReference value)
             {
+                ReceivedRPC = true;
                 RpcReceivedGameObject = value;
                 RpcReceivedNetworkObject = value;
             }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/NetworkObjectReferenceTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/NetworkObjectReferenceTests.cs
@@ -19,6 +19,8 @@ namespace Unity.Netcode.RuntimeTests
     {
         private class TestNetworkBehaviour : NetworkBehaviour
         {
+            public static bool ReceivedRPC;
+
             public NetworkVariable<NetworkObjectReference> TestVariable = new NetworkVariable<NetworkObjectReference>();
 
             public NetworkObject RpcReceivedNetworkObject;
@@ -148,6 +150,60 @@ namespace Unity.Netcode.RuntimeTests
             Assert.NotNull(networkObject);
             networkObjectReference.TryGet(out NetworkObject result);
             Assert.AreEqual(networkObject, result);
+        }
+
+        public enum NetworkObjectConstructorTypes
+        {
+            None,
+            NullNetworkObject,
+            NullGameObject
+        }
+
+        [UnityTest]
+        public IEnumerator TestSerializeNull([Values] NetworkObjectConstructorTypes networkObjectConstructorTypes)
+        {
+            TestNetworkBehaviour.ReceivedRPC = false;
+            using var networkObjectContext = UnityObjectContext.CreateNetworkObject();
+            var testNetworkBehaviour = networkObjectContext.Object.gameObject.AddComponent<TestNetworkBehaviour>();
+            networkObjectContext.Object.Spawn();
+
+            switch (networkObjectConstructorTypes)
+            {
+                case NetworkObjectConstructorTypes.None:
+                    {
+                        testNetworkBehaviour.SendReferenceServerRpc(new NetworkObjectReference());
+                        break;
+                    }
+                case NetworkObjectConstructorTypes.NullNetworkObject:
+                    {
+                        testNetworkBehaviour.SendReferenceServerRpc(new NetworkObjectReference((NetworkObject)null));
+                        break;
+                    }
+                case NetworkObjectConstructorTypes.NullGameObject:
+                    {
+                        testNetworkBehaviour.SendReferenceServerRpc(new NetworkObjectReference((GameObject)null));
+                        break;
+                    }
+            }
+
+
+            // wait for rpc completion
+            float t = 0;
+            while (!TestNetworkBehaviour.ReceivedRPC)
+            {
+
+                t += Time.deltaTime;
+                if (t > 5f)
+                {
+                    new AssertionException("RPC with NetworkBehaviour reference hasn't been received");
+                }
+
+                yield return null;
+            }
+
+            // validate
+            Assert.AreEqual(null, testNetworkBehaviour.RpcReceivedNetworkObject);
+            Assert.AreEqual(null, testNetworkBehaviour.RpcReceivedGameObject);
         }
 
         [UnityTest]
@@ -302,24 +358,6 @@ namespace Unity.Netcode.RuntimeTests
             Assert.Throws<ArgumentException>(() =>
             {
                 NetworkObjectReference outReference = gameObjectContext.Object;
-            });
-        }
-
-        [Test]
-        public void FailSerializeNullNetworkObject()
-        {
-            Assert.Throws<ArgumentNullException>(() =>
-            {
-                NetworkObjectReference outReference = (NetworkObject)null;
-            });
-        }
-
-        [Test]
-        public void FailSerializeNullGameObject()
-        {
-            Assert.Throws<ArgumentNullException>(() =>
-            {
-                NetworkObjectReference outReference = (GameObject)null;
             });
         }
 

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -2,7 +2,7 @@
     "name": "com.unity.netcode.gameobjects",
     "displayName": "Netcode for GameObjects",
     "description": "Netcode for GameObjects is a high-level netcode SDK that provides networking capabilities to GameObject/MonoBehaviour workflows within Unity and sits on top of underlying transport layer.",
-    "version": "2.0.0-pre.1",
+    "version": "2.0.0-pre.2",
     "unity": "6000.0",
     "dependencies": {
         "com.unity.nuget.mono-cecil": "1.11.4",


### PR DESCRIPTION
This PR updates NGO v2.0.0 with:

- Up-port of [PR-2872](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/2872) updates to remove `Animator` requirements for NetworkAnimator.
- Up-port of [PR-2874](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/2874) allow null values for `NetworkBehaviourReference` and `NetworkObjectReference`.
- Up-port of [PR-2820](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/2820) updates for anticipated `NetworkVariable` and `NetworkTransform`.


## Changelog

- Added: `AnticipatedNetworkVariable<T>`, which adds support for client anticipation of `NetworkVariable` values, allowing for more responsive gameplay.
- Added: `AnticipatedNetworkTransform`, which adds support for client anticipation of NetworkTransforms.
- Added: `NetworkVariableBase.ExceedsDirtinessThreshold` to allow network variables to throttle updates by only sending updates when the difference between the current and previous values exceeds a threshold. (This is exposed in `NetworkVariable<T>` with the callback `NetworkVariable<T>.CheckExceedsDirtinessThreshold`).
- Added: `NetworkVariableUpdateTraits`, which add additional throttling support: `MinSecondsBetweenUpdates` will prevent the `NetworkVariable` from sending updates more often than the specified time period (even if it exceeds the dirtiness threshold), while `MaxSecondsBetweenUpdates` will force a dirty `NetworkVariable` to send an update after the specified time period even if it has not yet exceeded the dirtiness threshold.
- Added: virtual method `NetworkVariableBase.OnInitialize` which can be used by `NetworkVariable` subclasses to add initialization code.
- Added: `NetworkTime.TickWithPartial`, which represents the current tick as a double that includes the fractional/partial tick value.
- Added: `NetworkTickSystem.AnticipationTick`, which can be helpful with implementation of client anticipation. This value represents the tick the current local client was at at the beginning of the most recent network round trip, which enables it to correlate server update ticks with the client tick that may have triggered them.
- Changed: `NetworkAnimator` no longer requires the `Animator` component to exist on the same `GameObject`.
- Changed: `NetworkObjectReference` and `NetworkBehaviourReference` to allow null references when constructing and serializing.

## Testing and Documentation

- Includes new and modified integration tests.
- Includes documentation for previously-undocumented public API entry points.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
