### PR TITLE
fix: scenemanager clean up ScenesLoaded after synch unloading of remaining scenes not used

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where `NetworkManager.ScenesLoaded` was not being updated if `PostSynchronizationSceneUnloading` was set and any loaded scenes not used during synchronization were unloaded. (#2971)
+- Fixed issue where `Rigidbody2d` under Unity 6000.0.11f1 has breaking changes where `velocity` is now `linearVelocity` and `isKinematic` is replaced by `bodyType`. (#2971)
 - Fixed issue where `NetworkSpawnManager.InstantiateAndSpawn` and `NetworkObject.InstantiateAndSpawn` were not honoring the ownerClientId parameter when using a client-server network topology. (#2968)
 - Fixed issue where internal delta serialization could not have a byte serializer defined when serializing deltas for other types. Added `[GenerateSerializationForType(typeof(byte))]` to both the `NetworkVariable` and `AnticipatedNetworkVariable` classes to assure a byte serializer is defined.(#2962)
 - Fixed issue when scene management was disabled and the session owner would still try to synchronize a late joining client. (#2962)

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkRigidBodyBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkRigidBodyBase.cs
@@ -177,7 +177,11 @@ namespace Unity.Netcode.Components
         {
             if (m_IsRigidbody2D)
             {
+#if COM_UNITY_MODULES_PHYSICS2D_LINEAR
+                m_Rigidbody2D.linearVelocity = linearVelocity;
+#else
                 m_Rigidbody2D.velocity = linearVelocity;
+#endif
             }
             else
             {
@@ -197,7 +201,11 @@ namespace Unity.Netcode.Components
         {
             if (m_IsRigidbody2D)
             {
+#if COM_UNITY_MODULES_PHYSICS2D_LINEAR
+                return m_Rigidbody2D.linearVelocity;
+#else
                 return m_Rigidbody2D.velocity;
+#endif
             }
             else
             {
@@ -481,7 +489,7 @@ namespace Unity.Netcode.Components
         {
             if (m_IsRigidbody2D)
             {
-                return m_Rigidbody2D.isKinematic;
+                return m_Rigidbody2D.bodyType == RigidbodyType2D.Kinematic;
             }
             else
             {
@@ -510,7 +518,7 @@ namespace Unity.Netcode.Components
         {
             if (m_IsRigidbody2D)
             {
-                m_Rigidbody2D.isKinematic = isKinematic;
+                m_Rigidbody2D.bodyType = isKinematic ? RigidbodyType2D.Kinematic : RigidbodyType2D.Dynamic;
             }
             else
             {

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkRigidBodyBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkRigidBodyBase.cs
@@ -246,7 +246,7 @@ namespace Unity.Netcode.Components
         {
             if (m_IsRigidbody2D)
             {
-                return Vector3.forward * m_Rigidbody2D.velocity;
+                return Vector3.forward * m_Rigidbody2D.angularVelocity;
             }
             else
             {
@@ -723,7 +723,11 @@ namespace Unity.Netcode.Components
 
             if (zeroVelocity)
             {
+#if COM_UNITY_MODULES_PHYSICS2D_LINEAR
+                m_Rigidbody2D.linearVelocity = Vector2.zero;
+#else
                 m_Rigidbody2D.velocity = Vector2.zero;
+#endif
                 m_Rigidbody2D.angularVelocity = 0.0f;
             }
 

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/DefaultSceneManagerHandler.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/DefaultSceneManagerHandler.cs
@@ -227,6 +227,10 @@ namespace Unity.Netcode
             foreach (var sceneToUnload in m_ScenesToUnload)
             {
                 SceneManager.UnloadSceneAsync(sceneToUnload);
+                if (sceneManager.ScenesLoaded.ContainsKey(sceneToUnload.handle))
+                {
+                    sceneManager.ScenesLoaded.Remove(sceneToUnload.handle);
+                }
             }
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/DefaultSceneManagerHandler.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/DefaultSceneManagerHandler.cs
@@ -227,6 +227,7 @@ namespace Unity.Netcode
             foreach (var sceneToUnload in m_ScenesToUnload)
             {
                 SceneManager.UnloadSceneAsync(sceneToUnload);
+                // Update the ScenesLoaded when we unload scenes
                 if (sceneManager.ScenesLoaded.ContainsKey(sceneToUnload.handle))
                 {
                     sceneManager.ScenesLoaded.Remove(sceneToUnload.handle);

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -2406,16 +2406,6 @@ namespace Unity.Netcode
                                 NetworkManager.ConnectionManager.CreateAndSpawnPlayer(NetworkManager.LocalClientId);
                             }
 
-                            // Client is now synchronized and fully "connected".  This also means the client can send "RPCs" at this time
-                            NetworkManager.ConnectionManager.InvokeOnClientConnectedCallback(NetworkManager.LocalClientId);
-
-                            // Notify the client that they have finished synchronizing
-                            OnSceneEvent?.Invoke(new SceneEvent()
-                            {
-                                SceneEventType = sceneEventData.SceneEventType,
-                                ClientId = NetworkManager.LocalClientId, // Client sent this to the server
-                            });
-
                             // Process any SceneEventType.ObjectSceneChanged messages that
                             // were deferred while synchronizing and migrate the associated
                             // NetworkObjects to their newly assigned scenes.
@@ -2428,6 +2418,16 @@ namespace Unity.Netcode
                             {
                                 SceneManagerHandler.UnloadUnassignedScenes(NetworkManager);
                             }
+
+                            // Client is now synchronized and fully "connected".  This also means the client can send "RPCs" at this time
+                            NetworkManager.ConnectionManager.InvokeOnClientConnectedCallback(NetworkManager.LocalClientId);
+
+                            // Notify the client that they have finished synchronizing
+                            OnSceneEvent?.Invoke(new SceneEvent()
+                            {
+                                SceneEventType = sceneEventData.SceneEventType,
+                                ClientId = NetworkManager.LocalClientId, // Client sent this to the server
+                            });
 
                             OnSynchronizeComplete?.Invoke(NetworkManager.LocalClientId);
 

--- a/com.unity.netcode.gameobjects/Runtime/com.unity.netcode.runtime.asmdef
+++ b/com.unity.netcode.gameobjects/Runtime/com.unity.netcode.runtime.asmdef
@@ -72,6 +72,11 @@
             "name": "com.unity.services.multiplayer",
             "expression": "0.2.0",
             "define": "MULTIPLAYER_SERVICES_SDK_INSTALLED"
+        },
+        {
+            "name": "Unity",
+            "expression": "6000.0.11f1",
+            "define": "COM_UNITY_MODULES_PHYSICS2D_LINEAR"
         }
     ],
     "noEngineReferences": false

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
@@ -677,6 +677,10 @@ namespace Unity.Netcode.TestHelpers.Runtime
             foreach (var sceneToUnload in m_ScenesToUnload)
             {
                 SceneManager.UnloadSceneAsync(sceneToUnload.Key);
+                if (sceneManager.ScenesLoaded.ContainsKey(sceneToUnload.Key.handle))
+                {
+                    sceneManager.ScenesLoaded.Remove(sceneToUnload.Key.handle);
+                }
             }
         }
 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
@@ -677,6 +677,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             foreach (var sceneToUnload in m_ScenesToUnload)
             {
                 SceneManager.UnloadSceneAsync(sceneToUnload.Key);
+                // Update the ScenesLoaded when we unload scenes
                 if (sceneManager.ScenesLoaded.ContainsKey(sceneToUnload.Key.handle))
                 {
                     sceneManager.ScenesLoaded.Remove(sceneToUnload.Key.handle);

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerSeneVerification.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerSeneVerification.cs
@@ -361,11 +361,28 @@ namespace TestProject.RuntimeTests
             }
 
             m_IsTestingVerifyScene = false;
+            var currentSceneName = m_CurrentScene;
             Assert.AreEqual(m_ServerNetworkManager.SceneManager.UnloadScene(m_CurrentScene), SceneEventProgressStatus.Started);
 
             // Now wait for scenes to unload
             yield return WaitForConditionOrTimeOut(ConditionPassed);
             AssertOnTimeout($"Timed out waiting for all clients to unload {m_CurrentSceneName}!\n{PrintFailedCondition()}");
+
+            // Verify that all NetworkSceneManager instances reflect the change in scenes synchronized
+            var scenesSynchronized = m_ServerNetworkManager.SceneManager.GetSynchronizedScenes();
+            foreach (var scene in scenesSynchronized)
+            {
+                Assert.False(scene.name.Equals(currentSceneName), $"Host still thinks scene {currentSceneName} is loaded and synchronized!");
+            }
+
+            foreach (var client in m_ClientNetworkManagers)
+            {
+                scenesSynchronized = client.SceneManager.GetSynchronizedScenes();
+                foreach (var scene in scenesSynchronized)
+                {
+                    Assert.False(scene.name.Equals(currentSceneName), $"Client-{client.LocalClientId} still thinks scene {currentSceneName} is loaded and synchronized!");
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fix for the NetworkManager.ScenesLoaded not being updated when `PostSynchronizationSceneUnloading` is set to true and there are scenes not used for a synchronization.

This also fixes the issue with the standards test failing when using 6000.0.11f1 (or higher) due to updates to NetworkRigidbody2D.

## Changelog

- Fixed: Issue where `NetworkManager.ScenesLoaded` was not being updated if `PostSynchronizationSceneUnloading` was set and any loaded scenes not used during synchronization were unloaded.
- Fixed: Issue where `Rigidbody2d` under Unity 6000.0.11f1 has breaking changes where `velocity` is now `linearVelocity` and `isKinematic` is replaced by `bodyType`.


## Testing and Documentation

- Includes integration test update to `NetworkSceneManagerSceneVerification.SceneVerifyBeforeLoadTest`.
- No documentation changes or additions were necessary.


<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
