### PR TITLE
fix: scenemanager clean up ScenesLoaded after synch unloading of remaining scenes not used [back port]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -15,6 +15,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where `NetworkManager.ScenesLoaded` was not being updated if `PostSynchronizationSceneUnloading` was set and any loaded scenes not used during synchronization were unloaded.(#2977)
 - Fixed issue where internal delta serialization could not have a byte serializer defined when serializing deltas for other types. Added `[GenerateSerializationForType(typeof(byte))]` to both the `NetworkVariable` and `AnticipatedNetworkVariable` classes to assure a byte serializer is defined. (#2953)
 - Fixed issue with the client count not being correct on the host or server side when a client disconnects itself from a session. (#2941)
 - Fixed issue with the host trying to send itself a message that it has connected when first starting up. (#2941)
@@ -23,7 +24,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed issue where `NetworkRigidbody2D` would not properly change body type based on the instance's authority when spawned. (#2916)
 - Fixed issue where a `NetworkObject` component's associated `NetworkBehaviour` components would not be detected if scene loading is disabled in the editor and the currently loaded scene has in-scene placed `NetworkObject`s. (#2906)
 - Fixed issue where an in-scene placed `NetworkObject` with `NetworkTransform` that is also parented under a `GameObject` would not properly synchronize when the parent `GameObject` had a world space position other than 0,0,0. (#2895)
-
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/DefaultSceneManagerHandler.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/DefaultSceneManagerHandler.cs
@@ -226,6 +226,11 @@ namespace Unity.Netcode
             foreach (var sceneToUnload in m_ScenesToUnload)
             {
                 SceneManager.UnloadSceneAsync(sceneToUnload);
+                // Update the ScenesLoaded when we unload scenes
+                if (sceneManager.ScenesLoaded.ContainsKey(sceneToUnload.handle))
+                {
+                    sceneManager.ScenesLoaded.Remove(sceneToUnload.handle);
+                }
             }
         }
 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
@@ -675,6 +675,11 @@ namespace Unity.Netcode.TestHelpers.Runtime
             foreach (var sceneToUnload in m_ScenesToUnload)
             {
                 SceneManager.UnloadSceneAsync(sceneToUnload.Key);
+                // Update the ScenesLoaded when we unload scenes
+                if (sceneManager.ScenesLoaded.ContainsKey(sceneToUnload.Key.handle))
+                {
+                    sceneManager.ScenesLoaded.Remove(sceneToUnload.Key.handle);
+                }
             }
         }
 

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerSeneVerification.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerSeneVerification.cs
@@ -360,10 +360,26 @@ namespace TestProject.RuntimeTests
 
             m_IsTestingVerifyScene = false;
             Assert.AreEqual(m_ServerNetworkManager.SceneManager.UnloadScene(m_CurrentScene), SceneEventProgressStatus.Started);
-
+            var currentSceneName = m_CurrentScene;
             // Now wait for scenes to unload
             yield return WaitForConditionOrTimeOut(ConditionPassed);
             AssertOnTimeout($"Timed out waiting for all clients to unload {m_CurrentSceneName}!\n{PrintFailedCondition()}");
+
+            // Verify that all NetworkSceneManager instances reflect the change in scenes synchronized
+            var scenesSynchronized = m_ServerNetworkManager.SceneManager.ScenesLoaded;
+            foreach (var scene in scenesSynchronized)
+            {
+                Assert.False(scene.Value.name.Equals(currentSceneName), $"Host still thinks scene {currentSceneName} is loaded and synchronized!");
+            }
+
+            foreach (var client in m_ClientNetworkManagers)
+            {
+                scenesSynchronized = client.SceneManager.ScenesLoaded;
+                foreach (var scene in scenesSynchronized)
+                {
+                    Assert.False(scene.Value.name.Equals(currentSceneName), $"Client-{client.LocalClientId} still thinks scene {currentSceneName} is loaded and synchronized!");
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fix for the NetworkManager.ScenesLoaded not being updated when `PostSynchronizationSceneUnloading` is set to true and there are scenes not used for a synchronization.

This is a back-port of #2971.


## Changelog

- Fixed: Issue where `NetworkManager.ScenesLoaded` was not being updated if `PostSynchronizationSceneUnloading` was set and any loaded scenes not used during synchronization were unloaded.


## Testing and Documentation

- Includes integration test update to `NetworkSceneManagerSceneVerification.SceneVerifyBeforeLoadTest`.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
