### PR TITLE
chore: 2.0.0-pre.3 additional last minute updates

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
-## [2.0.0-pre.2] - 2024-07-18
+## [2.0.0-pre.3] - 2024-07-18
 
 ### Added
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -9,6 +9,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ## [2.0.0-pre.3] - 2024-07-18
 
 ### Added
+- Added: `UnityTransport.GetNetworkDriver` and `UnityTransport.GetLocalEndpoint` methods to expose the driver and local endpoint being used. (#2978)
 
 ### Fixed
 

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -428,6 +428,31 @@ namespace Unity.Netcode.Transports.UTP
 
         protected NetworkDriver m_Driver;
 
+        /// <summary>
+        /// Gets a reference to the <see cref="Networking.Transport.NetworkDriver"/>.
+        /// </summary>
+        /// <returns>ref <see cref="Networking.Transport.NetworkDriver"/></returns>
+        public ref NetworkDriver GetNetworkDriver()
+        {
+            return ref m_Driver;
+        }
+
+        /// <summary>
+        /// Gets the local sytem's <see cref="NetworkEndpoint"/> that is assigned for the current network session.
+        /// </summary>
+        /// <remarks>
+        /// If the driver is not created it will return an invalid <see cref="NetworkEndpoint"/>.
+        /// </remarks>
+        /// <returns><see cref="NetworkEndpoint"/></returns>
+        public NetworkEndpoint GetLocalEndpoint()
+        {
+            if (m_Driver.IsCreated)
+            {
+                return m_Driver.GetLocalEndpoint();
+            }
+            return new NetworkEndpoint();
+        }
+
         private PacketLossCache m_PacketLossCache = new PacketLossCache();
 
         private State m_State = State.Disconnected;


### PR DESCRIPTION
- Updating the changelog version.
- Added some additional methods to UnityTransport to provide access to the driver and local endpoint.

## Changelog
- Added: `UnityTransport.GetNetworkDriver` and `UnityTransport.GetLocalEndpoint` methods to expose the driver and local endpoint being used.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
