### PR TITLE
fix: metrics tooltips and serialized type non optimized warning message handling

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -13,6 +13,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where the realtime network stats monitor was not able to display RPC traffic in release builds due to those stats being only available in development builds or the editor. (#2979)
 - Fixed issue where `NetworkManager.ScenesLoaded` was not being updated if `PostSynchronizationSceneUnloading` was set and any loaded scenes not used during synchronization were unloaded. (#2971)
 - Fixed issue where `Rigidbody2d` under Unity 6000.0.11f1 has breaking changes where `velocity` is now `linearVelocity` and `isKinematic` is replaced by `bodyType`. (#2971)
 - Fixed issue where `NetworkSpawnManager.InstantiateAndSpawn` and `NetworkObject.InstantiateAndSpawn` were not honoring the ownerClientId parameter when using a client-server network topology. (#2968)

--- a/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkConfig.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkConfig.cs
@@ -159,9 +159,21 @@ namespace Unity.Netcode
         public bool AutoSpawnPlayerPrefabClientSide = true;
 
 #if MULTIPLAYER_TOOLS
+        /// <summary>
+        /// Controls whether network messaging metrics will be gathered. (defaults to true)
+        /// There is a slight performance cost to having this enabled, and can increase in processing time based on network message traffic.
+        /// </summary>
+        /// <remarks>
+        /// The Realtime Network Stats Monitoring tool requires this to be enabled.
+        /// </remarks>
+        [Tooltip("Enable (default) if you want to gather messaging metrics. Realtime Network Stats Monitor requires this to be enabled. Disabling this can improve performance in release builds.")]
         public bool NetworkMessageMetrics = true;
 #endif
-
+        /// <summary>
+        /// When enabled (default, this enables network profiling information. This does come with a per message processing cost.
+        /// Network profiling information is automatically disabled in release builds.
+        /// </summary>
+        [Tooltip("Enable (default) if you want to profile network messages with development builds and defaults to being disabled in release builds. When disabled, network messaging profiling will be disabled in development builds.")]
         public bool NetworkProfilingMetrics = true;
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -27,7 +27,7 @@ namespace Unity.Netcode
         // RuntimeAccessModifiersILPP will make this `public`
         internal static readonly Dictionary<Type, Dictionary<uint, RpcReceiveHandler>> __rpc_func_table = new Dictionary<Type, Dictionary<uint, RpcReceiveHandler>>();
 
-#if DEVELOPMENT_BUILD || UNITY_EDITOR
+#if DEVELOPMENT_BUILD || UNITY_EDITOR || UNITY_MP_TOOLS_NET_STATS_MONITOR_ENABLED_IN_RELEASE
         // RuntimeAccessModifiersILPP will make this `public`
         internal static readonly Dictionary<Type, Dictionary<uint, string>> __rpc_name_table = new Dictionary<Type, Dictionary<uint, string>>();
 #endif
@@ -124,7 +124,7 @@ namespace Unity.Netcode
             }
 
             bufferWriter.Dispose();
-#if DEVELOPMENT_BUILD || UNITY_EDITOR
+#if DEVELOPMENT_BUILD || UNITY_EDITOR || UNITY_MP_TOOLS_NET_STATS_MONITOR_ENABLED_IN_RELEASE
             if (__rpc_name_table[GetType()].TryGetValue(rpcMethodId, out var rpcMethodName))
             {
                 NetworkManager.NetworkMetrics.TrackRpcSent(
@@ -252,7 +252,7 @@ namespace Unity.Netcode
             }
 
             bufferWriter.Dispose();
-#if DEVELOPMENT_BUILD || UNITY_EDITOR
+#if DEVELOPMENT_BUILD || UNITY_EDITOR || UNITY_MP_TOOLS_NET_STATS_MONITOR_ENABLED_IN_RELEASE
             if (__rpc_name_table[GetType()].TryGetValue(rpcMethodId, out var rpcMethodName))
             {
                 if (clientRpcParams.Send.TargetClientIds != null)
@@ -880,7 +880,7 @@ namespace Unity.Netcode
 #pragma warning restore IDE1006 // restore naming rule violation check
         {
             __rpc_func_table[GetType()][hash] = handler;
-#if DEVELOPMENT_BUILD || UNITY_EDITOR
+#if DEVELOPMENT_BUILD || UNITY_EDITOR || UNITY_MP_TOOLS_NET_STATS_MONITOR_ENABLED_IN_RELEASE
             __rpc_name_table[GetType()][hash] = rpcMethodName;
 #endif
         }
@@ -906,7 +906,7 @@ namespace Unity.Netcode
             if (!__rpc_func_table.ContainsKey(GetType()))
             {
                 __rpc_func_table[GetType()] = new Dictionary<uint, RpcReceiveHandler>();
-#if UNITY_EDITOR || DEVELOPMENT_BUILD
+#if UNITY_EDITOR || DEVELOPMENT_BUILD || UNITY_MP_TOOLS_NET_STATS_MONITOR_ENABLED_IN_RELEASE
                 __rpc_name_table[GetType()] = new Dictionary<uint, string>();
 #endif
                 __initializeRpcs();

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -29,7 +29,7 @@ namespace Unity.Netcode
         // RuntimeAccessModifiersILPP will make this `public`
         internal static readonly Dictionary<uint, RpcReceiveHandler> __rpc_func_table = new Dictionary<uint, RpcReceiveHandler>();
 
-#if DEVELOPMENT_BUILD || UNITY_EDITOR
+#if DEVELOPMENT_BUILD || UNITY_EDITOR || UNITY_MP_TOOLS_NET_STATS_MONITOR_ENABLED_IN_RELEASE
         // RuntimeAccessModifiersILPP will make this `public`
         internal static readonly Dictionary<uint, string> __rpc_name_table = new Dictionary<uint, string>();
 #endif
@@ -54,6 +54,7 @@ namespace Unity.Netcode
             var type = typeof(T);
             if (!s_SerializedType.Contains(type))
             {
+                s_SerializedType.Add(type);
                 if (NetworkLog.CurrentLogLevel <= LogLevel.Developer)
                 {
                     Debug.LogWarning($"[{type.Name}] Serialized type has not been optimized for use with Distributed Authority!");

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/RpcMessages.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/RpcMessages.cs
@@ -41,7 +41,7 @@ namespace Unity.Netcode
 
             payload = new FastBufferReader(reader.GetUnsafePtrAtCurrentPosition(), Allocator.None, reader.Length - reader.Position);
 
-#if DEVELOPMENT_BUILD || UNITY_EDITOR
+#if DEVELOPMENT_BUILD || UNITY_EDITOR || UNITY_MP_TOOLS_NET_STATS_MONITOR_ENABLED_IN_RELEASE
             if (NetworkBehaviour.__rpc_name_table[networkBehaviour.GetType()].TryGetValue(metadata.NetworkRpcMethodId, out var rpcMethodName))
             {
                 networkManager.NetworkMetrics.TrackRpcReceived(

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/BaseRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/BaseRpcTarget.cs
@@ -36,12 +36,12 @@ namespace Unity.Netcode
 
         private protected void SendMessageToClient(NetworkBehaviour behaviour, ulong clientId, ref RpcMessage message, NetworkDelivery delivery)
         {
-#if DEVELOPMENT_BUILD || UNITY_EDITOR
+#if DEVELOPMENT_BUILD || UNITY_EDITOR || UNITY_MP_TOOLS_NET_STATS_MONITOR_ENABLED_IN_RELEASE
             var size =
 #endif
                 behaviour.NetworkManager.MessageManager.SendMessage(ref message, delivery, clientId);
 
-#if DEVELOPMENT_BUILD || UNITY_EDITOR
+#if DEVELOPMENT_BUILD || UNITY_EDITOR || UNITY_MP_TOOLS_NET_STATS_MONITOR_ENABLED_IN_RELEASE
             if (NetworkBehaviour.__rpc_name_table[behaviour.GetType()].TryGetValue(message.Metadata.NetworkRpcMethodId, out var rpcMethodName))
             {
                 behaviour.NetworkManager.NetworkMetrics.TrackRpcSent(

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/LocalSendRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/LocalSendRpcTarget.cs
@@ -46,7 +46,7 @@ namespace Unity.Netcode
                 message.Handle(ref context);
                 length = tempBuffer.Length;
             }
-#if DEVELOPMENT_BUILD || UNITY_EDITOR
+#if DEVELOPMENT_BUILD || UNITY_EDITOR || UNITY_MP_TOOLS_NET_STATS_MONITOR_ENABLED_IN_RELEASE
             if (NetworkBehaviour.__rpc_name_table[behaviour.GetType()].TryGetValue(message.Metadata.NetworkRpcMethodId, out var rpcMethodName))
             {
                 networkManager.NetworkMetrics.TrackRpcSent(

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ProxyRpcTargetGroup.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ProxyRpcTargetGroup.cs
@@ -18,12 +18,12 @@ namespace Unity.Netcode
         internal override void Send(NetworkBehaviour behaviour, ref RpcMessage message, NetworkDelivery delivery, RpcParams rpcParams)
         {
             var proxyMessage = new ProxyMessage { Delivery = delivery, TargetClientIds = TargetClientIds.AsArray(), WrappedMessage = message };
-#if DEVELOPMENT_BUILD || UNITY_EDITOR
+#if DEVELOPMENT_BUILD || UNITY_EDITOR || UNITY_MP_TOOLS_NET_STATS_MONITOR_ENABLED_IN_RELEASE
             var size =
 #endif
                 behaviour.NetworkManager.MessageManager.SendMessage(ref proxyMessage, delivery, NetworkManager.ServerClientId);
 
-#if DEVELOPMENT_BUILD || UNITY_EDITOR
+#if DEVELOPMENT_BUILD || UNITY_EDITOR || UNITY_MP_TOOLS_NET_STATS_MONITOR_ENABLED_IN_RELEASE
             if (NetworkBehaviour.__rpc_name_table[behaviour.GetType()].TryGetValue(message.Metadata.NetworkRpcMethodId, out var rpcMethodName))
             {
                 foreach (var clientId in TargetClientIds)

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Serialization/NetworkVariableSerialization.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Serialization/NetworkVariableSerialization.cs
@@ -1,5 +1,4 @@
 using System;
-using UnityEngine;
 
 namespace Unity.Netcode
 {
@@ -56,10 +55,12 @@ namespace Unity.Netcode
         {
             if (IsDistributedAuthority)
             {
-                if (!Serializer.IsDistributedAuthorityOptimized)
+#if DEVELOPMENT_BUILD || UNITY_EDITOR
+                if (!NetworkManager.DisableNotOptimizedSerializedType && !Serializer.IsDistributedAuthorityOptimized)
                 {
-                    Debug.Log("This variable is not optimized for use with Distributed Authority");
+                    NetworkManager.LogSerializedTypeNotOptimized<T>();
                 }
+#endif
                 Serializer.WriteDistributedAuthority(writer, ref value);
             }
             else
@@ -121,10 +122,12 @@ namespace Unity.Netcode
         {
             if (IsDistributedAuthority)
             {
-                if (!Serializer.IsDistributedAuthorityOptimized)
+#if DEVELOPMENT_BUILD || UNITY_EDITOR
+                if (!NetworkManager.DisableNotOptimizedSerializedType && !Serializer.IsDistributedAuthorityOptimized)
                 {
-                    Debug.Log("This variable is not optimized for use with Distributed Authority");
+                    NetworkManager.LogSerializedTypeNotOptimized<T>();
                 }
+#endif
                 Serializer.WriteDeltaDistributedAuthority(writer, ref value, ref previousValue);
             }
             else

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -303,6 +303,11 @@ namespace Unity.Netcode.TestHelpers.Runtime
             OnOneTimeSetup();
 
             VerboseDebug($"Exiting {nameof(OneTimeSetup)}");
+
+#if DEVELOPMENT_BUILD || UNITY_EDITOR
+            // Default to not log the serialized type not optimized warning message when testing.
+            NetworkManager.DisableNotOptimizedSerializedType = true;
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
Added xml API documentation and tooltips to the `NetworkConfig.NetworkMessageMetrics` and `NetworkConfig.NetworkProfilingMetrics` properties.

Added a static helper method in `NetworkManager` to handle logging when a serialized type is not yet optimized for distributed authority.

Includes the up-port of #2980.

## Changelog

- Fixed issue where the realtime network stats monitor was not able to display RPC traffic in release builds due to those stats being only available in development builds or the editor.

## Testing and Documentation

- Includes integration tests.
- No documentation changes or additions were necessary.


<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
