### PR TITLE
chore: Anticipated not supported warning

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Components/AnticipatedNetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/AnticipatedNetworkTransform.cs
@@ -360,6 +360,10 @@ namespace Unity.Netcode.Components
 
         public override void OnNetworkSpawn()
         {
+            if (NetworkManager.DistributedAuthorityMode)
+            {
+                Debug.LogWarning($"This component is not currently supported in distributed authority.");
+            }
             base.OnNetworkSpawn();
             m_OutstandingAuthorityChange = true;
             ApplyAuthoritativeState();


### PR DESCRIPTION
notify user that this component is not supported in distributed authority mode

## Changelog

NA

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.


<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
