### PR TITLE
fix: deferred despawn gc allocation

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,13 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
-## [2.0.0-pre.3] - 2024-07-18
+## [2.0.0-pre.3] - 2024-07-23
 
 ### Added
 - Added: `UnityTransport.GetNetworkDriver` and `UnityTransport.GetLocalEndpoint` methods to expose the driver and local endpoint being used. (#2978)
 
 ### Fixed
 
+- Fixed issue where deferred despawn was causing GC allocations when converting an `IEnumerable` to a list.
 - Fixed issue where the realtime network stats monitor was not able to display RPC traffic in release builds due to those stats being only available in development builds or the editor. (#2979)
 - Fixed issue where `NetworkManager.ScenesLoaded` was not being updated if `PostSynchronizationSceneUnloading` was set and any loaded scenes not used during synchronization were unloaded. (#2971)
 - Fixed issue where `Rigidbody2d` under Unity 6000.0.11f1 has breaking changes where `velocity` is now `linearVelocity` and `isKinematic` is replaced by `bodyType`. (#2971)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -13,7 +13,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where deferred despawn was causing GC allocations when converting an `IEnumerable` to a list.
+- Fixed issue where deferred despawn was causing GC allocations when converting an `IEnumerable` to a list. (#2983)
 - Fixed issue where the realtime network stats monitor was not able to display RPC traffic in release builds due to those stats being only available in development builds or the editor. (#2979)
 - Fixed issue where `NetworkManager.ScenesLoaded` was not being updated if `PostSynchronizationSceneUnloading` was set and any loaded scenes not used during synchronization were unloaded. (#2971)
 - Fixed issue where `Rigidbody2d` under Unity 6000.0.11f1 has breaking changes where `velocity` is now `linearVelocity` and `isKinematic` is replaced by `bodyType`. (#2971)

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1820,11 +1820,14 @@ namespace Unity.Netcode
                 return;
             }
             var currentTick = serverTime.Tick;
-            var deferredCallbackObjects = DeferredDespawnObjects.Where((c) => c.HasDeferredDespawnCheck);
-            var deferredCallbackCount = deferredCallbackObjects.Count();
+            var deferredCallbackCount = DeferredDespawnObjects.Count();
             for (int i = 0; i < deferredCallbackCount - 1; i++)
             {
-                var deferredObjectEntry = deferredCallbackObjects.ElementAt(i);
+                var deferredObjectEntry = DeferredDespawnObjects[i];
+                if (!deferredObjectEntry.HasDeferredDespawnCheck)
+                {
+                    continue;
+                }
                 var networkObject = SpawnedObjects[deferredObjectEntry.NetworkObjectId];
                 // Double check to make sure user did not remove the callback
                 if (networkObject.OnDeferredDespawnComplete != null)
@@ -1849,9 +1852,11 @@ namespace Unity.Netcode
                 }
             }
 
-            var despawnObjects = DeferredDespawnObjects.Where((c) => c.TickToDespawn < currentTick).ToList();
-            foreach (var deferredObjectEntry in despawnObjects)
+            var despawnObjects = DeferredDespawnObjects.Where((c) => c.TickToDespawn < currentTick);
+            var despawnObjectsCount = despawnObjects.Count();
+            for (int i = 0; i < despawnObjectsCount; i++)
             {
+                var deferredObjectEntry = despawnObjects.ElementAt(i);
                 if (!SpawnedObjects.ContainsKey(deferredObjectEntry.NetworkObjectId))
                 {
                     DeferredDespawnObjects.Remove(deferredObjectEntry);


### PR DESCRIPTION
This resolves the issue where checking for deferred despawned `NetworkObject`s was causing a GC alloc per frame when converting an `IEnumerable` to a list.

[MTTB-83](https://jira.unity3d.com/browse/MTTB-83)

fix: #2891 

## Changelog

- Fixed: Issue where deferred despawn was causing GC allocations when converting an `IEnumerable` to a list.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
