### PR TITLE
fix: allow clients to set client synchronization mode distributed authority

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -25,6 +25,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+- Changed logic where clients can now set the `NetworkSceneManager` client synchronization mode when using a distributed authority network topology. (#2985)
+
 
 ## [2.0.0-pre.2] - 2024-06-17
 

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/DefaultSceneManagerHandler.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/DefaultSceneManagerHandler.cs
@@ -334,7 +334,7 @@ namespace Unity.Netcode
         {
             var sceneManager = networkManager.SceneManager;
             // In client-server, we don't let client's set this value.
-            // In dsitributed authority, since session owner can be promoted clients can set this value
+            // In distributed authority, since session owner can be promoted clients can set this value
             if (!networkManager.DistributedAuthorityMode && !networkManager.IsServer)
             {
                 if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/DefaultSceneManagerHandler.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/DefaultSceneManagerHandler.cs
@@ -333,8 +333,9 @@ namespace Unity.Netcode
         public void SetClientSynchronizationMode(ref NetworkManager networkManager, LoadSceneMode mode)
         {
             var sceneManager = networkManager.SceneManager;
-            // Don't let non-authority set this value
-            if ((!networkManager.DistributedAuthorityMode && !networkManager.IsServer) || (networkManager.DistributedAuthorityMode && !networkManager.LocalClient.IsSessionOwner))
+            // In client-server, we don't let client's set this value.
+            // In dsitributed authority, since session owner can be promoted clients can set this value
+            if (!networkManager.DistributedAuthorityMode && !networkManager.IsServer)
             {
                 if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
                 {
@@ -343,7 +344,7 @@ namespace Unity.Netcode
                 return;
             }
             else // Warn users if they are changing this after there are clients already connected and synchronized
-            if (networkManager.ConnectedClientsIds.Count > (networkManager.IsHost ? 1 : 0) && sceneManager.ClientSynchronizationMode != mode)
+            if (!networkManager.DistributedAuthorityMode && networkManager.ConnectedClientsIds.Count > (networkManager.IsHost ? 1 : 0) && sceneManager.ClientSynchronizationMode != mode)
             {
                 if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
                 {

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text;
 using UnityEngine;
 

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1853,7 +1853,7 @@ namespace Unity.Netcode
             }
 
             // Parse backwards so we can remove objects as we parse through them
-            for (int i = DeferredDespawnObjects.Count - 1; i > 0; i--)
+            for (int i = DeferredDespawnObjects.Count - 1; i >= 0; i--)
             {
                 var deferredObjectEntry = DeferredDespawnObjects[i];
                 if (deferredObjectEntry.TickToDespawn >= currentTick)

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using UnityEngine;
 
@@ -1821,7 +1822,7 @@ namespace Unity.Netcode
             }
             var currentTick = serverTime.Tick;
             var deferredCallbackCount = DeferredDespawnObjects.Count();
-            for (int i = 0; i < deferredCallbackCount - 1; i++)
+            for (int i = 0; i < deferredCallbackCount; i++)
             {
                 var deferredObjectEntry = DeferredDespawnObjects[i];
                 if (!deferredObjectEntry.HasDeferredDespawnCheck)
@@ -1852,9 +1853,15 @@ namespace Unity.Netcode
                 }
             }
 
-            var despawnObjects = DeferredDespawnObjects.Where((c) => c.TickToDespawn < currentTick);
-            foreach (var deferredObjectEntry in despawnObjects)
+            // Parse backwards so we can remove objects as we parse through them
+            for (int i = DeferredDespawnObjects.Count - 1; i > 0; i--)
             {
+                var deferredObjectEntry = DeferredDespawnObjects[i];
+                if (deferredObjectEntry.TickToDespawn >= currentTick)
+                {
+                    continue;
+                }
+
                 if (!SpawnedObjects.ContainsKey(deferredObjectEntry.NetworkObjectId))
                 {
                     DeferredDespawnObjects.Remove(deferredObjectEntry);

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1853,10 +1853,8 @@ namespace Unity.Netcode
             }
 
             var despawnObjects = DeferredDespawnObjects.Where((c) => c.TickToDespawn < currentTick);
-            var despawnObjectsCount = despawnObjects.Count();
-            for (int i = 0; i < despawnObjectsCount; i++)
+            foreach (var deferredObjectEntry in despawnObjects)
             {
-                var deferredObjectEntry = despawnObjects.ElementAt(i);
                 if (!SpawnedObjects.ContainsKey(deferredObjectEntry.NetworkObjectId))
                 {
                     DeferredDespawnObjects.Remove(deferredObjectEntry);

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
@@ -800,8 +800,9 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
             var sceneManager = networkManager.SceneManager;
 
-            // Don't let client's set this value
-            if (!networkManager.IsServer)
+            // In client-server, we don't let client's set this value.
+            // In dsitributed authority, since session owner can be promoted clients can set this value
+            if (!networkManager.DistributedAuthorityMode && !networkManager.IsServer)
             {
                 if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
                 {
@@ -809,7 +810,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 }
                 return;
             }
-            else if (networkManager.ConnectedClientsIds.Count > (networkManager.IsHost ? 1 : 0) && sceneManager.ClientSynchronizationMode != mode)
+            else if (!networkManager.DistributedAuthorityMode && networkManager.ConnectedClientsIds.Count > (networkManager.IsHost ? 1 : 0) && sceneManager.ClientSynchronizationMode != mode)
             {
                 if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
                 {

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerUsageTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerUsageTests.cs
@@ -39,7 +39,14 @@ namespace TestProject.RuntimeTests
         [Test]
         public void ClientSetClientSynchronizationMode()
         {
-            LogAssert.Expect(UnityEngine.LogType.Warning, "[Netcode] Clients should not set this value as it is automatically synchronized with the server's setting!");
+            if (!m_DistributedAuthority)
+            {
+                LogAssert.Expect(UnityEngine.LogType.Warning, "[Netcode] Clients should not set this value as it is automatically synchronized with the server's setting!");
+            }
+            else
+            {
+                LogAssert.NoUnexpectedReceived();
+            }
             m_ClientNetworkManagers[0].SceneManager.SetClientSynchronizationMode(LoadSceneMode.Single);
         }
 
@@ -49,11 +56,21 @@ namespace TestProject.RuntimeTests
         [UnityTest]
         public IEnumerator ServerSetClientSynchronizationModeAfterClientsConnected()
         {
-            // Verify that changing this setting when additional clients are connect will generate the warning
-            LogAssert.Expect(UnityEngine.LogType.Warning, "[Netcode] Server is changing client synchronization mode after clients have been synchronized! It is recommended to do this before clients are connected!");
+            if (!m_DistributedAuthority)
+            {
+                // Verify that changing this setting when additional clients are connect will generate the warning
+                LogAssert.Expect(UnityEngine.LogType.Warning, "[Netcode] Server is changing client synchronization mode after clients have been synchronized! It is recommended to do this before clients are connected!");
+            }
+            else
+            {
+                LogAssert.NoUnexpectedReceived();
+            }
+
             m_ServerNetworkManager.SceneManager.SetClientSynchronizationMode(LoadSceneMode.Additive);
+
             // Verify that changing this setting when no additional clients are connected will not generate a warning
             yield return StopOneClient(m_ClientNetworkManagers[0]);
+
             m_ServerNetworkManager.SceneManager.SetClientSynchronizationMode(LoadSceneMode.Additive);
             LogAssert.NoUnexpectedReceived();
         }


### PR DESCRIPTION
This update allows clients to set the client synchronization mode since any client can be promoted to session owner.

## Changelog

- Changed: Clients can set the `NetworkSceneManager` client synchronization mode when using a distributed authority network topology.

## Testing and Documentation

- No tests have been added.
- Documentation additions are necessary and [being tracked internally](https://docs.google.com/document/d/1yaljfx-ypRADhJ08mNpzXwFWsSJ1usqbQONfKrErZ34/edit)

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
