### PR TITLE
fix: Improve API doc for OnGainedOwnership and OnLostOwnership

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -806,7 +806,8 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// Gets called when the local client gains ownership of this object.
+        /// In client-server contexts, this method is invoked on both the server and the local client of the owner when <see cref="Netcode.NetworkObject"/> ownership is assigned.
+        /// <para>In distributed authority contexts, this method is only invoked on the local client that has been assigned ownership of the associated <see cref="Netcode.NetworkObject"/>.</para>
         /// </summary>
         public virtual void OnGainedOwnership() { }
 
@@ -834,7 +835,9 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// Gets called when ownership of this object is lost.
+        /// In client-server contexts, this method is invoked on the local client when it loses ownership of the associated <see cref="Netcode.NetworkObject"/>
+        /// and on the server when any client loses ownership.
+        /// <para>In distributed authority contexts, this method is only invoked on the local client that has lost ownership of the associated <see cref="Netcode.NetworkObject"/>.</para>
         /// </summary>
         public virtual void OnLostOwnership() { }
 
@@ -1138,7 +1141,7 @@ namespace Unity.Netcode
                 // Distributed Authority: All clients have read permissions, always try to write the value.
                 if (NetworkVariableFields[j].CanClientRead(targetClientId))
                 {
-                    // Write additional NetworkVariable information when length safety is enabled or when in distributed authority mode 
+                    // Write additional NetworkVariable information when length safety is enabled or when in distributed authority mode
                     if (ensureLengthSafety || distributedAuthority)
                     {
                         // Write the type being serialized for distributed authority (only for comb-server)


### PR DESCRIPTION
Updating the API doc for NetworkBehaviour.OnGainedOwnership and NetworkBehaviour.OnLostOwnership, per [issue 1255 in the docs repo](https://github.com/Unity-Technologies/com.unity.multiplayer.docs/issues/1255).

@NoelStephensUnity Please make sure you have a close look at the edits for client-server vs. distributed authority contexts. Pretty sure I got it right based on our chat yesterday, but need your eyes to be sure 👀 

Equivalent PR for 1.x version is here: #2996 

## Changelog

- Fixed: Added more detail to the API doc for NetworkBehaviour.OnGainedOwnership and NetworkBehaviour.OnLostOwnership.

## Testing and Documentation

- Includes edits to existing public API documentation.