### PR TITLE
fix: MPSNGM-365 Remove invalid ProxyMessage test

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
@@ -40,11 +40,6 @@ namespace Unity.Netcode.RuntimeTests
             public NetworkList<int> MyNetworkList = new NetworkList<int>(new List<int> { 1, 2, 3 });
             public NetworkVariable<int> MyNetworkVar = new NetworkVariable<int>(3);
 
-            [Rpc(SendTo.NotAuthority)]
-            public void TestNotAuthorityRpc(byte[] _)
-            {
-            }
-
             [Rpc(SendTo.Authority)]
             public void TestAuthorityRpc(byte[] _)
             {
@@ -261,15 +256,6 @@ namespace Unity.Netcode.RuntimeTests
             yield return m_ClientCodecHook.WaitForMessageReceived<NetworkVariableDeltaMessage>();
             component.MyNetworkList.Clear();
             yield return m_ClientCodecHook.WaitForMessageReceived<NetworkVariableDeltaMessage>();
-        }
-
-        [UnityTest]
-        public IEnumerator NotAuthorityRpc()
-        {
-            Client.LocalClient.PlayerObject.GetComponent<TestNetworkComponent>().TestNotAuthorityRpc(new byte[] { 1, 2, 3, 4 });
-
-            // Universal Rpcs are sent as a ProxyMessage (which contains an RpcMessage)
-            yield return m_ClientCodecHook.WaitForMessageReceived<ProxyMessage>();
         }
 
         [UnityTest]


### PR DESCRIPTION
<!-- Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->
[MPSNGM-365](https://jira.unity3d.com/browse/MPSNGM-356)

<!-- Add RFC link here if applicable. -->

## Changelog

- Removed: Test that is no longer valid as NGO was fixed to no longer send NotAuthority RPC proxy messages when only one client is connected. Moving the test into the DA test suite as it can be tested more completely there.
 
## Testing and Documentation

- No tests have been added. 1 DA test removed.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
