### PR TITLE
fix: nested networktransforms not updating

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -14,6 +14,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where nested `NetworkTransform` components were not getting updated. (#3016)
 - Fixed issue where `FixedStringSerializer<T>` was using `NetworkVariableSerialization<byte>.AreEqual` to determine if two bytes were equal causes an exception to be thrown due to no byte serializer having been defined. (#3009)
 - Fixed Issue where a state with dual triggers, inbound and outbound, could cause a false layer to layer state transition message to be sent to non-authority `NetworkAnimator` instances and cause a warning message to be logged. (#3008)
 - Fixed issue using collections within `NetworkVariable` where the collection would not detect changes to items or nested items. (#3004)

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
@@ -2960,7 +2960,7 @@ namespace Unity.Netcode.Components
 #else
             var forUpdate = true;
 #endif
-            NetworkManager?.NetworkTransformRegistration(this, forUpdate, false);
+            NetworkManager?.NetworkTransformRegistration(NetworkObject, forUpdate, false);
             DeregisterForTickUpdate(this);
             CanCommitToTransform = false;
         }
@@ -3069,7 +3069,7 @@ namespace Unity.Netcode.Components
             if (CanCommitToTransform)
             {
                 // Make sure authority doesn't get added to updates (no need to do this on the authority side)
-                m_CachedNetworkManager.NetworkTransformRegistration(this, forUpdate, false);
+                m_CachedNetworkManager.NetworkTransformRegistration(NetworkObject, forUpdate, false);
                 if (UseHalfFloatPrecision)
                 {
                     m_HalfPositionState = new NetworkDeltaPosition(currentPosition, m_CachedNetworkManager.ServerTime.Tick, math.bool3(SyncPositionX, SyncPositionY, SyncPositionZ));
@@ -3090,7 +3090,7 @@ namespace Unity.Netcode.Components
             else
             {
                 // Non-authority needs to be added to updates for interpolation and applying state purposes
-                m_CachedNetworkManager.NetworkTransformRegistration(this, forUpdate, true);
+                m_CachedNetworkManager.NetworkTransformRegistration(NetworkObject, forUpdate, true);
                 // Remove this instance from the tick update
                 DeregisterForTickUpdate(this);
                 ResetInterpolatedStateToCurrentAuthoritativeState();

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
@@ -2960,7 +2960,10 @@ namespace Unity.Netcode.Components
 #else
             var forUpdate = true;
 #endif
-            NetworkManager?.NetworkTransformRegistration(NetworkObject, forUpdate, false);
+            if (m_CachedNetworkObject != null)
+            {
+                NetworkManager?.NetworkTransformRegistration(m_CachedNetworkObject, forUpdate, false);
+            }
             DeregisterForTickUpdate(this);
             CanCommitToTransform = false;
         }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -2359,7 +2359,7 @@ namespace Unity.Netcode
                     {
                         m_ChildNetworkBehaviours.Add(networkBehaviours[i]);
                         var type = networkBehaviours[i].GetType();
-                        if (type.IsInstanceOfType(typeof(NetworkTransform)) || type.IsSubclassOf(typeof(NetworkTransform)))
+                        if (type == typeof(NetworkTransform) || type.IsInstanceOfType(typeof(NetworkTransform)) || type.IsSubclassOf(typeof(NetworkTransform)))
                         {
                             if (NetworkTransforms == null)
                             {

--- a/testproject/Assets/Tests/Manual/NestedNetworkTransforms/AutomatedPlayer-OA.prefab
+++ b/testproject/Assets/Tests/Manual/NestedNetworkTransforms/AutomatedPlayer-OA.prefab
@@ -51,6 +51,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -96,6 +99,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0d8ad30fca3f9a240bdce16f0166033b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  AuthorityMode: 1
   UseUnreliableDeltas: 0
   SyncPositionX: 1
   SyncPositionY: 1
@@ -115,7 +119,6 @@ MonoBehaviour:
   InLocalSpace: 1
   Interpolate: 1
   SlerpPosition: 1
-  IsServerAuthority: 1
   DebugTransform: 0
   LastUpdatedPosition: {x: 0, y: 0, z: 0}
   LastUpdatedScale: {x: 0, y: 0, z: 0}
@@ -295,6 +298,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -340,6 +346,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0d8ad30fca3f9a240bdce16f0166033b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  AuthorityMode: 1
   UseUnreliableDeltas: 0
   SyncPositionX: 1
   SyncPositionY: 1
@@ -359,7 +366,6 @@ MonoBehaviour:
   InLocalSpace: 1
   Interpolate: 1
   SlerpPosition: 1
-  IsServerAuthority: 1
   DebugTransform: 0
   LastUpdatedPosition: {x: 0, y: 0, z: 0}
   LastUpdatedScale: {x: 0, y: 0, z: 0}
@@ -388,7 +394,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 947981134, guid: 96e0a72e30d0c46c8a5c9a750e8f5807, type: 3}
       propertyPath: GlobalObjectIdHash
-      value: 503295152
+      value: 2714446911
       objectReference: {fileID: 0}
     - target: {fileID: 3809075828520557319, guid: 96e0a72e30d0c46c8a5c9a750e8f5807,
         type: 3}
@@ -557,6 +563,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dfb1af1a9249278438d2daa2877ee2ad, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  AuthorityMode: 1
   UseUnreliableDeltas: 1
   SyncPositionX: 1
   SyncPositionY: 1
@@ -576,7 +583,6 @@ MonoBehaviour:
   InLocalSpace: 0
   Interpolate: 1
   SlerpPosition: 0
-  IsServerAuthority: 1
   DebugTransform: 0
   LastUpdatedPosition: {x: 0, y: 0, z: 0}
   LastUpdatedScale: {x: 0, y: 0, z: 0}

--- a/testproject/Assets/Tests/Manual/NestedNetworkTransforms/AutomatedPlayerMover.cs
+++ b/testproject/Assets/Tests/Manual/NestedNetworkTransforms/AutomatedPlayerMover.cs
@@ -36,16 +36,16 @@ namespace TestProject.RuntimeTests
             }
         }
 
-        public override void OnNetworkSpawn()
+        protected override void OnNetworkPostSpawn()
         {
-            base.OnNetworkSpawn();
             if (CanCommitToTransform)
             {
                 UpdateDestination();
             }
+            base.OnNetworkPostSpawn();
         }
 
-        public override void OnUpdate()
+        private void Update()
         {
             if (!IsSpawned)
             {

--- a/testproject/Assets/Tests/Manual/NestedNetworkTransforms/ChildMover.cs
+++ b/testproject/Assets/Tests/Manual/NestedNetworkTransforms/ChildMover.cs
@@ -32,8 +32,6 @@ namespace TestProject.ManualTests
             return CanCommitToTransform;
         }
 
-        private Vector3 m_LastPredictedPosition;
-
         public void PlayerIsMoving(float movementDirection)
         {
             if (IsSpawned && CanCommitToTransform)
@@ -53,9 +51,9 @@ namespace TestProject.ManualTests
             return transform;
         }
 
-        public override void OnNetworkSpawn()
+        protected override void OnNetworkPostSpawn()
         {
-            if ((OnIsServerAuthoritative() && IsServer) || (!OnIsServerAuthoritative() && IsOwner))
+            if (CanCommitToTransform)
             {
                 m_RootParentTransform = GetRootParentTransform(transform);
                 if (RandomizeScale)
@@ -63,7 +61,7 @@ namespace TestProject.ManualTests
                     transform.localScale = transform.localScale * Random.Range(0.5f, 1.5f);
                 }
             }
-            base.OnNetworkSpawn();
+            base.OnNetworkPostSpawn();
         }
     }
 }

--- a/testproject/Assets/Tests/Manual/Scripts/IntegrationNetworkTransform.cs
+++ b/testproject/Assets/Tests/Manual/Scripts/IntegrationNetworkTransform.cs
@@ -19,9 +19,6 @@ namespace TestProject.ManualTests
 {
     public class IntegrationNetworkTransform : NetworkTransform
     {
-
-        public bool IsServerAuthority = true;
-
         public bool DebugTransform;
 
         public Vector3 LastUpdatedPosition;
@@ -52,11 +49,6 @@ namespace TestProject.ManualTests
                 m_AddLogEntry = InternalAddLogEntry;
             }
 #endif
-        }
-
-        protected override bool OnIsServerAuthoritative()
-        {
-            return IsServerAuthority;
         }
 
         protected override void OnAuthorityPushTransformState(ref NetworkTransformState networkTransformState)

--- a/testproject/Assets/Tests/Runtime/NetworkTransform/NestedNetworkTransformTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkTransform/NestedNetworkTransformTests.cs
@@ -2,24 +2,25 @@ using System.Collections;
 using System.Text;
 using NUnit.Framework;
 using TestProject.ManualTests;
+using Unity.Netcode.Components;
 using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
 namespace TestProject.RuntimeTests
 {
-    [TestFixture(Interpolation.Interpolation, Precision.Full, AuthoritativeModel.Server)]
-    [TestFixture(Interpolation.Interpolation, Precision.Full, AuthoritativeModel.Owner)]
-    [TestFixture(Interpolation.Interpolation, Precision.Half, AuthoritativeModel.Server)]
-    [TestFixture(Interpolation.Interpolation, Precision.Half, AuthoritativeModel.Owner)]
-    [TestFixture(Interpolation.Interpolation, Precision.Compressed, AuthoritativeModel.Server)]
-    [TestFixture(Interpolation.Interpolation, Precision.Compressed, AuthoritativeModel.Owner)]
-    [TestFixture(Interpolation.NoInterpolation, Precision.Full, AuthoritativeModel.Server)]
-    [TestFixture(Interpolation.NoInterpolation, Precision.Full, AuthoritativeModel.Owner)]
-    [TestFixture(Interpolation.NoInterpolation, Precision.Half, AuthoritativeModel.Server)]
-    [TestFixture(Interpolation.NoInterpolation, Precision.Half, AuthoritativeModel.Owner)]
-    [TestFixture(Interpolation.NoInterpolation, Precision.Compressed, AuthoritativeModel.Server)]
-    [TestFixture(Interpolation.NoInterpolation, Precision.Compressed, AuthoritativeModel.Owner)]
+    [TestFixture(Interpolation.Interpolation, Precision.Full, NetworkTransform.AuthorityModes.Server)]
+    [TestFixture(Interpolation.Interpolation, Precision.Full, NetworkTransform.AuthorityModes.Owner)]
+    [TestFixture(Interpolation.Interpolation, Precision.Half, NetworkTransform.AuthorityModes.Server)]
+    [TestFixture(Interpolation.Interpolation, Precision.Half, NetworkTransform.AuthorityModes.Owner)]
+    [TestFixture(Interpolation.Interpolation, Precision.Compressed, NetworkTransform.AuthorityModes.Server)]
+    [TestFixture(Interpolation.Interpolation, Precision.Compressed, NetworkTransform.AuthorityModes.Owner)]
+    [TestFixture(Interpolation.NoInterpolation, Precision.Full, NetworkTransform.AuthorityModes.Server)]
+    [TestFixture(Interpolation.NoInterpolation, Precision.Full, NetworkTransform.AuthorityModes.Owner)]
+    [TestFixture(Interpolation.NoInterpolation, Precision.Half, NetworkTransform.AuthorityModes.Server)]
+    [TestFixture(Interpolation.NoInterpolation, Precision.Half, NetworkTransform.AuthorityModes.Owner)]
+    [TestFixture(Interpolation.NoInterpolation, Precision.Compressed, NetworkTransform.AuthorityModes.Server)]
+    [TestFixture(Interpolation.NoInterpolation, Precision.Compressed, NetworkTransform.AuthorityModes.Owner)]
     public class NestedNetworkTransformTests : IntegrationTestWithApproximation
     {
         private const string k_TestScene = "NestedNetworkTransformTestScene";
@@ -39,7 +40,7 @@ namespace TestProject.RuntimeTests
         private Object m_PlayerPrefabResource;
         private Interpolation m_Interpolation;
         private Precision m_Precision;
-        private AuthoritativeModel m_Authority;
+        private NetworkTransform.AuthorityModes m_Authority;
 
         public enum Interpolation
         {
@@ -61,7 +62,7 @@ namespace TestProject.RuntimeTests
         }
 
 
-        public NestedNetworkTransformTests(Interpolation interpolation, Precision precision, AuthoritativeModel authoritativeModel)
+        public NestedNetworkTransformTests(Interpolation interpolation, Precision precision, NetworkTransform.AuthorityModes authoritativeModel)
         {
             m_Interpolation = interpolation;
             m_Precision = precision;
@@ -134,7 +135,7 @@ namespace TestProject.RuntimeTests
             networkTransform.UseQuaternionSynchronization = true;
             networkTransform.UseHalfFloatPrecision = m_Precision == Precision.Half || m_Precision == Precision.Compressed;
             networkTransform.UseQuaternionCompression = m_Precision == Precision.Compressed;
-            networkTransform.IsServerAuthority = m_Authority == AuthoritativeModel.Server;
+            networkTransform.AuthorityMode = m_Authority;
         }
 
 
@@ -189,7 +190,7 @@ namespace TestProject.RuntimeTests
             m_ValidationErrors.Clear();
             foreach (var connectedClient in m_ServerNetworkManager.ConnectedClientsIds)
             {
-                var authorityId = m_Authority == AuthoritativeModel.Server ? m_ServerNetworkManager.LocalClientId : connectedClient;
+                var authorityId = m_Authority == NetworkTransform.AuthorityModes.Server ? m_ServerNetworkManager.LocalClientId : connectedClient;
                 var playerToValidate = m_PlayerNetworkObjects[authorityId][connectedClient];
                 var playerNetworkTransforms = playerToValidate.GetComponentsInChildren<IntegrationNetworkTransform>();
                 foreach (var playerRelative in m_PlayerNetworkObjects)

--- a/testproject/Assets/Tests/Runtime/NetworkTransform/Resources/PlayerNestedTransforms.prefab
+++ b/testproject/Assets/Tests/Runtime/NetworkTransform/Resources/PlayerNestedTransforms.prefab
@@ -26,13 +26,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 344161399033526463}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -2, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2272675266166542847}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &8724994478026131689
 MeshRenderer:
@@ -51,6 +51,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -96,6 +99,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0d8ad30fca3f9a240bdce16f0166033b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  AuthorityMode: 0
+  UseUnreliableDeltas: 0
   SyncPositionX: 1
   SyncPositionY: 1
   SyncPositionZ: 1
@@ -105,20 +110,22 @@ MonoBehaviour:
   SyncScaleX: 1
   SyncScaleY: 1
   SyncScaleZ: 1
-  UseQuaternionSynchronization: 1
-  UseQuaternionCompression: 1
-  UseHalfFloatPrecision: 1
   PositionThreshold: 0.001
   RotAngleThreshold: 0.001
   ScaleThreshold: 0.001
+  UseQuaternionSynchronization: 1
+  UseQuaternionCompression: 0
+  UseHalfFloatPrecision: 1
   InLocalSpace: 1
-  Interpolate: 1
+  Interpolate: 0
   SlerpPosition: 1
-  IsServerAuthority: 0
   DebugTransform: 0
   LastUpdatedPosition: {x: 0, y: 0, z: 0}
   LastUpdatedScale: {x: 0, y: 0, z: 0}
   LastUpdatedRotation: {x: 0, y: 0, z: 0, w: 0}
+  PushedPosition: {x: 0, y: 0, z: 0}
+  PushedScale: {x: 0, y: 0, z: 0}
+  PushedRotation: {x: 0, y: 0, z: 0, w: 0}
   PreviousUpdatedPosition: {x: 0, y: 0, z: 0}
   PreviousUpdatedScale: {x: 0, y: 0, z: 0}
   PreviousUpdatedRotation: {x: 0, y: 0, z: 0, w: 0}
@@ -155,6 +162,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6307603743893504780}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0.5, z: 0}
   m_LocalScale: {x: 2, y: 2, z: 2}
@@ -163,7 +171,6 @@ Transform:
   - {fileID: 5095177694802425565}
   - {fileID: 2272675266166542847}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6307603743893504769
 MeshFilter:
@@ -190,6 +197,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -227,9 +237,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 951099334
+  GlobalObjectIdHash: 441869080
+  InScenePlacedSourceGlobalObjectIdHash: 0
+  DeferredDespawnTick: 0
+  Ownership: 1
   AlwaysReplicateAsRoot: 0
   SynchronizeTransform: 1
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 1
+  SpawnWithObservers: 1
   DontDestroyWithOwner: 0
   AutoObjectParentSync: 1
 --- !u!114 &3387617782067200397
@@ -274,6 +290,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dfb1af1a9249278438d2daa2877ee2ad, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  AuthorityMode: 0
+  UseUnreliableDeltas: 0
   SyncPositionX: 1
   SyncPositionY: 1
   SyncPositionZ: 1
@@ -283,20 +301,22 @@ MonoBehaviour:
   SyncScaleX: 1
   SyncScaleY: 1
   SyncScaleZ: 1
-  UseQuaternionSynchronization: 1
-  UseQuaternionCompression: 1
-  UseHalfFloatPrecision: 1
   PositionThreshold: 0.001
   RotAngleThreshold: 0.001
   ScaleThreshold: 0.001
+  UseQuaternionSynchronization: 1
+  UseQuaternionCompression: 0
+  UseHalfFloatPrecision: 1
   InLocalSpace: 0
-  Interpolate: 1
+  Interpolate: 0
   SlerpPosition: 0
-  IsServerAuthority: 0
   DebugTransform: 0
   LastUpdatedPosition: {x: 0, y: 0, z: 0}
   LastUpdatedScale: {x: 0, y: 0, z: 0}
   LastUpdatedRotation: {x: 0, y: 0, z: 0, w: 0}
+  PushedPosition: {x: 0, y: 0, z: 0}
+  PushedScale: {x: 0, y: 0, z: 0}
+  PushedRotation: {x: 0, y: 0, z: 0, w: 0}
   PreviousUpdatedPosition: {x: 0, y: 0, z: 0}
   PreviousUpdatedScale: {x: 0, y: 0, z: 0}
   PreviousUpdatedRotation: {x: 0, y: 0, z: 0, w: 0}
@@ -339,13 +359,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6425543486096047037}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 2, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6307603743893504768}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &313661067260263792
 MeshRenderer:
@@ -364,6 +384,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -409,6 +432,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0d8ad30fca3f9a240bdce16f0166033b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  AuthorityMode: 0
+  UseUnreliableDeltas: 0
   SyncPositionX: 1
   SyncPositionY: 1
   SyncPositionZ: 1
@@ -418,20 +443,22 @@ MonoBehaviour:
   SyncScaleX: 1
   SyncScaleY: 1
   SyncScaleZ: 1
-  UseQuaternionSynchronization: 1
-  UseQuaternionCompression: 1
-  UseHalfFloatPrecision: 1
   PositionThreshold: 0.001
   RotAngleThreshold: 0.001
   ScaleThreshold: 0.001
+  UseQuaternionSynchronization: 1
+  UseQuaternionCompression: 0
+  UseHalfFloatPrecision: 1
   InLocalSpace: 1
-  Interpolate: 1
+  Interpolate: 0
   SlerpPosition: 1
-  IsServerAuthority: 0
   DebugTransform: 0
   LastUpdatedPosition: {x: 0, y: 0, z: 0}
   LastUpdatedScale: {x: 0, y: 0, z: 0}
   LastUpdatedRotation: {x: 0, y: 0, z: 0, w: 0}
+  PushedPosition: {x: 0, y: 0, z: 0}
+  PushedScale: {x: 0, y: 0, z: 0}
+  PushedRotation: {x: 0, y: 0, z: 0, w: 0}
   PreviousUpdatedPosition: {x: 0, y: 0, z: 0}
   PreviousUpdatedScale: {x: 0, y: 0, z: 0}
   PreviousUpdatedRotation: {x: 0, y: 0, z: 0, w: 0}
@@ -461,6 +488,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8494372709139388141}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -468,5 +496,4 @@ Transform:
   m_Children:
   - {fileID: 1626890731237231805}
   m_Father: {fileID: 6307603743893504768}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}


### PR DESCRIPTION
This resolves the issue with nested `NetworkTransform` components (i.e. under the same `NetworkObject`) not updating.

[MTTB-363](https://jira.unity3d.com/browse/MTTB-363)

fix: #3002


## Changelog

- Fixed: Issue where nested `NetworkTransform` components were not getting updated.

## Testing and Documentation

- Includes integration test asset adjustments.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
