### PR TITLE
fix: networkanimator auto owner authoritative mode when in distributed authority

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -25,7 +25,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
-- Changed `NetworkAnimator` to automatically switch to owner authoritative mode when using a distributed authority network topology.
+- Changed `NetworkAnimator` to automatically switch to owner authoritative mode when using a distributed authority network topology. (#3021)
 - Changed permissions exception thrown in `NetworkList` to exiting early with a logged error that is now a unified permissions message within `NetworkVariableBase`. (#3004)
 - Changed permissions exception thrown in `NetworkVariable.Value` to exiting early with a logged error that is now a unified permissions message within `NetworkVariableBase`. (#3004)
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -25,6 +25,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+- Changed `NetworkAnimator` to automatically switch to owner authoritative mode when using a distributed authority network topology.
 - Changed permissions exception thrown in `NetworkList` to exiting early with a logged error that is now a unified permissions message within `NetworkVariableBase`. (#3004)
 - Changed permissions exception thrown in `NetworkVariable.Value` to exiting early with a logged error that is now a unified permissions message within `NetworkVariableBase`. (#3004)
 

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
@@ -498,9 +498,13 @@ namespace Unity.Netcode.Components
         /// <summary>
         /// Override this method and return false to switch to owner authoritative mode
         /// </summary>
+        /// <remarks>
+        /// When using a distributed authority network topology, this will default to
+        /// owner authoritative.
+        /// </remarks>
         protected virtual bool OnIsServerAuthoritative()
         {
-            return true;
+            return NetworkManager ? !NetworkManager.DistributedAuthorityMode : true;
         }
 
         // Animators only support up to 32 parameters


### PR DESCRIPTION
This PR just makes `NetworkAnimator` automatically switch to owner authoritative mode when using a distributed authority network topology.


## Changelog

- Changed: `NetworkAnimator` to automatically switch to owner authoritative mode when using a distributed authority network topology.


## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.


<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
