### PR TITLE
fix: Stop checking hierarchy changed in playmode

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,7 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where the `NetworkManagerHelper` was continuing to check for hierarchy changes when in play mode.
+- Fixed issue where the `NetworkManagerHelper` was continuing to check for hierarchy changes when in play mode. (#3026)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,7 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where the `NetworkManagerHelper` was continuing to check for heirarchy changes when in play mode.
+- Fixed issue where the `NetworkManagerHelper` was continuing to check for hierarchy changes when in play mode.
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where the `NetworkManagerHelper` was continuing to check for heirarchy changes when in play mode.
+
 ### Changed
 
 ## [2.0.0-pre.4] - 2024-08-21

--- a/com.unity.netcode.gameobjects/Editor/NetworkManagerHelper.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkManagerHelper.cs
@@ -61,6 +61,12 @@ namespace Unity.Netcode.Editor
                     {
                         s_LastKnownNetworkManagerParents.Clear();
                         ScenesInBuildActiveSceneCheck();
+                        EditorApplication.hierarchyChanged -= EditorApplication_hierarchyChanged;
+                        break;
+                    }
+                case PlayModeStateChange.EnteredEditMode:
+                    {
+                        EditorApplication.hierarchyChanged += EditorApplication_hierarchyChanged;
                         break;
                     }
             }
@@ -110,6 +116,12 @@ namespace Unity.Netcode.Editor
         /// </summary>
         private static void EditorApplication_hierarchyChanged()
         {
+            if (Application.isPlaying)
+            {
+                EditorApplication.hierarchyChanged -= EditorApplication_hierarchyChanged;
+                return;
+            }
+
             var allNetworkManagers = Resources.FindObjectsOfTypeAll<NetworkManager>();
             foreach (var networkManager in allNetworkManagers)
             {


### PR DESCRIPTION
This PR addresses a user pain where the `NetworkManagerHelper` would continue to perform checks when there were hierarchy changes which can impact performance.

[MTTB-375](https://jira.unity3d.com/browse/MTTB-375)

fix: #3017

## Changelog

- Fixed issue where the `NetworkManagerHelper` was continuing to check for hierarchy changes when in play mode.

## Testing and Documentation

- Tested manually.
- No documentation changes or additions were necessary.
