### PR TITLE
fix: Stop checking hierarchy changed in playmode

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 [Unreleased]
+
+### Added
+
+### Fixed
+
+- Fixed issue where the `NetworkManagerHelper` was continuing to check for hierarchy changes when in play mode.
+
+### Changed
+
+
+## [1.11.0] - 2024-08-20
+
 ### Added
 
 - Added `NetworkVariable.CheckDirtyState` that is to be used in tandem with collections in order to detect whether the collection or an item within the collection has changed. (#3005)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,7 +11,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where the `NetworkManagerHelper` was continuing to check for hierarchy changes when in play mode.
+- Fixed issue where the `NetworkManagerHelper` was continuing to check for hierarchy changes when in play mode. (#3027)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Editor/NetworkManagerHelper.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkManagerHelper.cs
@@ -61,6 +61,12 @@ namespace Unity.Netcode.Editor
                     {
                         s_LastKnownNetworkManagerParents.Clear();
                         ScenesInBuildActiveSceneCheck();
+                        EditorApplication.hierarchyChanged -= EditorApplication_hierarchyChanged;
+                        break;
+                    }
+                case PlayModeStateChange.EnteredEditMode:
+                    {
+                        EditorApplication.hierarchyChanged += EditorApplication_hierarchyChanged;
                         break;
                     }
             }
@@ -110,6 +116,12 @@ namespace Unity.Netcode.Editor
         /// </summary>
         private static void EditorApplication_hierarchyChanged()
         {
+            if (Application.isPlaying)
+            {
+                EditorApplication.hierarchyChanged -= EditorApplication_hierarchyChanged;
+                return;
+            }
+
             var allNetworkManagers = Resources.FindObjectsOfTypeAll<NetworkManager>();
             foreach (var networkManager in allNetworkManagers)
             {


### PR DESCRIPTION
This is a backport of #3026.
This PR addresses a user pain where the `NetworkManagerHelper` would continue to perform checks when there were hierarchy changes which can impact performance.

[MTTB-375](https://jira.unity3d.com/browse/MTTB-375)

fix: #3017

## Changelog

- Fixed issue where the `NetworkManagerHelper` was continuing to check for hierarchy changes when in play mode.

## Testing and Documentation

- Tested manually.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
