### PR TITLE
fix: prevent exception when showing despawned or destroyed NetworkObject

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 [Unreleased]
+
+### Added
+
+### Fixed
+
+- Fixed issue where the `NetworkSpawnManager.HandleNetworkObjectShow` could throw an exception if one of the `NetworkObject` components to show was destroyed during the same frame.
+
+### Changed
+
+
+## [1.11.0] - 2024-08-20
+
 ### Added
 
 - Added `NetworkVariable.CheckDirtyState` that is to be used in tandem with collections in order to detect whether the collection or an item within the collection has changed. (#3005)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,7 +11,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where the `NetworkSpawnManager.HandleNetworkObjectShow` could throw an exception if one of the `NetworkObject` components to show was destroyed during the same frame.
+- Fixed issue where the `NetworkSpawnManager.HandleNetworkObjectShow` could throw an exception if one of the `NetworkObject` components to show was destroyed during the same frame. (#3029)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1152,7 +1152,24 @@ namespace Unity.Netcode
                 ulong clientId = client.Key;
                 foreach (var networkObject in client.Value)
                 {
-                    SendSpawnCallForObject(clientId, networkObject);
+                    // Ignore if null or not spawned (v1.x.x the server should only show what is spawned)
+                    if (networkObject != null && networkObject.IsSpawned)
+                    {
+                        // Prevent exceptions from interrupting this iteration
+                        // so the ObjectsToShowToClient list will be fully processed
+                        // and cleard.
+                        try
+                        {
+                            SendSpawnCallForObject(clientId, networkObject);
+                        }
+                        catch(Exception ex)
+                        {
+                            if (NetworkManager.LogLevel <= LogLevel.Developer)
+                            {
+                                Debug.LogException(ex);
+                            }
+                        }
+                    }
                 }
             }
             ObjectsToShowToClient.Clear();

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1162,7 +1162,7 @@ namespace Unity.Netcode
                         {
                             SendSpawnCallForObject(clientId, networkObject);
                         }
-                        catch(Exception ex)
+                        catch (Exception ex)
                         {
                             if (NetworkManager.LogLevel <= LogLevel.Developer)
                             {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVisibilityTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVisibilityTests.cs
@@ -20,6 +20,8 @@ namespace Unity.Netcode.RuntimeTests
         private GameObject m_TestNetworkPrefab;
         private bool m_SceneManagementEnabled;
 
+        private GameObject m_SpawnedObject;
+
         public NetworkVisibilityTests(SceneManagementState sceneManagementState)
         {
             m_SceneManagementEnabled = sceneManagementState == SceneManagementState.SceneManagementEnabled;
@@ -40,7 +42,7 @@ namespace Unity.Netcode.RuntimeTests
 
         protected override IEnumerator OnServerAndClientsConnected()
         {
-            SpawnObject(m_TestNetworkPrefab, m_ServerNetworkManager);
+            m_SpawnedObject = SpawnObject(m_TestNetworkPrefab, m_ServerNetworkManager);
 
             yield return base.OnServerAndClientsConnected();
         }
@@ -54,7 +56,39 @@ namespace Unity.Netcode.RuntimeTests
             yield return WaitForConditionOrTimeOut(() => Object.FindObjectsOfType<NetworkVisibilityComponent>().Where((c) => c.IsSpawned).Count() == 2);
 #endif
 
-            Assert.IsFalse(s_GlobalTimeoutHelper.TimedOut, "Timed out waiting for the visible object count to equal 2!");
+            AssertOnTimeout("Timed out waiting for the visible object count to equal 2!");
+        }
+
+
+        [UnityTest]
+        public IEnumerator HideShowAndDeleteTest()
+        {
+#if UNITY_2023_1_OR_NEWER
+            yield return WaitForConditionOrTimeOut(() => Object.FindObjectsByType<NetworkVisibilityComponent>(FindObjectsSortMode.None).Where((c) => c.IsSpawned).Count() == 2);
+#else
+            yield return WaitForConditionOrTimeOut(() => Object.FindObjectsOfType<NetworkVisibilityComponent>().Where((c) => c.IsSpawned).Count() == 2);
+#endif
+            AssertOnTimeout("Timed out waiting for the visible object count to equal 2!");
+
+            var serverNetworkObject = m_SpawnedObject.GetComponent<NetworkObject>();
+
+            serverNetworkObject.NetworkHide(m_ClientNetworkManagers[0].LocalClientId);
+
+            yield return WaitForConditionOrTimeOut(() => Object.FindObjectsOfType<NetworkVisibilityComponent>().Where((c) => c.IsSpawned).Count() == 1);
+            AssertOnTimeout($"Timed out waiting for {m_SpawnedObject.name} to be hidden from client!");
+            var networkObjectId = serverNetworkObject.NetworkObjectId;
+            serverNetworkObject.NetworkShow(m_ClientNetworkManagers[0].LocalClientId);
+            serverNetworkObject.Despawn(true);
+
+            // Expect no exceptions
+            yield return s_DefaultWaitForTick;
+
+            // Now force a scenario where it normally would have caused an exception
+            m_ServerNetworkManager.SpawnManager.ObjectsToShowToClient.Add(m_ClientNetworkManagers[0].LocalClientId, new System.Collections.Generic.List<NetworkObject>());
+            m_ServerNetworkManager.SpawnManager.ObjectsToShowToClient[m_ClientNetworkManagers[0].LocalClientId].Add(null);
+
+            // Expect no exceptions
+            yield return s_DefaultWaitForTick;
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVisibilityTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVisibilityTests.cs
@@ -74,7 +74,11 @@ namespace Unity.Netcode.RuntimeTests
 
             serverNetworkObject.NetworkHide(m_ClientNetworkManagers[0].LocalClientId);
 
+#if UNITY_2023_1_OR_NEWER
+            yield return WaitForConditionOrTimeOut(() => Object.FindObjectsByType<NetworkVisibilityComponent>(FindObjectsSortMode.None).Where((c) => c.IsSpawned).Count() == 1);
+#else
             yield return WaitForConditionOrTimeOut(() => Object.FindObjectsOfType<NetworkVisibilityComponent>().Where((c) => c.IsSpawned).Count() == 1);
+#endif
             AssertOnTimeout($"Timed out waiting for {m_SpawnedObject.name} to be hidden from client!");
             var networkObjectId = serverNetworkObject.NetworkObjectId;
             serverNetworkObject.NetworkShow(m_ClientNetworkManagers[0].LocalClientId);


### PR DESCRIPTION
This resolves an issue where a `NetworkObject` component could be despawned or its `GameObject` destroyed in the same frame prior to attempting to show it.

[MTTB-377](https://jira.unity3d.com/browse/MTTB-377)
fix: #3023

## Changelog

- Fixed: Issue where the `NetworkSpawnManager.HandleNetworkObjectShow` could throw an exception if one of the `NetworkObject` components to show was destroyed during the same frame.

## Testing and Documentation

- Includes integration test `NetworkVisibilityTests.HideShowAndDeleteTest`.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
