### PR TITLE
fix: prevent exception when showing despawned NetworkObject - up port of #3029

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+-Fixed issue where the `NetworkSpawnManager.HandleNetworkObjectShow` could throw an exception if one of the `NetworkObject` components to show was destroyed during the same frame. (#3030)
+
 ### Changed
 
 ## [2.0.0-pre.4] - 2024-08-21

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1581,20 +1581,46 @@ namespace Unity.Netcode
             {
                 foreach (var entry in ClientsToShowObject)
                 {
-                    SendSpawnCallForObserverUpdate(entry.Value.ToArray(), entry.Key);
+                    if (entry.Key != null && entry.Key.IsSpawned)
+                    {
+                        try
+                        {
+                            SendSpawnCallForObserverUpdate(entry.Value.ToArray(), entry.Key);
+                        }
+                        catch (Exception ex)
+                        {
+                            if (NetworkManager.LogLevel <= LogLevel.Developer)
+                            {
+                                Debug.LogException(ex);
+                            }
+                        }
+                    }
                 }
                 ClientsToShowObject.Clear();
                 ObjectsToShowToClient.Clear();
                 return;
             }
 
-            // Handle NetworkObjects to show
+            // Server or Host handling of NetworkObjects to show
             foreach (var client in ObjectsToShowToClient)
             {
                 ulong clientId = client.Key;
                 foreach (var networkObject in client.Value)
                 {
-                    SendSpawnCallForObject(clientId, networkObject);
+                    if (networkObject != null && networkObject.IsSpawned)
+                    {
+                        try
+                        {
+                            SendSpawnCallForObject(clientId, networkObject);
+                        }
+                        catch (Exception ex)
+                        {
+                            if (NetworkManager.LogLevel <= LogLevel.Developer)
+                            {
+                                Debug.LogException(ex);
+                            }
+                        }
+                    }
                 }
             }
             ObjectsToShowToClient.Clear();


### PR DESCRIPTION
Up-port of #3029

This resolves an issue where a `NetworkObject` component could be despawned or its `GameObject` destroyed in the same frame prior to attempting to show it.

[MTTB-377](https://jira.unity3d.com/browse/MTTB-377)

fix: #3023

## Changelog

- Fixed: Issue where the `NetworkSpawnManager.HandleNetworkObjectShow` could throw an exception if one of the `NetworkObject` components to show was destroyed during the same frame.

## Testing and Documentation

- Includes integration test `NetworkVisibilityTests.HideShowAndDeleteTest`.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
