### PR TITLE
fix: allow the check for a NetworkObject component on NetworkBehaviours to be disabled

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,7 +10,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
-- Added "Check for NetworkObject Component" property to the Multiplayer->Netcode for GameObjects project settings. When disabled, this will bypass the in-editor `NetworkObject` check on `NetworkBehaviour` components.
+- Added "Check for NetworkObject Component" property to the Multiplayer->Netcode for GameObjects project settings. When disabled, this will bypass the in-editor `NetworkObject` check on `NetworkBehaviour` components. (#3031)
 
 ### Fixed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,6 +10,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
+- Added "Check for NetworkObject Component" property to the Multiplayer->Netcode for GameObjects project settings. When disabled, this will bypass the in-editor `NetworkObject` check on `NetworkBehaviour` components.
+
 ### Fixed
 
 ### Changed

--- a/com.unity.netcode.gameobjects/Editor/Configuration/NetcodeForGameObjectsSettings.cs
+++ b/com.unity.netcode.gameobjects/Editor/Configuration/NetcodeForGameObjectsSettings.cs
@@ -5,6 +5,7 @@ namespace Unity.Netcode.Editor.Configuration
     internal class NetcodeForGameObjectsEditorSettings
     {
         internal const string AutoAddNetworkObjectIfNoneExists = "AutoAdd-NetworkObject-When-None-Exist";
+        internal const string CheckForNetworkObject = "NetworkBehaviour-Check-For-NetworkObject";
         internal const string InstallMultiplayerToolsTipDismissedPlayerPrefKey = "Netcode_Tip_InstallMPTools_Dismissed";
 
         internal static int GetNetcodeInstallMultiplayerToolTips()
@@ -28,13 +29,28 @@ namespace Unity.Netcode.Editor.Configuration
             {
                 return EditorPrefs.GetBool(AutoAddNetworkObjectIfNoneExists);
             }
-
+            // Default for this is false
             return false;
         }
 
         internal static void SetAutoAddNetworkObjectSetting(bool autoAddSetting)
         {
             EditorPrefs.SetBool(AutoAddNetworkObjectIfNoneExists, autoAddSetting);
+        }
+
+        internal static bool GetCheckForNetworkObjectSetting()
+        {
+            if (EditorPrefs.HasKey(CheckForNetworkObject))
+            {
+                return EditorPrefs.GetBool(CheckForNetworkObject);
+            }
+            // Default for this is true
+            return true;
+        }
+
+        internal static void SetCheckForNetworkObjectSetting(bool checkForNetworkObject)
+        {
+            EditorPrefs.SetBool(CheckForNetworkObject, checkForNetworkObject);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Editor/Configuration/NetcodeSettingsProvider.cs
+++ b/com.unity.netcode.gameobjects/Editor/Configuration/NetcodeSettingsProvider.cs
@@ -81,6 +81,7 @@ namespace Unity.Netcode.Editor.Configuration
 
         internal static NetcodeSettingsLabel NetworkObjectsSectionLabel;
         internal static NetcodeSettingsToggle AutoAddNetworkObjectToggle;
+        internal static NetcodeSettingsToggle CheckForNetworkObjectToggle;
         internal static NetcodeSettingsLabel MultiplayerToolsLabel;
         internal static NetcodeSettingsToggle MultiplayerToolTipStatusToggle;
 
@@ -103,6 +104,11 @@ namespace Unity.Netcode.Editor.Configuration
                 AutoAddNetworkObjectToggle = new NetcodeSettingsToggle("Auto-Add NetworkObject Component", "When enabled, NetworkObject components are automatically added to GameObjects when NetworkBehaviour components are added first.", 20);
             }
 
+            if (CheckForNetworkObjectToggle == null)
+            {
+                CheckForNetworkObjectToggle = new NetcodeSettingsToggle("Check for NetworkObject Component", "When disabled, the automatic check on NetworkBehaviours for an associated NetworkObject component will not be performed.", 20);
+            }
+
             if (MultiplayerToolsLabel == null)
             {
                 MultiplayerToolsLabel = new NetcodeSettingsLabel("Multiplayer Tools", 20);
@@ -120,7 +126,9 @@ namespace Unity.Netcode.Editor.Configuration
             CheckForInitialize();
 
             var autoAddNetworkObjectSetting = NetcodeForGameObjectsEditorSettings.GetAutoAddNetworkObjectSetting();
+            var checkForNetworkObjectSetting = NetcodeForGameObjectsEditorSettings.GetCheckForNetworkObjectSetting();
             var multiplayerToolsTipStatus = NetcodeForGameObjectsEditorSettings.GetNetcodeInstallMultiplayerToolTips() == 0;
+
             var settings = NetcodeForGameObjectsProjectSettings.instance;
             var generateDefaultPrefabs = settings.GenerateDefaultNetworkPrefabs;
             var networkPrefabsPath = settings.TempNetworkPrefabsPath;
@@ -135,7 +143,9 @@ namespace Unity.Netcode.Editor.Configuration
                 GUILayout.BeginVertical("Box");
                 NetworkObjectsSectionLabel.DrawLabel();
                 autoAddNetworkObjectSetting = AutoAddNetworkObjectToggle.DrawToggle(autoAddNetworkObjectSetting);
+                checkForNetworkObjectSetting = CheckForNetworkObjectToggle.DrawToggle(checkForNetworkObjectSetting);
                 GUILayout.EndVertical();
+
 
                 GUILayout.BeginVertical("Box");
                 MultiplayerToolsLabel.DrawLabel();
@@ -184,6 +194,7 @@ namespace Unity.Netcode.Editor.Configuration
             if (EditorGUI.EndChangeCheck())
             {
                 NetcodeForGameObjectsEditorSettings.SetAutoAddNetworkObjectSetting(autoAddNetworkObjectSetting);
+                NetcodeForGameObjectsEditorSettings.SetCheckForNetworkObjectSetting(checkForNetworkObjectSetting);
                 NetcodeForGameObjectsEditorSettings.SetNetcodeInstallMultiplayerToolTips(multiplayerToolsTipStatus ? 0 : 1);
                 settings.GenerateDefaultNetworkPrefabs = generateDefaultPrefabs;
                 settings.TempNetworkPrefabsPath = networkPrefabsPath;

--- a/com.unity.netcode.gameobjects/Editor/Configuration/NetcodeSettingsProvider.cs
+++ b/com.unity.netcode.gameobjects/Editor/Configuration/NetcodeSettingsProvider.cs
@@ -106,7 +106,7 @@ namespace Unity.Netcode.Editor.Configuration
 
             if (CheckForNetworkObjectToggle == null)
             {
-                CheckForNetworkObjectToggle = new NetcodeSettingsToggle("Check for NetworkObject Component", "When disabled, the automatic check on NetworkBehaviours for an associated NetworkObject component will not be performed.", 20);
+                CheckForNetworkObjectToggle = new NetcodeSettingsToggle("Check for NetworkObject Component", "When disabled, the automatic check on NetworkBehaviours for an associated NetworkObject component will not be performed and Auto-Add NetworkObject Component will be disabled.", 20);
             }
 
             if (MultiplayerToolsLabel == null)
@@ -142,10 +142,14 @@ namespace Unity.Netcode.Editor.Configuration
             {
                 GUILayout.BeginVertical("Box");
                 NetworkObjectsSectionLabel.DrawLabel();
-                autoAddNetworkObjectSetting = AutoAddNetworkObjectToggle.DrawToggle(autoAddNetworkObjectSetting);
-                checkForNetworkObjectSetting = CheckForNetworkObjectToggle.DrawToggle(checkForNetworkObjectSetting);
-                GUILayout.EndVertical();
 
+                autoAddNetworkObjectSetting = AutoAddNetworkObjectToggle.DrawToggle(autoAddNetworkObjectSetting, checkForNetworkObjectSetting);
+                checkForNetworkObjectSetting = CheckForNetworkObjectToggle.DrawToggle(checkForNetworkObjectSetting);
+                if (autoAddNetworkObjectSetting && !checkForNetworkObjectSetting)
+                {
+                    autoAddNetworkObjectSetting = false;
+                }
+                GUILayout.EndVertical();
 
                 GUILayout.BeginVertical("Box");
                 MultiplayerToolsLabel.DrawLabel();
@@ -224,10 +228,13 @@ namespace Unity.Netcode.Editor.Configuration
     {
         private GUIContent m_ToggleContent;
 
-        public bool DrawToggle(bool currentSetting)
+        public bool DrawToggle(bool currentSetting, bool enabled = true)
         {
             EditorGUIUtility.labelWidth = m_LabelSize;
-            return EditorGUILayout.Toggle(m_ToggleContent, currentSetting, m_LayoutWidth);
+            GUI.enabled = enabled;
+            var returnValue = EditorGUILayout.Toggle(m_ToggleContent, currentSetting, m_LayoutWidth);
+            GUI.enabled = true;
+            return returnValue;
         }
 
         public NetcodeSettingsToggle(string labelText, string toolTip, float layoutOffset)

--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -352,6 +352,12 @@ namespace Unity.Netcode.Editor
                 return;
             }
 
+            // If this automatic check is disabled, then do not perform this check.
+            if (!NetcodeForGameObjectsEditorSettings.GetCheckForNetworkObjectSetting())
+            {
+                return;
+            }
+
             // Now get the root parent transform to the current GameObject (or itself)
             var rootTransform = GetRootParentTransform(gameObject.transform);
             if (!rootTransform.TryGetComponent<NetworkManager>(out var networkManager))


### PR DESCRIPTION
This PR adds an additional Multiplayer->Netcode for GameObjects property to control whether the in-editor `NetworkBehaviour` check for an associated `NetworkObject` is performed.
![image](https://github.com/user-attachments/assets/3f2bc220-82bf-432c-9bdc-a11b91a1f5c9)

[MTTB-373](https://jira.unity3d.com/browse/MTTB-373)

fix: #2966


## Changelog

- Added: "Check for NetworkObject Component" property to the Multiplayer->Netcode for GameObjects project settings. When disabled, this will bypass the in-editor `NetworkObject` check on `NetworkBehaviour` components.

## Testing and Documentation

- No tests have been added.
- Documentation changes will be determined. (wip)

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
