### PR TITLE
fix: unity collections 2-2-x support in 2022.3 with NGO v1.x.x

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 [Unreleased]
+
+### Added
+
+### Fixed
+
+- Fixed issue where collections v2.2.x was not supported when using UTP v2.2.x within Unity v2022.3. (#3033)
+
+### Changed
+
+
+## [1.11.0] - 2024-08-20
+
 ### Added
 
 - Added `NetworkVariable.CheckDirtyState` that is to be used in tandem with collections in order to detect whether the collection or an item within the collection has changed. (#3005)

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/CollectionSerializationUtility.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/CollectionSerializationUtility.cs
@@ -505,8 +505,13 @@ namespace Unity.Netcode
             writer.WriteValueSafe(changes);
             unsafe
             {
+#if UTP_TRANSPORT_2_0_ABOVE
+                var ptr = value.GetUnsafePtr();
+                var prevPtr = previousValue.GetUnsafePtr();
+#else
                 var ptr = (T*)value.GetUnsafePtr();
                 var prevPtr = (T*)previousValue.GetUnsafePtr();
+#endif
                 for (int i = 0; i < value.Length; ++i)
                 {
                     if (changes.IsSet(i))
@@ -549,7 +554,11 @@ namespace Unity.Netcode
 
                 unsafe
                 {
+#if UTP_TRANSPORT_2_0_ABOVE
+                    var ptr = value.GetUnsafePtr();
+#else
                     var ptr = (T*)value.GetUnsafePtr();
+#endif
                     for (var i = 0; i < value.Length; ++i)
                     {
                         if (changes.IsSet(i))
@@ -571,8 +580,13 @@ namespace Unity.Netcode
         public static unsafe void WriteNativeHashSetDelta<T>(FastBufferWriter writer, ref NativeHashSet<T> value, ref NativeHashSet<T> previousValue) where T : unmanaged, IEquatable<T>
         {
             // See WriteHashSet; this is the same algorithm, adjusted for the NativeHashSet API
+#if UTP_TRANSPORT_2_0_ABOVE
+            var added = stackalloc T[value.Count];
+            var removed = stackalloc T[previousValue.Count];
+#else
             var added = stackalloc T[value.Count()];
             var removed = stackalloc T[previousValue.Count()];
+#endif
             var addedCount = 0;
             var removedCount = 0;
             foreach (var item in value)
@@ -592,8 +606,11 @@ namespace Unity.Netcode
                     ++removedCount;
                 }
             }
-
+#if UTP_TRANSPORT_2_0_ABOVE
+            if (addedCount + removedCount >= value.Count)
+#else
             if (addedCount + removedCount >= value.Count())
+#endif
             {
                 writer.WriteByteSafe(1);
                 writer.WriteValueSafe(value);
@@ -643,9 +660,15 @@ namespace Unity.Netcode
             where TVal : unmanaged
         {
             // See WriteDictionary; this is the same algorithm, adjusted for the NativeHashMap API
+#if UTP_TRANSPORT_2_0_ABOVE
+            var added = stackalloc KVPair<TKey, TVal>[value.Count];
+            var changed = stackalloc KVPair<TKey, TVal>[value.Count];
+            var removed = stackalloc KVPair<TKey, TVal>[previousValue.Count];
+#else
             var added = stackalloc KeyValue<TKey, TVal>[value.Count()];
             var changed = stackalloc KeyValue<TKey, TVal>[value.Count()];
             var removed = stackalloc KeyValue<TKey, TVal>[previousValue.Count()];
+#endif
             var addedCount = 0;
             var changedCount = 0;
             var removedCount = 0;
@@ -672,8 +695,11 @@ namespace Unity.Netcode
                     ++removedCount;
                 }
             }
-
+#if UTP_TRANSPORT_2_0_ABOVE
+            if (addedCount + removedCount + changedCount >= value.Count)
+#else
             if (addedCount + removedCount + changedCount >= value.Count())
+#endif
             {
                 writer.WriteByteSafe(1);
                 writer.WriteValueSafe(value);

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableSerialization.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableSerialization.cs
@@ -1728,8 +1728,13 @@ namespace Unity.Netcode
                 return false;
             }
 
+#if UTP_TRANSPORT_2_0_ABOVE
+            var aptr = a.GetUnsafePtr();
+            var bptr = b.GetUnsafePtr();
+#else
             var aptr = (TValueType*)a.GetUnsafePtr();
             var bptr = (TValueType*)b.GetUnsafePtr();
+#endif
             return UnsafeUtility.MemCmp(aptr, bptr, sizeof(TValueType) * a.Length) == 0;
         }
 #endif
@@ -1857,9 +1862,14 @@ namespace Unity.Netcode
             {
                 return false;
             }
-
+#if UTP_TRANSPORT_2_0_ABOVE
+            var aptr = a.GetUnsafePtr();
+            var bptr = b.GetUnsafePtr();
+#else
             var aptr = (TValueType*)a.GetUnsafePtr();
             var bptr = (TValueType*)b.GetUnsafePtr();
+#endif
+
             for (var i = 0; i < a.Length; ++i)
             {
                 if (!EqualityEquals(ref aptr[i], ref bptr[i]))
@@ -1883,7 +1893,11 @@ namespace Unity.Netcode
                 return true;
             }
 
+#if UTP_TRANSPORT_2_0_ABOVE
+            if (a.Count != b.Count)
+#else
             if (a.Count() != b.Count())
+#endif
             {
                 return false;
             }
@@ -1995,8 +2009,11 @@ namespace Unity.Netcode
             {
                 return true;
             }
-
+#if UTP_TRANSPORT_2_0_ABOVE
+            if (a.Count != b.Count)
+#else
             if (a.Count() != b.Count())
+#endif
             {
                 return false;
             }

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/ResizableBitVector.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/ResizableBitVector.cs
@@ -95,11 +95,19 @@ namespace Unity.Netcode
             {
                 if (serializer.IsReader)
                 {
+#if UTP_TRANSPORT_2_0_ABOVE
+                    serializer.GetFastBufferReader().ReadBytesSafe(ptr, length);
+#else
                     serializer.GetFastBufferReader().ReadBytesSafe((byte*)ptr, length);
+#endif
                 }
                 else
                 {
+#if UTP_TRANSPORT_2_0_ABOVE
+                    serializer.GetFastBufferWriter().WriteBytesSafe(ptr, length);
+#else
                     serializer.GetFastBufferWriter().WriteBytesSafe((byte*)ptr, length);
+#endif
                 }
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferWriter.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferWriter.cs
@@ -772,7 +772,11 @@ namespace Unity.Netcode
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe void WriteBytes(NativeList<byte> value, int size = -1, int offset = 0)
         {
+#if UTP_TRANSPORT_2_0_ABOVE
+            byte* ptr = value.GetUnsafePtr();
+#else
             byte* ptr = (byte*)value.GetUnsafePtr();
+#endif
             WriteBytes(ptr, size == -1 ? value.Length : size, offset);
         }
 
@@ -816,7 +820,11 @@ namespace Unity.Netcode
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe void WriteBytesSafe(NativeList<byte> value, int size = -1, int offset = 0)
         {
+#if UTP_TRANSPORT_2_0_ABOVE
+            byte* ptr = value.GetUnsafePtr();
+#else
             byte* ptr = (byte*)value.GetUnsafePtr();
+#endif
             WriteBytesSafe(ptr, size == -1 ? value.Length : size, offset);
         }
 
@@ -985,7 +993,12 @@ namespace Unity.Netcode
         internal unsafe void WriteUnmanaged<T>(NativeList<T> value) where T : unmanaged
         {
             WriteUnmanaged(value.Length);
+
+#if UTP_TRANSPORT_2_0_ABOVE
+            var ptr = value.GetUnsafePtr();
+#else
             var ptr = (T*)value.GetUnsafePtr();
+#endif
             {
                 byte* bytes = (byte*)ptr;
                 WriteBytes(bytes, sizeof(T) * value.Length);
@@ -995,7 +1008,11 @@ namespace Unity.Netcode
         internal unsafe void WriteUnmanagedSafe<T>(NativeList<T> value) where T : unmanaged
         {
             WriteUnmanagedSafe(value.Length);
+#if UTP_TRANSPORT_2_0_ABOVE
+            var ptr = value.GetUnsafePtr();
+#else
             var ptr = (T*)value.GetUnsafePtr();
+#endif
             {
                 byte* bytes = (byte*)ptr;
                 WriteBytesSafe(bytes, sizeof(T) * value.Length);
@@ -1193,7 +1210,11 @@ namespace Unity.Netcode
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void WriteValueSafe<T>(NativeHashSet<T> value) where T : unmanaged, IEquatable<T>
         {
+#if UTP_TRANSPORT_2_0_ABOVE
+            WriteUnmanagedSafe(value.Count);
+#else
             WriteUnmanagedSafe(value.Count());
+#endif
             foreach (var item in value)
             {
                 var iReffable = item;
@@ -1206,7 +1227,11 @@ namespace Unity.Netcode
             where TKey : unmanaged, IEquatable<TKey>
             where TVal : unmanaged
         {
+#if UTP_TRANSPORT_2_0_ABOVE
+            WriteUnmanagedSafe(value.Count);
+#else
             WriteUnmanagedSafe(value.Count());
+#endif
             foreach (var item in value)
             {
                 (var key, var val) = (item.Key, item.Value);


### PR DESCRIPTION
This update provides support for using NGO v1.x.x. within Unity 2022.3 when using UTP v2.2.x that has dependencies upon collections v2.2.x.

[MTTB-310](https://jira.unity3d.com/browse/MTTB-310)

fix: #2960

## Changelog

- Fixed: Issue where collections v2.2.x was not supported when using UTP v2.2.x within Unity v2022.3.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
