### PR TITLE
chore: update MessageVersionData for service compatibility

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Messaging/ILPPMessageProvider.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/ILPPMessageProvider.cs
@@ -54,6 +54,7 @@ namespace Unity.Netcode
 
         // Enable this for integration tests that need no message types defined
         internal static bool IntegrationTestNoMessages;
+        internal static Dictionary<Type, NetworkMessageTypes> TypeToNetworkMessageType;
 
         public List<NetworkMessageManager.MessageWithHandler> GetMessages()
         {
@@ -81,7 +82,7 @@ namespace Unity.Netcode
             // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             // Add new Message types to this table paired with its new NetworkMessageTypes enum
             // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-            var messageTypes = new Dictionary<Type, NetworkMessageTypes>
+            TypeToNetworkMessageType = new Dictionary<Type, NetworkMessageTypes>
             {
                 { typeof(ConnectionApprovedMessage), NetworkMessageTypes.ConnectionApproved }, // This MUST be first
                 { typeof(ConnectionRequestMessage), NetworkMessageTypes.ConnectionRequest }, // This MUST be second
@@ -111,19 +112,19 @@ namespace Unity.Netcode
             };
 
             // Assure the type to lookup table count and NetworkMessageType enum count matches (i.e. to catch human error when adding new messages)
-            if (messageTypes.Count != messageTypeCount)
+            if (TypeToNetworkMessageType.Count != messageTypeCount)
             {
-                throw new Exception($"Message type to Message type index count mistmatch! Table Count: {messageTypes.Count} | Index Count: {messageTypeCount}");
+                throw new Exception($"Message type to Message type index count mistmatch! Table Count: {TypeToNetworkMessageType.Count} | Index Count: {messageTypeCount}");
             }
 
             // Now order the allowed types list based on the order of the NetworkMessageType enum
             foreach (var messageHandler in __network_message_types)
             {
-                if (!messageTypes.ContainsKey(messageHandler.MessageType))
+                if (!TypeToNetworkMessageType.ContainsKey(messageHandler.MessageType))
                 {
                     throw new Exception($"Missing message type from lookup table: {messageHandler.MessageType}");
                 }
-                adjustedMessageTypes[(int)messageTypes[messageHandler.MessageType]] = messageHandler;
+                adjustedMessageTypes[(int)TypeToNetworkMessageType[messageHandler.MessageType]] = messageHandler;
             }
 
             // return the NetworkMessageType enum ordered list

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
@@ -104,7 +104,10 @@ namespace Unity.Netcode
             var messageHashesInOrder = new NativeArray<uint>(length, Allocator.Temp);
             for (var i = 0; i < length; ++i)
             {
-                var messageVersion = new MessageVersionData();
+                var messageVersion = new MessageVersionData()
+                {
+                    SendMessageType = networkManager.DistributedAuthorityMode,
+                };
                 messageVersion.Deserialize(reader);
                 networkManager.ConnectionManager.MessageManager.SetVersion(context.SenderId, messageVersion.Hash, messageVersion.Version);
                 messageHashesInOrder[i] = messageVersion.Hash;

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionRequestMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionRequestMessage.cs
@@ -30,6 +30,7 @@ namespace Unity.Netcode
             {
                 messageVersion.Serialize(writer);
             }
+
             // ============================================================
             // END FORBIDDEN SEGMENT
             // ============================================================
@@ -65,9 +66,13 @@ namespace Unity.Netcode
             // must go AFTER the message version header.
             // ============================================================
             ByteUnpacker.ReadValueBitPacked(reader, out int length);
+
             for (var i = 0; i < length; ++i)
             {
-                var messageVersion = new MessageVersionData();
+                var messageVersion = new MessageVersionData()
+                {
+                    SendMessageType = networkManager.DistributedAuthorityMode,
+                };
                 messageVersion.Deserialize(reader);
                 networkManager.ConnectionManager.MessageManager.SetVersion(context.SenderId, messageVersion.Hash, messageVersion.Version);
 
@@ -79,6 +84,7 @@ namespace Unity.Netcode
                     receivedMessageVersion = messageVersion.Version;
                 }
             }
+
             // ============================================================
             // END FORBIDDEN SEGMENT
             // ============================================================

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/MessageMetadata.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/MessageMetadata.cs
@@ -7,17 +7,27 @@ namespace Unity.Netcode
     {
         public uint Hash;
         public int Version;
+        public uint NetworkMessageType;
 
+        internal bool SendMessageType;
         public void Serialize(FastBufferWriter writer)
         {
             writer.WriteValueSafe(Hash);
             BytePacker.WriteValueBitPacked(writer, Version);
+            if (SendMessageType)
+            {
+                BytePacker.WriteValueBitPacked(writer, NetworkMessageType);
+            }
         }
 
         public void Deserialize(FastBufferReader reader)
         {
             reader.ReadValueSafe(out Hash);
             ByteUnpacker.ReadValueBitPacked(reader, out Version);
+            if (SendMessageType)
+            {
+                ByteUnpacker.ReadValueBitPacked(reader, out NetworkMessageType);
+            }
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/NetworkMessageManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/NetworkMessageManager.cs
@@ -68,8 +68,8 @@ namespace Unity.Netcode
         private NativeList<ReceiveQueueItem> m_IncomingMessageQueue = new NativeList<ReceiveQueueItem>(16, Allocator.Persistent);
 
         // These array will grow as we need more message handlers. 4 is just a starting size.
-        private MessageHandler[] m_MessageHandlers = new MessageHandler[4];
-        private Type[] m_ReverseTypeMap = new Type[4];
+        private MessageHandler[] m_MessageHandlers = new MessageHandler[Enum.GetValues(typeof(ILPPMessageProvider.NetworkMessageTypes)).Length];
+        private Type[] m_ReverseTypeMap = new Type[Enum.GetValues(typeof(ILPPMessageProvider.NetworkMessageTypes)).Length];
 
         private Dictionary<Type, uint> m_MessageTypes = new Dictionary<Type, uint>();
         private Dictionary<ulong, NativeList<SendQueueItem>> m_SendQueues = new Dictionary<ulong, NativeList<SendQueueItem>>();

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Messaging/MessageVersionDataTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Messaging/MessageVersionDataTests.cs
@@ -1,0 +1,50 @@
+using System.Collections;
+using NUnit.Framework;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    [TestFixture(HostOrServer.DAHost)]
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    internal class MessageVersionDataTests : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 2;
+
+        private NetworkManager m_SessionOwner;
+
+        public MessageVersionDataTests(HostOrServer hostOrServer) : base(hostOrServer) { }
+
+        private void ValidateConnectionRequest(NetworkManager networkManager)
+        {
+            var message = networkManager.ConnectionManager.GenerateConnectionRequestMessage();
+
+            foreach (var messageVersionData in message.MessageVersions)
+            {
+                Assert.True(messageVersionData.SendMessageType == m_DistributedAuthority, $"Include {nameof(MessageVersionData.SendMessageType)} is {messageVersionData.SendMessageType} and distributed authority is {m_DistributedAuthority}!");
+                if (m_DistributedAuthority)
+                {
+                    var type = networkManager.ConnectionManager.MessageManager.GetMessageForHash(messageVersionData.Hash);
+                    var networkMessageType = ILPPMessageProvider.TypeToNetworkMessageType[type];
+                    Assert.True(messageVersionData.NetworkMessageType == (uint)networkMessageType, $"{nameof(MessageVersionData.NetworkMessageType)} is {messageVersionData.NetworkMessageType} but the hash type derived value is {networkMessageType}!");
+                }
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator MessageVersionDataTest()
+        {
+            m_SessionOwner = UseCMBService() ? m_ClientNetworkManagers[0] : m_ServerNetworkManager;
+
+            ValidateConnectionRequest(m_SessionOwner);
+
+            foreach (var client in m_ClientNetworkManagers)
+            {
+                ValidateConnectionRequest(client);
+            }
+
+            yield return null;
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Messaging/MessageVersionDataTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Messaging/MessageVersionDataTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b0666f7fceaeafa42b6f3f9514fb4778


### PR DESCRIPTION
First pass of sending `ILPPMessageProvider.NetworkMessageTypes` when using a distributed authority network topology.


## Changelog

NA

## Testing and Documentation

- Includes integration test.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
