### PR TITLE
fix: Add size validation to named and unnamed message sending

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,8 +10,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
-- Added "Check for NetworkObject Component" property to the Multiplayer->Netcode for GameObjects project settings. When disabled, this will bypass the in-editor `NetworkObject` check on `NetworkBehaviour` components. (#3034)
 - Added message size validation to named and unnamed message sending functions for better error messages. (#3043)
+- Added "Check for NetworkObject Component" property to the Multiplayer->Netcode for GameObjects project settings. When disabled, this will bypass the in-editor `NetworkObject` check on `NetworkBehaviour` components. (#3034)
 
 ### Fixed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,7 +11,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Added
 
 - Added "Check for NetworkObject Component" property to the Multiplayer->Netcode for GameObjects project settings. When disabled, this will bypass the in-editor `NetworkObject` check on `NetworkBehaviour` components. (#3034)
-- Added message size validation to named and unnamed message sending functions for better error messages. (#2363)
+- Added message size validation to named and unnamed message sending functions for better error messages. (#3043)
 
 ### Fixed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -11,6 +11,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Added
 
 - Added "Check for NetworkObject Component" property to the Multiplayer->Netcode for GameObjects project settings. When disabled, this will bypass the in-editor `NetworkObject` check on `NetworkBehaviour` components. (#3034)
+- Added message size validation to named and unnamed message sending functions for better error messages. (#2363)
 
 ### Fixed
 

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/CustomMessageManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/CustomMessageManager.cs
@@ -73,6 +73,8 @@ namespace Unity.Netcode
                 throw new ArgumentNullException(nameof(clientIds), "You must pass in a valid clientId List");
             }
 
+            ValidateMessageSize(messageBuffer, networkDelivery, isNamed: false);
+
             if (m_NetworkManager.IsHost)
             {
                 for (var i = 0; i < clientIds.Count; ++i)
@@ -108,6 +110,8 @@ namespace Unity.Netcode
         /// <param name="networkDelivery">The delivery type (QoS) to send data with</param>
         public void SendUnnamedMessage(ulong clientId, FastBufferWriter messageBuffer, NetworkDelivery networkDelivery = NetworkDelivery.ReliableSequenced)
         {
+            ValidateMessageSize(messageBuffer, networkDelivery, isNamed: false);
+
             if (m_NetworkManager.IsHost)
             {
                 if (clientId == m_NetworkManager.LocalClientId)
@@ -263,7 +267,7 @@ namespace Unity.Netcode
         /// <param name="networkDelivery">The delivery type (QoS) to send data with</param>
         public void SendNamedMessage(string messageName, ulong clientId, FastBufferWriter messageStream, NetworkDelivery networkDelivery = NetworkDelivery.ReliableSequenced)
         {
-            ValidateNamedMessage(messageStream, networkDelivery);
+            ValidateMessageSize(messageStream, networkDelivery, isNamed: true);
 
             ulong hash = 0;
             switch (m_NetworkManager.NetworkConfig.RpcHashSize)
@@ -305,27 +309,6 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// Validate the size of the message. If it's a non-fragmented delivery type the message must fit within the
-        /// max allowed size with headers also subtracted. Only validates in editor and development builds.
-        /// </summary>
-        /// <param name="messageStream">The named message payload</param>
-        /// <param name="networkDelivery">Delivery method</param>
-        /// <exception cref="OverflowException">Exception thrown in case validation fails</exception>
-        private unsafe void ValidateNamedMessage(FastBufferWriter messageStream, NetworkDelivery networkDelivery)
-        {
-#if DEVELOPMENT_BUILD || UNITY_EDITOR
-            var maxNonFragmentedSize = m_NetworkManager.MessageManager.NonFragmentedMessageMaxSize - FastBufferWriter.GetWriteSize<NetworkMessageHeader>() - sizeof(ulong)/*MessageName hash*/ - sizeof(NetworkBatchHeader);
-            if (networkDelivery != NetworkDelivery.ReliableFragmentedSequenced
-                && messageStream.Length > maxNonFragmentedSize)
-            {
-                throw new OverflowException($"Given named message size ({messageStream.Length} bytes) is greater than " +
-                    $"the maximum allowed for the selected delivery method ({maxNonFragmentedSize} bytes). Try using " +
-                    $"ReliableFragmentedSequenced delivery method instead.");
-            }
-#endif
-        }
-
-        /// <summary>
         /// Sends the named message
         /// </summary>
         /// <param name="messageName">The message name to send</param>
@@ -344,7 +327,7 @@ namespace Unity.Netcode
                 throw new ArgumentNullException(nameof(clientIds), "You must pass in a valid clientId List");
             }
 
-            ValidateNamedMessage(messageStream, networkDelivery);
+            ValidateMessageSize(messageStream, networkDelivery, isNamed: true);
 
             ulong hash = 0;
             switch (m_NetworkManager.NetworkConfig.RpcHashSize)
@@ -383,6 +366,33 @@ namespace Unity.Netcode
             {
                 m_NetworkManager.NetworkMetrics.TrackNamedMessageSent(clientIds, messageName, size);
             }
+        }
+
+        /// <summary>
+        /// Validate the size of the message. If it's a non-fragmented delivery type the message must fit within the
+        /// max allowed size with headers also subtracted. Named messages also include the hash
+        /// of the name string. Only validates in editor and development builds.
+        /// </summary>
+        /// <param name="messageStream">The named message payload</param>
+        /// <param name="networkDelivery">Delivery method</param>
+        /// <param name="isNamed">Is the message named (or unnamed)</param>
+        /// <exception cref="OverflowException">Exception thrown in case validation fails</exception>
+        private unsafe void ValidateMessageSize(FastBufferWriter messageStream, NetworkDelivery networkDelivery, bool isNamed)
+        {
+#if DEVELOPMENT_BUILD || UNITY_EDITOR
+            var maxNonFragmentedSize = m_NetworkManager.MessageManager.NonFragmentedMessageMaxSize - FastBufferWriter.GetWriteSize<NetworkMessageHeader>() - sizeof(NetworkBatchHeader);
+            if (isNamed)
+            {
+                maxNonFragmentedSize -= sizeof(ulong); // MessageName hash
+            }
+            if (networkDelivery != NetworkDelivery.ReliableFragmentedSequenced
+                && messageStream.Length > maxNonFragmentedSize)
+            {
+                throw new OverflowException($"Given message size ({messageStream.Length} bytes) is greater than " +
+                    $"the maximum allowed for the selected delivery method ({maxNonFragmentedSize} bytes). Try using " +
+                    $"ReliableFragmentedSequenced delivery method instead.");
+            }
+#endif
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/NetworkMessageManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/NetworkMessageManager.cs
@@ -730,7 +730,11 @@ namespace Unity.Netcode
                 }
 
                 ref var writeQueueItem = ref sendQueueItem.ElementAt(sendQueueItem.Length - 1);
-                writeQueueItem.Writer.TryBeginWrite(tmpSerializer.Length + headerSerializer.Length);
+                if (!writeQueueItem.Writer.TryBeginWrite(tmpSerializer.Length + headerSerializer.Length))
+                {
+                    Debug.LogError($"Not enough space to write message, size={tmpSerializer.Length + headerSerializer.Length} space used={writeQueueItem.Writer.Position} total size={writeQueueItem.Writer.Capacity}");
+                    continue;
+                }
 
                 writeQueueItem.Writer.WriteBytes(headerSerializer.GetUnsafePtr(), headerSerializer.Length);
                 writeQueueItem.Writer.WriteBytes(tmpSerializer.GetUnsafePtr(), tmpSerializer.Length);

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferWriter.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferWriter.cs
@@ -700,7 +700,7 @@ namespace Unity.Netcode
             }
             if (Handle->Position + size > Handle->AllowedWriteMark)
             {
-                throw new OverflowException($"Attempted to write without first calling {nameof(TryBeginWrite)}()");
+                throw new OverflowException($"Attempted to write without first calling {nameof(TryBeginWrite)}(), Position+Size={Handle->Position + size} > AllowedWriteMark={Handle->AllowedWriteMark}");
             }
 #endif
             UnsafeUtility.MemCpy((Handle->BufferPointer + Handle->Position), value + offset, size);
@@ -729,7 +729,7 @@ namespace Unity.Netcode
 
             if (!TryBeginWriteInternal(size))
             {
-                throw new OverflowException("Writing past the end of the buffer");
+                throw new OverflowException($"Writing past the end of the buffer, size is {size} bytes but remaining capacity is {Handle->Capacity - Handle->Position} bytes");
             }
             UnsafeUtility.MemCpy((Handle->BufferPointer + Handle->Position), value + offset, size);
             Handle->Position += size;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Messaging/NamedMessageTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Messaging/NamedMessageTests.cs
@@ -248,7 +248,7 @@ namespace Unity.Netcode.RuntimeTests
             var bufferSize = m_ServerNetworkManager.MessageManager.NonFragmentedMessageMaxSize;
             var messageName = Guid.NewGuid().ToString();
             var messageContent = new byte[msgSize];
-            var writer = new FastBufferWriter(bufferSize, Allocator.Temp, bufferSize*2);
+            var writer = new FastBufferWriter(bufferSize, Allocator.Temp, bufferSize * 2);
             using (writer)
             {
                 writer.TryBeginWrite(msgSize);
@@ -259,7 +259,7 @@ namespace Unity.Netcode.RuntimeTests
 
             msgSize++;
             messageContent = new byte[msgSize];
-            writer = new FastBufferWriter(bufferSize, Allocator.Temp, bufferSize*2);
+            writer = new FastBufferWriter(bufferSize, Allocator.Temp, bufferSize * 2);
             using (writer)
             {
                 writer.TryBeginWrite(msgSize);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Messaging/UnnamedMessageTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Messaging/UnnamedMessageTests.cs
@@ -202,7 +202,7 @@ namespace Unity.Netcode.RuntimeTests
             var msgSize = m_ServerNetworkManager.MessageManager.NonFragmentedMessageMaxSize - FastBufferWriter.GetWriteSize<NetworkMessageHeader>() - sizeof(NetworkBatchHeader);
             var bufferSize = m_ServerNetworkManager.MessageManager.NonFragmentedMessageMaxSize;
             var messageContent = new byte[msgSize];
-            var writer = new FastBufferWriter(bufferSize, Allocator.Temp, bufferSize*2);
+            var writer = new FastBufferWriter(bufferSize, Allocator.Temp, bufferSize * 2);
             using (writer)
             {
                 writer.TryBeginWrite(msgSize);
@@ -213,7 +213,7 @@ namespace Unity.Netcode.RuntimeTests
 
             msgSize++;
             messageContent = new byte[msgSize];
-            writer = new FastBufferWriter(bufferSize, Allocator.Temp, bufferSize*2);
+            writer = new FastBufferWriter(bufferSize, Allocator.Temp, bufferSize * 2);
             using (writer)
             {
                 writer.TryBeginWrite(msgSize);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Messaging/UnnamedMessageTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Messaging/UnnamedMessageTests.cs
@@ -194,5 +194,44 @@ namespace Unity.Netcode.RuntimeTests
                     });
             }
         }
+
+        [Test]
+        public unsafe void ErrorMessageIsPrintedWhenAttemptingToSendUnnamedMessageWithTooBigBuffer()
+        {
+            // First try a valid send with the maximum allowed size (this is atm 1272)
+            var msgSize = m_ServerNetworkManager.MessageManager.NonFragmentedMessageMaxSize - FastBufferWriter.GetWriteSize<NetworkMessageHeader>() - sizeof(NetworkBatchHeader);
+            var bufferSize = m_ServerNetworkManager.MessageManager.NonFragmentedMessageMaxSize;
+            var messageContent = new byte[msgSize];
+            var writer = new FastBufferWriter(bufferSize, Allocator.Temp, bufferSize*2);
+            using (writer)
+            {
+                writer.TryBeginWrite(msgSize);
+                writer.WriteBytes(messageContent, msgSize, 0);
+                m_ServerNetworkManager.CustomMessagingManager.SendUnnamedMessage(new List<ulong> { FirstClient.LocalClientId }, writer);
+                m_ServerNetworkManager.CustomMessagingManager.SendUnnamedMessage(FirstClient.LocalClientId, writer);
+            }
+
+            msgSize++;
+            messageContent = new byte[msgSize];
+            writer = new FastBufferWriter(bufferSize, Allocator.Temp, bufferSize*2);
+            using (writer)
+            {
+                writer.TryBeginWrite(msgSize);
+                writer.WriteBytes(messageContent, msgSize, 0);
+                var message = Assert.Throws<OverflowException>(
+                    () =>
+                    {
+                        m_ServerNetworkManager.CustomMessagingManager.SendUnnamedMessage(new List<ulong> { FirstClient.LocalClientId }, writer);
+                    }).Message;
+                Assert.IsTrue(message.Contains($"Given message size ({msgSize} bytes) is greater than the maximum"), $"Unexpected exception: {message}");
+
+                message = Assert.Throws<OverflowException>(
+                    () =>
+                    {
+                        m_ServerNetworkManager.CustomMessagingManager.SendUnnamedMessage(FirstClient.LocalClientId, writer);
+                    }).Message;
+                Assert.IsTrue(message.Contains($"Given message size ({msgSize} bytes) is greater than the maximum"), $"Unexpected exception: {message}");
+            }
+        }
     }
 }


### PR DESCRIPTION
Size validation added to the 4 entry points for Named/Unnamed message functions, where there is context to have more descriptive error messages as oppose to the generic serialisation messages you'll get when deeper in the call stack.

A few more details are also added to other places for better errors in generic message sending, like the TryBeginWrite check where the batch message header might push the message over the limit but you'd get a stange "Attempted to write without first calling TryBeginWrite()" later on.

[MTTB-378](https://jira.unity3d.com/browse/MTTB-378)

fix: #2363 

## Changelog

- Added message size validation to named and unnamed message sending functions for better error messages.

## Testing and Documentation

- Tests added

