### PR TITLE
fix: player prefab null exception when using prefabhash connection approval (backport-3042)

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where setting a prefab hash value during connection approval but not having a player prefab assigned could cause an exception when spawning a player. (#3046)
 - Fixed issue where collections v2.2.x was not supported when using UTP v2.2.x within Unity v2022.3. (#3033)
 - Fixed issue where the `NetworkManagerHelper` was continuing to check for hierarchy changes when in play mode. (#3027)
 

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -736,41 +736,21 @@ namespace Unity.Netcode
 
                 var client = AddClient(ownerClientId);
 
-                if (response.CreatePlayerObject)
+                if (response.CreatePlayerObject && (response.PlayerPrefabHash.HasValue || NetworkManager.NetworkConfig.PlayerPrefab != null))
                 {
-                    var prefabNetworkObject = NetworkManager.NetworkConfig.PlayerPrefab.GetComponent<NetworkObject>();
-                    var playerPrefabHash = response.PlayerPrefabHash ?? prefabNetworkObject.GlobalObjectIdHash;
-
-                    // Generate a SceneObject for the player object to spawn
-                    // Note: This is only to create the local NetworkObject, many of the serialized properties of the player prefab will be set when instantiated.
-                    var sceneObject = new NetworkObject.SceneObject
-                    {
-                        OwnerClientId = ownerClientId,
-                        IsPlayerObject = true,
-                        IsSceneObject = false,
-                        HasTransform = prefabNetworkObject.SynchronizeTransform,
-                        Hash = playerPrefabHash,
-                        TargetClientId = ownerClientId,
-                        Transform = new NetworkObject.SceneObject.TransformData
-                        {
-                            Position = response.Position.GetValueOrDefault(),
-                            Rotation = response.Rotation.GetValueOrDefault()
-                        }
-                    };
-
-                    // Create the player NetworkObject locally
-                    var networkObject = NetworkManager.SpawnManager.CreateLocalNetworkObject(sceneObject);
+                    var playerObject = response.PlayerPrefabHash.HasValue ? NetworkManager.SpawnManager.GetNetworkObjectToSpawn(response.PlayerPrefabHash.Value, ownerClientId, response.Position.GetValueOrDefault(), response.Rotation.GetValueOrDefault())
+                        : NetworkManager.SpawnManager.GetNetworkObjectToSpawn(NetworkManager.NetworkConfig.PlayerPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash, ownerClientId, response.Position.GetValueOrDefault(), response.Rotation.GetValueOrDefault());
 
                     // Spawn the player NetworkObject locally
                     NetworkManager.SpawnManager.SpawnNetworkObjectLocally(
-                        networkObject,
+                        playerObject,
                         NetworkManager.SpawnManager.GetNetworkObjectId(),
                         sceneObject: false,
                         playerObject: true,
                         ownerClientId,
                         destroyWithScene: false);
 
-                    client.AssignPlayerObject(ref networkObject);
+                    client.AssignPlayerObject(ref playerObject);
                 }
 
                 // Server doesn't send itself the connection approved message

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -753,6 +753,11 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
         protected virtual bool LogAllMessages => false;
 
+        protected virtual bool ShouldCheckForSpawnedPlayers()
+        {
+            return true;
+        }
+
         /// <summary>
         /// This starts the server and clients as long as <see cref="CanStartServerAndClients"/>
         /// returns true.
@@ -819,7 +824,10 @@ namespace Unity.Netcode.TestHelpers.Runtime
                         }
                     }
 
-                    ClientNetworkManagerPostStartInit();
+                    if (ShouldCheckForSpawnedPlayers())
+                    {
+                        ClientNetworkManagerPostStartInit();
+                    }
 
                     // Notification that at this time the server and client(s) are instantiated,
                     // started, and connected on both sides.
@@ -892,7 +900,10 @@ namespace Unity.Netcode.TestHelpers.Runtime
                         }
                     }
 
-                    ClientNetworkManagerPostStartInit();
+                    if (ShouldCheckForSpawnedPlayers())
+                    {
+                        ClientNetworkManagerPostStartInit();
+                    }
 
                     // Notification that at this time the server and client(s) are instantiated,
                     // started, and connected on both sides.


### PR DESCRIPTION
Backport of #3042
This PR resolves the issue where if you do not have a player prefab assigned but do have prefab hash provided in the connection approval process it would cause and exception to be thrown (due to the lack of the player prefab assignment).

fix: #3032 

## Changelog

- Fixed: Issue where setting a prefab hash value during connection approval but not having a player prefab assigned could cause an exception when spawning a player.

## Testing and Documentation

- Includes integration test updates to `ConnectionApproval`.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
