### PR TITLE
fix: exception thrown when rpc received for depsawned object (back-port)

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -15,7 +15,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where an exception could occur when receiving a universal RPC for a `NetworkObject` that has been despawned.
+- Fixed issue where an exception could occur when receiving a universal RPC for a `NetworkObject` that has been despawned. (#3055)
 - Fixed issue where setting a prefab hash value during connection approval but not having a player prefab assigned could cause an exception when spawning a player. (#3046)
 - Fixed issue where collections v2.2.x was not supported when using UTP v2.2.x within Unity v2022.3. (#3033)
 - Fixed issue where the `NetworkSpawnManager.HandleNetworkObjectShow` could throw an exception if one of the `NetworkObject` components to show was destroyed during the same frame. (#3029)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -15,6 +15,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where an exception could occur when receiving a universal RPC for a `NetworkObject` that has been despawned.
 - Fixed issue where setting a prefab hash value during connection approval but not having a player prefab assigned could cause an exception when spawning a player. (#3046)
 - Fixed issue where collections v2.2.x was not supported when using UTP v2.2.x within Unity v2022.3. (#3033)
 - Fixed issue where the `NetworkSpawnManager.HandleNetworkObjectShow` could throw an exception if one of the `NetworkObject` components to show was destroyed during the same frame. (#3029)

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ProxyMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ProxyMessage.cs
@@ -35,7 +35,13 @@ namespace Unity.Netcode
             var networkManager = (NetworkManager)context.SystemOwner;
             if (!networkManager.SpawnManager.SpawnedObjects.TryGetValue(WrappedMessage.Metadata.NetworkObjectId, out var networkObject))
             {
-                throw new InvalidOperationException($"An RPC called on a {nameof(NetworkObject)} that is not in the spawned objects list. Please make sure the {nameof(NetworkObject)} is spawned before calling RPCs.");
+                // If the NetworkObject no longer exists then just log a warning when developer mode logging is enabled and exit.
+                // This can happen if NetworkObject is despawned and a client sends an RPC before receiving the despawn message.
+                if (networkManager.LogLevel == LogLevel.Developer)
+                {
+                    NetworkLog.LogWarning($"[{WrappedMessage.Metadata.NetworkObjectId}, {WrappedMessage.Metadata.NetworkBehaviourId}, {WrappedMessage.Metadata.NetworkRpcMethodId}] An RPC called on a {nameof(NetworkObject)} that is not in the spawned objects list. Please make sure the {nameof(NetworkObject)} is spawned before calling RPCs.");
+                }
+                return;
             }
 
             var observers = networkObject.Observers;

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ProxyMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ProxyMessage.cs
@@ -1,4 +1,3 @@
-using System;
 using Unity.Collections;
 
 namespace Unity.Netcode

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/RpcMessages.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/RpcMessages.cs
@@ -61,7 +61,13 @@ namespace Unity.Netcode
             var networkManager = (NetworkManager)context.SystemOwner;
             if (!networkManager.SpawnManager.SpawnedObjects.TryGetValue(metadata.NetworkObjectId, out var networkObject))
             {
-                throw new InvalidOperationException($"An RPC called on a {nameof(NetworkObject)} that is not in the spawned objects list. Please make sure the {nameof(NetworkObject)} is spawned before calling RPCs.");
+                // If the NetworkObject no longer exists then just log a warning when developer mode logging is enabled and exit.
+                // This can happen if NetworkObject is despawned and a client sends an RPC before receiving the despawn message.
+                if (networkManager.LogLevel == LogLevel.Developer)
+                {
+                    NetworkLog.LogWarning($"[{metadata.NetworkObjectId}, {metadata.NetworkBehaviourId}, {metadata.NetworkRpcMethodId}] An RPC called on a {nameof(NetworkObject)} that is not in the spawned objects list. Please make sure the {nameof(NetworkObject)} is spawned before calling RPCs.");
+                }
+                return;
             }
             var networkBehaviour = networkObject.GetNetworkBehaviourAtOrderIndex(metadata.NetworkBehaviourId);
 


### PR DESCRIPTION
Backported from #3052
This resolves the issue where an exception is thrown if universal RPC is received after a `NetworkObject` has been despawned. Now it logs a warning if developer logging is enabled otherwise it just silently ignores the RPC.

[MTTB-361](https://jira.unity3d.com/browse/MTTB-361)
fix: #3007

## Changelog

- Fixed: Issue where an exception could occur when receiving a universal RPC for a `NetworkObject` that has been despawned.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
