### PR TITLE
fix: networkshow client connected scenemanagement disabled

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ClientConnectedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ClientConnectedMessage.cs
@@ -59,7 +59,10 @@ namespace Unity.Netcode
                     // - Hidden from the session owner
                     // - Owned by this client
                     // - Has NetworkObject.SpawnWithObservers set to true (the default)
-                    networkManager.SpawnManager.ShowHiddenObjectsToNewlyJoinedClient(ClientId);
+                    if (!networkManager.LocalClient.IsSessionOwner)
+                    {
+                        networkManager.SpawnManager.ShowHiddenObjectsToNewlyJoinedClient(ClientId);
+                    }
 
                     // We defer redistribution to the end of the NetworkUpdateStage.PostLateUpdate
                     networkManager.RedistributeToClient = true;

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
@@ -326,20 +326,30 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
             s_IsStarted = false;
 
-            // Shutdown the server which forces clients to disconnect
-            foreach (var networkManager in NetworkManagerInstances)
+            try
             {
-                networkManager.Shutdown();
-                s_Hooks.Remove(networkManager);
-            }
-
-            // Destroy the network manager instances
-            foreach (var networkManager in NetworkManagerInstances)
-            {
-                if (networkManager.gameObject != null)
+                // Shutdown the server which forces clients to disconnect
+                foreach (var networkManager in NetworkManagerInstances)
                 {
-                    Object.DestroyImmediate(networkManager.gameObject);
+                    if (networkManager != null && networkManager.IsListening)
+                    {
+                        networkManager?.Shutdown();
+                        s_Hooks.Remove(networkManager);
+                    }
                 }
+
+                // Destroy the network manager instances
+                foreach (var networkManager in NetworkManagerInstances)
+                {
+                    if (networkManager != null && networkManager.gameObject)
+                    {
+                        Object.DestroyImmediate(networkManager.gameObject);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogException(ex);
             }
 
             NetworkManagerInstances.Clear();

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/ExtendedNetworkShowAndHideTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/ExtendedNetworkShowAndHideTests.cs
@@ -6,23 +6,38 @@ using UnityEngine.TestTools;
 
 namespace Unity.Netcode.RuntimeTests
 {
-    [TestFixture(HostOrServer.DAHost)]
+    [TestFixture(HostOrServer.DAHost, true)]
+    [TestFixture(HostOrServer.DAHost, false)]
     public class ExtendedNetworkShowAndHideTests : NetcodeIntegrationTest
     {
         protected override int NumberOfClients => 3;
-
+        private bool m_EnableSceneManagement;
         private GameObject m_ObjectToSpawn;
         private NetworkObject m_SpawnedObject;
         private NetworkManager m_ClientToHideFrom;
         private NetworkManager m_LateJoinClient;
         private NetworkManager m_SpawnOwner;
 
-        public ExtendedNetworkShowAndHideTests(HostOrServer hostOrServer) : base(hostOrServer) { }
+        public ExtendedNetworkShowAndHideTests(HostOrServer hostOrServer, bool enableSceneManagement) : base(hostOrServer)
+        {
+            m_EnableSceneManagement = enableSceneManagement;
+        }
 
         protected override void OnServerAndClientsCreated()
         {
+            if (!UseCMBService())
+            {
+                m_ServerNetworkManager.NetworkConfig.EnableSceneManagement = m_EnableSceneManagement;
+            }
+
+            foreach (var client in m_ClientNetworkManagers)
+            {
+                client.NetworkConfig.EnableSceneManagement = m_EnableSceneManagement;
+            }
+
             m_ObjectToSpawn = CreateNetworkObjectPrefab("TestObject");
             m_ObjectToSpawn.SetActive(false);
+
             base.OnServerAndClientsCreated();
         }
 
@@ -81,7 +96,7 @@ namespace Unity.Netcode.RuntimeTests
         protected override void OnNewClientCreated(NetworkManager networkManager)
         {
             m_LateJoinClient = networkManager;
-
+            networkManager.NetworkConfig.EnableSceneManagement = m_EnableSceneManagement;
             networkManager.NetworkConfig.Prefabs = m_SpawnOwner.NetworkConfig.Prefabs;
             base.OnNewClientCreated(networkManager);
         }


### PR DESCRIPTION
This fixes the issue where `NetworkSpawnManager.ShowHiddenObjectsToNewlyJoinedClient` was being invoked on the session owner side when scene management was disabled.


## Changelog

NA (Found before released)

## Testing and Documentation

- Includes adjustments to integration test `ExtendedNetworkShowAndHideTests`.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
