### PR TITLE
fix: networkanimator only updates observers

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -21,6 +21,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where `NetworkAnimator` would send updates to non-observer clients. (#3057)
 - Fixed issue where an exception could occur when receiving a universal RPC for a `NetworkObject` that has been despawned. (#3052)
 - Fixed issue where a NetworkObject hidden from a client that is then promoted to be session owner was not being synchronized with newly joining clients.(#3051)
 - Fixed issue where clients could have a wrong time delta on `NetworkVariableBase` which could prevent from sending delta state updates. (#3045)

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
@@ -952,8 +952,14 @@ namespace Unity.Netcode.Components
                 {
                     // Just notify all remote clients and not the local server
                     m_ClientSendList.Clear();
-                    m_ClientSendList.AddRange(NetworkManager.ConnectedClientsIds);
-                    m_ClientSendList.Remove(NetworkManager.LocalClientId);
+                    foreach (var clientId in NetworkManager.ConnectedClientsIds)
+                    {
+                        if (clientId == NetworkManager.LocalClientId || !NetworkObject.Observers.Contains(clientId))
+                        {
+                            continue;
+                        }
+                        m_ClientSendList.Add(clientId);
+                    }
                     m_ClientRpcParams.Send.TargetClientIds = m_ClientSendList;
                     SendAnimStateClientRpc(m_AnimationMessage, m_ClientRpcParams);
                 }
@@ -1264,9 +1270,15 @@ namespace Unity.Netcode.Components
                 if (NetworkManager.ConnectedClientsIds.Count > (IsHost ? 2 : 1))
                 {
                     m_ClientSendList.Clear();
-                    m_ClientSendList.AddRange(NetworkManager.ConnectedClientsIds);
-                    m_ClientSendList.Remove(serverRpcParams.Receive.SenderClientId);
-                    m_ClientSendList.Remove(NetworkManager.ServerClientId);
+                    foreach (var clientId in NetworkManager.ConnectedClientsIds)
+                    {
+                        if (clientId == serverRpcParams.Receive.SenderClientId || clientId == NetworkManager.ServerClientId || !NetworkObject.Observers.Contains(clientId))
+                        {
+                            continue;
+                        }
+                        m_ClientSendList.Add(clientId);
+                    }
+
                     m_ClientRpcParams.Send.TargetClientIds = m_ClientSendList;
                     m_NetworkAnimatorStateChangeHandler.SendParameterUpdate(parametersUpdate, m_ClientRpcParams);
                 }
@@ -1321,9 +1333,14 @@ namespace Unity.Netcode.Components
                 if (NetworkManager.ConnectedClientsIds.Count > (IsHost ? 2 : 1))
                 {
                     m_ClientSendList.Clear();
-                    m_ClientSendList.AddRange(NetworkManager.ConnectedClientsIds);
-                    m_ClientSendList.Remove(serverRpcParams.Receive.SenderClientId);
-                    m_ClientSendList.Remove(NetworkManager.ServerClientId);
+                    foreach (var clientId in NetworkManager.ConnectedClientsIds)
+                    {
+                        if (clientId == serverRpcParams.Receive.SenderClientId || clientId == NetworkManager.ServerClientId || !NetworkObject.Observers.Contains(clientId))
+                        {
+                            continue;
+                        }
+                        m_ClientSendList.Add(clientId);
+                    }
                     m_ClientRpcParams.Send.TargetClientIds = m_ClientSendList;
                     m_NetworkAnimatorStateChangeHandler.SendAnimationUpdate(animationMessage, m_ClientRpcParams);
                 }
@@ -1390,9 +1407,14 @@ namespace Unity.Netcode.Components
             InternalSetTrigger(animationTriggerMessage.Hash, animationTriggerMessage.IsTriggerSet);
 
             m_ClientSendList.Clear();
-            m_ClientSendList.AddRange(NetworkManager.ConnectedClientsIds);
-            m_ClientSendList.Remove(NetworkManager.ServerClientId);
-
+            foreach (var clientId in NetworkManager.ConnectedClientsIds)
+            {
+                if (clientId == NetworkManager.ServerClientId || !NetworkObject.Observers.Contains(clientId))
+                {
+                    continue;
+                }
+                m_ClientSendList.Add(clientId);
+            }
             if (IsServerAuthoritative())
             {
                 m_NetworkAnimatorStateChangeHandler.QueueTriggerUpdateToClient(animationTriggerMessage, m_ClientRpcParams);

--- a/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
@@ -400,6 +400,103 @@ namespace TestProject.RuntimeTests
             AssertOnTimeout($"Timed out waiting for all clients to transition from synchronized cross fade!");
         }
 
+        private bool AllTriggersDetectedOnObserversOnly(OwnerShipMode ownerShipMode, ulong nonObserverId)
+        {
+            if (ownerShipMode == OwnerShipMode.ClientOwner)
+            {
+                if (!TriggerTest.ClientsThatTriggered.Contains(m_ServerNetworkManager.LocalClientId))
+                {
+                    return false;
+                }
+            }
+
+            foreach (var animatorTestHelper in AnimatorTestHelper.ClientSideInstances)
+            {
+                var currentClientId = animatorTestHelper.Value.NetworkManager.LocalClientId;
+                if (currentClientId == nonObserverId || (ownerShipMode == OwnerShipMode.ClientOwner && currentClientId == animatorTestHelper.Value.OwnerClientId))
+                {
+                    continue;
+                }
+
+                if (!TriggerTest.ClientsThatTriggered.Contains(currentClientId))
+                {
+                    return false;
+                }
+            }
+
+            // Should return false always
+            return !TriggerTest.ClientsThatTriggered.Contains(nonObserverId);
+        }
+
+        private bool AllObserversSameLayerWeight(OwnerShipMode ownerShipMode, int layer, float targetWeight, ulong nonObserverId)
+        {
+
+            if (ownerShipMode == OwnerShipMode.ClientOwner)
+            {
+                if (AnimatorTestHelper.ServerSideInstance.GetLayerWeight(layer) != targetWeight)
+                {
+                    return false;
+                }
+            }
+
+            foreach (var animatorTestHelper in AnimatorTestHelper.ClientSideInstances)
+            {
+                var currentClientId = animatorTestHelper.Value.NetworkManager.LocalClientId;
+                if (ownerShipMode == OwnerShipMode.ClientOwner && animatorTestHelper.Value.OwnerClientId == currentClientId)
+                {
+                    continue;
+                }
+                if (currentClientId == nonObserverId)
+                {
+                    if (animatorTestHelper.Value.GetLayerWeight(layer) == targetWeight)
+                    {
+                        return false;
+                    }
+                }
+                else
+                if (animatorTestHelper.Value.GetLayerWeight(layer) != targetWeight)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        [UnityTest]
+        public IEnumerator OnlyObserversAnimateTest()
+        {
+            // Spawn our test animator object
+            var objectInstance = SpawnPrefab(m_OwnerShipMode == OwnerShipMode.ClientOwner, m_AuthoritativeMode);
+            var networkObject = objectInstance.GetComponent<NetworkObject>();
+            // Wait for it to spawn server-side
+            var success = WaitForConditionOrTimeOutWithTimeTravel(() => AnimatorTestHelper.ServerSideInstance != null);
+            Assert.True(success, $"Timed out waiting for the server-side instance of {GetNetworkAnimatorName(m_AuthoritativeMode)} to be spawned!");
+
+            // Wait for it to spawn client-side
+            success = WaitForConditionOrTimeOutWithTimeTravel(WaitForClientsToInitialize);
+            Assert.True(success, $"Timed out waiting for the server-side instance of {GetNetworkAnimatorName(m_AuthoritativeMode)} to be spawned!");
+
+            var animatorTestHelper = m_OwnerShipMode == OwnerShipMode.ClientOwner ? AnimatorTestHelper.ClientSideInstances[m_ClientNetworkManagers[0].LocalClientId] : AnimatorTestHelper.ServerSideInstance;
+
+            networkObject.NetworkHide(m_ClientNetworkManagers[1].LocalClientId);
+
+            yield return WaitForConditionOrTimeOut(() => !m_ClientNetworkManagers[1].SpawnManager.SpawnedObjects.ContainsKey(networkObject.NetworkObjectId));
+            AssertOnTimeout($"Client-{m_ClientNetworkManagers[1].LocalClientId} timed out waiting to hide {networkObject.name}!");
+
+            if (m_AuthoritativeMode == AuthoritativeMode.ServerAuth)
+            {
+                animatorTestHelper = AnimatorTestHelper.ServerSideInstance;
+            }
+            animatorTestHelper.SetTrigger();
+            // Wait for all triggers to fire
+            yield return WaitForConditionOrTimeOut(() => AllTriggersDetectedOnObserversOnly(m_OwnerShipMode, m_ClientNetworkManagers[1].LocalClientId));
+            AssertOnTimeout($"Timed out waiting for all triggers to match!");
+
+            animatorTestHelper.SetLayerWeight(1, 0.75f);
+            // Wait for all instances to update their weight value for layer 1
+            success = WaitForConditionOrTimeOutWithTimeTravel(() => AllObserversSameLayerWeight(m_OwnerShipMode, 1, 0.75f, m_ClientNetworkManagers[1].LocalClientId));
+            Assert.True(success, $"Timed out waiting for all instances to match weight 0.75 on layer 1!");
+        }
 
         /// <summary>
         /// Verifies that triggers are synchronized with currently connected clients


### PR DESCRIPTION
This resolves the issue with `NetworkAnimator` sending animation updates to non-observers.
(#3058 is the v1.12.0 backport of this fix)

[MTTB-2](https://jira.unity3d.com/browse/MTTB-2)

fix: #2793

## Changelog

- Fixed: Issue where `NetworkAnimator` would send updates to non-observer clients.

## Testing and Documentation

- Includes integration test `NetworkAnimator.OnlyObserversAnimateTest`.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
