### PR TITLE
fix: INetworkSerializable NetworkLists in CMB

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -154,8 +154,7 @@ namespace Unity.Netcode
 
         private void WriteItem(FastBufferWriter writer, T value)
         {
-            if (NetworkVariableSerialization<T>.Serializer.Type == NetworkVariableType.Value
-                || NetworkVariableSerialization<T>.Serializer.Type == NetworkVariableType.Unknown)
+            if (NetworkVariableSerialization<T>.Serializer.Type == NetworkVariableType.Value)
             {
                 // Write the size of the item. This allows the CMB runtime to handle unknown types.
                 var sizePos = writer.Position;
@@ -197,11 +196,10 @@ namespace Unity.Netcode
 
         private void ReadItem(FastBufferReader reader, ref T value)
         {
-            if (NetworkVariableSerialization<T>.Serializer.Type == NetworkVariableType.Value
-                || NetworkVariableSerialization<T>.Serializer.Type == NetworkVariableType.Unknown)
+            if (NetworkVariableSerialization<T>.Serializer.Type == NetworkVariableType.Value)
             {
                 // Drop data used by CMB to read packets
-                ByteUnpacker.ReadValueBitPacked(reader, out int _);
+                reader.ReadValueSafe(out ushort _);
             }
             NetworkVariableSerialization<T>.Serializer.Read(reader, ref value);
         }

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -154,7 +154,7 @@ namespace Unity.Netcode
 
         private void WriteItem(FastBufferWriter writer, T value)
         {
-            if (NetworkVariableSerialization<T>.Serializer.Type == NetworkVariableType.Value)
+            if (NetworkVariableSerialization<T>.Serializer.Type == NetworkVariableType.UnmanagedNetworkSerializable)
             {
                 // Write the size of the item. This allows the CMB runtime to handle unknown types.
                 var sizePos = writer.Position;
@@ -196,7 +196,7 @@ namespace Unity.Netcode
 
         private void ReadItem(FastBufferReader reader, ref T value)
         {
-            if (NetworkVariableSerialization<T>.Serializer.Type == NetworkVariableType.Value)
+            if (NetworkVariableSerialization<T>.Serializer.Type == NetworkVariableType.UnmanagedNetworkSerializable)
             {
                 // Drop data used by CMB to read packets
                 reader.ReadValueSafe(out ushort _);

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -154,7 +154,8 @@ namespace Unity.Netcode
 
         private void WriteItem(FastBufferWriter writer, T value)
         {
-            if (NetworkVariableSerialization<T>.Serializer.Type == NetworkVariableType.Unknown)
+            if (NetworkVariableSerialization<T>.Serializer.Type == NetworkVariableType.Value
+                || NetworkVariableSerialization<T>.Serializer.Type == NetworkVariableType.Unknown)
             {
                 // Write the size of the item. This allows the CMB runtime to handle unknown types.
                 var sizePos = writer.Position;
@@ -163,7 +164,7 @@ namespace Unity.Netcode
                 NetworkVariableSerialization<T>.Serializer.Write(writer, ref value);
                 var currentPos = writer.Position;
                 writer.Seek(sizePos);
-                writer.WriteValueSafe((ushort) currentPos - startPos);
+                writer.WriteValueSafe((ushort)currentPos - startPos);
                 writer.Seek(currentPos);
             }
             else
@@ -196,15 +197,13 @@ namespace Unity.Netcode
 
         private void ReadItem(FastBufferReader reader, ref T value)
         {
-            if (NetworkVariableSerialization<T>.Serializer.Type == NetworkVariableType.Unknown)
+            if (NetworkVariableSerialization<T>.Serializer.Type == NetworkVariableType.Value
+                || NetworkVariableSerialization<T>.Serializer.Type == NetworkVariableType.Unknown)
             {
                 // Drop data used by CMB to read packets
                 ByteUnpacker.ReadValueBitPacked(reader, out int _);
             }
-            else
-            {
-                ReadItem(reader, ref value);
-            }
+            NetworkVariableSerialization<T>.Serializer.Read(reader, ref value);
         }
 
         /// <inheritdoc />

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -94,18 +94,18 @@ namespace Unity.Netcode
                 {
                     case NetworkListEvent<T>.EventType.Add:
                         {
-                            NetworkVariableSerialization<T>.Serializer.Write(writer, ref element.Value);
+                            WriteItem(writer, element.Value);
                         }
                         break;
                     case NetworkListEvent<T>.EventType.Insert:
                         {
                             BytePacker.WriteValueBitPacked(writer, element.Index);
-                            NetworkVariableSerialization<T>.Serializer.Write(writer, ref element.Value);
+                            WriteItem(writer, element.Value);
                         }
                         break;
                     case NetworkListEvent<T>.EventType.Remove:
                         {
-                            NetworkVariableSerialization<T>.Serializer.Write(writer, ref element.Value);
+                            WriteItem(writer, element.Value);
                         }
                         break;
                     case NetworkListEvent<T>.EventType.RemoveAt:
@@ -116,7 +116,7 @@ namespace Unity.Netcode
                     case NetworkListEvent<T>.EventType.Value:
                         {
                             BytePacker.WriteValueBitPacked(writer, element.Index);
-                            NetworkVariableSerialization<T>.Serializer.Write(writer, ref element.Value);
+                            WriteItem(writer, element.Value);
                         }
                         break;
                     case NetworkListEvent<T>.EventType.Clear:
@@ -148,7 +148,27 @@ namespace Unity.Netcode
             writer.WriteValueSafe((ushort)m_List.Length);
             for (int i = 0; i < m_List.Length; i++)
             {
-                NetworkVariableSerialization<T>.Serializer.Write(writer, ref m_List.ElementAt(i));
+                WriteItem(writer, m_List.ElementAt(i));
+            }
+        }
+
+        private void WriteItem(FastBufferWriter writer, T value)
+        {
+            if (NetworkVariableSerialization<T>.Serializer.Type == NetworkVariableType.Unknown)
+            {
+                // Write the size of the item. This allows the CMB runtime to handle unknown types.
+                var sizePos = writer.Position;
+                writer.WriteValueSafe((ushort)0);
+                var startPos = writer.Position;
+                NetworkVariableSerialization<T>.Serializer.Write(writer, ref value);
+                var currentPos = writer.Position;
+                writer.Seek(sizePos);
+                writer.WriteValueSafe((ushort) currentPos - startPos);
+                writer.Seek(currentPos);
+            }
+            else
+            {
+                NetworkVariableSerialization<T>.Serializer.Write(writer, ref value);
             }
         }
 
@@ -169,8 +189,21 @@ namespace Unity.Netcode
             for (int i = 0; i < count; i++)
             {
                 var value = new T();
-                NetworkVariableSerialization<T>.Serializer.Read(reader, ref value);
+                ReadItem(reader, ref value);
                 m_List.Add(value);
+            }
+        }
+
+        private void ReadItem(FastBufferReader reader, ref T value)
+        {
+            if (NetworkVariableSerialization<T>.Serializer.Type == NetworkVariableType.Unknown)
+            {
+                // Drop data used by CMB to read packets
+                ByteUnpacker.ReadValueBitPacked(reader, out int _);
+            }
+            else
+            {
+                ReadItem(reader, ref value);
             }
         }
 
@@ -186,7 +219,7 @@ namespace Unity.Netcode
                     case NetworkListEvent<T>.EventType.Add:
                         {
                             var value = new T();
-                            NetworkVariableSerialization<T>.Serializer.Read(reader, ref value);
+                            ReadItem(reader, ref value);
                             m_List.Add(value);
 
                             if (OnListChanged != null)
@@ -215,7 +248,7 @@ namespace Unity.Netcode
                         {
                             ByteUnpacker.ReadValueBitPacked(reader, out int index);
                             var value = new T();
-                            NetworkVariableSerialization<T>.Serializer.Read(reader, ref value);
+                            ReadItem(reader, ref value);
 
                             if (index < m_List.Length)
                             {
@@ -252,7 +285,7 @@ namespace Unity.Netcode
                     case NetworkListEvent<T>.EventType.Remove:
                         {
                             var value = new T();
-                            NetworkVariableSerialization<T>.Serializer.Read(reader, ref value);
+                            ReadItem(reader, ref value);
                             int index = m_List.IndexOf(value);
                             if (index == -1)
                             {
@@ -315,7 +348,7 @@ namespace Unity.Netcode
                         {
                             ByteUnpacker.ReadValueBitPacked(reader, out int index);
                             var value = new T();
-                            NetworkVariableSerialization<T>.Serializer.Read(reader, ref value);
+                            ReadItem(reader, ref value);
                             if (index >= m_List.Length)
                             {
                                 throw new Exception("Shouldn't be here, index is higher than list length");

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableTypes.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableTypes.cs
@@ -36,5 +36,6 @@ namespace Unity.Netcode
         Long = 15,
         ULong = 16,
         Unmanaged = 17,
+        UnmanagedNetworkSerializable = 18,
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Serialization/TypedSerializerImplementations.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Serialization/TypedSerializerImplementations.cs
@@ -1145,7 +1145,7 @@ namespace Unity.Netcode
     /// <typeparam name="T"></typeparam>
     internal class UnmanagedNetworkSerializableSerializer<T> : INetworkVariableSerializer<T> where T : unmanaged, INetworkSerializable
     {
-        public NetworkVariableType Type => NetworkVariableType.Value;
+        public NetworkVariableType Type => NetworkVariableType.UnmanagedNetworkSerializable;
         public bool IsDistributedAuthorityOptimized => false;
 
         public void WriteDistributedAuthority(FastBufferWriter writer, ref T value)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
@@ -37,8 +37,9 @@ namespace Unity.Netcode.RuntimeTests
 
         internal class TestNetworkComponent : NetworkBehaviour
         {
-            public NetworkList<int> MyNetworkList = new NetworkList<int>(new List<int> { 1, 2, 3 });
-            public NetworkVariable<int> MyNetworkVar = new NetworkVariable<int>(3);
+            public NetworkList<int> MyNetworkList = new(new List<int> { 1, 2, 3 });
+            public NetworkList<UnmanagedNetworkSerializableType> UserNetworkList = new(new List<UnmanagedNetworkSerializableType> { new() });
+            public NetworkVariable<int> MyNetworkVar = new(3);
 
             [Rpc(SendTo.Authority)]
             public void TestAuthorityRpc(byte[] _)
@@ -255,6 +256,15 @@ namespace Unity.Netcode.RuntimeTests
             component.MyNetworkList.RemoveAt(2);
             yield return m_ClientCodecHook.WaitForMessageReceived<NetworkVariableDeltaMessage>();
             component.MyNetworkList.Clear();
+            yield return m_ClientCodecHook.WaitForMessageReceived<NetworkVariableDeltaMessage>();
+        }
+
+        [UnityTest]
+        public IEnumerator NetworkListDelta_INetworkSerializable_WithValueUpdate()
+        {
+            var component = Client.LocalClient.PlayerObject.GetComponent<TestNetworkComponent>();
+
+            component.UserNetworkList.Add(new());
             yield return m_ClientCodecHook.WaitForMessageReceived<NetworkVariableDeltaMessage>();
         }
 


### PR DESCRIPTION
Add a size field to allow the Rust Server to read INetworkSerializable values inside NetworkLists

<!-- Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->
[MPSNGM-355](https://jira.unity3d.com/browse/MPSNGM-355)

<!-- Add RFC link here if applicable. -->

## Changelog

- Fixed: INetworkSerializable types inside NetworkLists

## Testing and Documentation

- No tests have been added.

