### PR TITLE
fix: player prefab spawning not honoring when spawnwithobservers is disabled

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where `NetworkObject.SpawnWithObservers` was not being honored when spawning the player prefab. (#3077)
 - Fixed issue with the client count not being correct on the host or server side when a client disconnects itself from a session. (#3075)
 
 ### Changed

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1613,7 +1613,12 @@ namespace Unity.Netcode
             }
             else if (NetworkManager.DistributedAuthorityMode && !NetworkManager.DAHost)
             {
-                NetworkManager.SpawnManager.SendSpawnCallForObject(NetworkManager.ServerClientId, this);
+                // If spawning with observers or if not spawning with observers but the observer count is greater than 1 (i.e. owner/authority creating),
+                // then we want to send a spawn notification.
+                if (SpawnWithObservers || !SpawnWithObservers && Observers.Count > 1)
+                {
+                    NetworkManager.SpawnManager.SendSpawnCallForObject(NetworkManager.ServerClientId, this);
+                }
             }
             else
             {
@@ -3053,10 +3058,15 @@ namespace Unity.Netcode
                         }
                     }
 
-                    // Add all known players to the observers list if they don't already exist
-                    foreach (var player in networkManager.SpawnManager.PlayerObjects)
+                    // Only add all other players as observers if we are spawning with observers,
+                    // otherwise user controls via NetworkShow.
+                    if (networkObject.SpawnWithObservers)
                     {
-                        networkObject.Observers.Add(player.OwnerClientId);
+                        // Add all known players to the observers list if they don't already exist
+                        foreach (var player in networkManager.SpawnManager.PlayerObjects)
+                        {
+                            networkObject.Observers.Add(player.OwnerClientId);
+                        }
                     }
                 }
             }

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -72,11 +72,22 @@ namespace Unity.Netcode
                     return;
                 }
             }
+
             foreach (var player in m_PlayerObjects)
             {
-                player.Observers.Add(playerObject.OwnerClientId);
-                playerObject.Observers.Add(player.OwnerClientId);
+                // If the player's SpawnWithObservers is not set then do not add the new player object's owner as an observer.
+                if (player.SpawnWithObservers)
+                {
+                    player.Observers.Add(playerObject.OwnerClientId);
+                }
+
+                // If the new player object's SpawnWithObservers is not set then do not add this player as an observer to the new player object.
+                if (playerObject.SpawnWithObservers)
+                {
+                    playerObject.Observers.Add(player.OwnerClientId);
+                }
             }
+
             m_PlayerObjects.Add(playerObject);
             if (!m_PlayerObjectsTable.ContainsKey(playerObject.OwnerClientId))
             {

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -545,9 +545,14 @@ namespace Unity.Netcode.TestHelpers.Runtime
         private bool AllPlayerObjectClonesSpawned(NetworkManager joinedClient)
         {
             m_InternalErrorLog.Clear();
+            // If we are not checking for spawned players then exit early with a success
+            if (!ShouldCheckForSpawnedPlayers())
+            {
+                return true;
+            }
+
             // Continue to populate the PlayerObjects list until all player object (local and clone) are found
             ClientNetworkManagerPostStart(joinedClient);
-
             var playerObjectRelative = m_ServerNetworkManager.SpawnManager.PlayerObjects.Where((c) => c.OwnerClientId == joinedClient.LocalClientId).FirstOrDefault();
             if (playerObjectRelative == null)
             {


### PR DESCRIPTION
**Regression Bug**
During the distributed authority updates a regression bug occurred where `NetworkObject.SpawnWithObservers` was no longer being honored in both client-server and distributed authority network topologies when spawning player prefabs.

[MTTB-479](https://jira.unity3d.com/browse/MTTB-479)

fix: #3076


## Changelog

- Fixed: Issue where `NetworkObject.SpawnWithObservers` was not being honored when spawning the player prefab.

## Testing and Documentation

- Includes integration test `PlayerSpawnNoObserversTest`.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
