### PR TITLE
fix: in-sceneobject NetworkObject update in editor tool

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -15,6 +15,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue with the in-scene network prefab instance update menu tool where it was not properly updating scenes when invoked on the root prefab instance. (#3084)
 - Fixed issue where `NetworkAnimator` would send updates to non-observer clients. (#3058)
 - Fixed issue where an exception could occur when receiving a universal RPC for a `NetworkObject` that has been despawned. (#3055)
 - Fixed issue where setting a prefab hash value during connection approval but not having a player prefab assigned could cause an exception when spawning a player. (#3046)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -74,6 +74,7 @@ namespace Unity.Netcode
         internal void RefreshAllPrefabInstances()
         {
             var instanceGlobalId = GlobalObjectId.GetGlobalObjectIdSlow(this);
+            NetworkObjectRefreshTool.PrefabNetworkObject = this;
             if (!PrefabUtility.IsPartOfAnyPrefab(this) || instanceGlobalId.identifierType != k_ImportedAssetObjectType)
             {
                 EditorUtility.DisplayDialog("Network Prefab Assets Only", "This action can only be performed on a network prefab asset.", "Ok");
@@ -81,11 +82,6 @@ namespace Unity.Netcode
             }
 
             // Handle updating the currently active scene
-            var networkObjects = FindObjectsByType<NetworkObject>(FindObjectsInactive.Include, FindObjectsSortMode.None);
-            foreach (var networkObject in networkObjects)
-            {
-                networkObject.OnValidate();
-            }
             NetworkObjectRefreshTool.ProcessActiveScene();
 
             // Refresh all build settings scenes
@@ -98,14 +94,14 @@ namespace Unity.Netcode
                     continue;
                 }
                 // Add the scene to be processed
-                NetworkObjectRefreshTool.ProcessScene(editorScene.path, false);
+                NetworkObjectRefreshTool.ProcessScene(editorScene.path, true);
             }
 
             // Process all added scenes
             NetworkObjectRefreshTool.ProcessScenes();
         }
 
-        private void OnValidate()
+        internal void OnValidate()
         {
             // do NOT regenerate GlobalObjectIdHash for NetworkPrefabs while Editor is in PlayMode
             if (EditorApplication.isPlaying && !string.IsNullOrEmpty(gameObject.scene.name))
@@ -197,6 +193,7 @@ namespace Unity.Netcode
                 if (sourceAsset != null && sourceAsset.GlobalObjectIdHash != 0 && InScenePlacedSourceGlobalObjectIdHash != sourceAsset.GlobalObjectIdHash)
                 {
                     InScenePlacedSourceGlobalObjectIdHash = sourceAsset.GlobalObjectIdHash;
+                    EditorUtility.SetDirty(this);
                 }
                 IsSceneObject = true;
             }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObjectRefreshTool.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObjectRefreshTool.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -21,6 +23,28 @@ namespace Unity.Netcode
 
         internal static Action AllScenesProcessed;
 
+        internal static NetworkObject PrefabNetworkObject;
+
+        internal static void LogInfo(string msg, bool append = false)
+        {
+            if (!append)
+            {
+                s_Log.AppendLine(msg);
+            }
+            else
+            {
+                s_Log.Append(msg);
+            }
+        }
+
+        internal static void FlushLog()
+        {
+            Debug.Log(s_Log.ToString());
+            s_Log.Clear();
+        }
+
+        private static StringBuilder s_Log = new StringBuilder();
+
         internal static void ProcessScene(string scenePath, bool processScenes = true)
         {
             if (!s_ScenesToUpdate.Contains(scenePath))
@@ -29,7 +53,10 @@ namespace Unity.Netcode
                 {
                     EditorSceneManager.sceneOpened += EditorSceneManager_sceneOpened;
                     EditorSceneManager.sceneSaved += EditorSceneManager_sceneSaved;
+                    s_Log.Clear();
+                    LogInfo("NetworkObject Refresh Scenes to Process:");
                 }
+                LogInfo($"[{scenePath}]", true);
                 s_ScenesToUpdate.Add(scenePath);
             }
             s_ProcessScenes = processScenes;
@@ -37,6 +64,7 @@ namespace Unity.Netcode
 
         internal static void ProcessActiveScene()
         {
+            FlushLog();
             var activeScene = SceneManager.GetActiveScene();
             if (s_ScenesToUpdate.Contains(activeScene.path) && s_ProcessScenes)
             {
@@ -54,10 +82,12 @@ namespace Unity.Netcode
             }
             else
             {
+                s_ProcessScenes = false;
                 s_CloseScenes = false;
                 EditorSceneManager.sceneSaved -= EditorSceneManager_sceneSaved;
                 EditorSceneManager.sceneOpened -= EditorSceneManager_sceneOpened;
                 AllScenesProcessed?.Invoke();
+                FlushLog();
             }
         }
 
@@ -68,9 +98,8 @@ namespace Unity.Netcode
                 // Provide a log of all scenes that were modified to the user
                 if (refreshed)
                 {
-                    Debug.Log($"Refreshed and saved updates to scene: {scene.name}");
+                    LogInfo($"Refreshed and saved updates to scene: {scene.name}");
                 }
-                s_ProcessScenes = false;
                 s_ScenesToUpdate.Remove(scene.path);
 
                 if (scene != SceneManager.GetActiveScene())
@@ -88,24 +117,41 @@ namespace Unity.Netcode
 
         private static void SceneOpened(Scene scene)
         {
+            LogInfo($"Processing scene {scene.name}:");
             if (s_ScenesToUpdate.Contains(scene.path))
             {
                 if (s_ProcessScenes)
                 {
-                    if (!EditorSceneManager.MarkSceneDirty(scene))
+                    var prefabInstances = PrefabUtility.FindAllInstancesOfPrefab(PrefabNetworkObject.gameObject);
+                    
+                    if (prefabInstances.Length > 0)
                     {
-                        Debug.Log($"Scene {scene.name} did not get marked as dirty!");
-                        FinishedProcessingScene(scene);
-                    }
-                    else
-                    {
-                        EditorSceneManager.SaveScene(scene);
+                        var instancesSceneLoadedSpecific = prefabInstances.Where((c)=> c.scene == scene).ToList();
+
+                        if (instancesSceneLoadedSpecific.Count > 0)
+                        {
+                            foreach (var prefabInstance in instancesSceneLoadedSpecific)
+                            {
+                                prefabInstance.GetComponent<NetworkObject>().OnValidate();
+                            }
+
+                            if (!EditorSceneManager.MarkSceneDirty(scene))
+                            {
+                                LogInfo($"Scene {scene.name} did not get marked as dirty!");
+                                FinishedProcessingScene(scene);
+                            }
+                            else
+                            {
+                                LogInfo($"Changes detected and applied!");
+                                EditorSceneManager.SaveScene(scene);
+                            }
+                            return;
+                        }
                     }
                 }
-                else
-                {
-                    FinishedProcessingScene(scene);
-                }
+
+                LogInfo($"No changes required.");
+                FinishedProcessingScene(scene);
             }
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObjectRefreshTool.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObjectRefreshTool.cs
@@ -123,10 +123,10 @@ namespace Unity.Netcode
                 if (s_ProcessScenes)
                 {
                     var prefabInstances = PrefabUtility.FindAllInstancesOfPrefab(PrefabNetworkObject.gameObject);
-                    
+
                     if (prefabInstances.Length > 0)
                     {
-                        var instancesSceneLoadedSpecific = prefabInstances.Where((c)=> c.scene == scene).ToList();
+                        var instancesSceneLoadedSpecific = prefabInstances.Where((c) => c.scene == scene).ToList();
 
                         if (instancesSceneLoadedSpecific.Count > 0)
                         {


### PR DESCRIPTION
This resolves an issue with the in-scene network prefab instance update menu tool where it was not properly updating scenes when invoked on the root prefab instance.

[MTTB-485](https://jira.unity3d.com/browse/MTTB-485)

fix: #3067


## Changelog

- Fixed: Issue with the in-scene network prefab instance update menu tool where it was not properly updating scenes when invoked on the root prefab instance.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
