### PR TITLE
fix: Destroying player object removes observers.

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1508,20 +1508,6 @@ namespace Unity.Netcode
                 SpawnedObjectsList.Remove(networkObject);
             }
 
-            // DANGO-TODO: When we fix the issue with observers not being applied to NetworkObjects,
-            // (client connect/disconnect) we can remove this hacky way of doing this.
-            // Basically, when a player disconnects and/or is destroyed they are removed as an observer from all other client
-            // NetworkOject instances.
-            if (networkObject.IsPlayerObject && !networkObject.IsOwner && networkObject.OwnerClientId != NetworkManager.LocalClientId)
-            {
-                foreach (var netObject in SpawnedObjects)
-                {
-                    if (netObject.Value.Observers.Contains(networkObject.OwnerClientId))
-                    {
-                        netObject.Value.Observers.Remove(networkObject.OwnerClientId);
-                    }
-                }
-            }
             if (networkObject.IsPlayerObject)
             {
                 RemovePlayerObject(networkObject);


### PR DESCRIPTION
Resolves issue when a player object is destroyed leaving the client connection intact - observers would be removed from network objects and not restored when a new player object is created for that client.

This issue affected 2.0.0 only.

fix: #3059

## Changelog

- Fixed: Destroying the clients player object would cause it to be removed from NetworkObject observers list and wouldn't restore them when the player object was recreated. Fixes regression from 1.11.

## Testing and Documentation

- Includes integration test PlayerSpawnNoObserversTest.SpawnDestoryRespawnPlayerObjectMaintainsObservers.
- No documentation changes or additions were necessary.
