### PR TITLE
fix: NetworkManager instantiate & destroy notifications and player spawn prefab offset

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -9,6 +9,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 [Unreleased]
 
 ### Added
+- Added a static `NetworkManager.OnInstantiated` event notification to be able to track when a new `NetworkManager` instance has been instantiated. (#3088)
+- Added a static `NetworkManager.OnDestroying` event notification to be able to track when an existing `NetworkManager` instance is being destroyed. (#3088)
 
 ### Fixed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -9,6 +9,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 [Unreleased]
 
 ### Added
+
 - Added a static `NetworkManager.OnInstantiated` event notification to be able to track when a new `NetworkManager` instance has been instantiated. (#3088)
 - Added a static `NetworkManager.OnDestroying` event notification to be able to track when an existing `NetworkManager` instance is being destroyed. (#3088)
 

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -751,8 +751,8 @@ namespace Unity.Netcode
                 // Server-side spawning (only if there is a prefab hash or player prefab provided)
                 if (!NetworkManager.DistributedAuthorityMode && response.CreatePlayerObject && (response.PlayerPrefabHash.HasValue || NetworkManager.NetworkConfig.PlayerPrefab != null))
                 {
-                    var playerObject = response.PlayerPrefabHash.HasValue ? NetworkManager.SpawnManager.GetNetworkObjectToSpawn(response.PlayerPrefabHash.Value, ownerClientId, response.Position.GetValueOrDefault(), response.Rotation.GetValueOrDefault())
-                        : NetworkManager.SpawnManager.GetNetworkObjectToSpawn(NetworkManager.NetworkConfig.PlayerPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash, ownerClientId, response.Position.GetValueOrDefault(), response.Rotation.GetValueOrDefault());
+                    var playerObject = response.PlayerPrefabHash.HasValue ? NetworkManager.SpawnManager.GetNetworkObjectToSpawn(response.PlayerPrefabHash.Value, ownerClientId, response.Position ?? null, response.Rotation ?? null)
+                    : NetworkManager.SpawnManager.GetNetworkObjectToSpawn(NetworkManager.NetworkConfig.PlayerPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash, ownerClientId, response.Position ?? null, response.Rotation ?? null);
 
                     // Spawn the player NetworkObject locally
                     NetworkManager.SpawnManager.SpawnNetworkObjectLocally(

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -896,7 +896,7 @@ namespace Unity.Netcode
         /// <summary>
         /// Client-Side Spawning in distributed authority mode uses this to spawn the player.
         /// </summary>
-        internal void CreateAndSpawnPlayer(ulong ownerId, Vector3 position = default, Quaternion rotation = default)
+        internal void CreateAndSpawnPlayer(ulong ownerId)
         {
             if (NetworkManager.DistributedAuthorityMode && NetworkManager.AutoSpawnPlayerPrefabClientSide)
             {
@@ -904,7 +904,7 @@ namespace Unity.Netcode
                 if (playerPrefab != null)
                 {
                     var globalObjectIdHash = playerPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash;
-                    var networkObject = NetworkManager.SpawnManager.GetNetworkObjectToSpawn(globalObjectIdHash, ownerId, position, rotation);
+                    var networkObject = NetworkManager.SpawnManager.GetNetworkObjectToSpawn(globalObjectIdHash, ownerId, playerPrefab.transform.position, playerPrefab.transform.rotation);
                     networkObject.IsSceneObject = false;
                     networkObject.SpawnAsPlayerObject(ownerId, networkObject.DestroyWithScene);
                 }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -17,6 +17,17 @@ namespace Unity.Netcode
     [AddComponentMenu("Netcode/Network Manager", -100)]
     public class NetworkManager : MonoBehaviour, INetworkUpdateSystem
     {
+        /// <summary>
+        /// Subscribe to this static event to get notifications when a <see cref="NetworkManager"/> instance has been instantiated.
+        /// </summary>
+        public static event Action<NetworkManager> OnInstantiated;
+
+        /// <summary>
+        /// Subscribe to this static event to get notifications when a <see cref="NetworkManager"/> instance is being destroyed.
+        /// </summary>
+        public static event Action<NetworkManager> OnDestroying;
+
+
 #if UNITY_EDITOR
         // Inspector view expand/collapse settings for this derived child class
         [HideInInspector]
@@ -1030,6 +1041,8 @@ namespace Unity.Netcode
 #if UNITY_EDITOR
             EditorApplication.playModeStateChanged += ModeChanged;
 #endif
+            // Notify we have instantiated a new instance of NetworkManager.
+            OnInstantiated?.Invoke(this);
         }
 
         private void OnEnable()
@@ -1631,6 +1644,9 @@ namespace Unity.Netcode
             ShutdownInternal();
 
             UnityEngine.SceneManagement.SceneManager.sceneUnloaded -= OnSceneUnloaded;
+
+            // Notify we are destroying NetworkManager
+            OnDestroying?.Invoke(this);
 
             if (Singleton == this)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -706,14 +706,14 @@ namespace Unity.Netcode
         /// Gets the right NetworkObject prefab instance to spawn. If a handler is registered or there is an override assigned to the 
         /// passed in globalObjectIdHash value, then that is what will be instantiated, spawned, and returned.
         /// </summary>
-        internal NetworkObject GetNetworkObjectToSpawn(uint globalObjectIdHash, ulong ownerId, Vector3 position = default, Quaternion rotation = default, bool isScenePlaced = false)
+        internal NetworkObject GetNetworkObjectToSpawn(uint globalObjectIdHash, ulong ownerId, Vector3? position, Quaternion? rotation, bool isScenePlaced = false)
         {
             NetworkObject networkObject = null;
             // If the prefab hash has a registered INetworkPrefabInstanceHandler derived class
             if (NetworkManager.PrefabHandler.ContainsHandler(globalObjectIdHash))
             {
                 // Let the handler spawn the NetworkObject
-                networkObject = NetworkManager.PrefabHandler.HandleNetworkPrefabSpawn(globalObjectIdHash, ownerId, position, rotation);
+                networkObject = NetworkManager.PrefabHandler.HandleNetworkPrefabSpawn(globalObjectIdHash, ownerId, position ?? default, rotation ?? default);
                 networkObject.NetworkManagerOwner = NetworkManager;
             }
             else
@@ -764,7 +764,9 @@ namespace Unity.Netcode
                 else
                 {
                     // Create prefab instance while applying any pre-assigned position and rotation values
-                    networkObject = UnityEngine.Object.Instantiate(networkPrefabReference, position, rotation).GetComponent<NetworkObject>();
+                    networkObject = UnityEngine.Object.Instantiate(networkPrefabReference).GetComponent<NetworkObject>();
+                    networkObject.transform.position = position ?? networkObject.transform.position;
+                    networkObject.transform.rotation = rotation ?? networkObject.transform.rotation;
                     networkObject.NetworkManagerOwner = NetworkManager;
                     networkObject.PrefabGlobalObjectIdHash = globalObjectIdHash;
                 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerEventsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerEventsTests.cs
@@ -13,6 +13,60 @@ namespace Unity.Netcode.RuntimeTests
         private NetworkManager m_ClientManager;
         private NetworkManager m_ServerManager;
 
+        private NetworkManager m_NetworkManagerInstantiated;
+        private bool m_Instantiated;
+        private bool m_Destroyed;
+
+        /// <summary>
+        /// Validates the <see cref="NetworkManager.OnInstantiated"/> and <see cref="NetworkManager.OnDestroying"/> event notifications
+        /// </summary>
+        [UnityTest]
+        public IEnumerator InstantiatedAndDestroyingNotifications()
+        {
+            NetworkManager.OnInstantiated += NetworkManager_OnInstantiated;
+            NetworkManager.OnDestroying += NetworkManager_OnDestroying;
+            var waitPeriod = new WaitForSeconds(0.01f);
+            var prefab = new GameObject("InstantiateDestroy");
+            var networkManagerPrefab = prefab.AddComponent<NetworkManager>();
+
+            Assert.IsTrue(m_Instantiated, $"{nameof(NetworkManager)} prefab did not get instantiated event notification!");
+            Assert.IsTrue(m_NetworkManagerInstantiated == networkManagerPrefab, $"{nameof(NetworkManager)} prefab parameter did not match!");
+
+            m_Instantiated = false;
+            m_NetworkManagerInstantiated = null;
+
+            for (int i = 0; i < 3; i++)
+            {
+                var instance = Object.Instantiate(prefab);
+                var networkManager = instance.GetComponent<NetworkManager>();
+                Assert.IsTrue(m_Instantiated, $"{nameof(NetworkManager)} instance-{i} did not get instantiated event notification!");
+                Assert.IsTrue(m_NetworkManagerInstantiated == networkManager, $"{nameof(NetworkManager)} instance-{i} parameter did not match!");
+                Object.DestroyImmediate(instance);
+                Assert.IsTrue(m_Destroyed, $"{nameof(NetworkManager)} instance-{i} did not get destroying event notification!");
+                m_Instantiated = false;
+                m_NetworkManagerInstantiated = null;
+                m_Destroyed = false;
+            }
+            m_NetworkManagerInstantiated = networkManagerPrefab;
+            Object.Destroy(prefab);
+            yield return null;
+            Assert.IsTrue(m_Destroyed, $"{nameof(NetworkManager)} prefab did not get destroying event notification!");
+            NetworkManager.OnInstantiated -= NetworkManager_OnInstantiated;
+            NetworkManager.OnDestroying -= NetworkManager_OnDestroying;
+        }
+
+        private void NetworkManager_OnInstantiated(NetworkManager networkManager)
+        {
+            m_Instantiated = true;
+            m_NetworkManagerInstantiated = networkManager;
+        }
+
+        private void NetworkManager_OnDestroying(NetworkManager networkManager)
+        {
+            m_Destroyed = true;
+            Assert.True(m_NetworkManagerInstantiated == networkManager, $"Destroying {nameof(NetworkManager)} and current instance is not a match for the one passed into the event!");
+        }
+
         [UnityTest]
         public IEnumerator OnServerStoppedCalledWhenServerStops()
         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/PlayerObjectTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/PlayerObjectTests.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using NUnit.Framework;
+using Unity.Mathematics;
 using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -117,6 +118,70 @@ namespace Unity.Netcode.RuntimeTests
                     }
                 }
 
+            }
+        }
+    }
+
+    /// <summary>
+    /// This test validates the player position and rotation is correct
+    /// relative to the prefab's initial settings if no changes are applied.
+    /// </summary>
+    [TestFixture(HostOrServer.DAHost)]
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    internal class PlayerSpawnPositionTests : IntegrationTestWithApproximation
+    {
+        protected override int NumberOfClients => 2;
+
+        public PlayerSpawnPositionTests(HostOrServer hostOrServer) : base(hostOrServer) { }
+
+        private Vector3 m_PlayerPosition;
+        private Quaternion m_PlayerRotation;
+
+        protected override void OnCreatePlayerPrefab()
+        {
+            var playerNetworkObject = m_PlayerPrefab.GetComponent<NetworkObject>();
+            m_PlayerPosition = GetRandomVector3(-10.0f, 10.0f);
+            m_PlayerRotation = Quaternion.Euler(GetRandomVector3(-180.0f, 180.0f));
+            playerNetworkObject.transform.position = m_PlayerPosition;
+            playerNetworkObject.transform.rotation = m_PlayerRotation;
+            base.OnCreatePlayerPrefab();
+        }
+
+        private void PlayerTransformMatches(NetworkObject player)
+        {
+            var position = player.transform.position;
+            var rotation = player.transform.rotation;
+            Assert.True(Approximately(m_PlayerPosition, position), $"Client-{player.OwnerClientId} position {position} does not match the prefab position {m_PlayerPosition}!");
+            Assert.True(Approximately(m_PlayerRotation, rotation), $"Client-{player.OwnerClientId} rotation {rotation.eulerAngles} does not match the prefab rotation {m_PlayerRotation.eulerAngles}!");
+        }
+
+        [UnityTest]
+        public IEnumerator PlayerSpawnPosition()
+        {
+            if (m_ServerNetworkManager.IsHost)
+            {
+                PlayerTransformMatches(m_ServerNetworkManager.LocalClient.PlayerObject);
+
+                foreach (var client in m_ClientNetworkManagers)
+                {
+                    yield return WaitForConditionOrTimeOut(() => client.SpawnManager.SpawnedObjects.ContainsKey(m_ServerNetworkManager.LocalClient.PlayerObject.NetworkObjectId));
+                    AssertOnTimeout($"Client-{client.LocalClientId} does not contain a player prefab instance for client-{m_ServerNetworkManager.LocalClientId}!");
+                    PlayerTransformMatches(client.SpawnManager.SpawnedObjects[m_ServerNetworkManager.LocalClient.PlayerObject.NetworkObjectId]);
+                }
+            }
+
+            foreach (var client in m_ClientNetworkManagers)
+            {
+                yield return WaitForConditionOrTimeOut(() => m_ServerNetworkManager.SpawnManager.SpawnedObjects.ContainsKey(client.LocalClient.PlayerObject.NetworkObjectId));
+                AssertOnTimeout($"Client-{m_ServerNetworkManager.LocalClientId} does not contain a player prefab instance for client-{client.LocalClientId}!");
+                PlayerTransformMatches(m_ServerNetworkManager.SpawnManager.SpawnedObjects[client.LocalClient.PlayerObject.NetworkObjectId]);
+                foreach (var subClient in m_ClientNetworkManagers)
+                {
+                    yield return WaitForConditionOrTimeOut(() => subClient.SpawnManager.SpawnedObjects.ContainsKey(client.LocalClient.PlayerObject.NetworkObjectId));
+                    AssertOnTimeout($"Client-{subClient.LocalClientId} does not contain a player prefab instance for client-{client.LocalClientId}!");
+                    PlayerTransformMatches(subClient.SpawnManager.SpawnedObjects[client.LocalClient.PlayerObject.NetworkObjectId]);
+                }
             }
         }
     }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/PlayerObjectTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/PlayerObjectTests.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using NUnit.Framework;
-using Unity.Mathematics;
 using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
 using UnityEngine.TestTools;


### PR DESCRIPTION
Small PR to:

- Provide instantiate and destroy notifications for `NetworkManager` 
  - [MTT-9170](https://jira.unity3d.com/browse/MTT-9170)
- Fixed an issue with a recently merged PR (not yet released) where the default player prefab's position and rotation would not be used when spawning.


## Changelog

- Added: A static `NetworkManager.OnInstantiated` event notification to be able to track when a new `NetworkManager` instance has been instantiated.
- Added: A static `NetworkManager.OnDestroying` event notification to be able to track when an existing `NetworkManager` instance is being destroyed.

## Testing and Documentation

- Includes integration test.
- Documentation additions to public site are necessary (_added to internal tracking_).

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
