### PR TITLE
fix: NetworkManager instantiate & destroy notifications and player spawn prefab offset (backport)

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,6 +10,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
+- Added a static `NetworkManager.OnInstantiated` event notification to be able to track when a new `NetworkManager` instance has been instantiated. (#3089)
+- Added a static `NetworkManager.OnDestroying` event notification to be able to track when an existing `NetworkManager` instance is being destroyed. (#3089)
 - Added message size validation to named and unnamed message sending functions for better error messages. (#3043)
 - Added "Check for NetworkObject Component" property to the Multiplayer->Netcode for GameObjects project settings. When disabled, this will bypass the in-editor `NetworkObject` check on `NetworkBehaviour` components. (#3034)
 

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -738,9 +738,8 @@ namespace Unity.Netcode
 
                 if (response.CreatePlayerObject && (response.PlayerPrefabHash.HasValue || NetworkManager.NetworkConfig.PlayerPrefab != null))
                 {
-                    var playerObject = response.PlayerPrefabHash.HasValue ? NetworkManager.SpawnManager.GetNetworkObjectToSpawn(response.PlayerPrefabHash.Value, ownerClientId, response.Position.GetValueOrDefault(), response.Rotation.GetValueOrDefault())
-                        : NetworkManager.SpawnManager.GetNetworkObjectToSpawn(NetworkManager.NetworkConfig.PlayerPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash, ownerClientId, response.Position.GetValueOrDefault(), response.Rotation.GetValueOrDefault());
-
+                    var playerObject = response.PlayerPrefabHash.HasValue ? NetworkManager.SpawnManager.GetNetworkObjectToSpawn(response.PlayerPrefabHash.Value, ownerClientId, response.Position ?? null, response.Rotation ?? null)
+                        : NetworkManager.SpawnManager.GetNetworkObjectToSpawn(NetworkManager.NetworkConfig.PlayerPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash, ownerClientId, response.Position ?? null, response.Rotation ?? null);
                     // Spawn the player NetworkObject locally
                     NetworkManager.SpawnManager.SpawnNetworkObjectLocally(
                         playerObject,

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -16,6 +16,16 @@ namespace Unity.Netcode
     [AddComponentMenu("Netcode/Network Manager", -100)]
     public class NetworkManager : MonoBehaviour, INetworkUpdateSystem
     {
+        /// <summary>
+        /// Subscribe to this static event to get notifications when a <see cref="NetworkManager"/> instance has been instantiated.
+        /// </summary>
+        public static event Action<NetworkManager> OnInstantiated;
+
+        /// <summary>
+        /// Subscribe to this static event to get notifications when a <see cref="NetworkManager"/> instance is being destroyed.
+        /// </summary>
+        public static event Action<NetworkManager> OnDestroying;
+
         // TODO: Deprecate...
         // The following internal values are not used, but because ILPP makes them public in the assembly, they cannot
         // be removed thanks to our semver validation.
@@ -715,6 +725,8 @@ namespace Unity.Netcode
 #if UNITY_EDITOR
             EditorApplication.playModeStateChanged += ModeChanged;
 #endif
+            // Notify we have instantiated a new instance of NetworkManager.
+            OnInstantiated?.Invoke(this);
         }
 
         private void OnEnable()
@@ -1273,6 +1285,9 @@ namespace Unity.Netcode
             ShutdownInternal();
 
             UnityEngine.SceneManagement.SceneManager.sceneUnloaded -= OnSceneUnloaded;
+
+            // Notify we are destroying NetworkManager
+            OnDestroying?.Invoke(this);
 
             if (Singleton == this)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -417,14 +417,14 @@ namespace Unity.Netcode
         /// Gets the right NetworkObject prefab instance to spawn. If a handler is registered or there is an override assigned to the 
         /// passed in globalObjectIdHash value, then that is what will be instantiated, spawned, and returned.
         /// </summary>
-        internal NetworkObject GetNetworkObjectToSpawn(uint globalObjectIdHash, ulong ownerId, Vector3 position = default, Quaternion rotation = default, bool isScenePlaced = false)
+        internal NetworkObject GetNetworkObjectToSpawn(uint globalObjectIdHash, ulong ownerId, Vector3? position, Quaternion? rotation, bool isScenePlaced = false)
         {
             NetworkObject networkObject = null;
             // If the prefab hash has a registered INetworkPrefabInstanceHandler derived class
             if (NetworkManager.PrefabHandler.ContainsHandler(globalObjectIdHash))
             {
                 // Let the handler spawn the NetworkObject
-                networkObject = NetworkManager.PrefabHandler.HandleNetworkPrefabSpawn(globalObjectIdHash, ownerId, position, rotation);
+                networkObject = NetworkManager.PrefabHandler.HandleNetworkPrefabSpawn(globalObjectIdHash, ownerId, position ?? default, rotation ?? default);
                 networkObject.NetworkManagerOwner = NetworkManager;
             }
             else
@@ -476,6 +476,8 @@ namespace Unity.Netcode
                 {
                     // Create prefab instance
                     networkObject = UnityEngine.Object.Instantiate(networkPrefabReference).GetComponent<NetworkObject>();
+                    networkObject.transform.position = position ?? networkObject.transform.position;
+                    networkObject.transform.rotation = rotation ?? networkObject.transform.rotation;
                     networkObject.NetworkManagerOwner = NetworkManager;
                     networkObject.PrefabGlobalObjectIdHash = globalObjectIdHash;
                 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/PlayerObjectTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/PlayerObjectTests.cs
@@ -79,7 +79,7 @@ namespace Unity.Netcode.RuntimeTests
         {
             yield return s_DefaultWaitForTick;
 
-            var playerObjects = m_ServerNetworkManager.SpawnManager.SpawnedObjectsList.Where((c)=> c.IsPlayerObject).ToList();
+            var playerObjects = m_ServerNetworkManager.SpawnManager.SpawnedObjectsList.Where((c) => c.IsPlayerObject).ToList();
 
             // Make sure clients did not spawn their player object on any of the clients including the owner.
             foreach (var client in m_ClientNetworkManagers)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/PlayerObjectTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/PlayerObjectTests.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Linq;
 using NUnit.Framework;
 using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
@@ -46,6 +47,114 @@ namespace Unity.Netcode.RuntimeTests
             yield return WaitForConditionOrTimeOut(() => m_ClientNetworkManagers[0].LocalClient.PlayerObject != playerLocalClient && !playerLocalClient.IsPlayerObject
             && m_ClientNetworkManagers[0].LocalClient.PlayerObject.IsPlayerObject);
             Assert.False(s_GlobalTimeoutHelper.TimedOut, "Timed out waiting for client-side player object to change!");
+        }
+    }
+
+    /// <summary>
+    /// Validate that when auto-player spawning but SpawnWithObservers is disabled,
+    /// the player instantiated is only spawned on the authority side.
+    /// </summary>
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    internal class PlayerSpawnNoObserversTest : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 2;
+
+        public PlayerSpawnNoObserversTest(HostOrServer hostOrServer) : base(hostOrServer) { }
+
+        protected override bool ShouldCheckForSpawnedPlayers()
+        {
+            return false;
+        }
+
+        protected override void OnCreatePlayerPrefab()
+        {
+            var playerNetworkObject = m_PlayerPrefab.GetComponent<NetworkObject>();
+            playerNetworkObject.SpawnWithObservers = false;
+            base.OnCreatePlayerPrefab();
+        }
+
+        [UnityTest]
+        public IEnumerator SpawnWithNoObservers()
+        {
+            yield return s_DefaultWaitForTick;
+
+            var playerObjects = m_ServerNetworkManager.SpawnManager.SpawnedObjectsList.Where((c)=> c.IsPlayerObject).ToList();
+
+            // Make sure clients did not spawn their player object on any of the clients including the owner.
+            foreach (var client in m_ClientNetworkManagers)
+            {
+                foreach (var playerObject in playerObjects)
+                {
+                    Assert.IsFalse(client.SpawnManager.SpawnedObjects.ContainsKey(playerObject.NetworkObjectId), $"Client-{client.LocalClientId} spawned player object for Client-{playerObject.NetworkObjectId}!");
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// This test validates the player position and rotation is correct
+    /// relative to the prefab's initial settings if no changes are applied.
+    /// </summary>
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    internal class PlayerSpawnPositionTests : IntegrationTestWithApproximation
+    {
+        protected override int NumberOfClients => 2;
+
+        public PlayerSpawnPositionTests(HostOrServer hostOrServer)
+        {
+            m_UseHost = hostOrServer == HostOrServer.Host;
+        }
+
+        private Vector3 m_PlayerPosition;
+        private Quaternion m_PlayerRotation;
+
+        protected override void OnCreatePlayerPrefab()
+        {
+            var playerNetworkObject = m_PlayerPrefab.GetComponent<NetworkObject>();
+            m_PlayerPosition = GetRandomVector3(-10.0f, 10.0f);
+            m_PlayerRotation = Quaternion.Euler(GetRandomVector3(-180.0f, 180.0f));
+            playerNetworkObject.transform.position = m_PlayerPosition;
+            playerNetworkObject.transform.rotation = m_PlayerRotation;
+            base.OnCreatePlayerPrefab();
+        }
+
+        private void PlayerTransformMatches(NetworkObject player)
+        {
+            var position = player.transform.position;
+            var rotation = player.transform.rotation;
+            Assert.True(Approximately(m_PlayerPosition, position), $"Client-{player.OwnerClientId} position {position} does not match the prefab position {m_PlayerPosition}!");
+            Assert.True(Approximately(m_PlayerRotation, rotation), $"Client-{player.OwnerClientId} rotation {rotation.eulerAngles} does not match the prefab rotation {m_PlayerRotation.eulerAngles}!");
+        }
+
+        [UnityTest]
+        public IEnumerator PlayerSpawnPosition()
+        {
+            if (m_ServerNetworkManager.IsHost)
+            {
+                PlayerTransformMatches(m_ServerNetworkManager.LocalClient.PlayerObject);
+
+                foreach (var client in m_ClientNetworkManagers)
+                {
+                    yield return WaitForConditionOrTimeOut(() => client.SpawnManager.SpawnedObjects.ContainsKey(m_ServerNetworkManager.LocalClient.PlayerObject.NetworkObjectId));
+                    AssertOnTimeout($"Client-{client.LocalClientId} does not contain a player prefab instance for client-{m_ServerNetworkManager.LocalClientId}!");
+                    PlayerTransformMatches(client.SpawnManager.SpawnedObjects[m_ServerNetworkManager.LocalClient.PlayerObject.NetworkObjectId]);
+                }
+            }
+
+            foreach (var client in m_ClientNetworkManagers)
+            {
+                yield return WaitForConditionOrTimeOut(() => m_ServerNetworkManager.SpawnManager.SpawnedObjects.ContainsKey(client.LocalClient.PlayerObject.NetworkObjectId));
+                AssertOnTimeout($"Client-{m_ServerNetworkManager.LocalClientId} does not contain a player prefab instance for client-{client.LocalClientId}!");
+                PlayerTransformMatches(m_ServerNetworkManager.SpawnManager.SpawnedObjects[client.LocalClient.PlayerObject.NetworkObjectId]);
+                foreach (var subClient in m_ClientNetworkManagers)
+                {
+                    yield return WaitForConditionOrTimeOut(() => subClient.SpawnManager.SpawnedObjects.ContainsKey(client.LocalClient.PlayerObject.NetworkObjectId));
+                    AssertOnTimeout($"Client-{subClient.LocalClientId} does not contain a player prefab instance for client-{client.LocalClientId}!");
+                    PlayerTransformMatches(subClient.SpawnManager.SpawnedObjects[client.LocalClient.PlayerObject.NetworkObjectId]);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Backport of #3088
- Provide instantiate and destroy notifications for `NetworkManager` 
  - [MTT-9170](https://jira.unity3d.com/browse/MTT-9170)
- Fixed an issue with a recently merged PR (not yet released) where the default player prefab's position and rotation would not be used when spawning.

## Changelog

- Added: A static `NetworkManager.OnInstantiated` event notification to be able to track when a new `NetworkManager` instance has been instantiated.
- Added: A static `NetworkManager.OnDestroying` event notification to be able to track when an existing `NetworkManager` instance is being destroyed.

## Testing and Documentation

- Includes integration test.
- Documentation additions to public site are necessary (_added to internal tracking_).

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
