### PR TITLE
fix: in-sceneobject NetworkObject update in editor tool (up-port)

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue with the in-scene network prefab instance update menu tool where it was not properly updating scenes when invoked on the root prefab instance. (#3092)
 - Fixed issue where applying the position and/or rotation to the `NetworkManager.ConnectionApprovalResponse` when connection approval and auto-spawn player prefab were enabled would not apply the position and/or rotation when the player prefab was instantiated. (#3078)
 - Fixed issue where `NetworkObject.SpawnWithObservers` was not being honored when spawning the player prefab. (#3077)
 - Fixed issue with the client count not being correct on the host or server side when a client disconnects itself from a session. (#3075)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -113,11 +113,6 @@ namespace Unity.Netcode
             }
 
             // Handle updating the currently active scene
-            var networkObjects = FindObjectsByType<NetworkObject>(FindObjectsInactive.Include, FindObjectsSortMode.None);
-            foreach (var networkObject in networkObjects)
-            {
-                networkObject.OnValidate();
-            }
             NetworkObjectRefreshTool.ProcessActiveScene();
 
             // Refresh all build settings scenes
@@ -130,14 +125,14 @@ namespace Unity.Netcode
                     continue;
                 }
                 // Add the scene to be processed
-                NetworkObjectRefreshTool.ProcessScene(editorScene.path, false);
+                NetworkObjectRefreshTool.ProcessScene(editorScene.path, true);
             }
 
             // Process all added scenes
             NetworkObjectRefreshTool.ProcessScenes();
         }
 
-        private void OnValidate()
+        internal void OnValidate()
         {
             // do NOT regenerate GlobalObjectIdHash for NetworkPrefabs while Editor is in PlayMode
             if (EditorApplication.isPlaying && !string.IsNullOrEmpty(gameObject.scene.name))
@@ -229,6 +224,7 @@ namespace Unity.Netcode
                 if (sourceAsset != null && sourceAsset.GlobalObjectIdHash != 0 && InScenePlacedSourceGlobalObjectIdHash != sourceAsset.GlobalObjectIdHash)
                 {
                     InScenePlacedSourceGlobalObjectIdHash = sourceAsset.GlobalObjectIdHash;
+                    EditorUtility.SetDirty(this);
                 }
                 IsSceneObject = true;
             }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObjectRefreshTool.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObjectRefreshTool.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -21,6 +23,28 @@ namespace Unity.Netcode
 
         internal static Action AllScenesProcessed;
 
+        internal static NetworkObject PrefabNetworkObject;
+
+        internal static void LogInfo(string msg, bool append = false)
+        {
+            if (!append)
+            {
+                s_Log.AppendLine(msg);
+            }
+            else
+            {
+                s_Log.Append(msg);
+            }
+        }
+
+        internal static void FlushLog()
+        {
+            Debug.Log(s_Log.ToString());
+            s_Log.Clear();
+        }
+
+        private static StringBuilder s_Log = new StringBuilder();
+
         internal static void ProcessScene(string scenePath, bool processScenes = true)
         {
             if (!s_ScenesToUpdate.Contains(scenePath))
@@ -29,7 +53,10 @@ namespace Unity.Netcode
                 {
                     EditorSceneManager.sceneOpened += EditorSceneManager_sceneOpened;
                     EditorSceneManager.sceneSaved += EditorSceneManager_sceneSaved;
+                    s_Log.Clear();
+                    LogInfo("NetworkObject Refresh Scenes to Process:");
                 }
+                LogInfo($"[{scenePath}]", true);
                 s_ScenesToUpdate.Add(scenePath);
             }
             s_ProcessScenes = processScenes;
@@ -37,6 +64,7 @@ namespace Unity.Netcode
 
         internal static void ProcessActiveScene()
         {
+            FlushLog();
             var activeScene = SceneManager.GetActiveScene();
             if (s_ScenesToUpdate.Contains(activeScene.path) && s_ProcessScenes)
             {
@@ -54,10 +82,12 @@ namespace Unity.Netcode
             }
             else
             {
+                s_ProcessScenes = false;
                 s_CloseScenes = false;
                 EditorSceneManager.sceneSaved -= EditorSceneManager_sceneSaved;
                 EditorSceneManager.sceneOpened -= EditorSceneManager_sceneOpened;
                 AllScenesProcessed?.Invoke();
+                FlushLog();
             }
         }
 
@@ -68,9 +98,8 @@ namespace Unity.Netcode
                 // Provide a log of all scenes that were modified to the user
                 if (refreshed)
                 {
-                    Debug.Log($"Refreshed and saved updates to scene: {scene.name}");
+                    LogInfo($"Refreshed and saved updates to scene: {scene.name}");
                 }
-                s_ProcessScenes = false;
                 s_ScenesToUpdate.Remove(scene.path);
 
                 if (scene != SceneManager.GetActiveScene())
@@ -88,24 +117,41 @@ namespace Unity.Netcode
 
         private static void SceneOpened(Scene scene)
         {
+            LogInfo($"Processing scene {scene.name}:");
             if (s_ScenesToUpdate.Contains(scene.path))
             {
                 if (s_ProcessScenes)
                 {
-                    if (!EditorSceneManager.MarkSceneDirty(scene))
+                    var prefabInstances = PrefabUtility.FindAllInstancesOfPrefab(PrefabNetworkObject.gameObject);
+
+                    if (prefabInstances.Length > 0)
                     {
-                        Debug.Log($"Scene {scene.name} did not get marked as dirty!");
-                        FinishedProcessingScene(scene);
-                    }
-                    else
-                    {
-                        EditorSceneManager.SaveScene(scene);
+                        var instancesSceneLoadedSpecific = prefabInstances.Where((c) => c.scene == scene).ToList();
+
+                        if (instancesSceneLoadedSpecific.Count > 0)
+                        {
+                            foreach (var prefabInstance in instancesSceneLoadedSpecific)
+                            {
+                                prefabInstance.GetComponent<NetworkObject>().OnValidate();
+                            }
+
+                            if (!EditorSceneManager.MarkSceneDirty(scene))
+                            {
+                                LogInfo($"Scene {scene.name} did not get marked as dirty!");
+                                FinishedProcessingScene(scene);
+                            }
+                            else
+                            {
+                                LogInfo($"Changes detected and applied!");
+                                EditorSceneManager.SaveScene(scene);
+                            }
+                            return;
+                        }
                     }
                 }
-                else
-                {
-                    FinishedProcessingScene(scene);
-                }
+
+                LogInfo($"No changes required.");
+                FinishedProcessingScene(scene);
             }
         }
 


### PR DESCRIPTION
Up-port of #3084
This resolves an issue with the in-scene network prefab instance update menu tool where it was not properly updating scenes when invoked on the root prefab instance.

[MTTB-485](https://jira.unity3d.com/browse/MTTB-485)

fix: #3067

## Changelog

- Fixed: Issue with the in-scene network prefab instance update menu tool where it was not properly updating scenes when invoked on the root prefab instance.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
