### PR TITLE
chore: updates to comb-server bypass and connection sequence configurations

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
@@ -48,6 +48,12 @@ namespace Unity.Netcode.Editor
         private SerializedProperty m_NetworkProfileMetrics;
         private SerializedProperty m_NetworkMessageMetrics;
 
+#if CMB_SERVICE_DEVELOPMENT
+        private SerializedProperty m_MajorVersion;
+        private SerializedProperty m_MinorVersion;
+        private SerializedProperty m_PatchVersion;
+#endif
+
         private NetworkManager m_NetworkManager;
         private bool m_Initialized;
 
@@ -120,8 +126,11 @@ namespace Unity.Netcode.Editor
 #if MULTIPLAYER_TOOLS
             m_NetworkMessageMetrics = m_NetworkConfigProperty.FindPropertyRelative("NetworkMessageMetrics");
 #endif
-
-
+#if CMB_SERVICE_DEVELOPMENT
+            m_MajorVersion = serializedObject.FindProperty(nameof(NetworkManager.MajorVersion));
+            m_MinorVersion = serializedObject.FindProperty(nameof(NetworkManager.MinorVersion));
+            m_PatchVersion = serializedObject.FindProperty(nameof(NetworkManager.PatchVersion));
+#endif
             m_RpcHashSizeProperty = m_NetworkConfigProperty.FindPropertyRelative("RpcHashSize");
             m_PrefabsList = m_NetworkConfigProperty
                 .FindPropertyRelative(nameof(NetworkConfig.Prefabs))
@@ -161,6 +170,11 @@ namespace Unity.Netcode.Editor
 #if MULTIPLAYER_TOOLS
             m_NetworkMessageMetrics = m_NetworkConfigProperty.FindPropertyRelative("NetworkMessageMetrics");
 #endif
+#if CMB_SERVICE_DEVELOPMENT
+            m_MajorVersion = serializedObject.FindProperty(nameof(NetworkManager.MajorVersion));
+            m_MinorVersion = serializedObject.FindProperty(nameof(NetworkManager.MinorVersion));
+            m_PatchVersion = serializedObject.FindProperty(nameof(NetworkManager.PatchVersion));
+#endif
 
             m_RpcHashSizeProperty = m_NetworkConfigProperty.FindPropertyRelative("RpcHashSize");
             m_PrefabsList = m_NetworkConfigProperty
@@ -173,10 +187,18 @@ namespace Unity.Netcode.Editor
             if (!m_NetworkManager.IsServer && !m_NetworkManager.IsClient)
             {
                 serializedObject.Update();
+
                 EditorGUILayout.PropertyField(m_RunInBackgroundProperty);
                 EditorGUILayout.PropertyField(m_LogLevelProperty);
-
                 EditorGUILayout.Space();
+
+#if CMB_SERVICE_DEVELOPMENT
+                EditorGUILayout.LabelField("Version:", EditorStyles.boldLabel);
+                EditorGUILayout.PropertyField(m_MajorVersion);
+                EditorGUILayout.PropertyField(m_MinorVersion);
+                EditorGUILayout.PropertyField(m_PatchVersion);
+                EditorGUILayout.Space();
+#endif
                 EditorGUILayout.LabelField("Network Settings", EditorStyles.boldLabel);
 #if MULTIPLAYER_SERVICES_SDK_INSTALLED
                 EditorGUILayout.PropertyField(m_NetworkTopologyProperty);

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
@@ -1492,14 +1492,6 @@ namespace Unity.Netcode.Components
 
             if (serializer.IsWriter)
             {
-                // DANGO-TODO: This magic value is sent to the server in order to identify the network transform.
-                // The server discards it before forwarding synchronization data to other clients.
-                if (NetworkManager.DistributedAuthorityMode && NetworkManager.CMBServiceConnection)
-                {
-                    var writer = serializer.GetFastBufferWriter();
-                    writer.WriteValueSafe(k_NetworkTransformStateMagic);
-                }
-
                 SynchronizeState.IsTeleportingNextFrame = true;
                 var transformToCommit = transform;
                 // If we are using Half Float Precision, then we want to only synchronize the authority's m_HalfPositionState.FullPosition in order for

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
@@ -1463,8 +1463,6 @@ namespace Unity.Netcode.Components
         // For test logging purposes
         internal NetworkTransformState SynchronizeState;
 
-        // DANGO-TODO: We will want to remove this when we migrate NetworkTransforms to a dedicated internal message
-        private const ushort k_NetworkTransformStateMagic = 0xf48d;
         #endregion
 
         #region ONSYNCHRONIZE

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -552,15 +552,19 @@ namespace Unity.Netcode
             var message = new ConnectionRequestMessage
             {
                 CMBServiceConnection = NetworkManager.CMBServiceConnection,
-                TickRate = NetworkManager.NetworkConfig.TickRate,
-                EnableSceneManagement = NetworkManager.NetworkConfig.EnableSceneManagement,
-
                 // Since only a remote client will send a connection request, we should always force the rebuilding of the NetworkConfig hash value
                 ConfigHash = NetworkManager.NetworkConfig.GetConfig(false),
                 ShouldSendConnectionData = NetworkManager.NetworkConfig.ConnectionApproval,
                 ConnectionData = NetworkManager.NetworkConfig.ConnectionData,
                 MessageVersions = new NativeArray<MessageVersionData>(MessageManager.MessageHandlers.Length, Allocator.Temp)
             };
+
+            if (NetworkManager.CMBServiceConnection)
+            {
+                message.ClientConfig.NGOVersion = NetworkManager.GetNGOVersion();
+                message.ClientConfig.TickRate = NetworkManager.NetworkConfig.TickRate;
+                message.ClientConfig.EnableSceneManagement = NetworkManager.NetworkConfig.EnableSceneManagement;
+            }
 
             for (int index = 0; index < MessageManager.MessageHandlers.Length; index++)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using UnityEngine;
 #if UNITY_EDITOR
 using UnityEditor;
+using PackageInfo = UnityEditor.PackageManager.PackageInfo;
 #endif
 using UnityEngine.SceneManagement;
 using Debug = UnityEngine.Debug;
@@ -874,6 +875,30 @@ namespace Unity.Netcode
 
         internal Override<ushort> PortOverride;
 
+
+        [HideInInspector]
+        [SerializeField]
+        [Range(0, 255)]
+        internal byte MajorVersion;
+        [HideInInspector]
+        [SerializeField]
+        [Range(0, 255)]
+        internal byte MinorVersion;
+        [HideInInspector]
+        [SerializeField]
+        [Range(0, 255)]
+        internal byte PatchVersion;
+
+        internal NGOVersion GetNGOVersion()
+        {
+            return new NGOVersion()
+            {
+                Major = MajorVersion,
+                Minor = MinorVersion,
+                Patch = PatchVersion
+            };
+        }
+
 #if UNITY_EDITOR
         internal static INetworkManagerHelper NetworkManagerHelper;
 
@@ -900,12 +925,40 @@ namespace Unity.Netcode
 
         }
 
+        private PackageInfo GetPackageInfo(string packageName)
+        {
+            return AssetDatabase.FindAssets("package").Select(AssetDatabase.GUIDToAssetPath).Where(x => AssetDatabase.LoadAssetAtPath<TextAsset>(x) != null).Select(PackageInfo.FindForAssetPath).Where(x => x != null).First(x => x.name == packageName);
+        }
+
+        private void SetPackageVersion()
+        {
+            var packageInfo = GetPackageInfo("com.unity.netcode.gameobjects");
+            if (packageInfo != null)
+            {
+                var versionSplit = packageInfo.version.Split(".");
+                if (versionSplit.Length == 3)
+                {
+                    MajorVersion = byte.Parse(versionSplit[0]);
+                    MinorVersion = byte.Parse(versionSplit[1]);
+                    PatchVersion = byte.Parse(versionSplit[2]);
+
+                    Debug.Log($"Major:({MajorVersion}) Minor({MinorVersion}) Patch({PatchVersion})");
+                }
+            }
+        }
+
         internal void OnValidate()
         {
             if (NetworkConfig == null)
             {
                 return; // May occur when the component is added
             }
+
+#if !CMB_SERVICE_DEVELOPMENT
+            SetPackageVersion();
+#else
+            Debug.Log($"Major:({MajorVersion}) Minor({MinorVersion}) Patch({PatchVersion})");
+#endif
 
             if (GetComponentInChildren<NetworkObject>() != null)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -941,8 +941,6 @@ namespace Unity.Netcode
                     MajorVersion = byte.Parse(versionSplit[0]);
                     MinorVersion = byte.Parse(versionSplit[1]);
                     PatchVersion = byte.Parse(versionSplit[2]);
-
-                    Debug.Log($"Major:({MajorVersion}) Minor({MinorVersion}) Patch({PatchVersion})");
                 }
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
@@ -5,18 +5,22 @@ namespace Unity.Netcode
 {
     internal struct ServiceConfig : INetworkSerializable
     {
+        public uint Version;
         public bool IsRestoredSession;
         public ulong CurrentSessionOwner;
 
         public void NetworkSerialize<T>(BufferSerializer<T> serializer) where T : IReaderWriter
         {
-            serializer.SerializeValue(ref IsRestoredSession);
             if (serializer.IsWriter)
             {
+                BytePacker.WriteValueBitPacked(serializer.GetFastBufferWriter(), Version);
+                serializer.SerializeValue(ref IsRestoredSession);
                 BytePacker.WriteValueBitPacked(serializer.GetFastBufferWriter(), CurrentSessionOwner);
             }
             else
             {
+                ByteUnpacker.ReadValueBitPacked(serializer.GetFastBufferReader(), out Version);
+                serializer.SerializeValue(ref IsRestoredSession);
                 ByteUnpacker.ReadValueBitPacked(serializer.GetFastBufferReader(), out CurrentSessionOwner);
             }
         }


### PR DESCRIPTION
This PR includes the more recent updates to the distributed authority service where:

- `NetworkManager` now has its package version serialized and set within it.
- `ConnectionRequestMessage` now serializes the `ClientConfig` when sending a connection request to the distributed authority service.
- `ConnectionApprovedMessage` now serializes the `ServiceConfig` when receiving the connection approved message/
- `NetworkTransform` no longer serializes the magic value during synchronization.

[MTT-9207](https://jira.unity3d.com/browse/MTT-9207)


## Changelog

NA

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.


<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
