### PR TITLE
fix: provide non Rigidbody contact events and Rigidbody prioritization

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,9 +10,9 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
     
-- Added `IContactEventHandlerWithInfo` that derives from `IContactEventHandler` that can be updated per frame to provide `ContactEventHandlerInfo` information to the `RigidbodyContactEventManager` when processing collisions.
-  - `ContactEventHandlerInfo.ProvideNonRigidBodyContactEvents`: When set to true, non-`Rigidbody` collisions with the registered `Rigidbody` will generate contact event notifications.
-  - `ContactEventHandlerInfo.HasContactEventPriority`: When set to true, the `Rigidbody` will be prioritized as the instance that generates the event if the `Rigidbody` colliding does not have priority.
+- Added `IContactEventHandlerWithInfo` that derives from `IContactEventHandler` that can be updated per frame to provide `ContactEventHandlerInfo` information to the `RigidbodyContactEventManager` when processing collisions. (#3094)
+  - `ContactEventHandlerInfo.ProvideNonRigidBodyContactEvents`: When set to true, non-`Rigidbody` collisions with the registered `Rigidbody` will generate contact event notifications. (#3094)
+  - `ContactEventHandlerInfo.HasContactEventPriority`: When set to true, the `Rigidbody` will be prioritized as the instance that generates the event if the `Rigidbody` colliding does not have priority. (#3094)
 - Added a static `NetworkManager.OnInstantiated` event notification to be able to track when a new `NetworkManager` instance has been instantiated. (#3088)
 - Added a static `NetworkManager.OnDestroying` event notification to be able to track when an existing `NetworkManager` instance is being destroyed. (#3088)
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -9,7 +9,10 @@ Additional documentation and release notes are available at [Multiplayer Documen
 [Unreleased]
 
 ### Added
-
+    
+- Added `IContactEventHandlerWithInfo` that derives from `IContactEventHandler` that can be updated per frame to provide `ContactEventHandlerInfo` information to the `RigidbodyContactEventManager` when processing collisions.
+  - `ContactEventHandlerInfo.ProvideNonRigidBodyContactEvents`: When set to true, non-`Rigidbody` collisions with the registered `Rigidbody` will generate contact event notifications.
+  - `ContactEventHandlerInfo.HasContactEventPriority`: When set to true, the `Rigidbody` will be prioritized as the instance that generates the event if the `Rigidbody` colliding does not have priority.
 - Added a static `NetworkManager.OnInstantiated` event notification to be able to track when a new `NetworkManager` instance has been instantiated. (#3088)
 - Added a static `NetworkManager.OnDestroying` event notification to be able to track when an existing `NetworkManager` instance is being destroyed. (#3088)
 

--- a/com.unity.netcode.gameobjects/Runtime/Components/RigidbodyContactEventManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/RigidbodyContactEventManager.cs
@@ -179,6 +179,12 @@ namespace Unity.Netcode.Components
                 {
                     m_HandlerInfo[contactEventHandler.Key] = handlerWithInfo.GetContactEventHandlerInfo();
                 }
+                else
+                {
+                    var info = m_HandlerInfo[contactEventHandler.Key];
+                    info.HasContactEventPriority = !m_RigidbodyMapping[contactEventHandler.Key].isKinematic;
+                    m_HandlerInfo[contactEventHandler.Key] = info;
+                }
             }
 
             ContactEventHandlerInfo contactEventHandlerInfo0;
@@ -235,17 +241,14 @@ namespace Unity.Netcode.Components
                     }
                 }
 
-                if (preferredContactHandler == null)
+                if (preferredContactHandler == null && otherContactHandler != null)
                 {
-                    if (otherContactHandler != null)
-                    {
-                        preferredContactHandler = otherContactHandler;
-                        preferredContactHandlerNonRigidbody = otherContactHandlerNonRigidbody;
-                        preferredRigidbody = otherRigidbody;
-                        otherContactHandler = null;
-                        otherContactHandlerNonRigidbody = false;
-                        otherRigidbody = null;
-                    }
+                    preferredContactHandler = otherContactHandler;
+                    preferredContactHandlerNonRigidbody = otherContactHandlerNonRigidbody;
+                    preferredRigidbody = otherRigidbody;
+                    otherContactHandler = null;
+                    otherContactHandlerNonRigidbody = false;
+                    otherRigidbody = null;
                 }
 
                 if (preferredContactHandler == null || (preferredContactHandler != null && otherContactHandler == null && !preferredContactHandlerNonRigidbody))


### PR DESCRIPTION
This extends the `RigidbodyContactEventManager` by adding a new interface that provides `ContactEventHandlerInfo`:
- `ContactEventHandlerInfo.ProvideNonRigidBodyContactEvents`: When set to true, non-`Rigidbody` collisions with the registered `Rigidbody` will generate contact event notifications.
  - If you want a registered `Rigidbody` to generate contact event notifications when colliding with non-registered objects that just have colliders (i.e. terrain, static world objects, etc.) , then setting this to true will generate contact events.

- `ContactEventHandlerInfo.HasContactEventPriority`: When set to true, the `Rigidbody` will be prioritized as the instance that generates the event if the `Rigidbody` colliding does not have priority.
  - If this value is tied to ownership and a non-kinematic body collides with a kinematic body and the sequence of the collision places the kinematic body first in the contact event processing, then the non-kinematic body will be considered "preferred" when triggering the contact event notification.

The `ContactEventHandlerInfo` is queried each time there are contact events to be processed.

This addition does not impact any previous configurations/uses of `RigidbodyContactEventManager`.

[MTT-9182](https://jira.unity3d.com/browse/MTT-9182)

## Changelog

- Added `IContactEventHandlerWithInfo` that derives from `IContactEventHandler` that can be updated per frame to provide `ContactEventHandlerInfo` information to the `RigidbodyContactEventManager` when processing collisions.
  - `ContactEventHandlerInfo.ProvideNonRigidBodyContactEvents`: When set to true, non-`Rigidbody` collisions with the registered `Rigidbody` will generate contact event notifications.
  - `ContactEventHandlerInfo.HasContactEventPriority`: When set to true, the `Rigidbody` will be prioritized as the instance that generates the event if the `Rigidbody` colliding does not have priority.
 

## Testing and Documentation

- Includes integration tests (wip).
- Requires public documentation update (part of Rigidbody pass).
- Includes XML API Documentation additions and updates.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
