### PR TITLE
fix: minor fixes for 2.1.0

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -9,7 +9,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 [Unreleased]
 
 ### Added
-    
+
+- Added ability to edit the `NetworkConfig.AutoSpawnPlayerPrefabClientSide` within the inspector view. (#3097)
 - Added `IContactEventHandlerWithInfo` that derives from `IContactEventHandler` that can be updated per frame to provide `ContactEventHandlerInfo` information to the `RigidbodyContactEventManager` when processing collisions. (#3094)
   - `ContactEventHandlerInfo.ProvideNonRigidBodyContactEvents`: When set to true, non-`Rigidbody` collisions with the registered `Rigidbody` will generate contact event notifications. (#3094)
   - `ContactEventHandlerInfo.HasContactEventPriority`: When set to true, the `Rigidbody` will be prioritized as the instance that generates the event if the `Rigidbody` colliding does not have priority. (#3094)
@@ -24,6 +25,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed issue with the client count not being correct on the host or server side when a client disconnects itself from a session. (#3075)
 
 ### Changed
+
+- Changed `NetworkConfig.AutoSpawnPlayerPrefabClientSide` is no longer automatically set when starting `NetworkManager`. (#3097)
 
 ## [2.0.0] - 2024-09-12
 

--- a/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
@@ -31,6 +31,7 @@ namespace Unity.Netcode.Editor
         private SerializedProperty m_NetworkTransportProperty;
         private SerializedProperty m_TickRateProperty;
 #if MULTIPLAYER_SERVICES_SDK_INSTALLED
+        private SerializedProperty m_AutoSpawnPlayerPrefabClientSide;
         private SerializedProperty m_NetworkTopologyProperty;
 #endif
         private SerializedProperty m_ClientConnectionBufferTimeoutProperty;
@@ -110,6 +111,7 @@ namespace Unity.Netcode.Editor
             m_TickRateProperty = m_NetworkConfigProperty.FindPropertyRelative("TickRate");
 #if MULTIPLAYER_SERVICES_SDK_INSTALLED
             m_NetworkTopologyProperty = m_NetworkConfigProperty.FindPropertyRelative("NetworkTopology");
+            m_AutoSpawnPlayerPrefabClientSide = m_NetworkConfigProperty.FindPropertyRelative("AutoSpawnPlayerPrefabClientSide");
 #endif
             m_ClientConnectionBufferTimeoutProperty = m_NetworkConfigProperty.FindPropertyRelative("ClientConnectionBufferTimeout");
             m_ConnectionApprovalProperty = m_NetworkConfigProperty.FindPropertyRelative("ConnectionApproval");
@@ -153,6 +155,7 @@ namespace Unity.Netcode.Editor
             m_TickRateProperty = m_NetworkConfigProperty.FindPropertyRelative("TickRate");
 #if MULTIPLAYER_SERVICES_SDK_INSTALLED
             m_NetworkTopologyProperty = m_NetworkConfigProperty.FindPropertyRelative("NetworkTopology");
+            m_AutoSpawnPlayerPrefabClientSide = m_NetworkConfigProperty.FindPropertyRelative("AutoSpawnPlayerPrefabClientSide");
 #endif
             m_ClientConnectionBufferTimeoutProperty = m_NetworkConfigProperty.FindPropertyRelative("ClientConnectionBufferTimeout");
             m_ConnectionApprovalProperty = m_NetworkConfigProperty.FindPropertyRelative("ConnectionApproval");
@@ -245,6 +248,10 @@ namespace Unity.Netcode.Editor
                 EditorGUILayout.LabelField("Prefab Settings", EditorStyles.boldLabel);
                 EditorGUILayout.PropertyField(m_ForceSamePrefabsProperty);
                 EditorGUILayout.PropertyField(m_PlayerPrefabProperty, new GUIContent("Default Player Prefab"));
+#if MULTIPLAYER_SERVICES_SDK_INSTALLED
+                EditorGUILayout.PropertyField(m_AutoSpawnPlayerPrefabClientSide, new GUIContent("Auto Spawn Player Prefab"));
+#endif
+
 
                 if (m_NetworkManager.NetworkConfig.HasOldPrefabList())
                 {

--- a/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
@@ -111,7 +111,11 @@ namespace Unity.Netcode.Editor
             m_TickRateProperty = m_NetworkConfigProperty.FindPropertyRelative("TickRate");
 #if MULTIPLAYER_SERVICES_SDK_INSTALLED
             m_NetworkTopologyProperty = m_NetworkConfigProperty.FindPropertyRelative("NetworkTopology");
-            m_AutoSpawnPlayerPrefabClientSide = m_NetworkConfigProperty.FindPropertyRelative("AutoSpawnPlayerPrefabClientSide");
+            // Only display the auto spawn property when the distributed authority network topology is selected
+            if (m_NetworkManager.NetworkConfig.NetworkTopology == NetworkTopologyTypes.DistributedAuthority)
+            {
+                m_AutoSpawnPlayerPrefabClientSide = m_NetworkConfigProperty.FindPropertyRelative("AutoSpawnPlayerPrefabClientSide");
+            }
 #endif
             m_ClientConnectionBufferTimeoutProperty = m_NetworkConfigProperty.FindPropertyRelative("ClientConnectionBufferTimeout");
             m_ConnectionApprovalProperty = m_NetworkConfigProperty.FindPropertyRelative("ConnectionApproval");
@@ -155,7 +159,11 @@ namespace Unity.Netcode.Editor
             m_TickRateProperty = m_NetworkConfigProperty.FindPropertyRelative("TickRate");
 #if MULTIPLAYER_SERVICES_SDK_INSTALLED
             m_NetworkTopologyProperty = m_NetworkConfigProperty.FindPropertyRelative("NetworkTopology");
-            m_AutoSpawnPlayerPrefabClientSide = m_NetworkConfigProperty.FindPropertyRelative("AutoSpawnPlayerPrefabClientSide");
+            // Only display the auto spawn property when the distributed authority network topology is selected
+            if (m_NetworkManager.NetworkConfig.NetworkTopology == NetworkTopologyTypes.DistributedAuthority)
+            {
+                m_AutoSpawnPlayerPrefabClientSide = m_NetworkConfigProperty.FindPropertyRelative("AutoSpawnPlayerPrefabClientSide");
+            }
 #endif
             m_ClientConnectionBufferTimeoutProperty = m_NetworkConfigProperty.FindPropertyRelative("ClientConnectionBufferTimeout");
             m_ConnectionApprovalProperty = m_NetworkConfigProperty.FindPropertyRelative("ConnectionApproval");
@@ -248,7 +256,11 @@ namespace Unity.Netcode.Editor
                 EditorGUILayout.LabelField("Prefab Settings", EditorStyles.boldLabel);
                 EditorGUILayout.PropertyField(m_ForceSamePrefabsProperty);
 #if MULTIPLAYER_SERVICES_SDK_INSTALLED
-                EditorGUILayout.PropertyField(m_AutoSpawnPlayerPrefabClientSide, new GUIContent("Auto Spawn Player Prefab"));
+                // Only display the auto spawn property when the distributed authority network topology is selected
+                if (m_NetworkManager.NetworkConfig.NetworkTopology == NetworkTopologyTypes.DistributedAuthority)
+                {
+                    EditorGUILayout.PropertyField(m_AutoSpawnPlayerPrefabClientSide, new GUIContent("Auto Spawn Player Prefab"));
+                }                
 #endif
                 EditorGUILayout.PropertyField(m_PlayerPrefabProperty, new GUIContent("Default Player Prefab"));
 

--- a/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
@@ -247,10 +247,11 @@ namespace Unity.Netcode.Editor
                 EditorGUILayout.Space();
                 EditorGUILayout.LabelField("Prefab Settings", EditorStyles.boldLabel);
                 EditorGUILayout.PropertyField(m_ForceSamePrefabsProperty);
-                EditorGUILayout.PropertyField(m_PlayerPrefabProperty, new GUIContent("Default Player Prefab"));
 #if MULTIPLAYER_SERVICES_SDK_INSTALLED
                 EditorGUILayout.PropertyField(m_AutoSpawnPlayerPrefabClientSide, new GUIContent("Auto Spawn Player Prefab"));
 #endif
+                EditorGUILayout.PropertyField(m_PlayerPrefabProperty, new GUIContent("Default Player Prefab"));
+
 
 
                 if (m_NetworkManager.NetworkConfig.HasOldPrefabList())

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1205,9 +1205,6 @@ namespace Unity.Netcode
 
             UpdateTopology();
 
-            //DANGOEXP TODO: Remove this before finalizing the experimental release
-            NetworkConfig.AutoSpawnPlayerPrefabClientSide = DistributedAuthorityMode;
-
             // Make sure the ServerShutdownState is reset when initializing
             if (server)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -336,7 +336,7 @@ namespace Unity.Netcode
 
             if (!HasAuthority)
             {
-                NetworkLog.LogError($"Only the authoirty can invoke {nameof(DeferDespawn)} and local Client-{NetworkManager.LocalClientId} is not the authority of {name}!");
+                NetworkLog.LogError($"Only the authority can invoke {nameof(DeferDespawn)} and local Client-{NetworkManager.LocalClientId} is not the authority of {name}!");
                 return;
             }
 


### PR DESCRIPTION
This PR contains minor quality of life changes for the NGO v2.1.0 release.



## Changelog

- Added: Ability to edit the `NetworkConfig.AutoSpawnPlayerPrefabClientSide` within the inspector view.
- Changed: `NetworkConfig.AutoSpawnPlayerPrefabClientSide` is no longer automatically set when starting `NetworkManager`.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
