### PR TITLE
chore: adjust ConnectionRequestMessage to use ClientConfig version as opposed to NGO version

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
@@ -48,12 +48,6 @@ namespace Unity.Netcode.Editor
         private SerializedProperty m_NetworkProfileMetrics;
         private SerializedProperty m_NetworkMessageMetrics;
 
-#if CMB_SERVICE_DEVELOPMENT
-        private SerializedProperty m_MajorVersion;
-        private SerializedProperty m_MinorVersion;
-        private SerializedProperty m_PatchVersion;
-#endif
-
         private NetworkManager m_NetworkManager;
         private bool m_Initialized;
 
@@ -126,11 +120,6 @@ namespace Unity.Netcode.Editor
 #if MULTIPLAYER_TOOLS
             m_NetworkMessageMetrics = m_NetworkConfigProperty.FindPropertyRelative("NetworkMessageMetrics");
 #endif
-#if CMB_SERVICE_DEVELOPMENT
-            m_MajorVersion = serializedObject.FindProperty(nameof(NetworkManager.MajorVersion));
-            m_MinorVersion = serializedObject.FindProperty(nameof(NetworkManager.MinorVersion));
-            m_PatchVersion = serializedObject.FindProperty(nameof(NetworkManager.PatchVersion));
-#endif
             m_RpcHashSizeProperty = m_NetworkConfigProperty.FindPropertyRelative("RpcHashSize");
             m_PrefabsList = m_NetworkConfigProperty
                 .FindPropertyRelative(nameof(NetworkConfig.Prefabs))
@@ -170,11 +159,6 @@ namespace Unity.Netcode.Editor
 #if MULTIPLAYER_TOOLS
             m_NetworkMessageMetrics = m_NetworkConfigProperty.FindPropertyRelative("NetworkMessageMetrics");
 #endif
-#if CMB_SERVICE_DEVELOPMENT
-            m_MajorVersion = serializedObject.FindProperty(nameof(NetworkManager.MajorVersion));
-            m_MinorVersion = serializedObject.FindProperty(nameof(NetworkManager.MinorVersion));
-            m_PatchVersion = serializedObject.FindProperty(nameof(NetworkManager.PatchVersion));
-#endif
 
             m_RpcHashSizeProperty = m_NetworkConfigProperty.FindPropertyRelative("RpcHashSize");
             m_PrefabsList = m_NetworkConfigProperty
@@ -192,13 +176,6 @@ namespace Unity.Netcode.Editor
                 EditorGUILayout.PropertyField(m_LogLevelProperty);
                 EditorGUILayout.Space();
 
-#if CMB_SERVICE_DEVELOPMENT
-                EditorGUILayout.LabelField("Version:", EditorStyles.boldLabel);
-                EditorGUILayout.PropertyField(m_MajorVersion);
-                EditorGUILayout.PropertyField(m_MinorVersion);
-                EditorGUILayout.PropertyField(m_PatchVersion);
-                EditorGUILayout.Space();
-#endif
                 EditorGUILayout.LabelField("Network Settings", EditorStyles.boldLabel);
 #if MULTIPLAYER_SERVICES_SDK_INSTALLED
                 EditorGUILayout.PropertyField(m_NetworkTopologyProperty);

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -573,7 +573,6 @@ namespace Unity.Netcode
 
             if (NetworkManager.CMBServiceConnection)
             {
-                message.ClientConfig.NGOVersion = NetworkManager.GetNGOVersion();
                 message.ClientConfig.TickRate = NetworkManager.NetworkConfig.TickRate;
                 message.ClientConfig.EnableSceneManagement = NetworkManager.NetworkConfig.EnableSceneManagement;
             }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -887,29 +887,6 @@ namespace Unity.Netcode
         internal Override<ushort> PortOverride;
 
 
-        [HideInInspector]
-        [SerializeField]
-        [Range(0, 255)]
-        internal byte MajorVersion;
-        [HideInInspector]
-        [SerializeField]
-        [Range(0, 255)]
-        internal byte MinorVersion;
-        [HideInInspector]
-        [SerializeField]
-        [Range(0, 255)]
-        internal byte PatchVersion;
-
-        internal NGOVersion GetNGOVersion()
-        {
-            return new NGOVersion()
-            {
-                Major = MajorVersion,
-                Minor = MinorVersion,
-                Patch = PatchVersion
-            };
-        }
-
 #if UNITY_EDITOR
         internal static INetworkManagerHelper NetworkManagerHelper;
 
@@ -941,33 +918,12 @@ namespace Unity.Netcode
             return AssetDatabase.FindAssets("package").Select(AssetDatabase.GUIDToAssetPath).Where(x => AssetDatabase.LoadAssetAtPath<TextAsset>(x) != null).Select(PackageInfo.FindForAssetPath).Where(x => x != null).First(x => x.name == packageName);
         }
 
-        private void SetPackageVersion()
-        {
-            var packageInfo = GetPackageInfo("com.unity.netcode.gameobjects");
-            if (packageInfo != null)
-            {
-                var versionSplit = packageInfo.version.Split(".");
-                if (versionSplit.Length == 3)
-                {
-                    MajorVersion = byte.Parse(versionSplit[0]);
-                    MinorVersion = byte.Parse(versionSplit[1]);
-                    PatchVersion = byte.Parse(versionSplit[2]);
-                }
-            }
-        }
-
         internal void OnValidate()
         {
             if (NetworkConfig == null)
             {
                 return; // May occur when the component is added
             }
-
-#if !CMB_SERVICE_DEVELOPMENT
-            SetPackageVersion();
-#else
-            Debug.Log($"Major:({MajorVersion}) Minor({MinorVersion}) Patch({PatchVersion})");
-#endif
 
             if (GetComponentInChildren<NetworkObject>() != null)
             {


### PR DESCRIPTION
This PR removes the NGO version number in favor of an incremental version number within the `ClientConfig`.

[MTT-9207](https://jira.unity3d.com/browse/MTT-9207)

## Changelog
NA

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
