### PR TITLE
fix: client-server owner authoritative nested NetworkTransform invalid synchronization

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -18,7 +18,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue with child `NetworkTransform` components clearing their initial prefab settings when in owner authoritative mode which resulted in improper synchronization.
+- Fixed issue with nested `NetworkTransform` components clearing their initial prefab settings when in owner authoritative mode on the server side while using a client-server network topology which resulted in improper synchronization of the nested `NetworkTransform` components. (#3099)
 - Fixed issue with service not getting synchronized with in-scene placed `NetworkObject` instances when a session owner starts a `SceneEventType.Load` event. (#3096)
 - Fixed issue with the in-scene network prefab instance update menu tool where it was not properly updating scenes when invoked on the root prefab instance. (#3092)
 - Fixed issue where applying the position and/or rotation to the `NetworkManager.ConnectionApprovalResponse` when connection approval and auto-spawn player prefab were enabled would not apply the position and/or rotation when the player prefab was instantiated. (#3078)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -18,6 +18,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue with child `NetworkTransform` components clearing their initial prefab settings when in owner authoritative mode which resulted in improper synchronization.
 - Fixed issue with service not getting synchronized with in-scene placed `NetworkObject` instances when a session owner starts a `SceneEventType.Load` event. (#3096)
 - Fixed issue with the in-scene network prefab instance update menu tool where it was not properly updating scenes when invoked on the root prefab instance. (#3092)
 - Fixed issue where applying the position and/or rotation to the `NetworkManager.ConnectionApprovalResponse` when connection approval and auto-spawn player prefab were enabled would not apply the position and/or rotation when the player prefab was instantiated. (#3078)

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
@@ -3065,18 +3065,17 @@ namespace Unity.Netcode.Components
         /// </summary>
         protected internal override void InternalOnNetworkPostSpawn()
         {
-            // This is a special case for client-server where a server is spawning a player but has yet to serialize anything.
+            // This is a special case for client-server where a server is spawning an owner authoritative NetworkObject but has yet to serialize anything.
             // When the server detects that:
             // - We are not in a distributed authority session (DAHost check).
             // - This is the first/root NetworkTransform.
-            // - The NetworkObject is a player object (i.e. server-side instantiated).
-            // - The player object is not the local player object (i.e. spawning a player for another client).
             // - We are in owner authoritative mode.
-            // - SynchronizeState is set to false.
+            // - The NetworkObject is not owned by the server.
+            // - The SynchronizeState.IsSynchronizing is set to false.
             // Then we want to:
             // - Force the "IsSynchronizing" flag so the NetworkTransform has its state updated properly and runs through the initialization again.
             // - Make sure the SynchronizingState is updated to the instantiated prefab's default flags/settings.
-            if (NetworkManager.IsServer && !NetworkManager.DistributedAuthorityMode && m_IsFirstNetworkTransform && NetworkObject.IsPlayerObject && !NetworkObject.IsLocalPlayer && !OnIsServerAuthoritative() && !SynchronizeState.IsSynchronizing)
+            if (NetworkManager.IsServer && !NetworkManager.DistributedAuthorityMode && m_IsFirstNetworkTransform && !OnIsServerAuthoritative() && !IsOwner && !SynchronizeState.IsSynchronizing)
             {
                 // Assure the first/root NetworkTransform has the synchronizing flag set so the server runs through the final post initialization steps
                 SynchronizeState.IsSynchronizing = true;

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
@@ -1487,7 +1487,6 @@ namespace Unity.Netcode.Components
                 HalfVectorRotation = new HalfVector4(),
                 HalfVectorScale = new HalfVector3(),
                 NetworkDeltaPosition = new NetworkDeltaPosition(),
-
             };
 
             if (serializer.IsWriter)
@@ -3050,12 +3049,45 @@ namespace Unity.Netcode.Components
             base.InternalOnNetworkSessionSynchronized();
         }
 
+        private void ApplyPlayerTransformState()
+        {
+            SynchronizeState.InLocalSpace = InLocalSpace;
+            SynchronizeState.UseInterpolation = Interpolate;
+            SynchronizeState.QuaternionSync = UseQuaternionSynchronization;
+            SynchronizeState.UseHalfFloatPrecision = UseHalfFloatPrecision;
+            SynchronizeState.QuaternionCompression = UseQuaternionCompression;
+            SynchronizeState.UsePositionSlerp = SlerpPosition;
+        }
+
         /// <summary>
         /// For dynamically spawned NetworkObjects, when the non-authority instance's client is already connected and
         /// the SynchronizeState is still pending synchronization then we want to finalize the synchornization at this time.
         /// </summary>
         protected internal override void InternalOnNetworkPostSpawn()
         {
+            // This is a special case for client-server where a server is spawning a player but has yet to serialize anything.
+            // When the server detects that:
+            // - We are not in a distributed authority session (DAHost check).
+            // - This is the first/root NetworkTransform.
+            // - The NetworkObject is a player object (i.e. server-side instantiated).
+            // - The player object is not the local player object (i.e. spawning a player for another client).
+            // - We are in owner authoritative mode.
+            // - SynchronizeState is set to false.
+            // Then we want to:
+            // - Force the "IsSynchronizing" flag so the NetworkTransform has its state updated properly and runs through the initialization again.
+            // - Make sure the SynchronizingState is updated to the instantiated prefab's default flags/settings.
+            if (NetworkManager.IsServer && !NetworkManager.DistributedAuthorityMode && m_IsFirstNetworkTransform && NetworkObject.IsPlayerObject && !NetworkObject.IsLocalPlayer && !OnIsServerAuthoritative() && !SynchronizeState.IsSynchronizing)
+            {
+                // Assure the first/root NetworkTransform has the synchronizing flag set so the server runs through the final post initialization steps
+                SynchronizeState.IsSynchronizing = true;
+                // Assure the SynchronizeState matches the initial prefab's values for each associated NetworkTransfrom (this includes root + all children)
+                foreach (var child in NetworkObject.NetworkTransforms)
+                {
+                    child.ApplyPlayerTransformState();
+                }
+                // Now fall through to the final synchronization portion of the spawning for NetworkTransform
+            }
+
             if (!CanCommitToTransform && NetworkManager.IsConnectedClient && SynchronizeState.IsSynchronizing)
             {
                 NonAuthorityFinalizeSynchronization();


### PR DESCRIPTION
This is a special case for client-server where a server is spawning an owner authoritative `NetworkObject` but has yet to serialize anything. When the server detects that:
  - We are not in a distributed authority session (DAHost check).
  - This is the first/root `NetworkTransform`.
  - The root `NetworkTransform` is owner authoritative.
  - The `NetworkObject` is not owned by the server.
  - The `SynchronizeState.IsSynchronizing` is set to false.
Then the server would skip the final initialization step which resulted in the loss of the initial `SynchronizeState` settings.

This PR checks for the above conditions during the initial spawning of a `NetworkObject` and then: 
  - Makes sure the `SynchronizingState` is updated to the instantiated prefab's default flags/settings.
  - Forces the `SynchronizingState.IsSynchronizing` flag so the `NetworkTransform` runs through the final initialization steps.

[MTTB-483](https://jira.unity3d.com/browse/MTTB-483)

fix: #3082 

## Changelog

- Fixed: Issue with nested `NetworkTransform` components clearing their initial prefab settings when in owner authoritative mode on the server side while using a client-server network topology which resulted in improper synchronization of the nested `NetworkTransform` components.

## Testing and Documentation

- Includes integration test updates.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
