### PR TITLE
fix(editor): NetworkPrefabProcessor not marking prefab list dirty

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/Configuration/NetworkPrefabProcessor.cs
+++ b/com.unity.netcode.gameobjects/Editor/Configuration/NetworkPrefabProcessor.cs
@@ -132,7 +132,7 @@ namespace Unity.Netcode.Editor.Configuration
 
             // Process the imported and deleted assets
             var markDirty = ProcessImportedAssets(importedAssets);
-            markDirty &= ProcessDeletedAssets(deletedAssets);
+            markDirty |= ProcessDeletedAssets(deletedAssets);
 
             if (markDirty)
             {


### PR DESCRIPTION
`NetworkPrefabProcessor` now marks the default `NetworkPrefabsList` `ScriptableObject` asset as dirty if there are new imports **OR** deletions.

The Unity Editor is now aware of the changes and able to write them to disk. This prevents the changes from being lost when the editor is quit and allows them to be tracked in version control.

Previously the script would only mark the list as dirty if there had been both new imports and deletions.

## Changelog

 - Fixed: Issue where `NetworkPrefabProcessor` would not mark the prefab list as dirty and prevent saving the `DefaultNetworkPrefabs` asset when only imports or only deletes were detected.

## Testing and Documentation

 - No tests have been added.
 - No documentation changes or additions were necessary