### PR TITLE
fix: prefab processor dirty up port (up port)

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -19,7 +19,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where `NetworkPrefabProcessor` would not mark the prefab list as dirty and prevent saving the `DefaultNetworkPrefabs` asset when only imports or only deletes were detected.
+- Fixed issue where `NetworkPrefabProcessor` would not mark the prefab list as dirty and prevent saving the `DefaultNetworkPrefabs` asset when only imports or only deletes were detected.(#3103)
 - Fixed issue with nested `NetworkTransform` components clearing their initial prefab settings when in owner authoritative mode on the server side while using a client-server network topology which resulted in improper synchronization of the nested `NetworkTransform` components. (#3099)
 - Fixed issue with service not getting synchronized with in-scene placed `NetworkObject` instances when a session owner starts a `SceneEventType.Load` event. (#3096)
 - Fixed issue with the in-scene network prefab instance update menu tool where it was not properly updating scenes when invoked on the root prefab instance. (#3092)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -19,6 +19,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where `NetworkPrefabProcessor` would not mark the prefab list as dirty and prevent saving the `DefaultNetworkPrefabs` asset when only imports or only deletes were detected.
 - Fixed issue with nested `NetworkTransform` components clearing their initial prefab settings when in owner authoritative mode on the server side while using a client-server network topology which resulted in improper synchronization of the nested `NetworkTransform` components. (#3099)
 - Fixed issue with service not getting synchronized with in-scene placed `NetworkObject` instances when a session owner starts a `SceneEventType.Load` event. (#3096)
 - Fixed issue with the in-scene network prefab instance update menu tool where it was not properly updating scenes when invoked on the root prefab instance. (#3092)

--- a/com.unity.netcode.gameobjects/Editor/Configuration/NetworkPrefabProcessor.cs
+++ b/com.unity.netcode.gameobjects/Editor/Configuration/NetworkPrefabProcessor.cs
@@ -132,7 +132,7 @@ namespace Unity.Netcode.Editor.Configuration
 
             // Process the imported and deleted assets
             var markDirty = ProcessImportedAssets(importedAssets);
-            markDirty &= ProcessDeletedAssets(deletedAssets);
+            markDirty |= ProcessDeletedAssets(deletedAssets);
 
             if (markDirty)
             {


### PR DESCRIPTION
This is an up-port of #3102

`NetworkPrefabProcessor` now marks the default `NetworkPrefabsList` `ScriptableObject` asset as dirty if there are new imports **OR** deletions.

The Unity Editor is now aware of the changes and able to write them to disk. This prevents the changes from being lost when the editor is quit and allows them to be tracked in version control.

Previously the script would only mark the list as dirty if there had been both new imports and deletions.

## Changelog

 - Fixed: Issue where `NetworkPrefabProcessor` would not mark the prefab list as dirty and prevent saving the `DefaultNetworkPrefabs` asset when only imports or only deletes were detected.

## Testing and Documentation

 - No tests have been added.
 - No documentation changes or additions were necessary