### PR TITLE
fix: NetworkAnimator parameter writebuffer limits causes exception

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where `NetworkAnimator` would statically allocate write buffer space for `Animator` parameters that could cause a write error if the number of parameters exceeded the space allocated.
+
 ### Changed
 
 ## [2.1.1] - 2024-10-18


### PR DESCRIPTION
This PR resolves the issue of exceeding the legacy parameter limitations defined within `NetworkAnimator`. Now, `NetworkAnimator` calculates how much space it needs to allocate to handle parameter serialization based on the `Animator`'s defined parameters.

fix: #3095

## Changelog

- Fixed: Issue where `NetworkAnimator` would statically allocate write buffer space for `Animator` parameters that could cause a write error if the number of parameters exceeded the space allocated.

## Testing and Documentation

- No tests were added.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
