### PR TITLE
fix: Distributed Authority codec tests not using message version

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
@@ -625,7 +625,8 @@ namespace Unity.Netcode.RuntimeTests
             }
 
             var writer = new FastBufferWriter(1024, Allocator.Temp);
-            message.Serialize(writer, 0);
+            // Serialize the message using the known message version
+            message.Serialize(writer, message.Version);
 
             var testName = TestContext.CurrentContext.Test.Name;
             if (!m_ExpectedMessages.ContainsKey(testName))

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
@@ -205,13 +205,14 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator NetworkVariableDelta()
         {
+            var component = Client.LocalClient.PlayerObject.GetComponent<TestNetworkComponent>();
             var message = new NetworkVariableDeltaMessage
             {
-                NetworkObjectId = 0,
-                NetworkBehaviourIndex = 1,
-                DeliveryMappedNetworkVariableIndex = new HashSet<int> { 2, 3, 4 },
+                NetworkObjectId = Client.LocalClient.PlayerObject.NetworkObjectId,
+                NetworkBehaviourIndex = component.NetworkBehaviourId,
+                DeliveryMappedNetworkVariableIndex = new HashSet<int> { 0, 1 },
                 TargetClientId = 5,
-                NetworkBehaviour = Client.LocalClient.PlayerObject.GetComponent<TestNetworkComponent>(),
+                NetworkBehaviour = component,
             };
 
             yield return SendMessage(ref message);
@@ -569,7 +570,7 @@ namespace Unity.Netcode.RuntimeTests
 
         private IEnumerator SendMessage<T>(ref T message) where T : INetworkMessage
         {
-            Client.MessageManager.SetVersion(k_ClientId, XXHash.Hash32(typeof(T).FullName), 0);
+            Client.MessageManager.SetVersion(k_ClientId, XXHash.Hash32(typeof(T).FullName), message.Version);
 
             var clientIds = new NativeArray<ulong>(1, Allocator.Temp);
             clientIds[0] = k_ClientId;

--- a/testproject/ProjectSettings/ProjectVersion.txt
+++ b/testproject/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 6000.0.10f1
-m_EditorVersionWithRevision: 6000.0.10f1 (413673acabac)
+m_EditorVersion: 6000.0.23f1
+m_EditorVersionWithRevision: 6000.0.23f1 (1c4764c07fb4)


### PR DESCRIPTION
This resolves the issue where the NetworkVariable and NetworkList codec tests were failing due to the expected serialized message was not using the `NetworkVariableDeltaMessage.Version` but always using version 0.


## Changelog

NA

## Testing and Documentation

- Includes integration codec test `CodecTestHooks` adjustment.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
