### PR TITLE
fix: Player removed from observers when player object despawns

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,8 +12,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where client is removed as an observer from spawned objects when their player instance is despawned.
-- Fixed issue where `NetworkAnimator` would statically allocate write buffer space for `Animator` parameters that could cause a write error if the number of parameters exceeded the space allocated.
+- Fixed issue where client is removed as an observer from spawned objects when their player instance is despawned. (#3110)
+- Fixed issue where `NetworkAnimator` would statically allocate write buffer space for `Animator` parameters that could cause a write error if the number of parameters exceeded the space allocated. (#3108)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where client is removed as an observer from spawned objects when their player instance is despawned.
 - Fixed issue where `NetworkAnimator` would statically allocate write buffer space for `Animator` parameters that could cause a write error if the number of parameters exceeded the space allocated.
 
 ### Changed

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
@@ -306,10 +306,6 @@ namespace Unity.Netcode.Components
         private void BuildTransitionStateInfoList()
         {
 #if UNITY_EDITOR
-            if (UnityEditor.EditorApplication.isUpdating || UnityEditor.EditorApplication.isPlayingOrWillChangePlaymode)
-            {
-                return;
-            }
             if (m_Animator == null)
             {
                 return;
@@ -1268,10 +1264,11 @@ namespace Unity.Netcode.Components
                         NetworkLog.LogError($"[DestinationState To Transition Info] Layer ({animationState.Layer}) sub-table does not contain destination state ({animationState.DestinationStateHash})!");
                     }
                 }
-                else if (NetworkManager.LogLevel == LogLevel.Developer)
-                {
-                    NetworkLog.LogError($"[DestinationState To Transition Info] Layer ({animationState.Layer}) does not exist!");
-                }
+                // For reference, it is valid to have no transition information 
+                //else if (NetworkManager.LogLevel == LogLevel.Developer)
+                //{
+                //    NetworkLog.LogError($"[DestinationState To Transition Info] Layer ({animationState.Layer}) does not exist!");
+                //}
             }
             else if (animationState.Transition && animationState.CrossFade)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -87,7 +87,13 @@ namespace Unity.Netcode
                     playerObject.Observers.Add(player.OwnerClientId);
                 }
             }
-            playerObject.Observers.Add(playerObject.OwnerClientId);
+
+            // Only if spawn with observers is set or we are using a distributed authority network topology and this is the client's player should we add
+            // the owner as an observer.
+            if (playerObject.SpawnWithObservers || (NetworkManager.DistributedAuthorityMode && NetworkManager.LocalClientId == playerObject.OwnerClientId))
+            {
+                playerObject.Observers.Add(playerObject.OwnerClientId);
+            }
 
             m_PlayerObjects.Add(playerObject);
             if (!m_PlayerObjectsTable.ContainsKey(playerObject.OwnerClientId))

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1550,20 +1550,6 @@ namespace Unity.Netcode
                 SpawnedObjectsList.Remove(networkObject);
             }
 
-            // DANGO-TODO: When we fix the issue with observers not being applied to NetworkObjects,
-            // (client connect/disconnect) we can remove this hacky way of doing this.
-            // Basically, when a player disconnects and/or is destroyed they are removed as an observer from all other client
-            // NetworkOject instances.
-            if (networkObject.IsPlayerObject && !networkObject.IsOwner && networkObject.OwnerClientId != NetworkManager.LocalClientId)
-            {
-                foreach (var netObject in SpawnedObjects)
-                {
-                    if (netObject.Value.Observers.Contains(networkObject.OwnerClientId))
-                    {
-                        netObject.Value.Observers.Remove(networkObject.OwnerClientId);
-                    }
-                }
-            }
             if (networkObject.IsPlayerObject)
             {
                 RemovePlayerObject(networkObject);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/PlayerObjectTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/PlayerObjectTests.cs
@@ -1,4 +1,7 @@
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using NUnit.Framework;
 using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
@@ -182,6 +185,154 @@ namespace Unity.Netcode.RuntimeTests
                     PlayerTransformMatches(subClient.SpawnManager.SpawnedObjects[client.LocalClient.PlayerObject.NetworkObjectId]);
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// This test validates that when a player is spawned it has all observers
+    /// properly set and the spawned and player object lists are properly populated.
+    /// It also validates that when a player is despawned and the client is still connected
+    /// that the client maintains its observers for other players.
+    /// </summary>
+    [TestFixture(HostOrServer.DAHost)]
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    internal class PlayerSpawnAndDespawnTests : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 4;
+
+        private List<NetworkManager> m_NetworkManagers = new List<NetworkManager>();
+        private StringBuilder m_ErrorLog = new StringBuilder();
+
+        public PlayerSpawnAndDespawnTests(HostOrServer hostOrServer) : base(hostOrServer) { }
+
+        protected override IEnumerator OnTearDown()
+        {
+            // Always clear in case test fails
+            m_NetworkManagers.Clear();
+            return base.OnTearDown();
+        }
+
+        private bool ValidateObservers(ulong playerClientId, NetworkObject player)
+        {
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                if (player != null && player.IsSpawned)
+                {
+                    if (!networkManager.SpawnManager.SpawnedObjects.ContainsKey(player.NetworkObjectId))
+                    {
+                        m_ErrorLog.AppendLine($"Client-{networkManager.LocalClientId} does not contain a spawned object entry {nameof(NetworkObject)}-{player.NetworkObjectId} for Client-{playerClientId}!");
+                        return false;
+                    }
+
+                    var playerClone = networkManager.SpawnManager.SpawnedObjects[player.NetworkObjectId];
+                    foreach (var clientId in networkManager.ConnectedClientsIds)
+                    {
+                        if (!playerClone.IsNetworkVisibleTo(clientId))
+                        {
+                            m_ErrorLog.AppendLine($"Client-{networkManager.LocalClientId} failed visibility check for Client-{clientId} on {nameof(NetworkObject)}-{player.NetworkObjectId} for Client-{playerClientId}!");
+                            return false;
+                        }
+                    }
+
+                    var foundPlayerClone = (NetworkObject)null;
+                    foreach (var playerObject in networkManager.SpawnManager.PlayerObjects)
+                    {
+                        if (playerObject.OwnerClientId == playerClientId && playerObject.NetworkObjectId == player.NetworkObjectId)
+                        {
+                            foundPlayerClone = playerObject;
+                            break;
+                        }
+                    }
+                    if (!foundPlayerClone)
+                    {
+                        m_ErrorLog.AppendLine($"Client-{networkManager.LocalClientId} does not contain a player entry for {nameof(NetworkObject)}-{player.NetworkObjectId} for Client-{playerClientId}!");
+                        return false;
+                    }
+
+                }
+                else
+                {
+                    // If the player client in question is despawned, then no NetworkManager instance
+                    // should contain a clone of that (or the client's NetworkManager instance as well)
+                    foreach (var playerClone in networkManager.SpawnManager.PlayerObjects)
+                    {
+                        if (playerClone.OwnerClientId == playerClientId)
+                        {
+                            m_ErrorLog.AppendLine($"Client-{networkManager.LocalClientId} contains a player {nameof(NetworkObject)}-{playerClone.NetworkObjectId} for Client-{playerClientId} when it should be despawned!");
+                            return false;
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+
+        private bool ValidateAllClientPlayerObservers()
+        {
+            m_ErrorLog.Clear();
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                var spawnedOrNot = networkManager.LocalClient.PlayerObject == null ? "despawned" : "spawned";
+                m_ErrorLog.AppendLine($"Validating Client-{networkManager.LocalClientId} {spawnedOrNot} player.");
+                if (networkManager.LocalClient == null)
+                {
+                    m_ErrorLog.AppendLine($"No {nameof(NetworkClient)} found for Client-{networkManager.LocalClientId}!");
+                    return false;
+                }
+                if (!ValidateObservers(networkManager.LocalClientId, networkManager.LocalClient.PlayerObject))
+                {
+                    m_ErrorLog.AppendLine($"Client-{networkManager.LocalClientId} validation pass failed.");
+                    return false;
+                }
+            }
+            return true;
+        }
+
+
+        [UnityTest]
+        public IEnumerator PlayerSpawnDespawn()
+        {
+            if (m_ServerNetworkManager.IsHost)
+            {
+                m_NetworkManagers.Add(m_ServerNetworkManager);
+            }
+            m_NetworkManagers.AddRange(m_ClientNetworkManagers);
+
+            // Validate all observers are properly set with all players spawned
+            yield return WaitForConditionOrTimeOut(ValidateAllClientPlayerObservers);
+            AssertOnTimeout($"First Validation Failed:\n {m_ErrorLog}");
+            var selectedClient = m_ClientNetworkManagers[Random.Range(0, m_ClientNetworkManagers.Count() - 1)];
+            var playerSelected = selectedClient.LocalClient.PlayerObject;
+
+            if (m_DistributedAuthority)
+            {
+                playerSelected.Despawn(false);
+            }
+            else
+            {
+                m_ServerNetworkManager.SpawnManager.SpawnedObjects[playerSelected.NetworkObjectId].Despawn(false);
+            }
+
+            // Validate all observers are properly set with one of the players despawned
+            yield return WaitForConditionOrTimeOut(ValidateAllClientPlayerObservers);
+            AssertOnTimeout($"Second Validation Failed:\n {m_ErrorLog}");
+
+            if (m_DistributedAuthority)
+            {
+                playerSelected.SpawnAsPlayerObject(selectedClient.LocalClientId, false);
+            }
+            else
+            {
+                var serverPlayerInstance = Object.Instantiate(m_ServerNetworkManager.NetworkConfig.PlayerPrefab);
+                serverPlayerInstance.GetComponent<NetworkObject>().SpawnAsPlayerObject(selectedClient.LocalClientId, false);
+            }
+
+            // Validate all observers are properly set when the client's player is respawned.
+            yield return WaitForConditionOrTimeOut(ValidateAllClientPlayerObservers);
+            AssertOnTimeout($"Third Validation Failed:\n {m_ErrorLog}");
+
+            m_NetworkManagers.Clear();
         }
     }
 }


### PR DESCRIPTION
This PR fixes the issue where a client would be removed as an observer from all NetworkObject instances if their player object is despawned.

## Changelog

- Fixed issue where client is removed as an observer from spawned objects when their player instance is despawned.


## Testing and Documentation

- Includes PlayerSpawnAndDespawnTests integration test.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
