### PR TITLE
fix: send to not owner server warning message

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,7 +12,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where `NetworkAnimator` would statically allocate write buffer space for `Animator` parameters that could cause a write error if the number of parameters exceeded the space allocated.
+- Fixed issue where `NotOwnerRpcTarget` or `OwnerRpcTarget` were not using their replacements `NotAuthorityRpcTarget` and `AuthorityRpcTarget` which would invoke a warning.
+- Fixed issue where `NetworkAnimator` would statically allocate write buffer space for `Animator` parameters that could cause a write error if the number of parameters exceeded the space allocated. (#3108)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ClientsAndHostRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ClientsAndHostRpcTarget.cs
@@ -17,7 +17,8 @@ namespace Unity.Netcode
                 // ClientsAndHost sends to everyone who runs any client logic
                 // So if the server is a host, this target includes it (as hosts run client logic)
                 // If the server is not a host, this target leaves it out, ergo the selection of NotServer.
-                if (behaviour.NetworkManager.ServerIsHost)
+                // If we are in distributed authority mode and connected to a service, then send to all clients.
+                if (behaviour.NetworkManager.ServerIsHost || (m_NetworkManager.DistributedAuthorityMode && m_NetworkManager.CMBServiceConnection))
                 {
                     m_UnderlyingTarget = behaviour.RpcTarget.Everyone;
                 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotServerRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/NotServerRpcTarget.cs
@@ -51,7 +51,13 @@ namespace Unity.Netcode
                         continue;
                     }
 
-                    if (clientId == behaviour.NetworkManager.LocalClientId)
+                    // If we are in distributed authority mode and connected to the service, then we exclude the owner/authority from the list
+                    if (m_NetworkManager.DistributedAuthorityMode && m_NetworkManager.CMBServiceConnection && clientId == behaviour.OwnerClientId)
+                    {
+                        continue;
+                    }
+
+                    if (clientId == m_NetworkManager.LocalClientId)
                     {
                         m_LocalSendRpcTarget.Send(behaviour, ref message, delivery, rpcParams);
                         continue;

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ServerRpcTarget.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcTargets/ServerRpcTarget.cs
@@ -1,8 +1,10 @@
+using Unity.Collections;
 namespace Unity.Netcode
 {
     internal class ServerRpcTarget : BaseRpcTarget
     {
         protected BaseRpcTarget m_UnderlyingTarget;
+        protected ProxyRpcTarget m_ProxyRpcTarget;
 
         public override void Dispose()
         {
@@ -11,13 +13,62 @@ namespace Unity.Netcode
                 m_UnderlyingTarget.Dispose();
                 m_UnderlyingTarget = null;
             }
+
+            if (m_ProxyRpcTarget != null)
+            {
+                m_ProxyRpcTarget.Dispose();
+                m_ProxyRpcTarget = null;
+            }
         }
 
         internal override void Send(NetworkBehaviour behaviour, ref RpcMessage message, NetworkDelivery delivery, RpcParams rpcParams)
         {
+            // For distributed authority the "server" is considered the authority of the object
             if (behaviour.NetworkManager.DistributedAuthorityMode && behaviour.NetworkManager.CMBServiceConnection)
             {
-                UnityEngine.Debug.LogWarning("[Invalid Target] There is no server to send to when in Distributed Authority mode!");
+                // If the local instance is the owner, then invoke the message locally on this behaviour
+                if (behaviour.IsOwner)
+                {
+                    var context = new NetworkContext
+                    {
+                        SenderId = m_NetworkManager.LocalClientId,
+                        Timestamp = m_NetworkManager.RealTimeProvider.RealTimeSinceStartup,
+                        SystemOwner = m_NetworkManager,
+                        // header information isn't valid since it's not a real message.
+                        // RpcMessage doesn't access this stuff so it's just left empty.
+                        Header = new NetworkMessageHeader(),
+                        SerializedHeaderSize = 0,
+                        MessageSize = 0
+                    };
+                    using var tempBuffer = new FastBufferReader(message.WriteBuffer, Allocator.None);
+                    message.ReadBuffer = tempBuffer;
+                    message.Handle(ref context);
+                    // If enabled, then add the RPC metrics for this 
+#if DEVELOPMENT_BUILD || UNITY_EDITOR || UNITY_MP_TOOLS_NET_STATS_MONITOR_ENABLED_IN_RELEASE
+                    int length = tempBuffer.Length;
+                    if (NetworkBehaviour.__rpc_name_table[behaviour.GetType()].TryGetValue(message.Metadata.NetworkRpcMethodId, out var rpcMethodName))
+                    {
+                        m_NetworkManager.NetworkMetrics.TrackRpcSent(
+                            m_NetworkManager.LocalClientId,
+                            behaviour.NetworkObject,
+                            rpcMethodName,
+                            behaviour.__getTypeName(),
+                            length);
+                    }
+#endif
+                }
+                else // Otherwise, send a proxied message to the owner of the object
+                {
+                    if (m_ProxyRpcTarget == null)
+                    {
+                        m_ProxyRpcTarget = new ProxyRpcTarget(behaviour.OwnerClientId, m_NetworkManager);
+                    }
+                    else
+                    {
+                        m_ProxyRpcTarget.SetClientId(behaviour.OwnerClientId);
+                    }
+                    m_ProxyRpcTarget.Send(behaviour, ref message, delivery, rpcParams);
+                }
                 return;
             }
 


### PR DESCRIPTION
This PR fixes the issue where sending a universal RPC with a `SendTo.NotOwner` or `SendTo.Owner` attribute parameter would cause warnings to be logged about sending to the server when using a distributed authority network topology.

fix: #3086


## Changelog

- Fixed: Issue where `NotOwnerRpcTarget` or `OwnerRpcTarget` were not using their replacements `NotAuthorityRpcTarget` and `AuthorityRpcTarget` which would invoke a warning.

## Testing and Documentation

- Includes integration test updates (internal manual test).
- Internal end-to-end test is slated to be added [MPSNGM-520](https://jira.unity3d.com/browse/MPSNGM-520)
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
