### PR TITLE
fix: Hide Debug Simulator for NGO 2.0+

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -21,6 +21,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+- The Debug Simulator section of the Unity Transport component was removed. This section was not functional anymore and users are now recommended to use the more featureful [Network Simulator](https://docs-multiplayer.unity3d.com/tools/current/tools-network-simulator/) tool from the Multiplayer Tools package instead.
+
 ## [2.1.1] - 2024-10-18
 
 ### Added

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -21,7 +21,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
-- The Debug Simulator section of the Unity Transport component was removed. This section was not functional anymore and users are now recommended to use the more featureful [Network Simulator](https://docs-multiplayer.unity3d.com/tools/current/tools-network-simulator/) tool from the Multiplayer Tools package instead.
+- The Debug Simulator section of the Unity Transport component was removed. This section was not functional anymore and users are now recommended to use the more featureful [Network Simulator](https://docs-multiplayer.unity3d.com/tools/current/tools-network-simulator/) tool from the Multiplayer Tools package instead. (#3121)
 
 ## [2.1.1] - 2024-10-18
 

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -405,6 +405,7 @@ namespace Unity.Netcode.Transports.UTP
 
 #if UTP_TRANSPORT_2_0_ABOVE
         [Obsolete("DebugSimulator is no longer supported and has no effect. Use Network Simulator from the Multiplayer Tools package.", false)]
+        [HideInInspector]
 #endif
         public SimulatorParameters DebugSimulator = new SimulatorParameters
         {


### PR DESCRIPTION
The Debug Simulator is non-functional when UTP 2.0+ is installed. Since NGO 2.0 is now depending on UTP 2.0, there's no reason to keep that section of the Unity Transport component around as it's just totally broken.

## Changelog

- Changed: The Debug Simulator section of the Unity Transport component was removed. This section was not functional anymore and users are now recommended to use the more featureful [Network Simulator](https://docs-multiplayer.unity3d.com/tools/current/tools-network-simulator/) tool from the Multiplayer Tools package instead.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.