### PR TITLE
fix: NetworkAnimator parameters writebuffer is limited [backport]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -17,6 +17,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where `NetworkAnimator` would statically allocate write buffer space for `Animator` parameters that could cause a write error if the number of parameters exceeded the space allocated.
 - Fixed issue with the in-scene network prefab instance update menu tool where it was not properly updating scenes when invoked on the root prefab instance. (#3084)
 - Fixed issue where `NetworkAnimator` would send updates to non-observer clients. (#3058)
 - Fixed issue where an exception could occur when receiving a universal RPC for a `NetworkObject` that has been despawned. (#3055)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -17,7 +17,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where `NetworkAnimator` would statically allocate write buffer space for `Animator` parameters that could cause a write error if the number of parameters exceeded the space allocated.
+- Fixed issue where `NetworkAnimator` would statically allocate write buffer space for `Animator` parameters that could cause a write error if the number of parameters exceeded the space allocated. (#3124)
 - Fixed issue with the in-scene network prefab instance update menu tool where it was not properly updating scenes when invoked on the root prefab instance. (#3084)
 - Fixed issue where `NetworkAnimator` would send updates to non-observer clients. (#3058)
 - Fixed issue where an exception could occur when receiving a universal RPC for a `NetworkObject` that has been despawned. (#3055)

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -481,10 +481,6 @@ namespace Unity.Netcode.Components
             return true;
         }
 
-        // Animators only support up to 32 parameters
-        // TODO: Look into making this a range limited property
-        private const int k_MaxAnimationParams = 32;
-
         private int[] m_TransitionHash;
         private int[] m_AnimationHash;
         private float[] m_LayerWeights;
@@ -508,7 +504,7 @@ namespace Unity.Netcode.Components
         }
 
         // 128 bytes per Animator
-        private FastBufferWriter m_ParameterWriter = new FastBufferWriter(k_MaxAnimationParams * sizeof(float), Allocator.Persistent);
+        private FastBufferWriter m_ParameterWriter;
 
         private NativeArray<AnimatorParamCache> m_CachedAnimatorParameters;
 
@@ -560,6 +556,14 @@ namespace Unity.Netcode.Components
 
         private void Awake()
         {
+            if (!m_Animator)
+            {
+#if !UNITY_EDITOR
+                Debug.LogError($"{nameof(NetworkAnimator)} {name} does not have an {nameof(UnityEngine.Animator)} assigned to it. The {nameof(NetworkAnimator)} will not initialize properly.");
+#endif
+                return;
+            }
+
             int layers = m_Animator.layerCount;
             // Initializing the below arrays for everyone handles an issue
             // when running in owner authoritative mode and the owner changes.
@@ -588,6 +592,9 @@ namespace Unity.Netcode.Components
                     m_LayerWeights[layer] = layerWeightNow;
                 }
             }
+
+            // The total initialization size calculated for the m_ParameterWriter write buffer.
+            var totalParameterSize = sizeof(uint);
 
             // Build our reference parameter values to detect when they change
             var parameters = m_Animator.parameters;
@@ -629,7 +636,37 @@ namespace Unity.Netcode.Components
                 }
 
                 m_CachedAnimatorParameters[i] = cacheParam;
+
+                // Calculate parameter sizes (index + type size)
+                switch (parameter.type)
+                {
+                    case AnimatorControllerParameterType.Int:
+                        {
+                            totalParameterSize += sizeof(int) * 2;
+                            break;
+                        }
+                    case AnimatorControllerParameterType.Bool:
+                    case AnimatorControllerParameterType.Trigger:
+                        {
+                            // Bool is serialized to 1 byte
+                            totalParameterSize += sizeof(int) + 1;
+                            break;
+                        }
+                    case AnimatorControllerParameterType.Float:
+                        {
+                            totalParameterSize += sizeof(int) + sizeof(float);
+                            break;
+                        }
+                }
             }
+
+            if (m_ParameterWriter.IsInitialized)
+            {
+                m_ParameterWriter.Dispose();
+            }
+
+            // Create our parameter write buffer for serialization
+            m_ParameterWriter = new FastBufferWriter(totalParameterSize, Allocator.Persistent);
         }
 
         /// <summary>


### PR DESCRIPTION
This is a backport of #3108.

This PR resolves the issue of exceeding the legacy parameter limitations defined within `NetworkAnimator`. Now, `NetworkAnimator` calculates how much space it needs to allocate to handle parameter serialization based on the `Animator`'s defined parameters.

## Changelog

- Fixed: Issue where `NetworkAnimator` would statically allocate write buffer space for `Animator` parameters that could cause a write error if the number of parameters exceeded the space allocated.

## Testing and Documentation

- No tests were added.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
