### PR TITLE
fix: NetworkVariable dispose original internal

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -187,7 +187,13 @@ namespace Unity.Netcode
             }
 
             m_InternalValue = default;
+
+            if (m_InternalOriginalValue is IDisposable internalOriginalValueDisposable)
+            {
+                internalOriginalValueDisposable.Dispose();
+            }
             m_InternalOriginalValue = default;
+
             if (m_HasPreviousValue && m_PreviousValue is IDisposable previousValueDisposable)
             {
                 m_HasPreviousValue = false;

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -181,25 +181,26 @@ namespace Unity.Netcode
             }
 
             m_IsDisposed = true;
+            // Dispose the internal value
             if (m_InternalValue is IDisposable internalValueDisposable)
             {
                 internalValueDisposable.Dispose();
             }
-
             m_InternalValue = default;
 
+            // Dispose the internal original value
             if (m_InternalOriginalValue is IDisposable internalOriginalValueDisposable)
             {
                 internalOriginalValueDisposable.Dispose();
             }
             m_InternalOriginalValue = default;
 
+            // Dispose the previous value if there is one
             if (m_HasPreviousValue && m_PreviousValue is IDisposable previousValueDisposable)
             {
                 m_HasPreviousValue = false;
                 previousValueDisposable.Dispose();
             }
-
             m_PreviousValue = default;
 
             base.Dispose();


### PR DESCRIPTION
This just makes sure the original internal value is disposed when disposing the `NetworkVariable`.
(Noticed issue when backporting)


## Changelog
NA

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
