### PR TITLE
fix: provide users ability to get client endpoint backport

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,6 +10,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
+- Added `UnityTransport.GetEndpoint` method to provide a way to obtain `NetworkEndpoint` information of a connection via client identifier. (#3131)
 - Added a static `NetworkManager.OnInstantiated` event notification to be able to track when a new `NetworkManager` instance has been instantiated. (#3089)
 - Added a static `NetworkManager.OnDestroying` event notification to be able to track when an existing `NetworkManager` instance is being destroyed. (#3089)
 - Added message size validation to named and unnamed message sending functions for better error messages. (#3043)

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1210,6 +1210,30 @@ namespace Unity.Netcode.Transports.UTP
         }
 
         /// <summary>
+        /// Provides the <see cref="NetworkEndpoint"/> for the NGO client identifier specified.
+        /// </summary>
+        /// <remarks>
+        /// - This is only really useful for direct connections.
+        /// - Relay connections and clients connected using a distributed authority network topology will not provide the client's actual endpoint information.
+        /// - For LAN topologies this should work as long as it is a direct connection and not a relay connection.
+        /// </remarks>
+        /// <param name="clientId">NGO client identifier to get endpoint information about.</param>
+        /// <returns><see cref="NetworkEndpoint"/></returns>
+        public NetworkEndpoint GetEndpoint(ulong clientId)
+        {
+            if (m_Driver.IsCreated && NetworkManager != null && NetworkManager.IsListening)
+            {
+                var transportId = NetworkManager.ConnectionManager.ClientIdToTransportId(clientId);
+                var networkConnection = ParseClientId(transportId);
+                if (m_Driver.GetConnectionState(networkConnection) == NetworkConnection.State.Connected)
+                {
+                    return m_Driver.RemoteEndPoint(networkConnection);
+                }
+            }
+            return new NetworkEndpoint();
+        }
+
+        /// <summary>
         /// Initializes the transport
         /// </summary>
         /// <param name="networkManager">The NetworkManager that initialized and owns the transport</param>

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerTransportTests.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections;
 using NUnit.Framework;
+using Unity.Netcode.TestHelpers.Runtime;
+using Unity.Netcode.Transports.UTP;
+using Unity.Networking.Transport;
 using UnityEngine;
 using UnityEngine.TestTools;
 
@@ -157,4 +160,51 @@ namespace Unity.Netcode.RuntimeTests
             }
         }
     }
+
+    /// <summary>
+    /// Verifies the UnityTransport.GetEndpoint method returns
+    /// valid NetworkEndPoint information.
+    /// </summary>
+    internal class TransportEndpointTests : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 2;
+
+        [UnityTest]
+        public IEnumerator GetEndpointReportedCorrectly()
+        {
+            var serverUnityTransport = m_ServerNetworkManager.NetworkConfig.NetworkTransport as UnityTransport;
+            var serverEndpoint = new NetworkEndPoint();
+            var clientEndpoint = new NetworkEndPoint();
+            foreach (var client in m_ClientNetworkManagers)
+            {
+                var unityTransport = client.NetworkConfig.NetworkTransport as UnityTransport;
+                serverEndpoint = unityTransport.GetEndpoint(m_ServerNetworkManager.LocalClientId);
+                clientEndpoint = serverUnityTransport.GetEndpoint(client.LocalClientId);
+                Assert.IsTrue(serverEndpoint.IsValid);
+                Assert.IsTrue(clientEndpoint.IsValid);
+                Assert.IsTrue(clientEndpoint.Address.Split(":")[0] == unityTransport.ConnectionData.Address);
+                Assert.IsTrue(serverEndpoint.Address.Split(":")[0] == serverUnityTransport.ConnectionData.Address);
+                Assert.IsTrue(serverEndpoint.Port == unityTransport.ConnectionData.Port);
+                Assert.IsTrue(clientEndpoint.Port >= serverUnityTransport.ConnectionData.Port);
+            }
+
+            // Now validate that when disconnected it returns a non-valid NetworkEndPoint
+            var clientId = m_ClientNetworkManagers[0].LocalClientId;
+            m_ClientNetworkManagers[0].Shutdown();
+            yield return s_DefaultWaitForTick;
+
+            serverEndpoint = (m_ClientNetworkManagers[0].NetworkConfig.NetworkTransport as UnityTransport).GetEndpoint(m_ServerNetworkManager.LocalClientId);
+            clientEndpoint = serverUnityTransport.GetEndpoint(clientId);
+            Assert.IsFalse(serverEndpoint.IsValid);
+            Assert.IsFalse(clientEndpoint.IsValid);
+
+            // Validate that invalid client identifiers return an invalid NetworkEndPoint
+            serverEndpoint = (m_ClientNetworkManagers[0].NetworkConfig.NetworkTransport as UnityTransport).GetEndpoint((ulong)UnityEngine.Random.Range(NumberOfClients + 1, 30));
+            clientEndpoint = serverUnityTransport.GetEndpoint((ulong)UnityEngine.Random.Range(NumberOfClients + 1, 30));
+            Assert.IsFalse(serverEndpoint.IsValid);
+            Assert.IsFalse(clientEndpoint.IsValid);
+        }
+    }
+
+
 }

--- a/testproject/Assets/Tests/Runtime/NetworkManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkManagerTests.cs
@@ -21,8 +21,7 @@ namespace TestProject.RuntimeTests
             SceneManagementEnabled,
             SceneManagementDisabled
         }
-
-        private bool m_EnableSceneManagement;
+        
         private NetworkObject m_NetworkObject;
         private bool m_NetworkObjectWasSpawned;
         private bool m_NetworkBehaviourIsHostWasSet;
@@ -85,7 +84,7 @@ namespace TestProject.RuntimeTests
 
         protected override void OnServerAndClientsCreated()
         {
-            m_ServerNetworkManager.NetworkConfig.EnableSceneManagement = m_EnableSceneManagement;
+            m_ServerNetworkManager.NetworkConfig.EnableSceneManagement = m_UseSceneManagement;
             m_NetworkObjectTestComponent.ConfigureClientConnected(m_ServerNetworkManager, OnClientConnectedCallback);
         }
 
@@ -108,7 +107,7 @@ namespace TestProject.RuntimeTests
 
         protected override void OnNewClientCreated(NetworkManager networkManager)
         {
-            networkManager.NetworkConfig.EnableSceneManagement = m_EnableSceneManagement;
+            networkManager.NetworkConfig.EnableSceneManagement = m_UseSceneManagement;
             foreach (var prefab in m_ServerNetworkManager.NetworkConfig.Prefabs.Prefabs)
             {
                 networkManager.NetworkConfig.Prefabs.Add(prefab);

--- a/testproject/Assets/Tests/Runtime/NetworkManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkManagerTests.cs
@@ -21,7 +21,7 @@ namespace TestProject.RuntimeTests
             SceneManagementEnabled,
             SceneManagementDisabled
         }
-        
+
         private NetworkObject m_NetworkObject;
         private bool m_NetworkObjectWasSpawned;
         private bool m_NetworkBehaviourIsHostWasSet;


### PR DESCRIPTION
Backport of #3130 
This PR adds a `UnityTransport.GetEndpoint` method to provide users the ability to obtain endpoint connection information about a specific client identifier.

## Changelog

- Added `UnityTransport.GetEndpoint` method to provide a way to obtain `NetworkEndpoint` information of a connection via client identifier.

## Testing and Documentation

- Includes integration test `TransportEndpointTests.GetEndpointReportedCorrectly`.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
