### PR TITLE
fix: synchronizing connected clients additively loaded scenes only when server

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -15,6 +15,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed in-scene `NertworkObject` synchronization issue when loading a scene with currently connected clients connected to a session created by a `NetworkManager` started as a server (i.e. not as a host). (#3133)
+- Fixed issue where a `NetworkManager` started as a server would not add itself as an observer to in-scene placed `NetworkObject`s instantiated and spawned by a scene loading event. (#3133)
 - Fixed issue where spawning a player using `NetworkObject.InstantiateAndSpawn` or `NetworkSpawnManager.InstantiateAndSpawn` would not update the `NetworkSpawnManager.PlayerObjects` or assign the newly spawned player to the `NetworkClient.PlayerObject`. (#3122)
 - Fixed issue where queued UnitTransport (NetworkTransport) message batches were being sent on the next frame. They are now sent at the end of the frame during `PostLateUpdate`.  (#3113)
 - Fixed issue where `NotOwnerRpcTarget` or `OwnerRpcTarget` were not using their replacements `NotAuthorityRpcTarget` and `AuthorityRpcTarget` which would invoke a warning. (#3111)

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1081,6 +1081,8 @@ namespace Unity.Netcode
             }
             else
             {
+                // Send to each individual client to assure only the in-scene placed NetworkObjects being observed by the client
+                // is serialized
                 foreach (var clientId in targetClientIds)
                 {
                     sceneEvent.TargetClientId = clientId;
@@ -1092,7 +1094,6 @@ namespace Unity.Netcode
                     NetworkManager.NetworkMetrics.TrackSceneEventSent(clientId, (uint)sceneEvent.SceneEventType, SceneNameFromHash(sceneEvent.SceneHash), size);
                 }
             }
-
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1081,12 +1081,16 @@ namespace Unity.Netcode
             }
             else
             {
-                var message = new SceneEventMessage
+                foreach (var clientId in targetClientIds)
                 {
-                    EventData = sceneEvent,
-                };
-                var size = NetworkManager.ConnectionManager.SendMessage(ref message, k_DeliveryType, targetClientIds);
-                NetworkManager.NetworkMetrics.TrackSceneEventSent(targetClientIds, (uint)SceneEventDataStore[sceneEventId].SceneEventType, SceneNameFromHash(SceneEventDataStore[sceneEventId].SceneHash), size);
+                    sceneEvent.TargetClientId = clientId;
+                    var message = new SceneEventMessage
+                    {
+                        EventData = sceneEvent,
+                    };
+                    var size = NetworkManager.ConnectionManager.SendMessage(ref message, k_DeliveryType, clientId);
+                    NetworkManager.NetworkMetrics.TrackSceneEventSent(clientId, (uint)sceneEvent.SceneEventType, SceneNameFromHash(sceneEvent.SceneHash), size);
+                }
             }
 
         }

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1119,6 +1119,12 @@ namespace Unity.Netcode
             // then add all connected clients as observers
             if (!NetworkManager.DistributedAuthorityMode && NetworkManager.IsServer && networkObject.SpawnWithObservers)
             {
+                // If running as a server only, then make sure to always add the server's client identifier
+                if (!NetworkManager.IsHost)
+                {
+                    networkObject.Observers.Add(NetworkManager.LocalClientId);
+                }
+
                 // Add client observers
                 for (int i = 0; i < NetworkManager.ConnectedClientsIds.Count; i++)
                 {

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestWithApproximation.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestWithApproximation.cs
@@ -87,6 +87,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
             return new Vector3(Random.Range(min, max), Random.Range(min, max), Random.Range(min, max));
         }
 
+        public IntegrationTestWithApproximation(NetworkTopologyTypes networkTopologyType, HostOrServer hostOrServer) : base(networkTopologyType, hostOrServer) { }
+
         public IntegrationTestWithApproximation(NetworkTopologyTypes networkTopologyType) : base(networkTopologyType) { }
 
         public IntegrationTestWithApproximation(HostOrServer hostOrServer) : base(hostOrServer) { }

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -1759,6 +1759,13 @@ namespace Unity.Netcode.TestHelpers.Runtime
             m_DistributedAuthority = m_NetworkTopologyType == NetworkTopologyTypes.DistributedAuthority;
         }
 
+        public NetcodeIntegrationTest(NetworkTopologyTypes networkTopologyType, HostOrServer hostOrServer)
+        {
+            m_NetworkTopologyType = networkTopologyType;
+            m_DistributedAuthority = m_NetworkTopologyType == NetworkTopologyTypes.DistributedAuthority;
+            m_UseHost = hostOrServer == HostOrServer.Host || hostOrServer == HostOrServer.DAHost;
+        }
+
         /// <summary>
         /// Optional Host or Server integration tests
         /// Constructor that allows you To break tests up as a host

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/InScenePlacedNetworkObjectTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/InScenePlacedNetworkObjectTests.cs
@@ -18,7 +18,7 @@ namespace TestProject.RuntimeTests
     [TestFixture(NetworkTopologyTypes.ClientServer, HostOrServer.Server)]
     public class InScenePlacedNetworkObjectTests : IntegrationTestWithApproximation
     {
-        protected override int NumberOfClients => 2;
+        protected override int NumberOfClients => 3;
 
         private const string k_SceneToLoad = "InSceneNetworkObject";
         private const string k_InSceneUnder = "InSceneUnderGameObject";
@@ -63,6 +63,7 @@ namespace TestProject.RuntimeTests
         [UnityTest]
         public IEnumerator InSceneNetworkObjectSynchAndSpawn()
         {
+            NetworkObjectTestComponent.VerboseDebug = true;
             // Because despawning a client will cause it to shutdown and clean everything in the
             // scene hierarchy, we have to prevent one of the clients from spawning initially before
             // we test synchronizing late joining clients with despawned in-scene placed NetworkObjects.
@@ -70,23 +71,25 @@ namespace TestProject.RuntimeTests
             // will be targeting to join late from the m_ClientNetworkManagers array, start the server
             // and the remaining client, despawn the in-scene NetworkObject, and then start and synchronize
             // the clientToTest.
-            var clientToTest = m_ClientNetworkManagers[1];
+            var clientToTest = m_ClientNetworkManagers[2];
             var clients = m_ClientNetworkManagers.ToList();
             clients.Remove(clientToTest);
             m_ClientNetworkManagers = clients.ToArray();
             m_CanStartServerAndClients = true;
+            NetworkObjectTestComponent.Reset();
             yield return StartServerAndClients();
             clients.Add(clientToTest);
             m_ClientNetworkManagers = clients.ToArray();
 
-            NetworkObjectTestComponent.ServerNetworkObjectInstance = null;
+
             m_ServerNetworkManager.SceneManager.OnSceneEvent += Server_OnSceneEvent;
             var status = m_ServerNetworkManager.SceneManager.LoadScene(k_SceneToLoad, LoadSceneMode.Additive);
             Assert.IsTrue(status == SceneEventProgressStatus.Started, $"When attempting to load scene {k_SceneToLoad} was returned the following progress status: {status}");
-
+            // We removed a client from the initial spawn and server should spawn too
+            var clientCount = TotalClients - (m_UseHost ? 1 : 0);
             // This verifies the scene loaded and the in-scene placed NetworkObjects spawned.
-            yield return WaitForConditionOrTimeOut(() => NetworkObjectTestComponent.SpawnedInstances.Count == TotalClients - 1);
-            AssertOnTimeout($"Timed out waiting for total spawned in-scene placed NetworkObjects to reach a count of {TotalClients - 1} and is currently {NetworkObjectTestComponent.SpawnedInstances.Count}");
+            yield return WaitForConditionOrTimeOut(() => NetworkObjectTestComponent.SpawnedInstances.Count == clientCount);
+            AssertOnTimeout($"Timed out waiting for total spawned in-scene placed NetworkObjects to reach a count of {clientCount} and is currently {NetworkObjectTestComponent.SpawnedInstances.Count}");
 
             // Get the server-side instance of the in-scene NetworkObject
             Assert.True(s_GlobalNetworkObjects.ContainsKey(m_ServerNetworkManager.LocalClientId), $"Could not find server instance of the test in-scene NetworkObject!");
@@ -103,6 +106,9 @@ namespace TestProject.RuntimeTests
             // Now late join a client
             NetworkObjectTestComponent.OnInSceneObjectDespawned += OnInSceneObjectDespawned;
             NetcodeIntegrationTestHelpers.StartOneClient(clientToTest);
+            // Spawned another client
+            clientCount++;
+
             yield return WaitForConditionOrTimeOut(() => (clientToTest.IsConnectedClient && clientToTest.IsListening));
             AssertOnTimeout($"Timed out waiting for {clientToTest.name} to reconnect!");
 
@@ -121,21 +127,24 @@ namespace TestProject.RuntimeTests
             // Now test that the despawned in-scene placed NetworkObject can be re-spawned (without having been registered as a NetworkPrefab)
             serverObject.Spawn();
 
-            yield return WaitForConditionOrTimeOut(() => NetworkObjectTestComponent.SpawnedInstances.Count == TotalClients);
-            AssertOnTimeout($"Timed out waiting for all in-scene instances to be spawned!  Current spawned count: {NetworkObjectTestComponent.SpawnedInstances.Count()} | Expected spawn count: {TotalClients}");
+            yield return WaitForConditionOrTimeOut(() => NetworkObjectTestComponent.SpawnedInstances.Count == clientCount);
+            AssertOnTimeout($"Timed out waiting for all in-scene instances to be spawned!  Current spawned count: {NetworkObjectTestComponent.SpawnedInstances.Count()} | Expected spawn count: {clientCount}");
 
             // Test NetworkHide on the first client
             var firstClientId = m_ClientNetworkManagers[0].LocalClientId;
 
             serverObject.NetworkHide(firstClientId);
+            clientCount--;
 
-            yield return WaitForConditionOrTimeOut(() => NetworkObjectTestComponent.SpawnedInstances.Count == TotalClients - 1);
-            AssertOnTimeout($"[NetworkHide] Timed out waiting for Client-{firstClientId} to despawn the in-scene placed NetworkObject! Current spawned count: {NetworkObjectTestComponent.SpawnedInstances.Count()} | Expected spawn count: {TotalClients - 1}");
+            yield return WaitForConditionOrTimeOut(() => NetworkObjectTestComponent.SpawnedInstances.Count == clientCount);
+            AssertOnTimeout($"[NetworkHide] Timed out waiting for Client-{firstClientId} to despawn the in-scene placed NetworkObject! Current spawned count: {NetworkObjectTestComponent.SpawnedInstances.Count()} | Expected spawn count: {clientCount}");
 
             // Validate that the first client can spawn the "netcode hidden" in-scene placed NetworkObject
             serverObject.NetworkShow(firstClientId);
-            yield return WaitForConditionOrTimeOut(() => NetworkObjectTestComponent.SpawnedInstances.Count == TotalClients);
-            AssertOnTimeout($"[NetworkShow] Timed out waiting for Client-{firstClientId} to spawn the in-scene placed NetworkObject! Current spawned count: {NetworkObjectTestComponent.SpawnedInstances.Count()} | Expected spawn count: {TotalClients}");
+            clientCount++;
+
+            yield return WaitForConditionOrTimeOut(() => NetworkObjectTestComponent.SpawnedInstances.Count == clientCount);
+            AssertOnTimeout($"[NetworkShow] Timed out waiting for Client-{firstClientId} to spawn the in-scene placed NetworkObject! Current spawned count: {NetworkObjectTestComponent.SpawnedInstances.Count()} | Expected spawn count: {clientCount}");
 
             CleanUpLoadedScene();
         }
@@ -152,7 +161,7 @@ namespace TestProject.RuntimeTests
             // will be targeting to join late from the m_ClientNetworkManagers array, start the server
             // and the remaining client, despawn the in-scene NetworkObject, and then start and synchronize
             // the clientToTest.
-            var clientToTest = m_ClientNetworkManagers[1];
+            var clientToTest = m_ClientNetworkManagers[2];
             var clients = m_ClientNetworkManagers.ToList();
             clients.Remove(clientToTest);
             m_ClientNetworkManagers = clients.ToArray();
@@ -174,12 +183,22 @@ namespace TestProject.RuntimeTests
             Assert.IsNotNull(firstClientInSceneObjectInstance, $"Could not get the client-side registration of {nameof(NetworkObjectTestComponent)}!");
             Assert.IsTrue(firstClientInSceneObjectInstance.NetworkManager == m_ClientNetworkManagers[0]);
 
+            var playerObjectToParent = m_UseHost ? m_ServerNetworkManager.LocalClient.PlayerObject : m_PlayerNetworkObjects[m_ServerNetworkManager.LocalClientId][m_ClientNetworkManagers[1].LocalClientId];
+            var clientSidePlayer = (NetworkObject)null;
+            if (!m_UseHost)
+            {
+                playerObjectToParent = m_PlayerNetworkObjects[m_ServerNetworkManager.LocalClientId][m_ClientNetworkManagers[1].LocalClientId];
+                clientSidePlayer = m_PlayerNetworkObjects[m_ClientNetworkManagers[0].LocalClientId][m_ClientNetworkManagers[1].LocalClientId];
+            }
+            else
+            {
+                clientSidePlayer = m_PlayerNetworkObjects[m_ClientNetworkManagers[0].LocalClientId][NetworkManager.ServerClientId];
+            }
+
             // Parent the object
-            serverInSceneObjectInstance.transform.parent = m_ServerNetworkManager.LocalClient.PlayerObject.transform;
+            serverInSceneObjectInstance.transform.parent = playerObjectToParent.transform;
 
-            var clientSideServerPlayer = m_PlayerNetworkObjects[m_ClientNetworkManagers[0].LocalClientId][NetworkManager.ServerClientId];
-
-            yield return WaitForConditionOrTimeOut(() => firstClientInSceneObjectInstance.transform.parent != null && firstClientInSceneObjectInstance.transform.parent == clientSideServerPlayer.transform);
+            yield return WaitForConditionOrTimeOut(() => firstClientInSceneObjectInstance.transform.parent != null && firstClientInSceneObjectInstance.transform.parent == clientSidePlayer.transform);
             AssertOnTimeout($"Timed out waiting for the client-side id ({m_ClientNetworkManagers[0].LocalClientId}) server player transform to be set on the client-side in-scene object!");
             // Now late join a client
             NetcodeIntegrationTestHelpers.StartOneClient(clientToTest);
@@ -191,15 +210,15 @@ namespace TestProject.RuntimeTests
             // Update the newly joined client information
             ClientNetworkManagerPostStartInit();
 
-            var lateJoinClientInSceneObjectInstance = NetworkObjectTestComponent.SpawnedInstances.Where((c) => c.NetworkManager == m_ClientNetworkManagers[1]).FirstOrDefault();
+            var lateJoinClientInSceneObjectInstance = NetworkObjectTestComponent.SpawnedInstances.Where((c) => c.NetworkManager == m_ClientNetworkManagers[2]).FirstOrDefault();
             Assert.IsNotNull(lateJoinClientInSceneObjectInstance, $"Could not get the client-side registration of {nameof(NetworkObjectTestComponent)} for the late joining client!");
 
             // Now get the late-joining client's instance for the server player
-            clientSideServerPlayer = m_PlayerNetworkObjects[clientToTest.LocalClientId][NetworkManager.ServerClientId];
+            clientSidePlayer = m_PlayerNetworkObjects[clientToTest.LocalClientId][clientSidePlayer.OwnerClientId];
 
             // Validate the late joined client's in-scene NetworkObject is parented to the server-side player
-            yield return WaitForConditionOrTimeOut(() => lateJoinClientInSceneObjectInstance.transform.parent != null && lateJoinClientInSceneObjectInstance.transform.parent == clientSideServerPlayer.transform);
-            AssertOnTimeout($"Timed out waiting for the client-side id ({m_ClientNetworkManagers[0].LocalClientId}) server player transform to be set on the client-side in-scene object!");
+            yield return WaitForConditionOrTimeOut(() => lateJoinClientInSceneObjectInstance.transform.parent != null && lateJoinClientInSceneObjectInstance.transform.parent == clientSidePlayer.transform);
+            AssertOnTimeout($"Timed out waiting for the client-side id ({m_ClientNetworkManagers[0].LocalClientId}) player transform to be set on the client-side in-scene object!");
         }
 
         private void OnSceneEvent(SceneEvent sceneEvent)
@@ -484,9 +503,6 @@ namespace TestProject.RuntimeTests
             var firstClientInSceneObjectInstance = NetworkObjectTestComponent.SpawnedInstances.Where((c) => c.NetworkManager == m_ClientNetworkManagers[0]).FirstOrDefault();
             Assert.IsNotNull(firstClientInSceneObjectInstance, $"Could not get the client-side registration of {nameof(NetworkObjectTestComponent)}!");
             Assert.IsTrue(firstClientInSceneObjectInstance.NetworkManager == m_ClientNetworkManagers[0]);
-
-            // Parent the object
-            var clientSideServerPlayer = m_PlayerNetworkObjects[m_ClientNetworkManagers[0].LocalClientId][NetworkManager.ServerClientId];
 
             serverInSceneObjectInstance.AutoObjectParentSync = parentSyncSettings == ParentSyncSettings.ParentSync;
             serverInSceneObjectInstance.SynchronizeTransform = transformSyncSettings == TransformSyncSettings.TransformSync;

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/InScenePlacedNetworkObjectTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/InScenePlacedNetworkObjectTests.cs
@@ -13,8 +13,9 @@ using UnityEngine.TestTools;
 
 namespace TestProject.RuntimeTests
 {
-    [TestFixture(NetworkTopologyTypes.DistributedAuthority)]
-    [TestFixture(NetworkTopologyTypes.ClientServer)]
+    [TestFixture(NetworkTopologyTypes.DistributedAuthority, HostOrServer.DAHost)]
+    [TestFixture(NetworkTopologyTypes.ClientServer, HostOrServer.Host)]
+    [TestFixture(NetworkTopologyTypes.ClientServer, HostOrServer.Server)]
     public class InScenePlacedNetworkObjectTests : IntegrationTestWithApproximation
     {
         protected override int NumberOfClients => 2;
@@ -26,7 +27,7 @@ namespace TestProject.RuntimeTests
         private bool m_CanStartServerAndClients;
         private string m_SceneLoading = k_SceneToLoad;
 
-        public InScenePlacedNetworkObjectTests(NetworkTopologyTypes networkTopologyType) : base(networkTopologyType) { }
+        public InScenePlacedNetworkObjectTests(NetworkTopologyTypes networkTopologyType, HostOrServer hostOrServer) : base(networkTopologyType, hostOrServer) { }
 
         protected override IEnumerator OnSetup()
         {

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerPopulateInSceneTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerPopulateInSceneTests.cs
@@ -11,8 +11,9 @@ using Object = UnityEngine.Object;
 namespace TestProject.RuntimeTests
 {
 
-    [TestFixture(NetworkTopologyTypes.DistributedAuthority)]
-    [TestFixture(NetworkTopologyTypes.ClientServer)]
+    [TestFixture(NetworkTopologyTypes.DistributedAuthority, HostOrServer.DAHost)]
+    [TestFixture(NetworkTopologyTypes.ClientServer, HostOrServer.Host)]
+    [TestFixture(NetworkTopologyTypes.ClientServer, HostOrServer.Server)]
     public class NetworkSceneManagerPopulateInSceneTests : NetcodeIntegrationTest
     {
         protected override int NumberOfClients => 0;
@@ -20,7 +21,7 @@ namespace TestProject.RuntimeTests
 
         protected Dictionary<uint, GameObject> m_InSceneObjectList = new Dictionary<uint, GameObject>();
 
-        public NetworkSceneManagerPopulateInSceneTests(NetworkTopologyTypes networkTopologyType) : base(networkTopologyType) { }
+        public NetworkSceneManagerPopulateInSceneTests(NetworkTopologyTypes networkTopologyType, HostOrServer hostOrServer) : base(networkTopologyType, hostOrServer) { }
 
         protected override IEnumerator OnSetup()
         {


### PR DESCRIPTION
This fixes the issue when starting NetworkManager as server only, connecting one or more clients, and then loading a scene and the in-scene placed NetworkObjects do not get synchronized with the clients (but once the scene is loaded late joining clients do get synchronized).


[MTTB-625](https://jira.unity3d.com/browse/MTTB-625)

<!-- Add RFC link here if applicable. -->

## Changelog

- Fixed: In-scene `NertworkObject` synchronization issue when loading a scene with currently connected clients connected to a session created by a `NetworkManager` started as a server (i.e. not as a host).
- Fixed: Issue where a `NetworkManager` started as a server would not add itself as an observer to in-scene placed `NetworkObject`s instantiated and spawned by a scene loading event.

## Testing and Documentation

- Includes updates to existing integration tests.
- No documentation changes or additions were necessary.


<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
