### PR TITLE
chore: object synchronization distributed authority mode when scene management disabled

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -1001,6 +1001,14 @@ namespace Unity.Netcode
             }
 
             var distributedAuthority = NetworkManager.DistributedAuthorityMode;
+
+            // If not using DA return early or if using DA and scene management is disabled then exit early Since we use NetworkShow to spawn
+            // objects on the newly connected client side.
+            if (!distributedAuthority || distributedAuthority && !NetworkManager.NetworkConfig.EnableSceneManagement)
+            {
+                return networkClient;
+            }
+
             var sessionOwnerId = NetworkManager.CurrentSessionOwner;
             var isSessionOwner = NetworkManager.LocalClient.IsSessionOwner;
             foreach (var networkObject in NetworkManager.SpawnManager.SpawnedObjectsList)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
@@ -141,6 +141,9 @@ namespace Unity.Netcode
 
             // Then show any NetworkObjects queued to be made visible/shown
             m_NetworkManager.SpawnManager.HandleNetworkObjectShow();
+
+            // Handle object redistribution (DA + disabled scene management only)
+            m_NetworkManager.HandleRedistributionToClients();
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -2894,7 +2894,7 @@ namespace Unity.Netcode
                 SyncObservers = syncObservers,
                 Observers = syncObservers ? Observers.ToArray() : null,
                 NetworkSceneHandle = NetworkSceneHandle,
-                Hash = HostCheckForGlobalObjectIdHashOverride(),
+                Hash = CheckForGlobalObjectIdHashOverride(),
                 OwnerObject = this,
                 TargetClientId = targetClientId
             };
@@ -3246,14 +3246,14 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// Only applies to Host mode.
+        /// Only applies to Hosts or session owners (for now)
         /// Will return the registered source NetworkPrefab's GlobalObjectIdHash if one exists.
         /// Server and Clients will always return the NetworkObject's GlobalObjectIdHash.
         /// </summary>
-        /// <returns></returns>
-        internal uint HostCheckForGlobalObjectIdHashOverride()
+        /// <returns>appropriate hash value</returns>
+        internal uint CheckForGlobalObjectIdHashOverride()
         {
-            if (NetworkManager.IsServer)
+            if (NetworkManager.IsServer || (NetworkManager.DistributedAuthorityMode && NetworkManager.LocalClient.IsSessionOwner))
             {
                 if (NetworkManager.PrefabHandler.ContainsHandler(this))
                 {

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ChangeOwnershipMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ChangeOwnershipMessage.cs
@@ -332,7 +332,7 @@ namespace Unity.Netcode
             // Sanity check that we are not sending duplicated change ownership messages
             if (networkObject.OwnerClientId == OwnerClientId)
             {
-                UnityEngine.Debug.LogError($"Unnecessary ownership changed message for {NetworkObjectId}.");
+                UnityEngine.Debug.LogError($"Client-{context.SenderId} sent unnecessary ownership changed message for {NetworkObjectId}.");
                 // Ignore the message
                 return;
             }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ChangeOwnershipMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ChangeOwnershipMessage.cs
@@ -332,8 +332,8 @@ namespace Unity.Netcode
             // Sanity check that we are not sending duplicated change ownership messages
             if (networkObject.OwnerClientId == OwnerClientId)
             {
-                UnityEngine.Debug.LogError($"Client-{context.SenderId} sent unnecessary ownership changed message for {NetworkObjectId}.");
-                // Ignore the message
+                // Log error and then ignore the message
+                UnityEngine.Debug.LogError($"Client-{context.SenderId} ({RequestClientId}) sent unnecessary ownership changed message for {NetworkObjectId}.");
                 return;
             }
 

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ClientConnectedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ClientConnectedMessage.cs
@@ -68,10 +68,11 @@ namespace Unity.Netcode
                     //    networkManager.SpawnManager.ShowHiddenObjectsToNewlyJoinedClient(ClientId);
                     //}
 
-                    // We defer redistribution to the end of the NetworkUpdateStage.PostLateUpdate
-                    networkManager.RedistributeToClient = true;
-                    networkManager.ClientToRedistribute = ClientId;
-                    networkManager.TickToRedistribute = networkManager.ServerTime.Tick + (int)(0.5f * networkManager.NetworkConfig.TickRate);
+                    /// We defer redistribution to happen after NetworkShow has been invoked
+                    /// <see cref="NetworkBehaviourUpdater.NetworkBehaviourUpdater_Tick"/>
+                    /// DANGO-TODO: Determine if this needs to be removed once the service handles object distribution
+                    networkManager.RedistributeToClients = true;
+                    networkManager.ClientsToRedistribute.Add(ClientId);
                 }
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ClientConnectedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ClientConnectedMessage.cs
@@ -55,19 +55,23 @@ namespace Unity.Netcode
                 // Don't redistribute for the local instance
                 if (ClientId != networkManager.LocalClientId)
                 {
+                    // Synchronize the client with spawned objects (relative to each client)
+                    networkManager.SpawnManager.SynchronizeObjectsToNewlyJoinedClient(ClientId);
+
+                    // Keeping for reference in case the above doesn't resolve for hidden objects (theoretically it should)
                     // Show any NetworkObjects that are:
                     // - Hidden from the session owner
                     // - Owned by this client
                     // - Has NetworkObject.SpawnWithObservers set to true (the default)
-                    if (!networkManager.LocalClient.IsSessionOwner)
-                    {
-                        networkManager.SpawnManager.ShowHiddenObjectsToNewlyJoinedClient(ClientId);
-                    }
+                    //if (!networkManager.LocalClient.IsSessionOwner)
+                    //{
+                    //    networkManager.SpawnManager.ShowHiddenObjectsToNewlyJoinedClient(ClientId);
+                    //}
 
                     // We defer redistribution to the end of the NetworkUpdateStage.PostLateUpdate
                     networkManager.RedistributeToClient = true;
                     networkManager.ClientToRedistribute = ClientId;
-                    networkManager.TickToRedistribute = networkManager.ServerTime.Tick + 20;
+                    networkManager.TickToRedistribute = networkManager.ServerTime.Tick + (int)(0.5f * networkManager.NetworkConfig.TickRate);
                 }
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -580,7 +580,6 @@ namespace Unity.Netcode
                     {
                         networkObject.ChildNetworkBehaviours[i].UpdateNetworkProperties();
                     }
-
                     size = NetworkManager.ConnectionManager.SendMessage(ref message, NetworkDelivery.ReliableSequenced, NetworkManager.ServerClientId);
                     NetworkManager.NetworkMetrics.TrackOwnershipChangeSent(NetworkManager.LocalClientId, networkObject, size);
                 }
@@ -1976,14 +1975,14 @@ namespace Unity.Netcode
         /// synchronizing in order to "show" (spawn) anything that might be currently hidden from
         /// the session owner.
         /// </summary>
+        /// <remarks>
+        /// Replacement is: SynchronizeObjectsToNewlyJoinedClient
+        /// </remarks>
         internal void ShowHiddenObjectsToNewlyJoinedClient(ulong newClientId)
         {
-            if (!NetworkManager.DistributedAuthorityMode)
+            if (NetworkManager == null || NetworkManager.ShutdownInProgress && NetworkManager.LogLevel <= LogLevel.Developer)
             {
-                if (NetworkManager == null || !NetworkManager.ShutdownInProgress && NetworkManager.LogLevel <= LogLevel.Developer)
-                {
-                    Debug.LogWarning($"[Internal Error] {nameof(ShowHiddenObjectsToNewlyJoinedClient)} invoked while !");
-                }
+                Debug.LogWarning($"[Internal Error] {nameof(ShowHiddenObjectsToNewlyJoinedClient)} invoked while shutdown is in progress!");
                 return;
             }
 
@@ -2010,6 +2009,47 @@ namespace Unity.Netcode
                         {
                             // Track if there is some other location where the client is being added to the observers list when the object is hidden from the session owner
                             Debug.LogWarning($"[{networkObject.name}] Has new client as an observer but it is hidden from the session owner!");
+                        }
+                        // For now, remove the client (impossible for the new client to have an instance since the session owner doesn't) to make sure newly added
+                        // code to handle this edge case works.
+                        networkObject.Observers.Remove(newClientId);
+                    }
+                    networkObject.NetworkShow(newClientId);
+                }
+            }
+        }
+
+        internal void SynchronizeObjectsToNewlyJoinedClient(ulong newClientId)
+        {
+            if (NetworkManager == null || NetworkManager.ShutdownInProgress && NetworkManager.LogLevel <= LogLevel.Developer)
+            {
+                Debug.LogWarning($"[Internal Error] {nameof(SynchronizeObjectsToNewlyJoinedClient)} invoked while shutdown is in progress!");
+                return;
+            }
+
+            if (!NetworkManager.DistributedAuthorityMode)
+            {
+                Debug.LogError($"[Internal Error] {nameof(SynchronizeObjectsToNewlyJoinedClient)} should only be invoked when using a distributed authority network topology!");
+                return;
+            }
+
+            if (NetworkManager.NetworkConfig.EnableSceneManagement)
+            {
+                Debug.LogError($"[Internal Error] {nameof(SynchronizeObjectsToNewlyJoinedClient)} should only be invoked when scene management is disabled!");
+                return;
+            }
+
+            var localClientId = NetworkManager.LocalClient.ClientId;
+            foreach (var networkObject in SpawnedObjectsList)
+            {
+                if (networkObject.SpawnWithObservers && networkObject.OwnerClientId == localClientId)
+                {
+                    if (networkObject.Observers.Contains(newClientId))
+                    {
+                        if (NetworkManager.LogLevel <= LogLevel.Developer)
+                        {
+                            // Temporary tracking to make sure we are not showing something already visibile (should never be the case for this)
+                            Debug.LogWarning($"[{nameof(SynchronizeObjectsToNewlyJoinedClient)}][{networkObject.name}] New client as already an observer!");
                         }
                         // For now, remove the client (impossible for the new client to have an instance since the session owner doesn't) to make sure newly added
                         // code to handle this edge case works.


### PR DESCRIPTION
This PR includes updates to NGO that gets client synchronization working properly in distributed authority mode when scene management is disabled.

[MTT-9208](https://jira.unity3d.com/browse/MTT-9208)


## Changelog

- Added: Proper client synchronization when using a distributed authority network topology and scene management is disabled.

## Testing and Documentation

- No tests have been added.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
