### PR TITLE
chore: refactor session version serialization and configuration

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Configuration/SessionConfig.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Configuration/SessionConfig.cs
@@ -1,0 +1,58 @@
+namespace Unity.Netcode
+{
+    internal class SessionConfig
+    {
+        /// <summary>
+        /// The running list of session versions
+        /// </summary>
+        public const uint NoFeatureCompatibility = 0;
+        public const uint BypassFeatureCompatible = 1;
+        public const uint ServerDistributionCompatible = 2;
+
+        // The most current session version (!!!!set this when you increment!!!!!)
+        public static uint PackageSessionVersion => ServerDistributionCompatible;
+
+        internal uint SessionVersion;
+
+        public bool ServiceSideDistribution;
+
+
+        /// <summary>
+        /// Service to client
+        /// Set when the client receives a <see cref="ConnectionApprovedMessage"/>
+        /// </summary>
+        /// <param name="serviceConfig">the session's settings</param>
+        public SessionConfig(ServiceConfig serviceConfig)
+        {
+            SessionVersion = serviceConfig.SessionVersion;
+            ServiceSideDistribution = serviceConfig.ServerRedistribution;
+        }
+
+        /// <summary>
+        /// Can be used to directly set the version.
+        /// </summary>
+        /// <remarks>
+        /// If a client connects that does not support session configuration then
+        /// this will be invoked. The default values set in the constructor should
+        /// assume that no features are available.
+        /// Can also be used for mock/integration testing version handling.
+        /// </remarks>
+        /// <param name="version">version to set</param>
+        public SessionConfig(uint version)
+        {
+            SessionVersion = version;
+            ServiceSideDistribution = false;
+        }
+
+        /// <summary>
+        /// Client to Service
+        /// Default package constructor set when <see cref="NetworkManager.Initialize(bool)"/> is invoked.
+        /// </summary>
+        public SessionConfig()
+        {
+            // The current
+            SessionVersion = PackageSessionVersion;
+            ServiceSideDistribution = false;
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Configuration/SessionConfig.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Configuration/SessionConfig.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e0512e5a3e1dc484bbbf98c03a574645

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -563,7 +563,7 @@ namespace Unity.Netcode
         {
             var message = new ConnectionRequestMessage
             {
-                CMBServiceConnection = NetworkManager.CMBServiceConnection,
+                DistributedAuthority = NetworkManager.DistributedAuthorityMode,
                 // Since only a remote client will send a connection request, we should always force the rebuilding of the NetworkConfig hash value
                 ConfigHash = NetworkManager.NetworkConfig.GetConfig(false),
                 ShouldSendConnectionData = NetworkManager.NetworkConfig.ConnectionApproval,
@@ -571,7 +571,7 @@ namespace Unity.Netcode
                 MessageVersions = new NativeArray<MessageVersionData>(MessageManager.MessageHandlers.Length, Allocator.Temp)
             };
 
-            if (NetworkManager.CMBServiceConnection)
+            if (NetworkManager.DistributedAuthorityMode)
             {
                 message.ClientConfig.SessionConfig = NetworkManager.SessionConfig;
                 message.ClientConfig.TickRate = NetworkManager.NetworkConfig.TickRate;

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -573,6 +573,7 @@ namespace Unity.Netcode
 
             if (NetworkManager.CMBServiceConnection)
             {
+                message.ClientConfig.SessionConfig = NetworkManager.SessionConfig;
                 message.ClientConfig.TickRate = NetworkManager.NetworkConfig.TickRate;
                 message.ClientConfig.EnableSceneManagement = NetworkManager.NetworkConfig.EnableSceneManagement;
             }
@@ -1001,6 +1002,14 @@ namespace Unity.Netcode
             }
 
             var distributedAuthority = NetworkManager.DistributedAuthorityMode;
+
+            // If not using DA return early or if using DA and scene management is disabled then exit early Since we use NetworkShow to spawn
+            // objects on the newly connected client side.
+            if (!distributedAuthority || distributedAuthority && !NetworkManager.NetworkConfig.EnableSceneManagement)
+            {
+                return networkClient;
+            }
+
             var sessionOwnerId = NetworkManager.CurrentSessionOwner;
             var isSessionOwner = NetworkManager.LocalClient.IsSessionOwner;
             foreach (var networkObject in NetworkManager.SpawnManager.SpawnedObjectsList)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -80,6 +80,8 @@ namespace Unity.Netcode
         }
 #endif
 
+        internal SessionConfig SessionConfig;
+
         internal static bool IsDistributedAuthority;
 
         /// <summary>
@@ -1155,6 +1157,12 @@ namespace Unity.Netcode
 
         internal void Initialize(bool server)
         {
+            // Always create a default session config when starting a NetworkManager instance
+            if (DistributedAuthorityMode)
+            {
+                SessionConfig = new SessionConfig();
+            }
+
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
             if (!DisableNotOptimizedSerializedType)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -82,6 +82,16 @@ namespace Unity.Netcode
 
         internal SessionConfig SessionConfig;
 
+        /// <summary>
+        /// Used for internal testing purposes
+        /// </summary>
+        internal delegate SessionConfig OnGetSessionConfigHandler();
+        internal OnGetSessionConfigHandler OnGetSessionConfig;
+        private SessionConfig GetSessionConfig()
+        {
+            return OnGetSessionConfig != null ? OnGetSessionConfig.Invoke() : new SessionConfig();
+        }
+
         internal static bool IsDistributedAuthority;
 
         /// <summary>
@@ -1157,12 +1167,6 @@ namespace Unity.Netcode
 
         internal void Initialize(bool server)
         {
-            // Always create a default session config when starting a NetworkManager instance
-            if (DistributedAuthorityMode)
-            {
-                SessionConfig = new SessionConfig();
-            }
-
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
             if (!DisableNotOptimizedSerializedType)
             {
@@ -1176,6 +1180,12 @@ namespace Unity.Netcode
             NetworkTransformUpdate.Clear();
 
             UpdateTopology();
+
+            // Always create a default session config when starting a NetworkManager instance
+            if (DistributedAuthorityMode)
+            {
+                SessionConfig = GetSessionConfig();
+            }
 
             // Make sure the ServerShutdownState is reset when initializing
             if (server)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/SessionVersionConnectionRequest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/SessionVersionConnectionRequest.cs
@@ -1,0 +1,106 @@
+using System.Collections;
+using NUnit.Framework;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    internal class SessionVersionConnectionRequest : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 0;
+
+        public SessionVersionConnectionRequest() : base(NetworkTopologyTypes.DistributedAuthority, HostOrServer.DAHost) { }
+
+        private bool m_UseValidSessionVersion;
+        private bool m_ClientWasDisconnected;
+        private NetworkManager m_ClientNetworkManager;
+
+        /// <summary>
+        /// Callback used to mock the scenario where a client has an invalid session version
+        /// </summary>
+        /// <returns><see cref="SessionConfig"/></returns>
+        private SessionConfig GetInavlidSessionConfig()
+        {
+            return new SessionConfig(m_ServerNetworkManager.SessionConfig.SessionVersion - 1);
+        }
+
+        /// <summary>
+        /// Overriding this method allows us to configure the newly instantiated client's
+        /// NetworkManager prior to it being started.
+        /// </summary>
+        /// <param name="networkManager">the newly instantiated NetworkManager</param>
+        protected override void OnNewClientCreated(NetworkManager networkManager)
+        {
+            m_ClientWasDisconnected = false;
+            m_ClientNetworkManager = networkManager;
+            m_ClientNetworkManager.OnClientDisconnectCallback += OnClientDisconnectCallback;
+            if (!m_UseValidSessionVersion)
+            {
+                networkManager.OnGetSessionConfig = GetInavlidSessionConfig;
+            }
+            base.OnNewClientCreated(networkManager);
+        }
+
+        /// <summary>
+        /// Tracks if the client was disconnected or not
+        /// </summary>
+        private void OnClientDisconnectCallback(ulong clientId)
+        {
+            m_ClientWasDisconnected = true;
+            m_ClientNetworkManager.OnClientDisconnectCallback -= OnClientDisconnectCallback;
+        }
+
+        /// <summary>
+        /// This handles disabling the internal integration test logic that waits for
+        /// clients to be connected. When we know the client will be disconnected,
+        /// we want to have the NetcodeIntegrationTest not wait for the client to
+        /// connect (otherwise it will timeout there and fail the test).
+        /// </summary>
+        /// <param name="networkManager"></param>
+        /// <returns>true = wait | false = don't wait</returns>
+        protected override bool ShouldWaitForNewClientToConnect(NetworkManager networkManager)
+        {
+            return m_UseValidSessionVersion;
+        }
+
+        /// <summary>
+        /// Validates that when the client's session config version is valid a client will be
+        /// allowed to connect and when it is not valid the client will be disconnected.
+        /// </summary>
+        /// <remarks>
+        /// This is just a mock of the service logic to validate everything on the NGO side is
+        /// working correctly.
+        /// </remarks>
+        /// <param name="useValidSessionVersion">true = use valid session version | false = use invalid session version</param>
+        [UnityTest]
+        public IEnumerator ValidateSessionVersion([Values] bool useValidSessionVersion)
+        {
+            // Test client being disconnected due to invalid session version
+            m_UseValidSessionVersion = useValidSessionVersion;
+            yield return CreateAndStartNewClient();
+            yield return s_DefaultWaitForTick;
+            if (!m_UseValidSessionVersion)
+            {
+                yield return WaitForConditionOrTimeOut(() => m_ClientWasDisconnected);
+                AssertOnTimeout("Client was not disconnected when it should have been!");
+                Assert.True(m_ClientNetworkManager.DisconnectReason == ConnectionRequestMessage.InvalidSessionVersionMessage, "Client did not receive the correct invalid session version message!");
+            }
+            else
+            {
+                Assert.False(m_ClientWasDisconnected, "Client was disconnected when it was expected to connect!");
+                Assert.True(m_ClientNetworkManager.IsConnectedClient, "Client did not connect properly using the correct session version!");
+            }
+        }
+
+        /// <summary>
+        /// Invoked at the end of each integration test pass.
+        /// Primarily used to clean up for the next pass.
+        /// </summary>
+        protected override IEnumerator OnTearDown()
+        {
+            m_ClientNetworkManager.OnClientDisconnectCallback -= OnClientDisconnectCallback;
+            m_ClientNetworkManager = null;
+            yield return base.OnTearDown();
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/SessionVersionConnectionRequest.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/SessionVersionConnectionRequest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 62913c78d28137141acc47ea8f63e657


### PR DESCRIPTION
This is a minor refactoring of #3132 in order to provide a more unified way to handle the session versioning (or "package version"). It includes a new `SessionConfig` that is configured upon approval and will be used to determine a session's supported features.


## Changelog

NA

## Testing and Documentation

- Includes integration tests.
- Validated against live service using internal asteroids repository main branch.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
