### PR TITLE
fix: Server only session issues with parent synchronize and networkobjecteditor

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/NetworkObjectEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkObjectEditor.cs
@@ -88,6 +88,14 @@ namespace Unity.Netcode.Editor
 
                         while (observerClientIds.MoveNext())
                         {
+                            if (!m_NetworkObject.NetworkManager.ConnectedClients.ContainsKey(observerClientIds.Current))
+                            {
+                                if ((observerClientIds.Current == 0 && m_NetworkObject.NetworkManager.IsHost) || observerClientIds.Current > 0)
+                                {
+                                    Debug.LogWarning($"Client-{observerClientIds.Current} is listed as an observer but is not connected!");
+                                }
+                                continue;
+                            }
                             if (m_NetworkObject.NetworkManager.ConnectedClients[observerClientIds.Current].PlayerObject != null)
                             {
                                 EditorGUILayout.ObjectField($"ClientId: {observerClientIds.Current}", m_NetworkObject.NetworkManager.ConnectedClients[observerClientIds.Current].PlayerObject, typeof(GameObject), false);

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ParentSyncMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ParentSyncMessage.cs
@@ -70,10 +70,6 @@ namespace Unity.Netcode
         public bool Deserialize(FastBufferReader reader, ref NetworkContext context, int receivedMessageVersion)
         {
             var networkManager = (NetworkManager)context.SystemOwner;
-            if (!networkManager.IsClient)
-            {
-                return false;
-            }
 
             ByteUnpacker.ReadValueBitPacked(reader, out NetworkObjectId);
             reader.ReadValueSafe(out m_BitField);


### PR DESCRIPTION
This PR resolves two issues discovered while fiddling around with a server hosted (i.e. non-host) session specific project.

- `NetworkBehaviorEditor`: Would throw exceptions if you tried to view the observers of a spawned `NetworkObject`.
- `ParentSyncMessage`: Was exiting when a server would receive a message from a client. We now allow clients to parent locally if they have the "Allow Owner to Parent" setting enabled.


## Changelog

- Fixed: Issue where `NetworkBehaviorEditor` would throw exceptions if you tried to view the observers of a spawned `NetworkObject`.
- Fixed: Issue where `ParentSyncMessage` was exiting early during serialization when a server would receive a message from a client. We now allow clients to parent locally if they have the "Allow Owner to Parent" setting enabled and so this is a valid scenario.

## Testing and Documentation

- No test were included.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
