### PR TITLE
fix: ObjectDisposedException on NetworkManager after shutting down the Transport

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1495,6 +1495,11 @@ namespace Unity.Netcode.Transports.UTP
         /// </summary>
         public override void Shutdown()
         {
+            if (m_NetworkManager && !m_NetworkManager.ShutdownInProgress)
+            {
+                Debug.LogWarning("Directly calling `UnityTransport.Shutdown()` results in unexpected shutdown behaviour. All pending events will be lost. Use `NetworkManager.Shutdown()` instead.");
+            }
+
             if (m_Driver.IsCreated)
             {
                 while (ProcessEvent() && m_Driver.IsCreated)
@@ -1519,6 +1524,7 @@ namespace Unity.Netcode.Transports.UTP
             DisposeInternals();
 
             m_ReliableReceiveQueues.Clear();
+            m_State = State.Disconnected;
 
             // We must reset this to zero because UTP actually re-uses clientIds if there is a clean disconnect
             m_ServerClientId = 0;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTestHelpers.cs
@@ -36,6 +36,24 @@ namespace Unity.Netcode.RuntimeTests
             Assert.Fail("Timed out while waiting for network event.");
         }
 
+        // Wait to ensure no event is sent.
+        public static IEnumerator EnsureNoNetworkEvent(List<TransportEvent> events, float timeout = MaxNetworkEventWaitTime)
+        {
+            int initialCount = events.Count;
+            float startTime = Time.realtimeSinceStartup;
+
+            while (Time.realtimeSinceStartup - startTime < timeout)
+            {
+                if (events.Count > initialCount)
+                {
+                    Assert.Fail("Received unexpected network event.");
+                }
+
+                yield return new WaitForSeconds(0.01f);
+            }
+        }
+
+
         // Common code to initialize a UnityTransport that logs its events.
         public static void InitializeTransport(out UnityTransport transport, out List<TransportEvent> events,
             int maxPayloadSize = UnityTransport.InitialMaxPayloadSize, int maxSendQueueSize = 0, NetworkFamily family = NetworkFamily.Ipv4)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
@@ -499,5 +499,46 @@ namespace Unity.Netcode.RuntimeTests
 
             yield return WaitForNetworkEvent(NetworkEvent.Data, m_Client1Events);
         }
+
+        public enum AfterShutdownAction
+        {
+            Send,
+            DisconnectRemoteClient,
+            DisconnectLocalClient,
+        }
+
+        [UnityTest]
+        public IEnumerator DoesNotActAfterShutdown([Values] AfterShutdownAction afterShutdownAction)
+        {
+            InitializeTransport(out m_Server, out m_ServerEvents);
+            InitializeTransport(out m_Client1, out m_Client1Events);
+
+            m_Server.StartServer();
+            m_Client1.StartClient();
+
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_Client1Events);
+
+            m_Server.Shutdown();
+
+            if (afterShutdownAction == AfterShutdownAction.Send)
+            {
+                var data = new ArraySegment<byte>(new byte[16]);
+                m_Server.Send(m_Client1.ServerClientId, data, NetworkDelivery.Reliable);
+
+                yield return EnsureNoNetworkEvent(m_Client1Events);
+            }
+            else if (afterShutdownAction == AfterShutdownAction.DisconnectRemoteClient)
+            {
+                m_Server.DisconnectRemoteClient(m_Client1.ServerClientId);
+
+                LogAssert.Expect(LogType.Assert, "DisconnectRemoteClient should be called on a listening server");
+            }
+            else if (afterShutdownAction == AfterShutdownAction.DisconnectLocalClient)
+            {
+                m_Server.DisconnectLocalClient();
+
+                yield return EnsureNoNetworkEvent(m_Client1Events);
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. Delete bullet points below that don't apply, and update the changelog section as appropriate. -->
Ensures that `UnityTransport` is marked as `Disconnected` after shutting down. This ensures that no exceptions are thrown when trying to use the transport after it has been shut down.

This PR also adds a warning message when a `UnityTransport` has a `NetworkManager` and `UnityTransport.Shutdown()` has been called outside of `NetworkManager.Shutdown()` as shutting down the `UnityTransport` directly will result in unexpected disconnection behaviour (connected clients will not get `Disconnect` events and pending messages may be dropped).

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->
fix: #3118 

<!-- Add RFC link here if applicable. -->

## Changelog

- Fixed:  Issue where an `ObjectDisposedException` was thrown when calling `NetworkManager.Shutdown()` after calling `UnityTransport.Shutdown()`

## Testing and Documentation

- Unit tests have been added to `UnityTransportTests` to ensure exceptions are not thrown when using the transport after shutting it down.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
