### PR TITLE
fix: make ClientConfig version signed

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionRequestMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionRequestMessage.cs
@@ -8,12 +8,12 @@ namespace Unity.Netcode
     internal struct ClientConfig : INetworkSerializable
     {
         public SessionConfig SessionConfig;
-        public uint SessionVersion => SessionConfig.SessionVersion;
+        public int SessionVersion => (int)SessionConfig.SessionVersion;
         public uint TickRate;
         public bool EnableSceneManagement;
 
         // Only gets deserialized but should never be used unless testing
-        public uint RemoteClientSessionVersion;
+        public int RemoteClientSessionVersion;
 
         public void NetworkSerialize<T>(BufferSerializer<T> serializer) where T : IReaderWriter
         {


### PR DESCRIPTION
`ConnectionRequestMessage::ClientConfig::SessionVersion` was originally signed but was changed to unsigned in https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3138. This is a breaking protocol change and we need to revert to the original behaviour. 

## Testing and Documentation

- Tested against CMB CI
