### PR TITLE
fix: adding extended timeout to all universal rpc tests

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
@@ -918,6 +918,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
         }
     }
 
+    [Timeout(1200000)]
     [TestFixture(HostOrServer.Host)]
     [TestFixture(HostOrServer.Server)]
     internal class UniversalRpcTestSendingNoOverride : UniversalRpcTestsBase
@@ -948,6 +949,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
     }
 
+    [Timeout(1200000)]
     [TestFixture(HostOrServer.Host)]
     [TestFixture(HostOrServer.Server)]
     internal class UniversalRpcTestSenderClientId : UniversalRpcTestsBase
@@ -978,6 +980,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
     }
 
+    [Timeout(1200000)]
     [TestFixture(HostOrServer.Host)]
     [TestFixture(HostOrServer.Server)]
     internal class UniversalRpcTestSendingNoOverrideWithParams : UniversalRpcTestsBase
@@ -1020,6 +1023,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
     }
 
+    [Timeout(1200000)]
     [TestFixture(HostOrServer.Host)]
     [TestFixture(HostOrServer.Server)]
     internal class UniversalRpcTestSendingNoOverrideWithParamsAndRpcParams : UniversalRpcTestsBase
@@ -1062,6 +1066,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
     }
 
+    [Timeout(1200000)]
     [TestFixture(HostOrServer.Host)]
     [TestFixture(HostOrServer.Server)]
     internal class UniversalRpcTestRequireOwnership : UniversalRpcTestsBase
@@ -1098,6 +1103,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
         }
     }
 
+    [Timeout(1200000)]
     [TestFixture(HostOrServer.Host)]
     [TestFixture(HostOrServer.Server)]
     internal class UniversalRpcTestDisallowedOverride : UniversalRpcTestsBase
@@ -1133,6 +1139,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
     }
 
+    [Timeout(1200000)]
     [TestFixture(HostOrServer.Host)]
     [TestFixture(HostOrServer.Server)]
     internal class UniversalRpcTestSendingWithTargetOverride : UniversalRpcTestsBase
@@ -1166,6 +1173,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
     }
 
+    [Timeout(1200000)]
     [TestFixture(HostOrServer.Host)]
     [TestFixture(HostOrServer.Server)]
     internal class UniversalRpcTestSendingWithSingleOverride : UniversalRpcTestsBase
@@ -1213,6 +1221,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
     }
 
+    [Timeout(1200000)]
     [TestFixture(HostOrServer.Host)]
     [TestFixture(HostOrServer.Server)]
     internal class UniversalRpcTestSendingWithSingleNotOverride : UniversalRpcTestsBase
@@ -1261,7 +1270,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
     }
 
     [Timeout(1200000)]
-    [TestFixture(HostOrServer.Host)]    
+    [TestFixture(HostOrServer.Host)]
     [TestFixture(HostOrServer.Server)]
     internal class UniversalRpcTestSendingWithGroupOverride : UniversalRpcTestsBase
     {
@@ -1288,7 +1297,6 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
         // Extending timeout since the added yield return causes this test to commonly timeout
         [Test]
-        [Ignore("Test Needs Refactor")]
         public void TestSendingWithGroupOverride(
             [Values] SendTo defaultSendTo,
             [ValueSource(nameof(RecipientGroups))] ulong[] recipient,
@@ -1339,7 +1347,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
         }
     }
 
-    
+
     [Timeout(1200000)]
     [TestFixture(HostOrServer.Host)]
     [TestFixture(HostOrServer.Server)]
@@ -1366,10 +1374,9 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             List
         }
 
-        
+
         // Extending timeout since the added yield return causes this test to commonly timeout
         [Test]
-        [Ignore("Test Needs Refactor")]
         public void TestSendingWithGroupNotOverride(
             [Values] SendTo defaultSendTo,
             [ValueSource(nameof(RecipientGroups))] ulong[] recipient,
@@ -1420,6 +1427,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
         }
     }
 
+    [Timeout(1200000)]
     [TestFixture(HostOrServer.Host)]
     [TestFixture(HostOrServer.Server)]
     internal class UniversalRpcTestDefaultSendToSpecifiedInParamsSendingToServerAndOwner : UniversalRpcTestsBase
@@ -1430,6 +1438,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
         }
     }
 
+    [Timeout(1200000)]
     [TestFixture(HostOrServer.Host)]
     [TestFixture(HostOrServer.Server)]
     internal class UniversalRpcTestDeferLocal : UniversalRpcTestsBase
@@ -1617,6 +1626,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
     }
 
+    [Timeout(1200000)]
     [TestFixture(HostOrServer.Host)]
     [TestFixture(HostOrServer.Server)]
     internal class UniversalRpcTestMutualRecursion : UniversalRpcTestsBase
@@ -1666,6 +1676,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
     }
 
+    [Timeout(1200000)]
     [TestFixture(HostOrServer.Host)]
     [TestFixture(HostOrServer.Server)]
     internal class UniversalRpcTestSelfRecursion : UniversalRpcTestsBase
@@ -1705,6 +1716,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
     }
 
+    [Timeout(1200000)]
     [TestFixture(ObjType.Server)]
     [TestFixture(ObjType.Client)]
     internal class UniversalRpcTestRpcTargetUse : UniversalRpcTestsBase


### PR DESCRIPTION
Adding extended timeout to all universal rpc tests


## Changelog

NA

## Testing and Documentation

- Includes timeout modifications to universal RPC tests.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
