### PR TITLE
fix: clamp spawntimeout to recommended range

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkConfig.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkConfig.cs
@@ -13,6 +13,14 @@ namespace Unity.Netcode
     [Serializable]
     public class NetworkConfig
     {
+        // Clamp spawn time outs to prevent dropping messages during scene events
+        // Note: The legacy versions of NGO defaulted to 1s which was too low. As
+        // well, the SpawnTimeOut is now being clamped to within this recommended
+        // range both via UI and when NetworkManager is validated.
+        internal const float MinSpawnTimeout = 10.0f;
+        // Clamp spawn time outs to no more than 1 hour (really that is a bit high)
+        internal const float MaxSpawnTimeout = 3600.0f;
+
         /// <summary>
         /// The protocol version. Different versions doesn't talk to each other.
         /// </summary>
@@ -132,6 +140,8 @@ namespace Unity.Netcode
         /// The amount of time a message will be held (deferred) if the destination NetworkObject needed to process the message doesn't exist yet. If the NetworkObject is not spawned within this time period, all deferred messages for that NetworkObject will be dropped.
         /// </summary>
         [Tooltip("The amount of time a message will be held (deferred) if the destination NetworkObject needed to process the message doesn't exist yet. If the NetworkObject is not spawned within this time period, all deferred messages for that NetworkObject will be dropped.")]
+        
+        [Range(MinSpawnTimeout, MaxSpawnTimeout)]
         public float SpawnTimeout = 10f;
 
         /// <summary>
@@ -175,6 +185,21 @@ namespace Unity.Netcode
         /// </summary>
         [Tooltip("Enable (default) if you want to profile network messages with development builds and defaults to being disabled in release builds. When disabled, network messaging profiling will be disabled in development builds.")]
         public bool NetworkProfilingMetrics = true;
+
+        /// <summary>
+        /// Invoked by <see cref="NetworkManager"/> when it is validated.
+        /// </summary>
+        /// <remarks>
+        /// Used to check for potential legacy values that have already been serialized and/or
+        /// runtime modifications to a property outside of the recommended range.
+        /// For each property checked below, provide a brief description of the reason.
+        /// </remarks>
+        internal void OnValidate()
+        {
+            // Legacy NGO versions defaulted this value to 1 second that has since been determiend
+            // any range less than 10 seconds can lead to dropped messages during scene events.
+            SpawnTimeout = Mathf.Clamp(SpawnTimeout, MinSpawnTimeout, MaxSpawnTimeout);
+        }
 
         /// <summary>
         /// Returns a base64 encoded version of the configuration

--- a/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkConfig.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkConfig.cs
@@ -140,7 +140,7 @@ namespace Unity.Netcode
         /// The amount of time a message will be held (deferred) if the destination NetworkObject needed to process the message doesn't exist yet. If the NetworkObject is not spawned within this time period, all deferred messages for that NetworkObject will be dropped.
         /// </summary>
         [Tooltip("The amount of time a message will be held (deferred) if the destination NetworkObject needed to process the message doesn't exist yet. If the NetworkObject is not spawned within this time period, all deferred messages for that NetworkObject will be dropped.")]
-        
+
         [Range(MinSpawnTimeout, MaxSpawnTimeout)]
         public float SpawnTimeout = 10f;
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -955,6 +955,9 @@ namespace Unity.Netcode
                 return; // May occur when the component is added
             }
 
+            // Do a validation pass on NetworkConfig properties
+            NetworkConfig.OnValidate();
+
             if (GetComponentInChildren<NetworkObject>() != null)
             {
                 if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -2007,12 +2007,14 @@ namespace Unity.Netcode
 
         internal bool InternalTrySetParent(NetworkObject parent, bool worldPositionStays = true)
         {
-            if (parent != null && (IsSpawned ^ parent.IsSpawned))
+            if (parent != null && (IsSpawned ^ parent.IsSpawned) && NetworkManager != null && !NetworkManager.ShutdownInProgress)
             {
-                if (NetworkManager != null && !NetworkManager.ShutdownInProgress)
+                if (NetworkManager.LogLevel <= LogLevel.Developer)
                 {
-                    return false;
+                    var nameOfNotSpawnedObject = IsSpawned ? $" the parent ({parent.name})" : $"the child ({name})";
+                    NetworkLog.LogWarning($"Parenting failed because {nameOfNotSpawnedObject} is not spawned!");
                 }
+                return false;
             }
 
             m_CachedWorldPositionStays = worldPositionStays;

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1903,10 +1903,12 @@ namespace Unity.Netcode
             SendSceneEventData(sceneEventData.SceneEventId, NetworkManager.ConnectedClientsIds.Where(c => c != sessionOwner).ToArray());
 
             m_IsSceneEventActive = false;
+
+            sceneEventData.SceneEventType = SceneEventType.LoadComplete;
             //First, notify local server that the scene was loaded
             OnSceneEvent?.Invoke(new SceneEvent()
             {
-                SceneEventType = SceneEventType.LoadComplete,
+                SceneEventType = sceneEventData.SceneEventType,
                 LoadSceneMode = sceneEventData.LoadSceneMode,
                 SceneName = SceneNameFromHash(sceneEventData.SceneHash),
                 ClientId = NetworkManager.LocalClientId,


### PR DESCRIPTION
This PR assures that `NetworkConfig.SpawnTimeOut` is clamped to a range from 10 to 3600 seconds.
The minimum clamp prevents projects that started with older versions of NGO where the default was 1s vs the current 10s. 

## Changelog

- Fixed: Issue where the legacy default SpawnTimeout value of 1 second was not being updated automatically and could frequently lead to dropped pending messages during a scene event.


## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
