### PR TITLE
fix: server, host, or session owner not populating in-scene placed object table when started

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -17,6 +17,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where the server, host, or session owner would not populate the in-scene place `NetworkObject` table if the scene was loaded prior to starting the `NetworkManager`.
 - Fixed issue where the `NetworkObjectIdHash` value could be incorrect when entering play mode while still in prefab edit mode with pending changes and using MPPM. (#3162)
 - Fixed issue where a sever only `NetworkManager` instance would spawn the actual `NetworkPrefab`'s `GameObject` as opposed to creating an instance of it. (#3160)
 - Fixed issue where only the session owner (as opposed to all clients) would handle spawning prefab overrides properly when using a distributed authority network topology. (#3160)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -17,7 +17,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue where the server, host, or session owner would not populate the in-scene place `NetworkObject` table if the scene was loaded prior to starting the `NetworkManager`.
+- Fixed issue where the server, host, or session owner would not populate the in-scene place `NetworkObject` table if the scene was loaded prior to starting the `NetworkManager`. (#3177)
 - Fixed issue where the `NetworkObjectIdHash` value could be incorrect when entering play mode while still in prefab edit mode with pending changes and using MPPM. (#3162)
 - Fixed issue where a sever only `NetworkManager` instance would spawn the actual `NetworkPrefab`'s `GameObject` as opposed to creating an instance of it. (#3160)
 - Fixed issue where only the session owner (as opposed to all clients) would handle spawning prefab overrides properly when using a distributed authority network topology. (#3160)

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1449,6 +1449,15 @@ namespace Unity.Netcode
                 }
             }
 
+            // Since we are spawing in-scene placed NetworkObjects for already loaded scenes,
+            // we need to add any in-scene placed NetworkObject to our tracking table 
+            var clearFirst = true;
+            foreach(var sceneLoaded in NetworkManager.SceneManager.ScenesLoaded)
+            {
+                NetworkManager.SceneManager.PopulateScenePlacedObjects(sceneLoaded.Value, clearFirst);
+                clearFirst = false;
+            }
+            
             // Notify all in-scene placed NetworkObjects have been spawned
             foreach (var networkObject in networkObjectsToSpawn)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1452,12 +1452,12 @@ namespace Unity.Netcode
             // Since we are spawing in-scene placed NetworkObjects for already loaded scenes,
             // we need to add any in-scene placed NetworkObject to our tracking table 
             var clearFirst = true;
-            foreach(var sceneLoaded in NetworkManager.SceneManager.ScenesLoaded)
+            foreach (var sceneLoaded in NetworkManager.SceneManager.ScenesLoaded)
             {
                 NetworkManager.SceneManager.PopulateScenePlacedObjects(sceneLoaded.Value, clearFirst);
                 clearFirst = false;
             }
-            
+
             // Notify all in-scene placed NetworkObjects have been spawned
             foreach (var networkObject in networkObjectsToSpawn)
             {


### PR DESCRIPTION
This PR fixes an issue where the server, host,  or session owner was not populating the in-scene placed `NetworkObject` table when spawning in-scene placed `NetworkObjects` that were within one or more scenes loaded before starting the `NetworkManager`.

[MTTB-870](https://jira.unity3d.com/browse/MTTB-870)

<!-- Add RFC link here if applicable. -->

## Changelog

- Fixed: Issue where the server, host, or session owner would not populate the in-scene place `NetworkObject` table if the scene was loaded prior to starting the `NetworkManager`.

## Testing and Documentation

- No tests have been added (needs to be manually tested).
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
