### PR TITLE
chore: enabling renovate bot on develop

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,38 @@
+{
+  "baseBranches": ["develop", "develop-2.0.0"],
+  
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>unity/renovate-config"
+  ],
+  "prConcurrentLimit": 100,
+  // Ignore commits produced by github actions workflows
+  "gitIgnoredAuthors": ["githubaction@githubaction.com"],
+  "ignorePaths": [
+    "**/node_modules/**",
+    // Don't renovate files in special folders using ~ as suffix
+    "**/*~/**"
+  ],
+  "packageRules": [
+
+    // Run unity-upm-project and unity-upm-package only on weekends to reduce PR noise
+    // Also ensure dependencies won't be downgraded when they don't exist in the public repositories
+    {
+      "matchManagers": [
+        "unity-upm-project",
+        "unity-upm-package"
+      ],
+      "enabled": "true",
+      "schedule": [
+        "every weekend"
+      ],
+      "rollbackPrs": false
+    },
+
+    // Enable automerge for Bokken image updates
+    {
+      "matchDatasources": ["unity-bokken"],
+      "automerge": false,
+    },
+  ],
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,7 +14,6 @@
     "**/*~/**"
   ],
   "packageRules": [
-
     // Run unity-upm-project and unity-upm-package only on weekends to reduce PR noise
     // Also ensure dependencies won't be downgraded when they don't exist in the public repositories
     {

--- a/.github/workflows/renovate-validation.yml
+++ b/.github/workflows/renovate-validation.yml
@@ -1,0 +1,40 @@
+# Refer to https://internaldocs.unity.com/renovate/ for more documentation
+
+# This workflow is for validating the Renovate configuration and docker image
+# updates for it.
+name: Renovate Validation
+on:
+  workflow_dispatch:
+    inputs:
+      log-level:
+        type: choice
+        description: Select log level for Renovate
+        options:
+          - trace
+          - debug
+          - info
+          - warn
+          - error
+        default: info
+        required: false
+  pull_request:
+    paths:
+      # we trigger validation on any changes to the renovate workflow files
+      - .github/workflows/renovate*.yml
+      # as well as for any possible location for the renovate config file
+      - .github/renovate.json?
+
+
+jobs:
+  renovate-validation:
+    # The reusable workflow will be updated by renovate if there's a new version
+    uses: Unity-Technologies/renovate-workflows/.github/workflows/run.yml@v5.0.0
+    with:
+      # This is the image that contains our custom renovate and will be auto
+      # updated by Renovate itself.
+      image: europe-docker.pkg.dev/unity-cds-services-prd/ds-docker/renovate:10.1.3@sha256:fdeed7bb524bd67611eb91ee1a5e990c8c73ed62c84a0cd5ef66c87eb5fd0d70
+      dry-run: full
+      log-level: ${{ github.event.inputs.log-level }}
+    secrets:
+      renovate-auth-secret: ${{ secrets.RENOVATE_AUTH_SECRET }}
+      github-com-token: ${{ secrets.GH_COM_TOKEN }}

--- a/.github/workflows/renovate-validation.yml
+++ b/.github/workflows/renovate-validation.yml
@@ -1,5 +1,3 @@
-# Refer to https://internaldocs.unity.com/renovate/ for more documentation
-
 # This workflow is for validating the Renovate configuration and docker image
 # updates for it.
 name: Renovate Validation

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -16,8 +16,8 @@ on:
         default: info
         required: false
   schedule:
-    # Daily scheduled run.
-    - cron: '0 0 * * *'
+    # Every 6 hours at the 6th minute.
+    - cron: '06 */6 * * *'
 
 jobs:
   renovate:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,33 @@
+# This workflow runs Renovate against the current repo and will create PRs with outdated dependencies.
+name: Renovate
+
+on:
+  workflow_dispatch:
+    inputs:
+      log-level:
+        type: choice
+        description: Select log level for Renovate
+        options:
+          - trace
+          - debug
+          - info
+          - warn
+          - error
+        default: info
+        required: false
+  schedule:
+    # Daily scheduled run.
+    - cron: '0 0 * * *'
+
+jobs:
+  renovate:
+    # The reusable workflow will be updated by renovate if there's a new version
+    uses: Unity-Technologies/renovate-workflows/.github/workflows/run.yml@v5.0.0
+    with:
+      # This is the image that contains our custom renovate and will be auto
+      # updated by Renovate itself.
+      image: europe-docker.pkg.dev/unity-cds-services-prd/ds-docker/renovate:10.1.3@sha256:fdeed7bb524bd67611eb91ee1a5e990c8c73ed62c84a0cd5ef66c87eb5fd0d70
+      log-level: ${{ github.event.inputs.log-level }}
+    secrets:
+      renovate-auth-secret: ${{ secrets.RENOVATE_AUTH_SECRET }}
+      github-com-token: ${{ secrets.GH_COM_TOKEN }}


### PR DESCRIPTION
This PR aims to add files necessary for enabling unity-renovate bot to run on this repository and make automated PRs with dependencies of this repo (as per documentation)

This is a backport since [PR was created for develop-2.0.0 branch](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3191) From my knowledge the PRs created by the bot will target main repository branch (which currently is develop)