### PR TITLE
chore: update rigidbody deprecations

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where `NetworkRigidBody2D` was still using the deprecated `isKinematic` property in Unity versions 2022.3 and newer. (#3199)
 - Fixed issue where an exception was thrown when calling `NetworkManager.Shutdown` after calling `UnityTransport.Shutdown`. (#3118)
 
 ### Changed

--- a/com.unity.netcode.gameobjects/Components/NetworkRigidbody2D.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkRigidbody2D.cs
@@ -52,7 +52,16 @@ namespace Unity.Netcode.Components
             // Turn off physics for the rigid body until spawned, otherwise
             // clients can run fixed update before the first full
             // NetworkTransform update
-            m_Rigidbody.isKinematic = true;
+            SetIsKinematic(true);
+        }
+
+        private void SetIsKinematic(bool isKinematic)
+        {
+#if UNITY_2022_3_OR_NEWER
+            m_Rigidbody.bodyType = isKinematic ? RigidbodyType2D.Kinematic : RigidbodyType2D.Dynamic;
+#else
+            m_Rigidbody.isKinematic = isKinematic;
+#endif
         }
 
         /// <summary>
@@ -89,7 +98,7 @@ namespace Unity.Netcode.Components
             }
 
             // If you have authority then you are not kinematic
-            m_Rigidbody.isKinematic = !m_IsAuthority;
+            SetIsKinematic(!m_IsAuthority);
 
             // Set interpolation of the Rigidbody2D based on authority
             // With authority: let local transform handle interpolation

--- a/testproject/Assets/Tests/Runtime/Physics/NetworkRigidbodyTests.cs
+++ b/testproject/Assets/Tests/Runtime/Physics/NetworkRigidbodyTests.cs
@@ -97,27 +97,21 @@ namespace TestProject.RuntimeTests
             Assert.True(serverClientPlayerNetworkRigidbody2d.WasKinematicBeforeSpawn);
             Assert.True(clientServerPlayerNetworkRigidbody2d.WasKinematicBeforeSpawn);
 
-            // Validate kinematic settings after spawn
-            var serverLocalPlayerRigidbody2d = m_ServerNetworkManager.LocalClient.PlayerObject.GetComponent<Rigidbody2D>();
-            var clientLocalPlayerRigidbody2d = m_ClientNetworkManagers[0].LocalClient.PlayerObject.GetComponent<Rigidbody2D>();
-            var serverClientPlayerRigidbody2d = m_PlayerNetworkObjects[m_ServerNetworkManager.LocalClientId][m_ClientNetworkManagers[0].LocalClientId].GetComponent<Rigidbody2D>();
-            var clientServerPlayerRigidbody2d = m_PlayerNetworkObjects[m_ClientNetworkManagers[0].LocalClientId][m_ServerNetworkManager.LocalClientId].GetComponent<Rigidbody2D>();
-
             var isOwnerAuthority = m_AuthorityMode == NetworkTransformRigidBodyTestComponent.AuthorityModes.Owner;
             if (isOwnerAuthority)
             {
                 // can commit player has authority and should have a kinematic mode of false (or true in case body was already kinematic).
-                Assert.True(!serverLocalPlayerRigidbody2d.isKinematic);
-                Assert.True(!clientLocalPlayerRigidbody2d.isKinematic);
-                Assert.True(serverClientPlayerRigidbody2d.isKinematic);
-                Assert.True(clientServerPlayerRigidbody2d.isKinematic);
+                Assert.True(!serverLocalPlayerNetworkRigidbody2d.IsKinematic());
+                Assert.True(!clientLocalPlayerNetworkRigidbody2d.IsKinematic());
+                Assert.True(serverClientPlayerNetworkRigidbody2d.IsKinematic());
+                Assert.True(clientServerPlayerNetworkRigidbody2d.IsKinematic());
             }
             else
             {
-                Assert.True(!serverLocalPlayerRigidbody2d.isKinematic);
-                Assert.True(clientLocalPlayerRigidbody2d.isKinematic);
-                Assert.True(!serverClientPlayerRigidbody2d.isKinematic);
-                Assert.True(clientServerPlayerRigidbody2d.isKinematic);
+                Assert.True(!serverLocalPlayerNetworkRigidbody2d.IsKinematic());
+                Assert.True(clientLocalPlayerNetworkRigidbody2d.IsKinematic());
+                Assert.True(!serverClientPlayerNetworkRigidbody2d.IsKinematic());
+                Assert.True(clientServerPlayerNetworkRigidbody2d.IsKinematic());
             }
         }
 #endif

--- a/testproject/Assets/Tests/Runtime/Physics/NetworkTransformRigidBodyTestComponent.cs
+++ b/testproject/Assets/Tests/Runtime/Physics/NetworkTransformRigidBodyTestComponent.cs
@@ -26,9 +26,19 @@ namespace TestProject.RuntimeTests
     {
         public bool WasKinematicBeforeSpawn;
 
+
+        internal bool IsKinematic()
+        {
+#if UNITY_2022_3_OR_NEWER
+            return GetComponent<Rigidbody2D>().bodyType == RigidbodyType2D.Kinematic;
+#else
+            return GetComponent<Rigidbody2D>().isKinematic;
+#endif
+        }
+
         protected override void OnNetworkPreSpawn(ref NetworkManager networkManager)
         {
-            WasKinematicBeforeSpawn = GetComponent<Rigidbody2D>().isKinematic;
+            WasKinematicBeforeSpawn = IsKinematic();
             base.OnNetworkPreSpawn(ref networkManager);
         }
     }


### PR DESCRIPTION
This PR updates NetworkRigidbody2D and the associated tests to the deprecation of `isKinematic`.

## Changelog

- Fixed: Issue where `NetworkRigidBody2D` was still using the deprecated `isKinematic` property in Unity versions 2022.3 and newer.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.


<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
