### PR TITLE
fix: client owned NetworkObject with prefabhandler destroy order incorrect on host-server side (Backport)

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where a spawned `NetworkObject` that was registered with a prefab handler and owned by a client would invoke destroy more than once on the host-server side if the client disconnected while the `NetworkObject` was still spawned. (#3202)
 - Fixed issue where an exception was thrown when calling `NetworkManager.Shutdown` after calling `UnityTransport.Shutdown`. (#3118)
 
 ### Changed

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -967,6 +967,11 @@ namespace Unity.Netcode
                     {
                         if (NetworkManager.PrefabHandler.ContainsHandler(ConnectedClients[clientId].PlayerObject.GlobalObjectIdHash))
                         {
+                            // If the player is spawned, then despawn before invoking HandleNetworkPrefabDestroy
+                            if (playerObject.IsSpawned)
+                            {
+                                NetworkManager.SpawnManager.DespawnObject(ConnectedClients[clientId].PlayerObject, false);
+                            }
                             NetworkManager.PrefabHandler.HandleNetworkPrefabDestroy(ConnectedClients[clientId].PlayerObject);
                         }
                         else if (playerObject.IsSpawned)
@@ -984,38 +989,31 @@ namespace Unity.Netcode
 
                 // Get the NetworkObjects owned by the disconnected client
                 var clientOwnedObjects = NetworkManager.SpawnManager.GetClientOwnedObjects(clientId);
-                if (clientOwnedObjects == null)
+
+                // Handle despawn & destroy or change ownership
+                for (int i = clientOwnedObjects.Count - 1; i >= 0; i--)
                 {
-                    // This could happen if a client is never assigned a player object and is disconnected
-                    // Only log this in verbose/developer mode
-                    if (NetworkManager.LogLevel == LogLevel.Developer)
+                    var ownedObject = clientOwnedObjects[i];
+                    if (ownedObject != null)
                     {
-                        NetworkLog.LogWarning($"ClientID {clientId} disconnected with (0) zero owned objects!  Was a player prefab not assigned?");
-                    }
-                }
-                else
-                {
-                    // Handle changing ownership and prefab handlers
-                    for (int i = clientOwnedObjects.Count - 1; i >= 0; i--)
-                    {
-                        var ownedObject = clientOwnedObjects[i];
-                        if (ownedObject != null)
+                        if (!ownedObject.DontDestroyWithOwner)
                         {
-                            if (!ownedObject.DontDestroyWithOwner)
+                            if (NetworkManager.PrefabHandler.ContainsHandler(clientOwnedObjects[i].GlobalObjectIdHash))
                             {
-                                if (NetworkManager.PrefabHandler.ContainsHandler(clientOwnedObjects[i].GlobalObjectIdHash))
+                                if (ownedObject.IsSpawned)
                                 {
-                                    NetworkManager.PrefabHandler.HandleNetworkPrefabDestroy(clientOwnedObjects[i]);
+                                    NetworkManager.SpawnManager.DespawnObject(ownedObject, false);
                                 }
-                                else
-                                {
-                                    Object.Destroy(ownedObject.gameObject);
-                                }
+                                NetworkManager.PrefabHandler.HandleNetworkPrefabDestroy(clientOwnedObjects[i]);
                             }
-                            else if (!NetworkManager.ShutdownInProgress)
+                            else
                             {
-                                ownedObject.RemoveOwnership();
+                                Object.Destroy(ownedObject.gameObject);
                             }
+                        }
+                        else if (!NetworkManager.ShutdownInProgress)
+                        {
+                            ownedObject.RemoveOwnership();
                         }
                     }
                 }

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -994,27 +994,28 @@ namespace Unity.Netcode
                 for (int i = clientOwnedObjects.Count - 1; i >= 0; i--)
                 {
                     var ownedObject = clientOwnedObjects[i];
-                    if (ownedObject != null)
+                    if (!ownedObject)
                     {
-                        if (!ownedObject.DontDestroyWithOwner)
+                        continue;
+                    }
+                    if (!ownedObject.DontDestroyWithOwner)
+                    {
+                        if (NetworkManager.PrefabHandler.ContainsHandler(clientOwnedObjects[i].GlobalObjectIdHash))
                         {
-                            if (NetworkManager.PrefabHandler.ContainsHandler(clientOwnedObjects[i].GlobalObjectIdHash))
+                            if (ownedObject.IsSpawned)
                             {
-                                if (ownedObject.IsSpawned)
-                                {
-                                    NetworkManager.SpawnManager.DespawnObject(ownedObject, false);
-                                }
-                                NetworkManager.PrefabHandler.HandleNetworkPrefabDestroy(clientOwnedObjects[i]);
+                                NetworkManager.SpawnManager.DespawnObject(ownedObject, false);
                             }
-                            else
-                            {
-                                Object.Destroy(ownedObject.gameObject);
-                            }
+                            NetworkManager.PrefabHandler.HandleNetworkPrefabDestroy(clientOwnedObjects[i]);
                         }
-                        else if (!NetworkManager.ShutdownInProgress)
+                        else
                         {
-                            ownedObject.RemoveOwnership();
+                            Object.Destroy(ownedObject.gameObject);
                         }
+                    }
+                    else if (!NetworkManager.ShutdownInProgress)
+                    {
+                        ownedObject.RemoveOwnership();
                     }
                 }
 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
@@ -527,6 +527,29 @@ namespace Unity.Netcode.TestHelpers.Runtime
             }
         }
 
+        /// <summary>
+        /// Creates a <see cref="NetworkObject"/> to be used with integration testing
+        /// </summary>
+        /// <param name="baseName">namr of the object</param>
+        /// <param name="owner">owner of the object</param>
+        /// <param name="moveToDDOL">when true, the instance is automatically migrated into the DDOL</param>
+        /// <returns></returns>
+        internal static GameObject CreateNetworkObject(string baseName, NetworkManager owner, bool moveToDDOL = false)
+        {
+            var gameObject = new GameObject
+            {
+                name = baseName
+            };
+            var networkObject = gameObject.AddComponent<NetworkObject>();
+            networkObject.NetworkManagerOwner = owner;
+            MakeNetworkObjectTestPrefab(networkObject);
+            if (moveToDDOL)
+            {
+                Object.DontDestroyOnLoad(gameObject);
+            }
+            return gameObject;
+        }
+
         public static GameObject CreateNetworkObjectPrefab(string baseName, NetworkManager server, params NetworkManager[] clients)
         {
             void AddNetworkPrefab(NetworkConfig config, NetworkPrefab prefab)
@@ -538,13 +561,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             Assert.IsNotNull(server, prefabCreateAssertError);
             Assert.IsFalse(server.IsListening, prefabCreateAssertError);
 
-            var gameObject = new GameObject
-            {
-                name = baseName
-            };
-            var networkObject = gameObject.AddComponent<NetworkObject>();
-            networkObject.NetworkManagerOwner = server;
-            MakeNetworkObjectTestPrefab(networkObject);
+            var gameObject = CreateNetworkObject(baseName, server);
             var networkPrefab = new NetworkPrefab() { Prefab = gameObject };
 
             // We could refactor this test framework to share a NetworkPrefabList instance, but at this point it's

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkPrefabOverrideTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkPrefabOverrideTests.cs
@@ -1,0 +1,341 @@
+using System.Collections;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    /// <summary>
+    /// Integration test that validates spawning instances of <see cref="NetworkPrefab"/>s with overrides and
+    /// <see cref="NetworkPrefabHandler"/> registered overrides.
+    /// </summary>
+    [TestFixture(HostOrServer.Server)]
+    [TestFixture(HostOrServer.Host)]
+    internal class NetworkPrefabOverrideTests : NetcodeIntegrationTest
+    {
+        private const string k_PrefabRootName = "PrefabObj";
+        protected override int NumberOfClients => 2;
+
+        private NetworkPrefab m_ClientSidePlayerPrefab;
+        private NetworkPrefab m_PrefabOverride;
+
+        public NetworkPrefabOverrideTests(HostOrServer hostOrServer) : base(hostOrServer) { }
+
+        /// <summary>
+        /// Prefab override handler that will instantiate the ServerSideInstance (m_PlayerPrefab) only on server instances
+        /// and will spawn the ClientSideInstance (m_ClientSidePlayerPrefab.Prefab) only on clients and/or a host.
+        /// </summary>
+        public class TestPrefabOverrideHandler : MonoBehaviour, INetworkPrefabInstanceHandler
+        {
+            public GameObject ServerSideInstance;
+            public GameObject ClientSideInstance;
+            private NetworkManager m_NetworkManager;
+
+            private void Start()
+            {
+                m_NetworkManager = GetComponent<NetworkManager>();
+                m_NetworkManager.PrefabHandler.AddHandler(ServerSideInstance, this);
+            }
+
+            private void OnDestroy()
+            {
+                if (m_NetworkManager != null && m_NetworkManager.PrefabHandler != null)
+                {
+                    m_NetworkManager.PrefabHandler.RemoveHandler(ServerSideInstance);
+                }
+            }
+
+            public NetworkObject Instantiate(ulong ownerClientId, Vector3 position, Quaternion rotation)
+            {
+                var instance = m_NetworkManager.IsClient ? Instantiate(ClientSideInstance) : Instantiate(ServerSideInstance);
+                return instance.GetComponent<NetworkObject>();
+            }
+
+            public void Destroy(NetworkObject networkObject)
+            {
+                Object.Destroy(networkObject);
+            }
+        }
+
+
+        internal class SpawnDespawnDestroyNotifications : NetworkBehaviour
+        {
+
+            public int Despawned { get; private set; }
+            public int Destroyed { get; private set; }
+
+            private bool m_WasSpawned;
+
+            private ulong m_LocalClientId;
+
+            public override void OnNetworkSpawn()
+            {
+                m_WasSpawned = true;
+                m_LocalClientId = NetworkManager.LocalClientId;
+                base.OnNetworkSpawn();
+            }
+
+            public override void OnNetworkDespawn()
+            {
+                Assert.True(Destroyed == 0, $"{name} on client-{m_LocalClientId} should have a destroy invocation count of 0 but it is {Destroyed}!");
+                Assert.True(Despawned == 0, $"{name} on client-{m_LocalClientId} should have a despawn invocation count of 0 but it is {Despawned}!");
+                Despawned++;
+                base.OnNetworkDespawn();
+            }
+
+            public override void OnDestroy()
+            {
+                // When the original prefabs are destroyed, we want to ignore this check (those instances are never spawned)
+                if (m_WasSpawned)
+                {
+                    Assert.True(Despawned == 1, $"{name} on client-{m_LocalClientId} should have a despawn invocation count of 1 but it is {Despawned}!");
+                    Assert.True(Destroyed == 0, $"{name} on client-{m_LocalClientId} should have a destroy invocation count of 0 but it is {Destroyed}!");
+                }
+                Destroyed++;
+
+                base.OnDestroy();
+            }
+        }
+
+        /// <summary>
+        /// Mock component for testing that the client-side player is using the right
+        /// network prefab.
+        /// </summary>
+        public class ClientSideOnlyComponent : MonoBehaviour
+        {
+
+        }
+
+        /// <summary>
+        /// When we create the player prefab, make a modified instance that will be used
+        /// with the <see cref="TestPrefabOverrideHandler"/>.
+        /// </summary>
+        protected override void OnCreatePlayerPrefab()
+        {
+            var clientPlayer = Object.Instantiate(m_PlayerPrefab);
+            clientPlayer.AddComponent<ClientSideOnlyComponent>();
+            Object.DontDestroyOnLoad(clientPlayer);
+            m_ClientSidePlayerPrefab = new NetworkPrefab()
+            {
+                Prefab = clientPlayer,
+            };
+
+            base.OnCreatePlayerPrefab();
+        }
+
+        /// <summary>
+        /// Add the additional <see cref="NetworkPrefab"/>s and <see cref="TestPrefabOverrideHandler"/>s to
+        /// all <see cref="NetworkManager"/> instances.
+        /// </summary>
+        protected override void OnServerAndClientsCreated()
+        {
+            // Create a NetworkPrefab with an override
+
+            var basePrefab = NetcodeIntegrationTestHelpers.CreateNetworkObject($"{k_PrefabRootName}-base", m_ServerNetworkManager, true);
+            basePrefab.AddComponent<SpawnDespawnDestroyNotifications>();
+            var targetPrefab = NetcodeIntegrationTestHelpers.CreateNetworkObject($"{k_PrefabRootName}-over", m_ServerNetworkManager, true);
+            targetPrefab.AddComponent<SpawnDespawnDestroyNotifications>();
+            m_PrefabOverride = new NetworkPrefab()
+            {
+                Prefab = basePrefab,
+                Override = NetworkPrefabOverride.Prefab,
+                SourcePrefabToOverride = basePrefab,
+                OverridingTargetPrefab = targetPrefab,
+            };
+
+            // Add the prefab override handler for instance specific player prefabs to the server side
+            var playerPrefabOverrideHandler = m_ServerNetworkManager.gameObject.AddComponent<TestPrefabOverrideHandler>();
+            playerPrefabOverrideHandler.ServerSideInstance = m_PlayerPrefab;
+            playerPrefabOverrideHandler.ClientSideInstance = m_ClientSidePlayerPrefab.Prefab;
+
+            // Add the NetworkPrefab with override
+            m_ServerNetworkManager.NetworkConfig.Prefabs.Add(m_PrefabOverride);
+            // Add the client player prefab that will be used on clients (and the host)
+            m_ServerNetworkManager.NetworkConfig.Prefabs.Add(m_ClientSidePlayerPrefab);
+
+            foreach (var networkManager in m_ClientNetworkManagers)
+            {
+                // Add the prefab override handler for instance specific player prefabs to the client side
+                playerPrefabOverrideHandler = networkManager.gameObject.AddComponent<TestPrefabOverrideHandler>();
+                playerPrefabOverrideHandler.ServerSideInstance = m_PlayerPrefab;
+                playerPrefabOverrideHandler.ClientSideInstance = m_ClientSidePlayerPrefab.Prefab;
+
+                // Add the NetworkPrefab with override
+                networkManager.NetworkConfig.Prefabs.Add(m_PrefabOverride);
+                // Add the client player prefab that will be used on clients (and the host)
+                networkManager.NetworkConfig.Prefabs.Add(m_ClientSidePlayerPrefab);
+            }
+
+            m_PrefabOverride.Prefab.GetComponent<NetworkObject>().IsSceneObject = false;
+            m_PrefabOverride.SourcePrefabToOverride.GetComponent<NetworkObject>().IsSceneObject = false;
+            m_PrefabOverride.OverridingTargetPrefab.GetComponent<NetworkObject>().IsSceneObject = false;
+            m_ClientSidePlayerPrefab.Prefab.GetComponent<NetworkObject>().IsSceneObject = false;
+
+            base.OnServerAndClientsCreated();
+        }
+
+        protected override IEnumerator OnTearDown()
+        {
+            if (m_PrefabOverride != null)
+            {
+                if (m_PrefabOverride.SourcePrefabToOverride)
+                {
+                    Object.Destroy(m_PrefabOverride.SourcePrefabToOverride);
+                }
+
+                if (m_PrefabOverride.OverridingTargetPrefab)
+                {
+                    Object.Destroy(m_PrefabOverride.OverridingTargetPrefab);
+                }
+            }
+
+            if (m_ClientSidePlayerPrefab != null)
+            {
+                if (m_ClientSidePlayerPrefab.Prefab)
+                {
+                    Object.Destroy(m_ClientSidePlayerPrefab.Prefab);
+                }
+            }
+            m_ClientSidePlayerPrefab = null;
+            m_PrefabOverride = null;
+
+            yield return base.OnTearDown();
+        }
+
+
+        private GameObject GetPlayerNetworkPrefabObject(NetworkManager networkManager)
+        {
+            return networkManager.IsClient ? m_ClientSidePlayerPrefab.Prefab : m_PlayerPrefab;
+        }
+
+        [UnityTest]
+        public IEnumerator PrefabOverrideTests()
+        {
+            var prefabNetworkObject = (NetworkObject)null;
+            var spawnedGlobalObjectId = (uint)0;
+
+            var networkManagers = m_ClientNetworkManagers.ToList();
+            if (m_UseHost)
+            {
+                networkManagers.Insert(0, m_ServerNetworkManager);
+            }
+            else
+            {
+                // If running as just a server, validate that all player prefab clone instances are the server side version
+                prefabNetworkObject = GetPlayerNetworkPrefabObject(m_ServerNetworkManager).GetComponent<NetworkObject>();
+                foreach (var playerEntry in m_PlayerNetworkObjects[m_ServerNetworkManager.LocalClientId])
+                {
+                    spawnedGlobalObjectId = playerEntry.Value.GlobalObjectIdHash;
+                    Assert.IsTrue(prefabNetworkObject.GlobalObjectIdHash == spawnedGlobalObjectId, $"Server-Side {playerEntry.Value.name} was spawned as prefab ({spawnedGlobalObjectId}) but we expected ({prefabNetworkObject.GlobalObjectIdHash})!");
+                }
+            }
+
+            // Validates prefab overrides via the NetworkPrefabHandler.
+            // Validate the player prefab instance clones relative to all NetworkManagers.
+            foreach (var networkManager in networkManagers)
+            {
+                // Get the expected player prefab to be spawned based on the NetworkManager
+                prefabNetworkObject = GetPlayerNetworkPrefabObject(networkManager).GetComponent<NetworkObject>();
+                if (networkManager.IsClient)
+                {
+                    spawnedGlobalObjectId = networkManager.LocalClient.PlayerObject.GlobalObjectIdHash;
+                    Assert.IsTrue(prefabNetworkObject.GlobalObjectIdHash == spawnedGlobalObjectId, $"{networkManager.name} spawned player prefab ({spawnedGlobalObjectId}) did not match the expected one ({prefabNetworkObject.GlobalObjectIdHash})!");
+                }
+
+                foreach (var playerEntry in m_PlayerNetworkObjects[networkManager.LocalClientId])
+                {
+                    // We already checked our locally spawned player prefab above
+                    if (playerEntry.Key == networkManager.LocalClientId)
+                    {
+                        continue;
+                    }
+                    spawnedGlobalObjectId = playerEntry.Value.GlobalObjectIdHash;
+                    Assert.IsTrue(prefabNetworkObject.GlobalObjectIdHash == spawnedGlobalObjectId, $"Client-{networkManager.LocalClientId} clone of {playerEntry.Value.name} was spawned as prefab ({spawnedGlobalObjectId}) but we expected ({prefabNetworkObject.GlobalObjectIdHash})!");
+                }
+            }
+
+            // Validates prefab overrides via NetworkPrefab configuration.
+            var spawnedInstance = (NetworkObject)null;
+            var networkManagerOwner = m_ServerNetworkManager;
+
+            // Clients and Host will spawn the OverridingTargetPrefab while a dedicated server will spawn the SourcePrefabToOverride
+            var expectedServerGlobalObjectIdHash = networkManagerOwner.IsClient ? m_PrefabOverride.OverridingTargetPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash : m_PrefabOverride.SourcePrefabToOverride.GetComponent<NetworkObject>().GlobalObjectIdHash;
+            var expectedClientGlobalObjectIdHash = m_PrefabOverride.OverridingTargetPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash;
+
+            spawnedInstance = NetworkObject.InstantiateAndSpawn(m_PrefabOverride.SourcePrefabToOverride, networkManagerOwner, networkManagerOwner.LocalClientId);
+            var builder = new StringBuilder();
+            bool ObjectSpawnedOnAllNetworkMangers()
+            {
+                builder.Clear();
+                if (!m_ServerNetworkManager.SpawnManager.SpawnedObjects.ContainsKey(spawnedInstance.NetworkObjectId))
+                {
+                    builder.AppendLine($"Client-{m_ServerNetworkManager.LocalClientId} failed to spawn {spawnedInstance.name}-{spawnedInstance.NetworkObjectId}!");
+                    return false;
+                }
+                var instanceGID = m_ServerNetworkManager.SpawnManager.SpawnedObjects[spawnedInstance.NetworkObjectId].GlobalObjectIdHash;
+                if (instanceGID != expectedServerGlobalObjectIdHash)
+                {
+                    builder.AppendLine($"Client-{m_ServerNetworkManager.LocalClientId} instance {spawnedInstance.name}-{spawnedInstance.NetworkObjectId} GID is {instanceGID} but was expected to be {expectedServerGlobalObjectIdHash}!");
+                    return false;
+                }
+
+                foreach (var networkManger in m_ClientNetworkManagers)
+                {
+                    if (!networkManger.SpawnManager.SpawnedObjects.ContainsKey(spawnedInstance.NetworkObjectId))
+                    {
+                        builder.AppendLine($"Client-{networkManger.LocalClientId} failed to spawn {spawnedInstance.name}-{spawnedInstance.NetworkObjectId}!");
+                        return false;
+                    }
+                    instanceGID = networkManger.SpawnManager.SpawnedObjects[spawnedInstance.NetworkObjectId].GlobalObjectIdHash;
+                    if (instanceGID != expectedClientGlobalObjectIdHash)
+                    {
+                        builder.AppendLine($"Client-{networkManger.LocalClientId} instance {spawnedInstance.name}-{spawnedInstance.NetworkObjectId} GID is {instanceGID} but was expected to be {expectedClientGlobalObjectIdHash}!");
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            yield return WaitForConditionOrTimeOut(ObjectSpawnedOnAllNetworkMangers);
+            AssertOnTimeout($"The spawned prefab override validation failed!\n {builder}");
+
+            // Verify that the despawn and destroy order of operations is correct for client owned NetworkObjects and the nunmber of times each is invoked is correct
+            expectedServerGlobalObjectIdHash = networkManagerOwner.IsClient ? m_PrefabOverride.OverridingTargetPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash : m_PrefabOverride.SourcePrefabToOverride.GetComponent<NetworkObject>().GlobalObjectIdHash;
+            expectedClientGlobalObjectIdHash = m_PrefabOverride.OverridingTargetPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash;
+
+            spawnedInstance = NetworkObject.InstantiateAndSpawn(m_PrefabOverride.SourcePrefabToOverride, networkManagerOwner, m_ClientNetworkManagers[0].LocalClientId);
+
+
+            yield return WaitForConditionOrTimeOut(ObjectSpawnedOnAllNetworkMangers);
+            AssertOnTimeout($"The spawned prefab override validation failed!\n {builder}");
+            var clientId = m_ClientNetworkManagers[0].LocalClientId;
+            m_ClientNetworkManagers[0].Shutdown();
+
+            // Wait until all of the client's owned objects are destroyed
+            // If no asserts occur, then the despawn & destroy order of operations and invocation count is correct
+            /// For more information look at: <see cref="SpawnDespawnDestroyNotifications"/>
+            bool ClientDisconnected(ulong clientId)
+            {
+                var clientOwnedObjects = m_ServerNetworkManager.SpawnManager.SpawnedObjects.Where((c) => c.Value.OwnerClientId == clientId).ToList();
+                if (clientOwnedObjects.Count > 0)
+                {
+                    return false;
+                }
+
+                clientOwnedObjects = m_ClientNetworkManagers[1].SpawnManager.SpawnedObjects.Where((c) => c.Value.OwnerClientId == clientId).ToList();
+                if (clientOwnedObjects.Count > 0)
+                {
+                    return false;
+                }
+                return true;
+            }
+
+            yield return WaitForConditionOrTimeOut(() => ClientDisconnected(clientId));
+            AssertOnTimeout($"Timed out waiting for client to disconnect!");
+        }
+    }
+}
+

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkPrefabOverrideTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkPrefabOverrideTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a9e880f2982b3ad4794454a95cea6582
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This is a back-port of #3200

*Replication of the issue is as follows:*
- Using a client-server network topology
  - At least one client must be connected to a host or server.
- NetworkObjects are spawned with:
  - Ownership belonging to a connected client.
    - _Does not occur if they are owned by the server._
  - Don't destroy with owner is not enabled (i.e. it will destroy when the client leaves)
    - _Does not occur if don't destroy with owner is enabled._
- While the NetworkObjects (owned by the client) are still spawned, the client disconnects.

NGO V1: On the host/server side, the Destroy method is called prior to the OnNetworkDespawn.

This also includes:
- Improvements to integration test helpers and some fixes to `NetworkObject.InstantiateAndSpawn`.
- Bug fixes for `NetworkObject.InstantiateAndSpawn`.
- `NetworkPrefabOverrideTests` was backported from v2.

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->

fix: #3190

## Changelog

Fixed: Issue where a spawned `NetworkObject` that was registered with a prefab handler and owned by a client would invoke destroy more than once on the host-server side if the client disconnected while the `NetworkObject` was still spawned.
Fixed: Issue where `NetworkObject.InstantiateAndSpawn` would not honor the `isPlayerObject` parameter.
Fixed: Issue where `NetworkObject.InstantiateAndSpawn` would not make an instance of a network prefab but would spawn the network prefab itself.

## Testing and Documentation

- Includes integration test: `NetworkPrefabOverrideTests`.
- No documentation changes or additions were necessary.