### PR TITLE
fix: distribute parented children distributing with root parent

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue with distributing parented children that have the distributable and/or transferrable permissions set and have the same owner as the root parent, that has the distributable permission set, upon the owning client disconnecting when using a distributed authority network topology.
 - Fixed issue where a spawned `NetworkObject` that was registered with a prefab handler and owned by a client would invoke destroy more than once on the host-server side if the client disconnected while the `NetworkObject` was still spawned. (#3200)
 
 ### Changed

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,7 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue with distributing parented children that have the distributable and/or transferrable permissions set and have the same owner as the root parent, that has the distributable permission set, upon the owning client disconnecting when using a distributed authority network topology.
+- Fixed issue with distributing parented children that have the distributable and/or transferrable permissions set and have the same owner as the root parent, that has the distributable permission set, were not being distributed to the same client upon the owning client disconnecting when using a distributed authority network topology. (#3203)
 - Fixed issue where a spawned `NetworkObject` that was registered with a prefab handler and owned by a client would invoke destroy more than once on the host-server side if the client disconnected while the `NetworkObject` was still spawned. (#3200)
 
 ### Changed

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -1225,7 +1225,7 @@ namespace Unity.Netcode
                                     }
                                     NetworkManager.SpawnManager.ChangeOwnership(ownedObject, targetOwner, true);
                                     // DANGO-TODO: Should we try handling inactive NetworkObjects?
-                                    // Ownership gets passed down to all children
+                                    // Ownership gets passed down to all children that have the same owner.
                                     var childNetworkObjects = ownedObject.GetComponentsInChildren<NetworkObject>();
                                     foreach (var childObject in childNetworkObjects)
                                     {
@@ -1245,6 +1245,14 @@ namespace Unity.Netcode
                                         {
                                             continue;
                                         }
+
+                                        // If the child's owner is not the client disconnected and the objects are marked with either distributable or transferable, then
+                                        // do not change ownership.
+                                        if (childObject.OwnerClientId != clientId && (childObject.IsOwnershipDistributable || childObject.IsOwnershipTransferable))
+                                        {
+                                            continue;
+                                        }
+
                                         NetworkManager.SpawnManager.ChangeOwnership(childObject, targetOwner, true);
                                         if (EnableDistributeLogging)
                                         {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1659,7 +1659,20 @@ namespace Unity.Netcode
                 }
                 if (NetworkManager.NetworkConfig.EnableSceneManagement)
                 {
-                    NetworkSceneHandle = NetworkManager.SceneManager.ClientSceneHandleToServerSceneHandle[gameObject.scene.handle];
+                    if (!NetworkManager.SceneManager.ClientSceneHandleToServerSceneHandle.ContainsKey(gameObject.scene.handle))
+                    {
+                        // Most likely this issue is due to an integration test
+                        if (NetworkManager.LogLevel <= LogLevel.Developer)
+                        {
+                            NetworkLog.LogWarning($"Failed to find scene handle {gameObject.scene.handle} for {gameObject.name}!");
+                        }
+                        // Just use the existing handle
+                        NetworkSceneHandle = gameObject.scene.handle;
+                    }
+                    else
+                    {
+                        NetworkSceneHandle = NetworkManager.SceneManager.ClientSceneHandleToServerSceneHandle[gameObject.scene.handle];
+                    }
                 }
                 if (DontDestroyWithOwner && !IsOwnershipDistributable)
                 {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/ParentChildDistibutionTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/ParentChildDistibutionTests.cs
@@ -1,0 +1,264 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    internal class ParentChildDistibutionTests : IntegrationTestWithApproximation
+    {
+        protected override int NumberOfClients => 4;
+
+        private GameObject m_GenericPrefab;
+        private ulong m_OriginalOwnerId;
+        private List<NetworkObject> m_TargetSpawnedObjects = new List<NetworkObject>();
+        private List<NetworkObject> m_AltTargetSpawnedObjects = new List<NetworkObject>();
+        private Dictionary<ulong, List<NetworkObject>> m_AncillarySpawnedObjects = new Dictionary<ulong, List<NetworkObject>>();
+        private List<NetworkManager> m_NetworkManagers = new List<NetworkManager>();
+        private StringBuilder m_ErrorMsg = new StringBuilder();
+
+        public ParentChildDistibutionTests() : base(HostOrServer.DAHost)
+        {
+        }
+
+        protected override IEnumerator OnTearDown()
+        {
+            m_NetworkManagers.Clear();
+            m_TargetSpawnedObjects.Clear();
+            m_AncillarySpawnedObjects.Clear();
+            m_AltTargetSpawnedObjects.Clear();
+            return base.OnTearDown();
+        }
+
+        protected override void OnServerAndClientsCreated()
+        {
+            m_GenericPrefab = CreateNetworkObjectPrefab("GenPrefab");
+            var networkObject = m_GenericPrefab.GetComponent<NetworkObject>();
+            networkObject.DontDestroyWithOwner = true;
+            base.OnServerAndClientsCreated();
+        }
+
+        private bool AllTargetedInstancesSpawned()
+        {
+            m_ErrorMsg.Clear();
+            foreach (var client in m_NetworkManagers)
+            {
+                foreach (var spawnedObject in m_TargetSpawnedObjects)
+                {
+                    if (!client.SpawnManager.SpawnedObjects.ContainsKey(spawnedObject.NetworkObjectId))
+                    {
+                        m_ErrorMsg.AppendLine($"{client.name} has not spawned {spawnedObject.name}!");
+                    }
+                }
+            }
+
+            return m_ErrorMsg.Length == 0;
+        }
+
+        private bool AllAncillaryInstancesSpawned()
+        {
+            m_ErrorMsg.Clear();
+            foreach (var client in m_NetworkManagers)
+            {
+                foreach (var clientObjects in m_AncillarySpawnedObjects)
+                {
+                    foreach (var spawnedObject in clientObjects.Value)
+                    {
+                        if (!client.SpawnManager.SpawnedObjects.ContainsKey(spawnedObject.NetworkObjectId))
+                        {
+                            m_ErrorMsg.AppendLine($"{client.name} has not spawned {spawnedObject.name}!");
+                        }
+                    }
+                }
+            }
+
+            return m_ErrorMsg.Length == 0;
+        }
+
+        /// <summary>
+        /// Validates that a new owner is assigned to all of the targeted objects
+        /// </summary>
+        private bool TargetedObjectsChangedOwnership()
+        {
+            m_ErrorMsg.Clear();
+            var newOwnerId = m_OriginalOwnerId;
+            foreach (var spawnedObject in m_AltTargetSpawnedObjects)
+            {
+                if (spawnedObject.OwnerClientId == m_OriginalOwnerId)
+                {
+                    m_ErrorMsg.AppendLine($"{spawnedObject.name} still is owned by Client-{m_OriginalOwnerId}!");
+                }
+                else if (m_OriginalOwnerId == newOwnerId)
+                {
+                    newOwnerId = spawnedObject.OwnerClientId;
+                }
+
+                if (spawnedObject.OwnerClientId != newOwnerId)
+                {
+                    m_ErrorMsg.AppendLine($"{spawnedObject.name} is not owned by Client-{newOwnerId}!");
+                }
+            }
+            return m_ErrorMsg.Length == 0;
+        }
+
+        private bool AncillaryObjectsKeptOwnership()
+        {
+            m_ErrorMsg.Clear();
+            foreach (var clientObjects in m_AncillarySpawnedObjects)
+            {
+                foreach (var spawnedObject in clientObjects.Value)
+                {
+                    if (spawnedObject.OwnerClientId != clientObjects.Key)
+                    {
+                        m_ErrorMsg.AppendLine($"{spawnedObject.name} changed ownership to Client-{spawnedObject.OwnerClientId}!");
+                    }
+                }
+            }
+            return m_ErrorMsg.Length == 0;
+        }
+
+        public enum DistributionTypes
+        {
+            UponConnect,
+            UponDisconnect
+        }
+
+
+        [UnityTest]
+        public IEnumerator DistributeOwnerHierarchy([Values] DistributionTypes distributionType)
+        {
+            m_NetworkManagers.Clear();
+            m_TargetSpawnedObjects.Clear();
+            m_AncillarySpawnedObjects.Clear();
+            m_AltTargetSpawnedObjects.Clear();
+
+            if (distributionType == DistributionTypes.UponConnect)
+            {
+                m_ClientNetworkManagers[3].Shutdown();
+            }
+
+            if (!UseCMBService())
+            {
+                m_NetworkManagers.Add(m_ServerNetworkManager);
+            }
+            m_NetworkManagers.AddRange(m_ClientNetworkManagers);
+            if (distributionType == DistributionTypes.UponConnect)
+            {
+                m_NetworkManagers.Remove(m_ClientNetworkManagers[3]);
+            }
+
+            // When testing connect redistribution, 
+            var instances = distributionType == DistributionTypes.UponDisconnect ? 1 : 2;
+            var rootObject = (GameObject)null;
+            var childOne = (GameObject)null;
+            var childTwo = (GameObject)null;
+            var networkObject = (NetworkObject)null;
+            
+            for (int i = 0; i < instances; i++)
+            {
+                rootObject = SpawnObject(m_GenericPrefab, m_ClientNetworkManagers[0]);
+                networkObject = rootObject.GetComponent<NetworkObject>();
+                networkObject.SetOwnershipStatus(NetworkObject.OwnershipStatus.Distributable);
+                m_TargetSpawnedObjects.Add(networkObject);
+
+                // Used to validate nested transferable transfers to the same owner
+                childOne = SpawnObject(m_GenericPrefab, m_ClientNetworkManagers[0]);
+                networkObject = childOne.GetComponent<NetworkObject>();
+                networkObject.SetOwnershipStatus(NetworkObject.OwnershipStatus.Transferable);
+                m_TargetSpawnedObjects.Add(networkObject);
+
+                // Used to validate nested distributable transfers to the same owner
+                childTwo = SpawnObject(m_GenericPrefab, m_ClientNetworkManagers[0]);
+                networkObject = childTwo.GetComponent<NetworkObject>();
+                networkObject.SetOwnershipStatus(NetworkObject.OwnershipStatus.Distributable);
+                m_TargetSpawnedObjects.Add(childTwo.GetComponent<NetworkObject>());
+
+                childOne.transform.parent = rootObject.transform;
+                childTwo.transform.parent = rootObject.transform;
+            }
+            yield return WaitForConditionOrTimeOut(AllTargetedInstancesSpawned);
+            AssertOnTimeout($"Timed out waiting for all targeted cloned instances to spawn!\n {m_ErrorMsg}");
+
+            // Used to validate that other children do not transfer ownership when redistributing.
+
+            var altAchildOne = SpawnObject(m_GenericPrefab, m_ClientNetworkManagers[1]);
+            var altAchildTwo = SpawnObject(m_GenericPrefab, m_ClientNetworkManagers[1]);
+            m_AncillarySpawnedObjects.Add(m_ClientNetworkManagers[1].LocalClientId, new List<NetworkObject>());
+            networkObject = altAchildOne.GetComponent<NetworkObject>();
+            networkObject.SetOwnershipStatus(NetworkObject.OwnershipStatus.Distributable);
+            m_AncillarySpawnedObjects[m_ClientNetworkManagers[1].LocalClientId].Add(networkObject);
+            altAchildOne.transform.parent = rootObject.transform;
+
+            networkObject = altAchildTwo.GetComponent<NetworkObject>();
+            networkObject.SetOwnershipStatus(NetworkObject.OwnershipStatus.Transferable);
+            m_AncillarySpawnedObjects[m_ClientNetworkManagers[1].LocalClientId].Add(networkObject);
+            altAchildTwo.transform.parent = rootObject.transform;
+
+            var altBchildOne = SpawnObject(m_GenericPrefab, m_ClientNetworkManagers[2]);
+            var altBchildTwo = SpawnObject(m_GenericPrefab, m_ClientNetworkManagers[2]);
+            m_AncillarySpawnedObjects.Add(m_ClientNetworkManagers[2].LocalClientId, new List<NetworkObject>());
+            networkObject = altBchildOne.GetComponent<NetworkObject>();
+            networkObject.SetOwnershipStatus(NetworkObject.OwnershipStatus.Distributable);
+            m_AncillarySpawnedObjects[m_ClientNetworkManagers[2].LocalClientId].Add(networkObject);
+            altBchildOne.transform.parent = rootObject.transform;
+
+            networkObject = altBchildTwo.GetComponent<NetworkObject>();
+            networkObject.SetOwnershipStatus(NetworkObject.OwnershipStatus.Transferable);
+            m_AncillarySpawnedObjects[m_ClientNetworkManagers[2].LocalClientId].Add(networkObject);
+            altBchildTwo.transform.parent = rootObject.transform;
+
+            yield return WaitForConditionOrTimeOut(AllAncillaryInstancesSpawned);
+            AssertOnTimeout($"Timed out waiting for all ancillary cloned instances to spawn!\n {m_ErrorMsg}");
+
+            // Now disconnect the client that owns the rootObject
+            // Get the original clientId
+            m_OriginalOwnerId = m_ClientNetworkManagers[0].LocalClientId;
+
+            if (distributionType == DistributionTypes.UponDisconnect)
+            {
+                // Swap out the original owner's NetworkObject with one of the other client's since those instances will
+                // be destroyed when the client disconnects.
+                foreach (var entry in m_TargetSpawnedObjects)
+                {
+                    m_AltTargetSpawnedObjects.Add(m_ClientNetworkManagers[1].SpawnManager.SpawnedObjects[entry.NetworkObjectId]);
+                }
+                // Disconnect the client to trigger object redistribution
+                m_ClientNetworkManagers[0].Shutdown();
+            }
+            else
+            {
+                m_ClientNetworkManagers[3].StartClient();
+                yield return WaitForConditionOrTimeOut(() => m_ClientNetworkManagers[3].IsConnectedClient);
+                AssertOnTimeout($"{m_ClientNetworkManagers[3].name} failed to reconnect!");
+            }
+
+            // Verify all of the targeted objects changed ownership to the same client
+            yield return WaitForConditionOrTimeOut(TargetedObjectsChangedOwnership);
+            AssertOnTimeout($"All targeted objects did not get distributed to the same owner!\n {m_ErrorMsg}");
+
+            // When enabled, you should see one of the two root instances that have children get distributed to
+            // the reconnected client.
+            if (m_EnableVerboseDebug && distributionType == DistributionTypes.UponConnect)
+            {
+                m_ErrorMsg.Clear();
+                m_ErrorMsg.AppendLine($"Original targeted objects owner: {m_OriginalOwnerId}");
+                foreach (var spawnedObject in m_TargetSpawnedObjects)
+                {
+                    m_ErrorMsg.AppendLine($"{spawnedObject.name} new owner: {spawnedObject.OwnerClientId}");
+                }
+                Debug.Log($"{m_ErrorMsg}");
+            }
+
+            // We only want to make sure no other children owned by still connected clients change ownership
+            if (distributionType == DistributionTypes.UponDisconnect)
+            {
+                // Verify the ancillary objects kept the same ownership
+                yield return WaitForConditionOrTimeOut(AncillaryObjectsKeptOwnership);
+                AssertOnTimeout($"All ancillary objects did not get distributed to the same owner!\n {m_ErrorMsg}");
+            }
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/ParentChildDistibutionTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/ParentChildDistibutionTests.cs
@@ -87,13 +87,25 @@ namespace Unity.Netcode.RuntimeTests
             var newOwnerId = m_OriginalOwnerId;
             foreach (var spawnedObject in m_AltTargetSpawnedObjects)
             {
-                if (spawnedObject.OwnerClientId == m_OriginalOwnerId)
+                var isParentLocked = spawnedObject.transform.parent != null ? spawnedObject.transform.parent.GetComponent<NetworkObject>().IsOwnershipLocked : false;
+                if (!isParentLocked && !spawnedObject.IsOwnershipLocked && spawnedObject.OwnerClientId == m_OriginalOwnerId)
                 {
                     m_ErrorMsg.AppendLine($"{spawnedObject.name} still is owned by Client-{m_OriginalOwnerId}!");
                 }
-                else if (m_OriginalOwnerId == newOwnerId)
+                else if (!isParentLocked && !spawnedObject.IsOwnershipLocked && m_OriginalOwnerId == newOwnerId)
                 {
                     newOwnerId = spawnedObject.OwnerClientId;
+                }
+                else if ((isParentLocked || spawnedObject.IsOwnershipLocked) && spawnedObject.OwnerClientId != m_OriginalOwnerId)
+                {
+                    if (isParentLocked)
+                    {
+                        m_ErrorMsg.AppendLine($"{spawnedObject.name}'s parent was locked but its owner changed to Client-{m_OriginalOwnerId}!");
+                    }
+                    else
+                    {
+                        m_ErrorMsg.AppendLine($"{spawnedObject.name} was locked but its owner changed to Client-{m_OriginalOwnerId}!");
+                    }
                 }
 
                 if (spawnedObject.OwnerClientId != newOwnerId)
@@ -126,9 +138,16 @@ namespace Unity.Netcode.RuntimeTests
             UponDisconnect
         }
 
+        public enum OwnershipLocking
+        {
+            NoLocking,
+            LockRootParent,
+            LockTargetChild,
+        }
+
 
         [UnityTest]
-        public IEnumerator DistributeOwnerHierarchy([Values] DistributionTypes distributionType)
+        public IEnumerator DistributeOwnerHierarchy([Values] DistributionTypes distributionType, [Values] OwnershipLocking ownershipLock)
         {
             m_NetworkManagers.Clear();
             m_TargetSpawnedObjects.Clear();
@@ -162,6 +181,10 @@ namespace Unity.Netcode.RuntimeTests
                 rootObject = SpawnObject(m_GenericPrefab, m_ClientNetworkManagers[0]);
                 networkObject = rootObject.GetComponent<NetworkObject>();
                 networkObject.SetOwnershipStatus(NetworkObject.OwnershipStatus.Distributable);
+                if (ownershipLock == OwnershipLocking.LockRootParent && distributionType == DistributionTypes.UponConnect)
+                {
+                    networkObject.SetOwnershipLock(true);
+                }
                 m_TargetSpawnedObjects.Add(networkObject);
 
                 // Used to validate nested transferable transfers to the same owner
@@ -174,6 +197,10 @@ namespace Unity.Netcode.RuntimeTests
                 childTwo = SpawnObject(m_GenericPrefab, m_ClientNetworkManagers[0]);
                 networkObject = childTwo.GetComponent<NetworkObject>();
                 networkObject.SetOwnershipStatus(NetworkObject.OwnershipStatus.Distributable);
+                if (ownershipLock == OwnershipLocking.LockTargetChild && distributionType == DistributionTypes.UponConnect)
+                {
+                    networkObject.SetOwnershipLock(true);
+                }
                 m_TargetSpawnedObjects.Add(childTwo.GetComponent<NetworkObject>());
 
                 childOne.transform.parent = rootObject.transform;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/ParentChildDistibutionTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/ParentChildDistibutionTests.cs
@@ -156,7 +156,7 @@ namespace Unity.Netcode.RuntimeTests
             var childOne = (GameObject)null;
             var childTwo = (GameObject)null;
             var networkObject = (NetworkObject)null;
-            
+
             for (int i = 0; i < instances; i++)
             {
                 rootObject = SpawnObject(m_GenericPrefab, m_ClientNetworkManagers[0]);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/ParentChildDistibutionTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/ParentChildDistibutionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 45d9d6508546cda4dba613ef82b6e51e


### PR DESCRIPTION
This fixes an issue with distributing parented children that have the distributable and/or transferrable permissions set and have the same owner as the root parent, that has the distributable permission set, were not being distributed to the same client upon the owning client disconnecting when using a distributed authority network topology.

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->


## Changelog

- Fixed: Issue with distributing parented children that have the distributable and/or transferrable permissions set and have the same owner as the root parent, that has the distributable permission set, were not being distributed to the same client upon the owning client disconnecting when using a distributed authority network topology.


## Testing and Documentation

- Includes  integration test `ParentChildDistibutionTests`.
- Public documentation for rules to object distribution with parented NetworkObjects: [PR-1423](https://github.com/Unity-Technologies/com.unity.multiplayer.docs/pull/1423)


<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
