### PR TITLE
chore: update example overriding scenes networkprefabs dedicated server

### DIFF
--- a/Examples/OverridingScenesAndPrefabs/Assets/Scripts/MoverScriptNoRigidbody.cs
+++ b/Examples/OverridingScenesAndPrefabs/Assets/Scripts/MoverScriptNoRigidbody.cs
@@ -174,7 +174,9 @@ public class MoverScriptNoRigidbody : NetworkTransform
         }
 
         m_ParentedText?.gameObject.SetActive(true);
+#if !DEDICATED_SERVER
         UpdateParentedText();
+#endif
         base.OnNetworkPostSpawn();
     }
 
@@ -201,7 +203,9 @@ public class MoverScriptNoRigidbody : NetworkTransform
         {
             Debug.Log($"Parented under {parentNetworkObject.name}");
         }
+#if !DEDICATED_SERVER
         UpdateParentedText();
+#endif
         base.OnNetworkObjectParentChanged(parentNetworkObject);
     }
 
@@ -334,6 +338,7 @@ public class MoverScriptNoRigidbody : NetworkTransform
         m_PlayerBallMotion.HasMotion(moveMotion);
     }
 
+#if !DEDICATED_SERVER
     /// <summary>
     /// Updates player TextMesh relative to each client's camera view
     /// </summary>
@@ -373,4 +378,5 @@ public class MoverScriptNoRigidbody : NetworkTransform
             }
         }
     }
+#endif
 }

--- a/Examples/OverridingScenesAndPrefabs/Assets/Scripts/NetworkPrefabOverrideHandler.cs
+++ b/Examples/OverridingScenesAndPrefabs/Assets/Scripts/NetworkPrefabOverrideHandler.cs
@@ -52,6 +52,7 @@ public class NetworkPrefabOverrideHandler : MonoBehaviour, INetworkPrefabInstanc
 
     public void Destroy(NetworkObject networkObject)
     {
+#if !DEDICATED_SERVER
         // Another useful thing about handling this instantiation and destruction of a NetworkObject is that you can do house cleaning
         // prior to the object being destroyed. This handles the scenario where the server is following a player and the player disconnects.
         // Before destroying the player object, we want to unparent the camera and reset the player being followed.
@@ -59,6 +60,7 @@ public class NetworkPrefabOverrideHandler : MonoBehaviour, INetworkPrefabInstanc
         {
             m_NetworkManager.ClearFollowPlayer();
         }
+#endif
         Destroy(networkObject.gameObject);
     }
 }

--- a/Examples/OverridingScenesAndPrefabs/Assets/Scripts/SceneBootstrapLoader.cs
+++ b/Examples/OverridingScenesAndPrefabs/Assets/Scripts/SceneBootstrapLoader.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Unity.Netcode;
-
 using UnityEngine;
 using UnityEngine.SceneManagement;
 #if UNITY_EDITOR
@@ -105,6 +104,8 @@ public class SceneBootstrapLoader : MonoBehaviour
         m_NetworkManager = GetComponent<NetworkManagerBootstrapper>();
     }
 
+    public event Action OnMainMenuLoaded;
+
     /// <summary>
     /// Should be invoked by bootstrap when first starting the applicaiton and should be loaded upon exiting
     /// a session and shutting down the <see cref="NetworkManagerBootstrapper"/>.
@@ -114,6 +115,7 @@ public class SceneBootstrapLoader : MonoBehaviour
         if (!m_NetworkManager.IsListening)
         {
             SceneManager.LoadScene(m_MainMenuScene, LoadSceneMode.Single);
+            OnMainMenuLoaded?.Invoke();
         }
         else
         {
@@ -147,9 +149,6 @@ public class SceneBootstrapLoader : MonoBehaviour
     }
 
     #region SCENE PRE & POST START LOADING METHODS
-
-
-
     private IEnumerator PreSceneLoading(StartAsTypes startAsType)
     {
         var sceneDefines = startAsType == StartAsTypes.Client ? ClientSceneDefines : ServerSceneDefines;
@@ -188,11 +187,14 @@ public class SceneBootstrapLoader : MonoBehaviour
             {
                 m_NetworkManager.StartServer();
             }
+#if !DEDICATED_SERVER
             else
             {
                 m_NetworkManager.StartHost();
             }
+#endif
         }
+#if !DEDICATED_SERVER
         else
         {
             m_NetworkManager.OnClientStopped += OnNetworkManagerShutdown;
@@ -209,6 +211,7 @@ public class SceneBootstrapLoader : MonoBehaviour
                 m_NetworkManager.StartClient();
             }
         }
+#endif
     }
 
     /// <summary>
@@ -265,7 +268,7 @@ public class SceneBootstrapLoader : MonoBehaviour
     {
         m_SceneJustLoaded = scene.name;
     }
-    #endregion
+#endregion
 
     #region SERVER POST START CONFIGURATION AND ADDITIONAL SHARED SCENE LOADING
     /// <summary>

--- a/Examples/OverridingScenesAndPrefabs/Assets/Scripts/ServerHostClientText.cs
+++ b/Examples/OverridingScenesAndPrefabs/Assets/Scripts/ServerHostClientText.cs
@@ -63,7 +63,9 @@ public class ServerHostClientText : NetworkBehaviour
         base.OnNetworkDespawn();
     }
 
+#if !DEDICATED_SERVER
     private bool m_LastFocusedValue;
+
     private void OnGUI()
     {
         if (!IsSpawned || m_LastFocusedValue == Application.isFocused)
@@ -82,4 +84,5 @@ public class ServerHostClientText : NetworkBehaviour
             m_DisplayText.color = m_ColorAlpha;
         }
     }
+#endif
 }

--- a/Examples/OverridingScenesAndPrefabs/Assets/Scripts/ServerInfoDisplay.cs
+++ b/Examples/OverridingScenesAndPrefabs/Assets/Scripts/ServerInfoDisplay.cs
@@ -1,4 +1,6 @@
+#if !DEDICATED_SERVER
 using Unity.Netcode;
+#endif
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -6,7 +8,7 @@ public class ServerInfoDisplay : MonoBehaviour
 {
     public Text ServerTime;
     public Text PlayerCount;
-
+#if !DEDICATED_SERVER
     private void OnGUI()
     {
         if (!NetworkManager.Singleton || !NetworkManager.Singleton.IsListening)
@@ -24,4 +26,5 @@ public class ServerInfoDisplay : MonoBehaviour
             PlayerCount.text = $"Player Count: {NetworkManager.Singleton.ConnectedClients.Count}";
         }
     }
+#endif
 }

--- a/Examples/OverridingScenesAndPrefabs/Assets/Settings.meta
+++ b/Examples/OverridingScenesAndPrefabs/Assets/Settings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f07d39c4f18773945af7943acf04dff7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Examples/OverridingScenesAndPrefabs/Assets/Settings/Build Profiles.meta
+++ b/Examples/OverridingScenesAndPrefabs/Assets/Settings/Build Profiles.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 38b8655f79da8bd4ea13982ac8833b71
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Examples/OverridingScenesAndPrefabs/Assets/Settings/Build Profiles/New Windows Server Profile.asset
+++ b/Examples/OverridingScenesAndPrefabs/Assets/Settings/Build Profiles/New Windows Server Profile.asset
@@ -1,0 +1,49 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 15003, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: New Windows Server Profile
+  m_EditorClassIdentifier: 
+  m_AssetVersion: 1
+  m_BuildTarget: 19
+  m_Subtarget: 1
+  m_PlatformId: 8d1e1bca926649cba89d37a4c66e8b3d
+  m_PlatformBuildProfile:
+    rid: 4481205133896843345
+  m_OverrideGlobalSceneList: 0
+  m_Scenes: []
+  m_ScriptingDefines:
+  - DEDICATED_SERVER
+  m_PlayerSettingsYaml:
+    m_Settings: []
+  references:
+    version: 2
+    RefIds:
+    - rid: 4481205133896843345
+      type: {class: WindowsPlatformSettings, ns: UnityEditor.WindowsStandalone, asm: UnityEditor.WindowsStandalone.Extensions}
+      data:
+        m_Development: 0
+        m_ConnectProfiler: 0
+        m_BuildWithDeepProfilingSupport: 0
+        m_AllowDebugging: 0
+        m_WaitForManagedDebugger: 0
+        m_ManagedDebuggerFixedPort: 0
+        m_ExplicitNullChecks: 0
+        m_ExplicitDivideByZeroChecks: 0
+        m_ExplicitArrayBoundsChecks: 0
+        m_CompressionType: 0
+        m_InstallInBuildFolder: 0
+        m_WindowsBuildAndRunDeployTarget: 0
+        m_Architecture: 0
+        m_CreateSolution: 0
+        m_CopyPDBFiles: 0
+        m_WindowsDevicePortalAddress: 
+        m_WindowsDevicePortalUsername: 

--- a/Examples/OverridingScenesAndPrefabs/Assets/Settings/Build Profiles/New Windows Server Profile.asset.meta
+++ b/Examples/OverridingScenesAndPrefabs/Assets/Settings/Build Profiles/New Windows Server Profile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ceabbe1f96a84864d8cecdc70db0a1f8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adding support to the Overriding Scenes and NetworkPrefabs example for dedicated server builds.


## Changelog

NA

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
