### PR TITLE
fix: NetworkObject.DeferDespawn not respecting DestroyGameObject parameter

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,7 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed `NetworkObject.DeferDespawn` to respect the `DestroyGameObject` parameter.
+- Fixed `NetworkObject.DeferDespawn` to respect the `DestroyGameObject` parameter. (#3219)
 - Changed the `NetworkTimeSystem.Sync` method to use half RTT to calculate the desired local time offset as opposed to the full RTT. (#3212)
 - Fixed issue where a spawned `NetworkObject` that was registered with a prefab handler and owned by a client would invoke destroy more than once on the host-server side if the client disconnected while the `NetworkObject` was still spawned. (#3200)
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed `NetworkObject.DeferDespawn` to respect the `DestroyGameObject` parameter.
 - Changed the `NetworkTimeSystem.Sync` method to use half RTT to calculate the desired local time offset as opposed to the full RTT. (#3212)
 - Fixed issue where a spawned `NetworkObject` that was registered with a prefab handler and owned by a client would invoke destroy more than once on the host-server side if the client disconnected while the `NetworkObject` was still spawned. (#3200)
 

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/DestroyObjectMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/DestroyObjectMessage.cs
@@ -150,7 +150,7 @@ namespace Unity.Netcode
                     {
                         networkObject.DeferredDespawnTick = DeferredDespawnTick;
                         var hasCallback = networkObject.OnDeferredDespawnComplete != null;
-                        networkManager.SpawnManager.DeferDespawnNetworkObject(NetworkObjectId, DeferredDespawnTick, hasCallback);
+                        networkManager.SpawnManager.DeferDespawnNetworkObject(NetworkObjectId, DeferredDespawnTick, hasCallback, DestroyGameObject);
                         return;
                     }
                 }

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1582,19 +1582,16 @@ namespace Unity.Netcode
                     }
                 }
 
-                if (networkObject.IsSceneObject == false && destroyGameObject == false)
-                {
-                    // DANGO-TODO: Check that this is still a valid restriction
-                    Debug.LogWarning("Only Scene Objects are valid to not be destroyed when despawned");
-                }
-
                 if (m_TargetClientIds.Count > 0 && !NetworkManager.ShutdownInProgress)
                 {
+                    // DANGO-TODO: Reconfigure Client-side object destruction on despawn
+                    bool destroyOnClient = !(networkObject.IsSceneObject == false && destroyGameObject == false);
+
                     var message = new DestroyObjectMessage
                     {
                         NetworkObjectId = networkObject.NetworkObjectId,
                         DeferredDespawnTick = networkObject.DeferredDespawnTick,
-                        DestroyGameObject = networkObject.IsSceneObject != false ? destroyGameObject : true,
+                        DestroyGameObject = destroyOnClient,
                         IsTargetedDestroy = false,
                         IsDistributedAuthority = distributedAuthority,
                     };
@@ -1607,6 +1604,7 @@ namespace Unity.Netcode
             }
 
             networkObject.IsSpawned = false;
+            networkObject.DeferredDespawnTick = 0;
 
             if (SpawnedObjects.Remove(networkObject.NetworkObjectId))
             {

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1450,7 +1450,7 @@ namespace Unity.Netcode
             }
 
             // Since we are spawing in-scene placed NetworkObjects for already loaded scenes,
-            // we need to add any in-scene placed NetworkObject to our tracking table 
+            // we need to add any in-scene placed NetworkObject to our tracking table
             var clearFirst = true;
             foreach (var sceneLoaded in NetworkManager.SceneManager.ScenesLoaded)
             {
@@ -1580,6 +1580,12 @@ namespace Unity.Netcode
                     {
                         m_TargetClientIds.Add(NetworkManager.ServerClientId);
                     }
+                }
+
+                if (networkObject.IsSceneObject == false && destroyGameObject == false)
+                {
+                    // DANGO-TODO: Check that this is still a valid restriction
+                    Debug.LogWarning("Only Scene Objects are valid to not be destroyed when despawned");
                 }
 
                 if (m_TargetClientIds.Count > 0 && !NetworkManager.ShutdownInProgress)
@@ -1920,6 +1926,7 @@ namespace Unity.Netcode
         {
             public int TickToDespawn;
             public bool HasDeferredDespawnCheck;
+            public bool DestroyGameObject;
             public ulong NetworkObjectId;
         }
 
@@ -1931,12 +1938,13 @@ namespace Unity.Netcode
         /// <param name="networkObjectId">associated NetworkObject</param>
         /// <param name="tickToDespawn">when to despawn the NetworkObject</param>
         /// <param name="hasDeferredDespawnCheck">if true, user script is to be invoked to determine when to despawn</param>
-        internal void DeferDespawnNetworkObject(ulong networkObjectId, int tickToDespawn, bool hasDeferredDespawnCheck)
+        internal void DeferDespawnNetworkObject(ulong networkObjectId, int tickToDespawn, bool hasDeferredDespawnCheck, bool destroyGameObject)
         {
             var deferredDespawnObject = new DeferredDespawnObject()
             {
                 TickToDespawn = tickToDespawn,
                 HasDeferredDespawnCheck = hasDeferredDespawnCheck,
+                DestroyGameObject = destroyGameObject,
                 NetworkObjectId = networkObjectId,
             };
             DeferredDespawnObjects.Add(deferredDespawnObject);
@@ -2001,7 +2009,7 @@ namespace Unity.Netcode
                 }
                 var networkObject = SpawnedObjects[deferredObjectEntry.NetworkObjectId];
                 // Local instance despawns the instance
-                OnDespawnObject(networkObject, true);
+                OnDespawnObject(networkObject, deferredObjectEntry.DestroyGameObject);
                 DeferredDespawnObjects.Remove(deferredObjectEntry);
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1584,14 +1584,12 @@ namespace Unity.Netcode
 
                 if (m_TargetClientIds.Count > 0 && !NetworkManager.ShutdownInProgress)
                 {
-                    // DANGO-TODO: Reconfigure Client-side object destruction on despawn
-                    bool destroyOnClient = !(networkObject.IsSceneObject == false && destroyGameObject == false);
-
                     var message = new DestroyObjectMessage
                     {
                         NetworkObjectId = networkObject.NetworkObjectId,
                         DeferredDespawnTick = networkObject.DeferredDespawnTick,
-                        DestroyGameObject = destroyOnClient,
+                        // DANGO-TODO: Reconfigure Client-side object destruction on despawn
+                        DestroyGameObject = networkObject.IsSceneObject != false ? destroyGameObject : true,
                         IsTargetedDestroy = false,
                         IsDistributedAuthority = distributedAuthority,
                     };

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -1244,6 +1244,20 @@ namespace Unity.Netcode.TestHelpers.Runtime
             VerboseDebug($"Exiting {nameof(TearDown)}");
             LogWaitForMessages();
             NetcodeLogAssert.Dispose();
+            // Assure any remaining NetworkManagers are destroyed
+            DestroyNetworkManagers();
+        }
+
+        /// <summary>
+        /// Destroys any remaining NetworkManager instances
+        /// </summary>
+        private void DestroyNetworkManagers()
+        {
+            var networkManagers = Object.FindObjectsByType<NetworkManager>(FindObjectsSortMode.None);
+            foreach (var networkManager in networkManagers)
+            {
+                Object.DestroyImmediate(networkManager.gameObject);
+            }
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -1156,6 +1156,9 @@ namespace Unity.Netcode.TestHelpers.Runtime
             // reset the m_ServerWaitForTick for the next test to initialize
             s_DefaultWaitForTick = new WaitForSecondsRealtime(1.0f / k_DefaultTickRate);
             VerboseDebug($"Exiting {nameof(ShutdownAndCleanUp)}");
+
+            // Assure any remaining NetworkManagers are destroyed
+            DestroyNetworkManagers();
         }
 
         protected IEnumerator CoroutineShutdownAndCleanUp()
@@ -1195,6 +1198,9 @@ namespace Unity.Netcode.TestHelpers.Runtime
             // reset the m_ServerWaitForTick for the next test to initialize
             s_DefaultWaitForTick = new WaitForSecondsRealtime(1.0f / k_DefaultTickRate);
             VerboseDebug($"Exiting {nameof(ShutdownAndCleanUp)}");
+
+            // Assure any remaining NetworkManagers are destroyed
+            DestroyNetworkManagers();
         }
 
         /// <summary>
@@ -1244,8 +1250,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             VerboseDebug($"Exiting {nameof(TearDown)}");
             LogWaitForMessages();
             NetcodeLogAssert.Dispose();
-            // Assure any remaining NetworkManagers are destroyed
-            DestroyNetworkManagers();
+
         }
 
         /// <summary>

--- a/testproject/Assets/Tests/Runtime/MessageOrdering.cs
+++ b/testproject/Assets/Tests/Runtime/MessageOrdering.cs
@@ -66,7 +66,7 @@ namespace TestProject.RuntimeTests
             {
                 client.NetworkConfig.Prefabs.Add(validNetworkPrefab);
             }
-
+            m_Prefab.gameObject.SetActive(false);
             // Start the instances
             if (!NetcodeIntegrationTestHelpers.Start(true, server, clients))
             {
@@ -80,6 +80,7 @@ namespace TestProject.RuntimeTests
             // [Host-Side] Check to make sure all clients are connected
             yield return NetcodeIntegrationTestHelpers.WaitForClientsConnectedToServer(server, clients.Length + 1, null, 512);
 
+            m_Prefab.gameObject.SetActive(true);
             var serverObject = Object.Instantiate(m_Prefab, Vector3.zero, Quaternion.identity);
             NetworkObject serverNetworkObject = serverObject.GetComponent<NetworkObject>();
             serverNetworkObject.NetworkManagerOwner = server;
@@ -125,7 +126,7 @@ namespace TestProject.RuntimeTests
             {
                 client.NetworkConfig.Prefabs.Add(validNetworkPrefab);
             }
-
+            m_Prefab.gameObject.SetActive(false);
             // Start the instances
             if (!NetcodeIntegrationTestHelpers.Start(true, m_ServerNetworkManager, m_ClientNetworkManagers))
             {
@@ -138,7 +139,7 @@ namespace TestProject.RuntimeTests
 
             // [Host-Side] Check to make sure all clients are connected
             yield return NetcodeIntegrationTestHelpers.WaitForClientsConnectedToServer(m_ServerNetworkManager, m_ClientNetworkManagers.Length + 1, null, 512);
-
+            m_Prefab.gameObject.SetActive(true);
             var serverObject = Object.Instantiate(m_Prefab, Vector3.zero, Quaternion.identity);
             NetworkObject serverNetworkObject = serverObject.GetComponent<NetworkObject>();
             serverNetworkObject.NetworkManagerOwner = m_ServerNetworkManager;
@@ -229,7 +230,7 @@ namespace TestProject.RuntimeTests
             }
 
             var waitForTickInterval = new WaitForSeconds(1.0f / server.NetworkConfig.TickRate);
-
+            m_Prefab.gameObject.SetActive(false);
             // Start the instances
             if (!NetcodeIntegrationTestHelpers.Start(false, server, clients))
             {
@@ -242,7 +243,7 @@ namespace TestProject.RuntimeTests
 
             // [Host-Side] Check to make sure all clients are connected
             yield return NetcodeIntegrationTestHelpers.WaitForClientsConnectedToServer(server, clients.Length, null, 512);
-
+            m_Prefab.gameObject.SetActive(true);
             var serverObject = Object.Instantiate(m_Prefab, Vector3.zero, Quaternion.identity);
             NetworkObject serverNetworkObject = serverObject.GetComponent<NetworkObject>();
             serverNetworkObject.NetworkManagerOwner = server;

--- a/testproject/Assets/Tests/Runtime/MessageOrdering.cs
+++ b/testproject/Assets/Tests/Runtime/MessageOrdering.cs
@@ -66,7 +66,7 @@ namespace TestProject.RuntimeTests
             {
                 client.NetworkConfig.Prefabs.Add(validNetworkPrefab);
             }
-            m_Prefab.gameObject.SetActive(false);
+
             // Start the instances
             if (!NetcodeIntegrationTestHelpers.Start(true, server, clients))
             {
@@ -80,7 +80,6 @@ namespace TestProject.RuntimeTests
             // [Host-Side] Check to make sure all clients are connected
             yield return NetcodeIntegrationTestHelpers.WaitForClientsConnectedToServer(server, clients.Length + 1, null, 512);
 
-            m_Prefab.gameObject.SetActive(true);
             var serverObject = Object.Instantiate(m_Prefab, Vector3.zero, Quaternion.identity);
             NetworkObject serverNetworkObject = serverObject.GetComponent<NetworkObject>();
             serverNetworkObject.NetworkManagerOwner = server;
@@ -126,7 +125,7 @@ namespace TestProject.RuntimeTests
             {
                 client.NetworkConfig.Prefabs.Add(validNetworkPrefab);
             }
-            m_Prefab.gameObject.SetActive(false);
+
             // Start the instances
             if (!NetcodeIntegrationTestHelpers.Start(true, m_ServerNetworkManager, m_ClientNetworkManagers))
             {
@@ -139,7 +138,7 @@ namespace TestProject.RuntimeTests
 
             // [Host-Side] Check to make sure all clients are connected
             yield return NetcodeIntegrationTestHelpers.WaitForClientsConnectedToServer(m_ServerNetworkManager, m_ClientNetworkManagers.Length + 1, null, 512);
-            m_Prefab.gameObject.SetActive(true);
+
             var serverObject = Object.Instantiate(m_Prefab, Vector3.zero, Quaternion.identity);
             NetworkObject serverNetworkObject = serverObject.GetComponent<NetworkObject>();
             serverNetworkObject.NetworkManagerOwner = m_ServerNetworkManager;
@@ -230,7 +229,7 @@ namespace TestProject.RuntimeTests
             }
 
             var waitForTickInterval = new WaitForSeconds(1.0f / server.NetworkConfig.TickRate);
-            m_Prefab.gameObject.SetActive(false);
+
             // Start the instances
             if (!NetcodeIntegrationTestHelpers.Start(false, server, clients))
             {
@@ -243,7 +242,7 @@ namespace TestProject.RuntimeTests
 
             // [Host-Side] Check to make sure all clients are connected
             yield return NetcodeIntegrationTestHelpers.WaitForClientsConnectedToServer(server, clients.Length, null, 512);
-            m_Prefab.gameObject.SetActive(true);
+
             var serverObject = Object.Instantiate(m_Prefab, Vector3.zero, Quaternion.identity);
             NetworkObject serverNetworkObject = serverObject.GetComponent<NetworkObject>();
             serverNetworkObject.NetworkManagerOwner = server;

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/InScenePlacedNetworkObjectTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/InScenePlacedNetworkObjectTests.cs
@@ -56,7 +56,7 @@ namespace TestProject.RuntimeTests
         public enum DespawnMode
         {
             Despawn,
-            DeferredDespawn,
+            DeferDespawn,
         }
 
         /// <summary>
@@ -69,9 +69,9 @@ namespace TestProject.RuntimeTests
         [UnityTest]
         public IEnumerator InSceneNetworkObjectSynchAndSpawn([Values] DespawnMode despawnMode)
         {
-            if (!m_DistributedAuthority && despawnMode == DespawnMode.DeferredDespawn)
+            if (!m_DistributedAuthority && despawnMode == DespawnMode.DeferDespawn)
             {
-                Assert.Ignore("Deferred Despawn is only valid with Distributed Authority mode.");
+                Assert.Ignore($"Test ignored as DeferDespawn is only valid with Distributed Authority mode.");
             }
 
             NetworkObjectTestComponent.VerboseDebug = true;
@@ -149,12 +149,6 @@ namespace TestProject.RuntimeTests
 
             yield return WaitForConditionOrTimeOut(() => NetworkObjectTestComponent.SpawnedInstances.Count == clientCount);
             AssertOnTimeout($"Timed out waiting for all in-scene instances to be spawned!  Current spawned count: {NetworkObjectTestComponent.SpawnedInstances.Count()} | Expected spawn count: {clientCount}");
-
-            if (despawnMode == DespawnMode.DeferredDespawn)
-            {
-                // TODO: Check if this is the expected behavior
-                serverObject.DeferredDespawnTick = 0;
-            }
 
             // Test NetworkHide on the first client
             var firstClientId = m_ClientNetworkManagers[0].LocalClientId;

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/InScenePlacedNetworkObjectTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/InScenePlacedNetworkObjectTests.cs
@@ -53,6 +53,12 @@ namespace TestProject.RuntimeTests
             return m_CanStartServerAndClients;
         }
 
+        public enum DespawnMode
+        {
+            Despawn,
+            DeferredDespawn,
+        }
+
         /// <summary>
         /// This verifies that in-scene placed NetworkObjects will be properly
         /// synchronized if:
@@ -61,8 +67,13 @@ namespace TestProject.RuntimeTests
         /// NetworkObject as a NetworkPrefab
         /// </summary>
         [UnityTest]
-        public IEnumerator InSceneNetworkObjectSynchAndSpawn()
+        public IEnumerator InSceneNetworkObjectSynchAndSpawn([Values] DespawnMode despawnMode)
         {
+            if (!m_DistributedAuthority && despawnMode == DespawnMode.DeferredDespawn)
+            {
+                Assert.Ignore("Deferred Despawn is only valid with Distributed Authority mode.");
+            }
+
             NetworkObjectTestComponent.VerboseDebug = true;
             // Because despawning a client will cause it to shutdown and clean everything in the
             // scene hierarchy, we have to prevent one of the clients from spawning initially before
@@ -99,7 +110,16 @@ namespace TestProject.RuntimeTests
 
             // Despawn the in-scene placed NetworkObject
             Debug.Log("Despawning In-Scene placed NetworkObject");
-            serverObject.Despawn(false);
+
+            if (despawnMode == DespawnMode.Despawn)
+            {
+                serverObject.Despawn(false);
+            }
+            else
+            {
+                serverObject.DeferDespawn(1, false);
+            }
+
             yield return WaitForConditionOrTimeOut(() => NetworkObjectTestComponent.SpawnedInstances.Count == 0);
             AssertOnTimeout($"Timed out waiting for all in-scene instances to be despawned!  Current spawned count: {NetworkObjectTestComponent.SpawnedInstances.Count()}");
 
@@ -129,6 +149,12 @@ namespace TestProject.RuntimeTests
 
             yield return WaitForConditionOrTimeOut(() => NetworkObjectTestComponent.SpawnedInstances.Count == clientCount);
             AssertOnTimeout($"Timed out waiting for all in-scene instances to be spawned!  Current spawned count: {NetworkObjectTestComponent.SpawnedInstances.Count()} | Expected spawn count: {clientCount}");
+
+            if (despawnMode == DespawnMode.DeferredDespawn)
+            {
+                // TODO: Check if this is the expected behavior
+                serverObject.DeferredDespawnTick = 0;
+            }
 
             // Test NetworkHide on the first client
             var firstClientId = m_ClientNetworkManagers[0].LocalClientId;


### PR DESCRIPTION
Ensure that `DeferDespawn` respects the `DestroyGameObject` parameter for in-scene placed network objects.

Add unit and integration tests around deferred despawning.

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->
[MTTB-972](https://jira.unity3d.com/browse/MTTB-972)

<!-- Add RFC link here if applicable. -->

## Changelog

- Fixed: Pass the `DestroyGameObject` parameter correctly through the `DeferDespawn` codepath

## Testing and Documentation

- Includes unit tests.
- Includes integration tests.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
