### PR TITLE
chore: remove unitytransport debug asserts [up-port]

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1223,7 +1223,7 @@ namespace Unity.Netcode.Transports.UTP
 #if DEBUG
             if (m_State != State.Listening)
             {
-                Debug.LogWarning("DisconnectRemoteClient should be called on a listening server!");
+                Debug.LogWarning($"{nameof(DisconnectRemoteClient)} should only be called on a listening server!");
                 return;
             }
 #endif

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1220,7 +1220,13 @@ namespace Unity.Netcode.Transports.UTP
         /// <param name="clientId">The client to disconnect</param>
         public override void DisconnectRemoteClient(ulong clientId)
         {
-            Debug.Assert(m_State == State.Listening, "DisconnectRemoteClient should be called on a listening server");
+#if DEBUG
+            if (m_State != State.Listening)
+            {
+                Debug.LogWarning("DisconnectRemoteClient should be called on a listening server!");
+                return;
+            }
+#endif
 
             if (m_State == State.Listening)
             {
@@ -1292,7 +1298,13 @@ namespace Unity.Netcode.Transports.UTP
         /// <param name="networkManager">The NetworkManager that initialized and owns the transport</param>
         public override void Initialize(NetworkManager networkManager = null)
         {
-            Debug.Assert(sizeof(ulong) == UnsafeUtility.SizeOf<NetworkConnection>(), "Netcode connection id size does not match UTP connection id size");
+#if DEBUG
+            if (sizeof(ulong) != UnsafeUtility.SizeOf<NetworkConnection>())
+            {
+                Debug.LogWarning($"Netcode connection id size {sizeof(ulong)} does not match UTP connection id size {UnsafeUtility.SizeOf<NetworkConnection>()}!");
+                return;
+            }
+#endif
 
             m_NetworkManager = networkManager;
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
@@ -531,7 +531,7 @@ namespace Unity.Netcode.RuntimeTests
             {
                 m_Server.DisconnectRemoteClient(m_Client1.ServerClientId);
 
-                LogAssert.Expect(LogType.Assert, "DisconnectRemoteClient should be called on a listening server");
+                LogAssert.Expect(LogType.Warning, $"{nameof(UnityTransport.DisconnectRemoteClient)} should only be called on a listening server!");
             }
             else if (afterShutdownAction == AfterShutdownAction.DisconnectLocalClient)
             {


### PR DESCRIPTION
This is an up-port of the adjustments made in #3213.

## Changelog

NA

## Testing and Documentation

- Includes modification to the `UnityTransportTests` integration test.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
