### PR TITLE
fix: Exception with disabled GameObjects and NetworkTransforms

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed exception being thrown when a `GameObject` with an associated `NetworkTransform` is disabled. (#3243)
 - Changed the `NetworkTimeSystem.Sync` method to use half RTT to calculate the desired local time offset as opposed to the full RTT. (#3212)
 - Fixed issue where a spawned `NetworkObject` that was registered with a prefab handler and owned by a client would invoke destroy more than once on the host-server side if the client disconnected while the `NetworkObject` was still spawned. (#3200)
 - Fixed issue where `NetworkVariableBase` derived classes were not being re-initialized if the associated `NetworkObject` instance was not destroyed and re-spawned. (#3181)

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkTransformMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkTransformMessage.cs
@@ -73,7 +73,7 @@ namespace Unity.Netcode
                 networkObject = networkManager.SpawnManager.SpawnedObjects[networkObjectId];
                 if (networkObject.ChildNetworkBehaviours.Count <= networkBehaviourId || networkObject.ChildNetworkBehaviours[networkBehaviourId] == null)
                 {
-                    Debug.LogError($"[{nameof(NetworkTransformMessage)}][Invalid][length] Targeted {nameof(NetworkTransform)}, {nameof(NetworkBehaviour.NetworkBehaviourId)} ({networkBehaviourId}), does not exist! Make sure you are not spawning {nameof(NetworkObject)}s with disabled {nameof(GameObject)}s that have {nameof(NetworkBehaviour)} components on them.");
+                    Debug.LogError($"[{nameof(NetworkTransformMessage)}][Invalid] Targeted {nameof(NetworkTransform)}, {nameof(NetworkBehaviour.NetworkBehaviourId)} ({networkBehaviourId}), does not exist! Make sure you are not spawning {nameof(NetworkObject)}s with disabled {nameof(GameObject)}s that have {nameof(NetworkBehaviour)} components on them.");
                     return false;
                 }
 
@@ -81,7 +81,7 @@ namespace Unity.Netcode
                 var transform = networkObject.ChildNetworkBehaviours[networkBehaviourId] as NetworkTransform;
                 if (transform == null)
                 {
-                    Debug.LogError($"[{nameof(NetworkTransformMessage)}][Invalid][cast] Targeted {nameof(NetworkTransform)}, {nameof(NetworkBehaviour.NetworkBehaviourId)} ({networkBehaviourId}), does not exist! Make sure you are not spawning {nameof(NetworkObject)}s with disabled {nameof(GameObject)}s that have {nameof(NetworkBehaviour)} components on them.");
+                    Debug.LogError($"[{nameof(NetworkTransformMessage)}][Invalid] Targeted {nameof(NetworkTransform)}, {nameof(NetworkBehaviour.NetworkBehaviourId)} ({networkBehaviourId}), does not exist! Make sure you are not spawning {nameof(NetworkObject)}s with disabled {nameof(GameObject)}s that have {nameof(NetworkBehaviour)} components on them.");
                     return false;
                 }
 

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkTransformMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkTransformMessage.cs
@@ -71,8 +71,21 @@ namespace Unity.Netcode
             if (isSpawnedLocally)
             {
                 networkObject = networkManager.SpawnManager.SpawnedObjects[networkObjectId];
+                if (networkObject.ChildNetworkBehaviours.Count <= networkBehaviourId || networkObject.ChildNetworkBehaviours[networkBehaviourId] == null)
+                {
+                    Debug.LogError($"[{nameof(NetworkTransformMessage)}][Invalid][length] Targeted {nameof(NetworkTransform)}, {nameof(NetworkBehaviour.NetworkBehaviourId)} ({networkBehaviourId}), does not exist! Make sure you are not spawning {nameof(NetworkObject)}s with disabled {nameof(GameObject)}s that have {nameof(NetworkBehaviour)} components on them.");
+                    return false;
+                }
+
                 // Get the target NetworkTransform
-                NetworkTransform = networkObject.ChildNetworkBehaviours[networkBehaviourId] as NetworkTransform;
+                var transform = networkObject.ChildNetworkBehaviours[networkBehaviourId] as NetworkTransform;
+                if (transform == null)
+                {
+                    Debug.LogError($"[{nameof(NetworkTransformMessage)}][Invalid][cast] Targeted {nameof(NetworkTransform)}, {nameof(NetworkBehaviour.NetworkBehaviourId)} ({networkBehaviourId}), does not exist! Make sure you are not spawning {nameof(NetworkObject)}s with disabled {nameof(GameObject)}s that have {nameof(NetworkBehaviour)} components on them.");
+                    return false;
+                }
+
+                NetworkTransform = transform;
                 isServerAuthoritative = NetworkTransform.IsServerAuthoritative();
                 ownerAuthoritativeServerSide = !isServerAuthoritative && networkManager.IsServer;
 
@@ -81,8 +94,8 @@ namespace Unity.Netcode
             }
             else
             {
-                // Deserialize the state
-                reader.ReadNetworkSerializableInPlace(ref State);
+                Debug.LogError($"[{nameof(NetworkTransformMessage)}][Invalid] Target NetworkObject does not exist!");
+                return false;
             }
 
             unsafe

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkTransformMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkTransformMessage.cs
@@ -98,7 +98,7 @@ namespace Unity.Netcode
                 // If we are the DAHost and the NetworkObject is hidden from the host we still need to forward this message.
                 if (ownerAuthoritativeServerSide)
                 {
-                    // We need to deserialize the state so we can send it to other connected clients (i.e. it will be re-serialized again).
+                    // We need to deserialize the state to our local State property so we can extract the reliability used.
                     reader.ReadNetworkSerializableInPlace(ref State);
                     // Fall through to act like a proxy for this message.
                 }
@@ -151,7 +151,10 @@ namespace Unity.Netcode
                         ownerClientId = context.SenderId;
                     }
 
-                    var networkDelivery = State.IsReliableStateUpdate() ? NetworkDelivery.ReliableSequenced : NetworkDelivery.UnreliableSequenced;
+                    // Depending upon whether it is spawned locally or not, get the deserialized state
+                    var stateToUse = NetworkTransform != null ? NetworkTransform.InboundState : State;
+                    // Determine the reliability used to send the message
+                    var networkDelivery = stateToUse.IsReliableStateUpdate() ? NetworkDelivery.ReliableSequenced : NetworkDelivery.UnreliableSequenced;
 
                     // Forward the state update if there are any remote clients to foward it to
                     if (networkManager.ConnectionManager.ConnectedClientsList.Count > (networkManager.IsHost ? 2 : 1))

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkTransformMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkTransformMessage.cs
@@ -94,8 +94,20 @@ namespace Unity.Netcode
             }
             else
             {
-                Debug.LogError($"[{nameof(NetworkTransformMessage)}][Invalid] Target NetworkObject does not exist!");
-                return false;
+                ownerAuthoritativeServerSide = networkManager.DAHost;
+                // If we are the DAHost and the NetworkObject is hidden from the host we still need to forward this message.
+                if (ownerAuthoritativeServerSide)
+                {
+                    // We need to deserialize the state so we can send it to other connected clients (i.e. it will be re-serialized again).
+                    reader.ReadNetworkSerializableInPlace(ref State);
+                    // Fall through to act like a proxy for this message.
+                }
+                else
+                {
+                    // Otherwise we can error out because we either shouldn't be receiving this message.
+                    Debug.LogError($"[{nameof(NetworkTransformMessage)}][Invalid] Target NetworkObject ({networkObjectId}) does not exist!");
+                    return false;
+                }
             }
 
             unsafe
@@ -118,12 +130,6 @@ namespace Unity.Netcode
                         {
                             ByteUnpacker.ReadValueBitPacked(reader, out targetId);
                             targetIds[i] = targetId;
-                        }
-
-                        if (!isSpawnedLocally)
-                        {
-                            // If we are the DAHost and the NetworkObject is hidden from the host we still need to forward this message
-                            ownerAuthoritativeServerSide = networkManager.DAHost && !isSpawnedLocally;
                         }
                     }
 
@@ -173,7 +179,6 @@ namespace Unity.Netcode
                             {
                                 continue;
                             }
-
                             networkManager.MessageManager.SendMessage(ref currentMessage, networkDelivery, clientId);
                         }
                         // Dispose of the reader used for forwarding

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformErrorTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformErrorTests.cs
@@ -11,8 +11,8 @@ namespace Unity.Netcode.RuntimeTests
     {
         protected override int NumberOfClients => 1;
 
-        private GameObject m_ServerPrefab;
-        private GameObject m_ClientPrefab;
+        private GameObject m_AuthorityPrefab;
+        private GameObject m_NonAuthorityPrefab;
 
         private HostAndClientPrefabHandler m_HostAndClientPrefabHandler;
 
@@ -24,23 +24,30 @@ namespace Unity.Netcode.RuntimeTests
         /// </summary>
         private class HostAndClientPrefabHandler : INetworkPrefabInstanceHandler
         {
-            private readonly GameObject m_HostPrefab;
-            private readonly GameObject m_ClientPrefab;
+            /// <summary>
+            /// The registered prefab is the prefab the networking stack is instantiated with.
+            /// Registering the prefab simulates the prefab that exists on the authority.
+            /// </summary>
+            private readonly GameObject m_RegisteredPrefab;
 
-            public HostAndClientPrefabHandler(GameObject hostPrefab, GameObject clientPrefab)
+            /// <summary>
+            /// Mocks the registered prefab changing on the non-authority after registration.
+            /// Allows testing situations mismatched GameObject state between the authority and non-authority.
+            /// </summary>
+            private readonly GameObject m_InstantiatedPrefab;
+
+            public HostAndClientPrefabHandler(GameObject authorityPrefab, GameObject nonAuthorityPrefab)
             {
-                m_HostPrefab = hostPrefab;
-                m_ClientPrefab = clientPrefab;
+                m_RegisteredPrefab = authorityPrefab;
+                m_InstantiatedPrefab = nonAuthorityPrefab;
             }
 
+            /// <summary>
+            /// Returns the prefab that will mock the instantiated prefab not matching the registered prefab
+            /// </summary>
             public NetworkObject Instantiate(ulong ownerClientId, Vector3 position, Quaternion rotation)
             {
-                // Owner clientID
-                if (ownerClientId == 0)
-                {
-                    return Object.Instantiate(m_ClientPrefab).GetComponent<NetworkObject>();
-                }
-                return Object.Instantiate(m_HostPrefab).GetComponent<NetworkObject>();
+                return Object.Instantiate(m_InstantiatedPrefab).GetComponent<NetworkObject>();
             }
 
             public void Destroy(NetworkObject networkObject)
@@ -50,7 +57,8 @@ namespace Unity.Netcode.RuntimeTests
 
             public void Register(NetworkManager networkManager)
             {
-                networkManager.PrefabHandler.AddHandler(m_HostPrefab, this);
+                // Register the version that will be spawned by the authority (i.e. Host)
+                networkManager.PrefabHandler.AddHandler(m_RegisteredPrefab, this);
             }
         }
 
@@ -67,18 +75,20 @@ namespace Unity.Netcode.RuntimeTests
 
         protected override void OnServerAndClientsCreated()
         {
-            // Full non-disabled GameObjects prefab on server side
-            m_ServerPrefab = CreateNetworkObjectPrefab("ServerPrefab");
-            AddChildToNetworkObject<EmptyNetworkBehaviour>(m_ServerPrefab.transform);
-            AddChildToNetworkObject<EmptyNetworkBehaviour>(m_ServerPrefab.transform);
-            AddChildToNetworkObject<NetworkTransform>(m_ServerPrefab.transform);
+            // Create a prefab that has many child NetworkBehaviours
+            m_AuthorityPrefab = CreateNetworkObjectPrefab("AuthorityPrefab");
+            AddChildToNetworkObject<EmptyNetworkBehaviour>(m_AuthorityPrefab.transform);
+            AddChildToNetworkObject<EmptyNetworkBehaviour>(m_AuthorityPrefab.transform);
+            AddChildToNetworkObject<NetworkTransform>(m_AuthorityPrefab.transform);
 
-            // Mock disabled GameObjects prefab on client side
-            m_ClientPrefab = CreateNetworkObjectPrefab("ClientPrefab");
-            AddChildToNetworkObject<NetworkTransform>(m_ClientPrefab.transform);
+            // Create a second prefab with only one NetworkBehaviour
+            // This simulates the GameObjects on the other NetworkBehaviours being disabled
+            m_NonAuthorityPrefab = CreateNetworkObjectPrefab("NonAuthorityPrefab");
+            AddChildToNetworkObject<NetworkTransform>(m_NonAuthorityPrefab.transform);
 
-            // Create and register prefab handler to handle server and client versions of prefabs
-            m_HostAndClientPrefabHandler = new HostAndClientPrefabHandler(m_ServerPrefab, m_ClientPrefab);
+            // Create and register a prefab handler
+            // The prefab handler will behave as if the GameObjects have been disabled on the non-authority client
+            m_HostAndClientPrefabHandler = new HostAndClientPrefabHandler(m_AuthorityPrefab, m_NonAuthorityPrefab);
             m_HostAndClientPrefabHandler.Register(m_ServerNetworkManager);
             foreach (var client in m_ClientNetworkManagers)
             {
@@ -92,14 +102,14 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator DisabledGameObjectErrorTest()
         {
-            var instance = SpawnObject(m_ServerPrefab, m_ServerNetworkManager);
+            var instance = SpawnObject(m_AuthorityPrefab, m_ServerNetworkManager);
             var networkObjectInstance = instance.GetComponent<NetworkObject>();
 
             yield return WaitForConditionOrTimeOut(() => ObjectSpawnedOnAllClients(networkObjectInstance.NetworkObjectId));
             AssertOnTimeout("Timed out waiting for object to spawn!");
 
-            LogAssert.Expect(LogType.Error, "[Netcode] NetworkBehaviour index 3 was out of bounds for ClientPrefab(Clone). NetworkBehaviours must be the same, and in the same order, between server and client.");
-            LogAssert.Expect(LogType.Error, "[NetworkTransformMessage][Invalid][length] Targeted NetworkTransform, NetworkBehaviourId (3), does not exist! Make sure you are not spawning NetworkObjects with disabled GameObjects that have NetworkBehaviour components on them.");
+            LogAssert.Expect(LogType.Error, "[Netcode] NetworkBehaviour index 3 was out of bounds for NonAuthorityPrefab(Clone). NetworkBehaviours must be the same, and in the same order, between server and client.");
+            LogAssert.Expect(LogType.Error, "[NetworkTransformMessage][Invalid] Targeted NetworkTransform, NetworkBehaviourId (3), does not exist! Make sure you are not spawning NetworkObjects with disabled GameObjects that have NetworkBehaviour components on them.");
 
             yield return new WaitForSeconds(0.3f);
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformErrorTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformErrorTests.cs
@@ -1,0 +1,120 @@
+using System.Collections;
+using Unity.Netcode.Components;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+
+namespace Unity.Netcode.RuntimeTests
+{
+    internal class NetworkTransformErrorTests : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 1;
+
+        private GameObject m_ServerPrefab;
+        private GameObject m_ClientPrefab;
+
+        private HostAndClientPrefabHandler m_HostAndClientPrefabHandler;
+
+        public class EmptyNetworkBehaviour : NetworkBehaviour { }
+
+        /// <summary>
+        /// PrefabHandler that tracks and separates the client GameObject from the host GameObject.
+        /// Allows independent management of client and host game world while still instantiating NetworkObjects as expected.
+        /// </summary>
+        private class HostAndClientPrefabHandler : INetworkPrefabInstanceHandler
+        {
+            private readonly GameObject m_HostPrefab;
+            private readonly GameObject m_ClientPrefab;
+
+            public HostAndClientPrefabHandler(GameObject hostPrefab, GameObject clientPrefab)
+            {
+                m_HostPrefab = hostPrefab;
+                m_ClientPrefab = clientPrefab;
+            }
+
+            public NetworkObject Instantiate(ulong ownerClientId, Vector3 position, Quaternion rotation)
+            {
+                // Owner clientID
+                if (ownerClientId == 0)
+                {
+                    return Object.Instantiate(m_ClientPrefab).GetComponent<NetworkObject>();
+                }
+                return Object.Instantiate(m_HostPrefab).GetComponent<NetworkObject>();
+            }
+
+            public void Destroy(NetworkObject networkObject)
+            {
+                Object.Destroy(networkObject.gameObject);
+            }
+
+            public void Register(NetworkManager networkManager)
+            {
+                networkManager.PrefabHandler.AddHandler(m_HostPrefab, this);
+            }
+        }
+
+        /// <summary>
+        /// Creates a GameObject and sets the transform parent to the given transform
+        /// Adds a component of the given type to the GameObject
+        /// </summary>
+        private static void AddChildToNetworkObject<T>(Transform transform) where T : Component
+        {
+            var gameObj = new GameObject();
+            gameObj.transform.parent = transform;
+            gameObj.AddComponent<T>();
+        }
+
+        protected override void OnServerAndClientsCreated()
+        {
+            // Full non-disabled GameObjects prefab on server side
+            m_ServerPrefab = CreateNetworkObjectPrefab("ServerPrefab");
+            AddChildToNetworkObject<EmptyNetworkBehaviour>(m_ServerPrefab.transform);
+            AddChildToNetworkObject<EmptyNetworkBehaviour>(m_ServerPrefab.transform);
+            AddChildToNetworkObject<NetworkTransform>(m_ServerPrefab.transform);
+
+            // Mock disabled GameObjects prefab on client side
+            m_ClientPrefab = CreateNetworkObjectPrefab("ClientPrefab");
+            AddChildToNetworkObject<NetworkTransform>(m_ClientPrefab.transform);
+
+            // Create and register prefab handler to handle server and client versions of prefabs
+            m_HostAndClientPrefabHandler = new HostAndClientPrefabHandler(m_ServerPrefab, m_ClientPrefab);
+            m_HostAndClientPrefabHandler.Register(m_ServerNetworkManager);
+            foreach (var client in m_ClientNetworkManagers)
+            {
+                m_HostAndClientPrefabHandler.Register(client);
+            }
+
+            base.OnServerAndClientsCreated();
+        }
+
+
+        [UnityTest]
+        public IEnumerator DisabledGameObjectErrorTest()
+        {
+            var instance = SpawnObject(m_ServerPrefab, m_ServerNetworkManager);
+            var networkObjectInstance = instance.GetComponent<NetworkObject>();
+
+            yield return WaitForConditionOrTimeOut(() => ObjectSpawnedOnAllClients(networkObjectInstance.NetworkObjectId));
+            AssertOnTimeout("Timed out waiting for object to spawn!");
+
+            LogAssert.Expect(LogType.Error, "[Netcode] NetworkBehaviour index 3 was out of bounds for ClientPrefab(Clone). NetworkBehaviours must be the same, and in the same order, between server and client.");
+            LogAssert.Expect(LogType.Error, "[NetworkTransformMessage][Invalid][length] Targeted NetworkTransform, NetworkBehaviourId (3), does not exist! Make sure you are not spawning NetworkObjects with disabled GameObjects that have NetworkBehaviour components on them.");
+
+            yield return new WaitForSeconds(0.3f);
+        }
+
+        private bool ObjectSpawnedOnAllClients(ulong networkObjectId)
+        {
+            foreach (var client in m_ClientNetworkManagers)
+            {
+                if (!client.SpawnManager.SpawnedObjects.ContainsKey(networkObjectId))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformErrorTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformErrorTests.cs
@@ -104,12 +104,16 @@ namespace Unity.Netcode.RuntimeTests
         {
             var instance = SpawnObject(m_AuthorityPrefab, m_ServerNetworkManager);
             var networkObjectInstance = instance.GetComponent<NetworkObject>();
+            var networkTransformInstance = instance.GetComponent<NetworkTransform>();
 
             yield return WaitForConditionOrTimeOut(() => ObjectSpawnedOnAllClients(networkObjectInstance.NetworkObjectId));
             AssertOnTimeout("Timed out waiting for object to spawn!");
 
-            LogAssert.Expect(LogType.Error, "[Netcode] NetworkBehaviour index 3 was out of bounds for NonAuthorityPrefab(Clone). NetworkBehaviours must be the same, and in the same order, between server and client.");
-            LogAssert.Expect(LogType.Error, "[NetworkTransformMessage][Invalid] Targeted NetworkTransform, NetworkBehaviourId (3), does not exist! Make sure you are not spawning NetworkObjects with disabled GameObjects that have NetworkBehaviour components on them.");
+            LogAssert.Expect(LogType.Error, $"[Netcode] {nameof(NetworkBehaviour)} index {networkTransformInstance.NetworkBehaviourId} was out of bounds for NonAuthorityPrefab(Clone). " +
+                $"{nameof(NetworkBehaviour)}s must be the same, and in the same order, between server and client.");
+            LogAssert.Expect(LogType.Error, $"[{nameof(NetworkTransformMessage)}][Invalid] Targeted {nameof(NetworkTransform)}, {nameof(NetworkBehaviour.NetworkBehaviourId)} " +
+                $"({networkTransformInstance.NetworkBehaviourId}), does not exist! Make sure you are not spawning {nameof(NetworkObject)}s with disabled {nameof(GameObject)}s that have " +
+                $"{nameof(NetworkBehaviour)} components on them.");
 
             yield return new WaitForSeconds(0.3f);
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformErrorTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformErrorTests.cs
@@ -98,22 +98,28 @@ namespace Unity.Netcode.RuntimeTests
             base.OnServerAndClientsCreated();
         }
 
-
+        /// <summary>
+        /// Validates the fix where <see cref="NetworkTransformMessage"/> would throw an exception
+        /// if a user sets a <see cref="GameObject"/> with one or more <see cref="NetworkBehaviour"/> components
+        /// to inactive.
+        /// </summary>
         [UnityTest]
         public IEnumerator DisabledGameObjectErrorTest()
         {
             var instance = SpawnObject(m_AuthorityPrefab, m_ServerNetworkManager);
             var networkObjectInstance = instance.GetComponent<NetworkObject>();
-            var networkTransformInstance = instance.GetComponent<NetworkTransform>();
+            var networkTransformInstance = instance.GetComponentInChildren<NetworkTransform>();
 
             yield return WaitForConditionOrTimeOut(() => ObjectSpawnedOnAllClients(networkObjectInstance.NetworkObjectId));
             AssertOnTimeout("Timed out waiting for object to spawn!");
 
-            LogAssert.Expect(LogType.Error, $"[Netcode] {nameof(NetworkBehaviour)} index {networkTransformInstance.NetworkBehaviourId} was out of bounds for NonAuthorityPrefab(Clone). " +
-                $"{nameof(NetworkBehaviour)}s must be the same, and in the same order, between server and client.");
-            LogAssert.Expect(LogType.Error, $"[{nameof(NetworkTransformMessage)}][Invalid] Targeted {nameof(NetworkTransform)}, {nameof(NetworkBehaviour.NetworkBehaviourId)} " +
+            var errorMessage = $"[Netcode] {nameof(NetworkBehaviour)} index {networkTransformInstance.NetworkBehaviourId} was out of bounds for {m_NonAuthorityPrefab.name}(Clone). " +
+                $"{nameof(NetworkBehaviour)}s must be the same, and in the same order, between server and client.";
+            LogAssert.Expect(LogType.Error, errorMessage);
+            errorMessage = $"[{nameof(NetworkTransformMessage)}][Invalid] Targeted {nameof(NetworkTransform)}, {nameof(NetworkBehaviour.NetworkBehaviourId)} " +
                 $"({networkTransformInstance.NetworkBehaviourId}), does not exist! Make sure you are not spawning {nameof(NetworkObject)}s with disabled {nameof(GameObject)}s that have " +
-                $"{nameof(NetworkBehaviour)} components on them.");
+                $"{nameof(NetworkBehaviour)} components on them.";
+            LogAssert.Expect(LogType.Error, errorMessage);
 
             yield return new WaitForSeconds(0.3f);
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformErrorTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformErrorTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9f0f7bfcdffd47139aae1788ee8d2063
+timeCreated: 1738881698


### PR DESCRIPTION
<!-- Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->
[MTTB-959](https://jira.unity3d.com/browse/MTTB-959)

<!-- Add RFC link here if applicable. -->

## Changelog

- Fixed: Log an appropriate error if the user has disabled a `GameObject` associated with a `NetworkBehaviour`. Do not throw an excpetion.

## Testing and Documentation

- Includes unit tests.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
