### PR TITLE
ci: Test fixes develop 2.0.0

### DIFF
--- a/.yamato/code-coverage.yml
+++ b/.yamato/code-coverage.yml
@@ -16,7 +16,7 @@ code_coverage_{{ platform.name }}_{{ editor }}:
   commands:
     - npm install -g upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - unity-downloader-cli -u {{ editor }} -c Editor --fast --wait
-    - {% if platform.name == "ubuntu" %}DISPLAY=:0 {% endif %} upm-ci package test -u {{ editor }} --package-path com.unity.netcode.gameobjects --enable-code-coverage --code-coverage-options 'generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Netcode.Editor,+Unity.Netcode.Runtime' --extra-utr-arg="--extra-editor-arg=--burst-disable-compilation --extra-editor-arg=-testCategory --extra-editor-arg=!Performance --timeout=1800 --reruncount=1 --clean-library-on-rerun"
+    - {% if platform.name == "ubuntu" %}DISPLAY=:0 {% endif %} upm-ci package test -u {{ editor }} --package-path upm-ci~/packages/com.unity.netcode.gameobjects --enable-code-coverage --code-coverage-options 'generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Netcode.Editor,+Unity.Netcode.Runtime' --extra-utr-arg="--extra-editor-arg=--burst-disable-compilation --extra-editor-arg=-testCategory --extra-editor-arg=!Performance --timeout=1800 --reruncount=1 --clean-library-on-rerun"
   artifacts:
     logs:
       paths:

--- a/.yamato/code-coverage.yml
+++ b/.yamato/code-coverage.yml
@@ -24,7 +24,7 @@ code_coverage_{{ platform.name }}_{{ editor }}:
 {% endif %}
 
     - upm-pvp create-test-project test-project --packages "upm-ci~/packages/*.tgz" --filter "com.unity.netcode.gameobjects" --unity .Editor
-    - {% if platform.name == "ubuntu" %}DISPLAY=:0 {% endif %} {% if platform.name == "win" %} utr.bat {% else %} ./utr {% endif %} --suite=editor --suite=playmode --editor-location=.Editor --testproject=test-project --enable-code-coverage --coverage-options 'generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Netcode.Editor,+Unity.Netcode.Runtime' --artifacts-path=test-results  --extra-editor-arg=--burst-disable-compilation --extra-editor-arg=-testCategory --extra-editor-arg=!Performance --timeout=1800 --reruncount=1 --clean-library-on-rerun
+    - {% if platform.name == "ubuntu" %}DISPLAY=:0 {% endif %} {% if platform.name == "win" %} utr.bat {% else %} ./utr {% endif %} --suite=editor --suite=playmode --editor-location=.Editor --testproject=test-project --enable-code-coverage --coverage-options 'generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Netcode.Editor,+Unity.Netcode.Runtime' --artifacts-path=test-results --coverage-results-path=test-results/CoverageResults  --extra-editor-arg=--burst-disable-compilation --extra-editor-arg=-testCategory --extra-editor-arg=!Performance --timeout=1800 --reruncount=1 --clean-library-on-rerun
   artifacts:
     logs:
       paths:

--- a/.yamato/code-coverage.yml
+++ b/.yamato/code-coverage.yml
@@ -16,7 +16,7 @@ code_coverage_{{ platform.name }}_{{ editor }}:
   commands:
     - npm install -g upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - unity-downloader-cli -u {{ editor }} -c Editor --fast --wait
-    - {% if platform.name == "ubuntu" %}DISPLAY=:0 {% endif %} upm-ci package test -u {{ editor }} --package-path upm-ci~/packages/com.unity.netcode.gameobjects --enable-code-coverage --code-coverage-options 'generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Netcode.Editor,+Unity.Netcode.Runtime' --extra-utr-arg="--extra-editor-arg=--burst-disable-compilation --extra-editor-arg=-testCategory --extra-editor-arg=!Performance --timeout=1800 --reruncount=1 --clean-library-on-rerun"
+    - {% if platform.name == "ubuntu" %}DISPLAY=:0 {% endif %} upm-ci package test -u {{ editor }} --package-path upm-ci~/packages/com.unity.netcode.gameobjects.tgz --enable-code-coverage --code-coverage-options 'generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Netcode.Editor,+Unity.Netcode.Runtime' --extra-utr-arg="--extra-editor-arg=--burst-disable-compilation --extra-editor-arg=-testCategory --extra-editor-arg=!Performance --timeout=1800 --reruncount=1 --clean-library-on-rerun"
   artifacts:
     logs:
       paths:

--- a/.yamato/code-coverage.yml
+++ b/.yamato/code-coverage.yml
@@ -15,6 +15,14 @@ code_coverage_{{ platform.name }}_{{ editor }}:
     flavor: {{ platform.flavor }}
   commands:
     - unity-downloader-cli -u {{ editor }} -c Editor --fast --wait
+      # Platform specific UTR setup
+      - |
+{% if platform.name == "win" %}
+        curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
+{% else %}
+        curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr && chmod +x utr
+{% endif %}
+
     - upm-pvp create-test-project test-project --packages "upm-ci~/packages/*.tgz" --filter "com.unity.netcode.gameobjects" --unity .Editor
     - {% if platform.name == "ubuntu" %}DISPLAY=:0 {% endif %} {% if platform.name == "win" %} utr.bat {% else %} ./utr {% endif %} --suite=editor --suite=playmode --editor-location=.Editor --testproject=test-project --enable-code-coverage --coverage-options 'generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Netcode.Editor,+Unity.Netcode.Runtime' --artifacts-path=test-results  --extra-editor-arg=--burst-disable-compilation --extra-editor-arg=-testCategory --extra-editor-arg=!Performance --timeout=1800 --reruncount=1 --clean-library-on-rerun
   artifacts:

--- a/.yamato/code-coverage.yml
+++ b/.yamato/code-coverage.yml
@@ -14,9 +14,9 @@ code_coverage_{{ platform.name }}_{{ editor }}:
     image: {{ platform.image }}
     flavor: {{ platform.flavor }}
   commands:
-    - npm install -g upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - unity-downloader-cli -u {{ editor }} -c Editor --fast --wait
-    - {% if platform.name == "ubuntu" %}DISPLAY=:0 {% endif %} upm-ci package test -u {{ editor }} --package-path upm-ci~/packages/com.unity.netcode.gameobjects.tgz --enable-code-coverage --code-coverage-options 'generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Netcode.Editor,+Unity.Netcode.Runtime' --extra-utr-arg="--extra-editor-arg=--burst-disable-compilation --extra-editor-arg=-testCategory --extra-editor-arg=!Performance --timeout=1800 --reruncount=1 --clean-library-on-rerun"
+    - upm-pvp create-test-project test-project --packages "upm-ci~/packages/*.tgz" --filter "com.unity.netcode.gameobjects" --unity .Editor
+    - {% if platform.name == "ubuntu" %}DISPLAY=:0 {% endif %} upm-pvp test --unity .Editor --project test-project  --enable-code-coverage --coverage-options 'generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Netcode.Editor,+Unity.Netcode.Runtime' --test-options="--extra-editor-arg=--burst-disable-compilation --extra-editor-arg=-testCategory --extra-editor-arg=!Performance --timeout=1800 --reruncount=1 --clean-library-on-rerun"
   artifacts:
     logs:
       paths:

--- a/.yamato/code-coverage.yml
+++ b/.yamato/code-coverage.yml
@@ -28,7 +28,7 @@ code_coverage_{{ platform.name }}_{{ editor }}:
   artifacts:
     logs:
       paths:
-        - "upm-ci~/test-results/**/*"
+        - "test-results/**/*"
   dependencies:
     - .yamato/package-pack.yml#package_pack_-_ngo_{{ platform.name }}
 {% endfor -%}

--- a/.yamato/code-coverage.yml
+++ b/.yamato/code-coverage.yml
@@ -15,8 +15,8 @@ code_coverage_{{ platform.name }}_{{ editor }}:
     flavor: {{ platform.flavor }}
   commands:
     - unity-downloader-cli -u {{ editor }} -c Editor --fast --wait
-      # Platform specific UTR setup
-      - |
+    # Platform specific UTR setup
+    - |
 {% if platform.name == "win" %}
         curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
 {% else %}

--- a/.yamato/code-coverage.yml
+++ b/.yamato/code-coverage.yml
@@ -16,7 +16,7 @@ code_coverage_{{ platform.name }}_{{ editor }}:
   commands:
     - unity-downloader-cli -u {{ editor }} -c Editor --fast --wait
     - upm-pvp create-test-project test-project --packages "upm-ci~/packages/*.tgz" --filter "com.unity.netcode.gameobjects" --unity .Editor
-    - {% if platform.name == "ubuntu" %}DISPLAY=:0 {% endif %} upm-pvp test --unity .Editor --project test-project  --enable-code-coverage --coverage-options 'generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Netcode.Editor,+Unity.Netcode.Runtime' --test-options="--extra-editor-arg=--burst-disable-compilation --extra-editor-arg=-testCategory --extra-editor-arg=!Performance --timeout=1800 --reruncount=1 --clean-library-on-rerun"
+    - {% if platform.name == "ubuntu" %}DISPLAY=:0 {% endif %} {% if platform.name == "win" %} utr.bat {% else %} ./utr {% endif %} --suite=editor --suite=playmode --editor-location=.Editor --testproject=test-project --enable-code-coverage --coverage-options 'generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.Netcode.Editor,+Unity.Netcode.Runtime' --artifacts-path=test-results  --extra-editor-arg=--burst-disable-compilation --extra-editor-arg=-testCategory --extra-editor-arg=!Performance --timeout=1800 --reruncount=1 --clean-library-on-rerun
   artifacts:
     logs:
       paths:

--- a/com.unity.netcode.gameobjects/Editor/HiddenScriptEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/HiddenScriptEditor.cs
@@ -1,7 +1,4 @@
 using Unity.Netcode.Components;
-#if UNITY_UNET_PRESENT
-using Unity.Netcode.Transports.UNET;
-#endif
 using Unity.Netcode.Transports.UTP;
 using UnityEditor;
 using UnityEngine;
@@ -28,6 +25,8 @@ namespace Unity.Netcode.Editor
         }
     }
 #if UNITY_UNET_PRESENT
+    using Unity.Netcode.Transports.UNET;
+
     /// <summary>
     /// Internal use. Hides the script field for UNetTransport.
     /// </summary>

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
@@ -1793,7 +1793,7 @@ namespace Unity.Netcode.Components
 #else
             var position = InLocalSpace ? transformToUse.localPosition : transformToUse.position;
             var rotation = InLocalSpace ? transformToUse.localRotation : transformToUse.rotation;
-            var positionThreshold =  Vector3.one * PositionThreshold;
+            var positionThreshold = Vector3.one * PositionThreshold;
             var rotationThreshold = Vector3.one * RotAngleThreshold;
 #endif
             var rotAngles = rotation.eulerAngles;

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/Metrics/WaitForMetricValues.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/Metrics/WaitForMetricValues.cs
@@ -21,7 +21,7 @@ namespace Unity.Netcode.TestHelpers.Runtime.Metrics
             dispatcher.RegisterObserver(this);
         }
 
-        abstract public void Observe(MetricCollection collection);
+        public abstract void Observe(MetricCollection collection);
 
         public void AssertMetricValuesHaveNotBeenFound()
         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/MetricsDispatchTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/MetricsDispatchTests.cs
@@ -1,9 +1,14 @@
 #if MULTIPLAYER_TOOLS
-using System;
+// System namespaces
 using System.Collections;
+using System;
+
+// Test framework
 using NUnit.Framework;
-using Unity.Multiplayer.Tools.NetStats;
 using UnityEngine.TestTools;
+
+// Unity namespaces
+using Unity.Multiplayer.Tools.NetStats;
 using Unity.Netcode.TestHelpers.Runtime;
 
 namespace Unity.Netcode.RuntimeTests.Metrics

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/NetworkObjectMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/NetworkObjectMetricsTests.cs
@@ -1,12 +1,18 @@
 #if MULTIPLAYER_TOOLS
+// System namespaces
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+
+// Test framework
 using NUnit.Framework;
-using Unity.Multiplayer.Tools.MetricTypes;
-using UnityEngine;
 using UnityEngine.TestTools;
 
+// Unity core
+using UnityEngine;
+
+// Unity multiplayer specific
+using Unity.Multiplayer.Tools.MetricTypes;
 using Unity.Netcode.TestHelpers.Runtime.Metrics;
 
 namespace Unity.Netcode.RuntimeTests.Metrics

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/NetworkVariableMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/NetworkVariableMetricsTests.cs
@@ -1,9 +1,14 @@
 #if MULTIPLAYER_TOOLS
+// System namespaces
 using System.Collections;
 using System.Linq;
+
+// Test framework
 using NUnit.Framework;
-using Unity.Multiplayer.Tools.MetricTypes;
 using UnityEngine.TestTools;
+
+// Unity namespaces
+using Unity.Multiplayer.Tools.MetricTypes;
 using Unity.Netcode.TestHelpers.Runtime.Metrics;
 
 namespace Unity.Netcode.RuntimeTests.Metrics

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/OwnershipChangeMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/OwnershipChangeMetricsTests.cs
@@ -1,11 +1,18 @@
 #if MULTIPLAYER_TOOLS
+// System namespaces
 using System.Collections;
 using System.Linq;
+
+// Test framework
 using NUnit.Framework;
-using Unity.Collections;
-using Unity.Multiplayer.Tools.MetricTypes;
-using UnityEngine;
 using UnityEngine.TestTools;
+
+// Unity core
+using Unity.Collections;
+using UnityEngine;
+
+// Unity netcode and multiplayer specific
+using Unity.Multiplayer.Tools.MetricTypes;
 using Unity.Netcode.TestHelpers.Runtime;
 using Unity.Netcode.TestHelpers.Runtime.Metrics;
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/PacketMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/PacketMetricsTests.cs
@@ -1,10 +1,17 @@
 #if MULTIPLAYER_TOOLS
 #if MULTIPLAYER_TOOLS_1_0_0_PRE_7
+// System namespaces
 using System.Collections;
+
+// Test framework
 using NUnit.Framework;
-using Unity.Collections;
-using Unity.Multiplayer.Tools.MetricTypes;
 using UnityEngine.TestTools;
+
+// Unity core
+using Unity.Collections;
+
+// Unity multiplayer specific
+using Unity.Multiplayer.Tools.MetricTypes;
 using Unity.Netcode.TestHelpers.Runtime.Metrics;
 
 namespace Unity.Netcode.RuntimeTests.Metrics

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/RpcMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/RpcMetricsTests.cs
@@ -1,10 +1,17 @@
 #if MULTIPLAYER_TOOLS
+// System namespaces
 using System.Collections;
 using System.Linq;
-using NUnit.Framework;
+
+// Unity core namespaces
 using Unity.Collections;
-using Unity.Multiplayer.Tools.MetricTypes;
 using UnityEngine.TestTools;
+
+// Unity test framework
+using NUnit.Framework;
+
+// Unity multiplayer specific
+using Unity.Multiplayer.Tools.MetricTypes;
 using Unity.Netcode.TestHelpers.Runtime.Metrics;
 
 namespace Unity.Netcode.RuntimeTests.Metrics

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/RpcMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/RpcMetricsTests.cs
@@ -3,10 +3,11 @@ using System.Linq;
 using Unity.Collections;
 using UnityEngine.TestTools;
 using NUnit.Framework;
-using Unity.Multiplayer.Tools.MetricTypes;
 using Unity.Netcode.TestHelpers.Runtime.Metrics;
 
 #if MULTIPLAYER_TOOLS
+using Unity.Multiplayer.Tools.MetricTypes;
+
 namespace Unity.Netcode.RuntimeTests.Metrics
 {
     internal class RpcMetricsTests : DualClientMetricTestBase

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/RpcMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/RpcMetricsTests.cs
@@ -1,8 +1,17 @@
 using System.Collections;
 using System.Linq;
-using Unity.Collections;
-using UnityEngine.TestTools;
+// System namespaces first
+using System.Collections;
+using System.Linq;
+
+// Test framework namespaces second
 using NUnit.Framework;
+using UnityEngine.TestTools;
+
+// Unity core namespaces third
+using Unity.Collections;
+
+// Unity specific packages last
 using Unity.Netcode.TestHelpers.Runtime.Metrics;
 
 #if MULTIPLAYER_TOOLS

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/RpcMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/RpcMetricsTests.cs
@@ -1,19 +1,12 @@
-#if MULTIPLAYER_TOOLS
-// System namespaces
 using System.Collections;
 using System.Linq;
-
-// Unity core namespaces
 using Unity.Collections;
 using UnityEngine.TestTools;
-
-// Unity test framework
 using NUnit.Framework;
-
-// Unity multiplayer specific
 using Unity.Multiplayer.Tools.MetricTypes;
 using Unity.Netcode.TestHelpers.Runtime.Metrics;
 
+#if MULTIPLAYER_TOOLS
 namespace Unity.Netcode.RuntimeTests.Metrics
 {
     internal class RpcMetricsTests : DualClientMetricTestBase

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/RttMetricsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Metrics/RttMetricsTests.cs
@@ -1,13 +1,20 @@
 #if MULTIPLAYER_TOOLS
 #if MULTIPLAYER_TOOLS_1_0_0_PRE_7
 
+// System namespaces
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+
+// Test framework
 using NUnit.Framework;
-using Unity.Collections;
-using Unity.Multiplayer.Tools.MetricTypes;
 using UnityEngine.TestTools;
+
+// Unity core
+using Unity.Collections;
+
+// Unity netcode and multiplayer specific
+using Unity.Multiplayer.Tools.MetricTypes;
 using Unity.Netcode.TestHelpers.Runtime;
 using Unity.Netcode.TestHelpers.Runtime.Metrics;
 

--- a/minimalproject/Packages/manifest.json
+++ b/minimalproject/Packages/manifest.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
-    "com.unity.netcode.gameobjects": "file:../../com.unity.netcode.gameobjects"
+    "com.unity.netcode.gameobjects": "file:../../com.unity.netcode.gameobjects",
+    "com.unity.ide.rider": "3.0.31"
   },
   "testables": [
     "com.unity.netcode.gameobjects"

--- a/testproject-tools-integration/Assets/Tests/Runtime/SceneEventTests.cs
+++ b/testproject-tools-integration/Assets/Tests/Runtime/SceneEventTests.cs
@@ -2,13 +2,18 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+
 using NUnit.Framework;
+using UnityEngine.TestTools;
+
+using Unity.Collections;
+using UnityEngine.SceneManagement;
+
 using Unity.Multiplayer.Tools.MetricTypes;
 using Unity.Netcode;
-using Unity.Netcode.TestHelpers.Runtime.Metrics;
-using UnityEngine.SceneManagement;
-using UnityEngine.TestTools;
 using Unity.Netcode.TestHelpers.Runtime;
+using Unity.Netcode.TestHelpers.Runtime.Metrics;
+
 using SceneEventType = Unity.Netcode.SceneEventType;
 
 namespace TestProject.ToolsIntegration.RuntimeTests


### PR DESCRIPTION
This PR addresses some test failures in new CI definition

1. Code Coverage failure--> This test was failing because packed package couldn't be find because the path was wrongly pointing to different place. This is fixed by this PR bu utilizing upm-pvp in place of upm-ci
2. minimalproject standards failure
3. testproject-tools-integration standards failure