### PR TITLE
fix: selecting everything selects session owner only

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where the `NetworkObject.Ownership` custom editor did not take the default "Everything" flag into consideration. (#3305)
 - Fixed DestroyObject flow on non-authority game clients. (#3291)
 - Fixed exception being thrown when a `GameObject` with an associated `NetworkTransform` is disabled. (#3243)
 - Fixed issue where the scene migration synchronization table was not cleaned up if the `GameObject` of a `NetworkObject` is destroyed before it should have been. (#3230)
@@ -24,6 +25,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+- Changed root in-scene placed `NetworkObject` instances now will always have either the `Distributable` permission set unless the `SessionOwer` permission is set. (#3305)
 - Changed the `NetworkTimeSystem.Sync` method to use half RTT to calculate the desired local time offset as opposed to the full RTT. (#3212)
 
 ## [2.2.0] - 2024-12-12

--- a/com.unity.netcode.gameobjects/Editor/NetworkObjectEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkObjectEditor.cs
@@ -117,15 +117,22 @@ namespace Unity.Netcode.Editor
             {
                 EditorGUI.BeginChangeCheck();
                 serializedObject.UpdateIfRequiredOrScript();
+
+                // Get the current ownership property and precalculate values in order to handle
+                // the exclusion or inclusion of "all" or just the session owner flags.
                 var ownershipProperty = serializedObject.FindProperty(nameof(NetworkObject.Ownership));
                 var previousOwnership = (NetworkObject.OwnershipStatus)ownershipProperty.intValue;
                 var hadAll = previousOwnership == k_AllOwnershipFlags;
                 var hadSessionOwner = ownershipProperty.intValue == k_SessionOwnerFlagAsInt;
+
                 DrawPropertiesExcluding(serializedObject, k_HiddenFields);
 
+                // If the ownership flags were changed
                 var currentOwnership = (NetworkObject.OwnershipStatus)ownershipProperty.intValue;
                 if (currentOwnership != previousOwnership)
                 {
+                    // Determine if we need to handle setting or removing the session owner flag specifically
+                    // when a user selects the "All" enum flag value.
                     var hasSessionOwner = currentOwnership.HasFlag(NetworkObject.OwnershipStatus.SessionOwner);
                     if (hasSessionOwner)
                     {

--- a/com.unity.netcode.gameobjects/Editor/NetworkObjectEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkObjectEditor.cs
@@ -114,10 +114,34 @@ namespace Unity.Netcode.Editor
             {
                 EditorGUI.BeginChangeCheck();
                 serializedObject.UpdateIfRequiredOrScript();
+                var ownershipProperty = serializedObject.FindProperty(nameof(NetworkObject.Ownership));
+                var sceneObjectProperty = serializedObject.FindProperty(nameof(NetworkObject.IsSceneObject));
+                var previousOwnership = (NetworkObject.OwnershipStatus)ownershipProperty.intValue;
+                var allFilter = NetworkObject.OwnershipStatus.RequestRequired | NetworkObject.OwnershipStatus.Transferable | NetworkObject.OwnershipStatus.Distributable;
+                var hadAll = previousOwnership == allFilter;
+                var wasNone = previousOwnership == 0;
+                var hadSessionOwner = ownershipProperty.intValue == (int)NetworkObject.OwnershipStatus.SessionOwner;
                 DrawPropertiesExcluding(serializedObject, k_HiddenFields);
-                if (m_NetworkObject.IsOwnershipSessionOwner)
+
+                var currentOwnership = (NetworkObject.OwnershipStatus)ownershipProperty.intValue;
+                if (currentOwnership != previousOwnership)
                 {
-                    m_NetworkObject.Ownership = NetworkObject.OwnershipStatus.SessionOwner;
+                    var hasSessionOwner = currentOwnership.HasFlag(NetworkObject.OwnershipStatus.SessionOwner);
+                    if (hasSessionOwner)
+                    {
+                        if (ownershipProperty.intValue == -1 && !hadAll)
+                        {
+                            ownershipProperty.intValue = (int)allFilter;
+                        }
+                        else if ((hadAll && !hadSessionOwner) || (!hadAll && !hadSessionOwner))
+                        {
+                            ownershipProperty.intValue = (int)NetworkObject.OwnershipStatus.SessionOwner;
+                        }
+                        else if (hadSessionOwner && hasSessionOwner)
+                        {
+                            ownershipProperty.intValue &= (int)~NetworkObject.OwnershipStatus.SessionOwner;
+                        }
+                    }
                 }
                 serializedObject.ApplyModifiedProperties();
                 EditorGUI.EndChangeCheck();

--- a/com.unity.netcode.gameobjects/Editor/NetworkObjectEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkObjectEditor.cs
@@ -14,6 +14,9 @@ namespace Unity.Netcode.Editor
     [CanEditMultipleObjects]
     public class NetworkObjectEditor : UnityEditor.Editor
     {
+        private const NetworkObject.OwnershipStatus k_AllOwnershipFlags = NetworkObject.OwnershipStatus.RequestRequired | NetworkObject.OwnershipStatus.Transferable | NetworkObject.OwnershipStatus.Distributable;
+        private const int k_SessionOwnerFlagAsInt = (int)NetworkObject.OwnershipStatus.SessionOwner;
+
         private bool m_Initialized;
         private NetworkObject m_NetworkObject;
         private bool m_ShowObservers;
@@ -115,12 +118,9 @@ namespace Unity.Netcode.Editor
                 EditorGUI.BeginChangeCheck();
                 serializedObject.UpdateIfRequiredOrScript();
                 var ownershipProperty = serializedObject.FindProperty(nameof(NetworkObject.Ownership));
-                var sceneObjectProperty = serializedObject.FindProperty(nameof(NetworkObject.IsSceneObject));
                 var previousOwnership = (NetworkObject.OwnershipStatus)ownershipProperty.intValue;
-                var allFilter = NetworkObject.OwnershipStatus.RequestRequired | NetworkObject.OwnershipStatus.Transferable | NetworkObject.OwnershipStatus.Distributable;
-                var hadAll = previousOwnership == allFilter;
-                var wasNone = previousOwnership == 0;
-                var hadSessionOwner = ownershipProperty.intValue == (int)NetworkObject.OwnershipStatus.SessionOwner;
+                var hadAll = previousOwnership == k_AllOwnershipFlags;
+                var hadSessionOwner = ownershipProperty.intValue == k_SessionOwnerFlagAsInt;
                 DrawPropertiesExcluding(serializedObject, k_HiddenFields);
 
                 var currentOwnership = (NetworkObject.OwnershipStatus)ownershipProperty.intValue;
@@ -131,15 +131,15 @@ namespace Unity.Netcode.Editor
                     {
                         if (ownershipProperty.intValue == -1 && !hadAll)
                         {
-                            ownershipProperty.intValue = (int)allFilter;
+                            ownershipProperty.intValue = (int)k_AllOwnershipFlags;
                         }
                         else if ((hadAll && !hadSessionOwner) || (!hadAll && !hadSessionOwner))
                         {
-                            ownershipProperty.intValue = (int)NetworkObject.OwnershipStatus.SessionOwner;
+                            ownershipProperty.intValue = k_SessionOwnerFlagAsInt;
                         }
                         else if (hadSessionOwner && hasSessionOwner)
                         {
-                            ownershipProperty.intValue &= (int)~NetworkObject.OwnershipStatus.SessionOwner;
+                            ownershipProperty.intValue &= ~k_SessionOwnerFlagAsInt;
                         }
                     }
                 }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -509,10 +509,25 @@ namespace Unity.Netcode
         public enum OwnershipStatus
         {
             None = 0,
+            /// <summary>
+            ///  When set, this instance will be automatically redistributed when a client joins (if not locked or no request is pending) or leaves.
+            /// </summary>
             Distributable = 1 << 0,
+            /// <summary>
+            /// When set, a non-owner can obtain ownership immediately (without requesting and as long as it is not locked).
+            /// </summary>
             Transferable = 1 << 1,
+            /// <summary>
+            /// When set, a non-owner must request ownership from the owner (will always get locked once ownership is transferred).
+            /// </summary>
             RequestRequired = 1 << 2,
+            /// <summary>
+            /// When set, only the current session owner may have ownership over this object.
+            /// </summary>
             SessionOwner = 1 << 3,
+            /// <summary>
+            /// Used within the inspector view only. When selected it will set the Distributable, Transferable, and RequestRequired flags or if those flags are already set it will select the SessionOwner flag by itself.
+            /// </summary>
             All = ~0,
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -508,6 +508,9 @@ namespace Unity.Netcode
         [Flags]
         public enum OwnershipStatus
         {
+            /// <summary>
+            ///  When set, this instance will have no permissions (i.e. cannot distribute, transfer, etc).
+            /// </summary>
             None = 0,
             /// <summary>
             ///  When set, this instance will be automatically redistributed when a client joins (if not locked or no request is pending) or leaves.

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -322,6 +322,15 @@ namespace Unity.Netcode
 
                 // Default scene migration synchronization to false for in-scene placed NetworkObjects
                 SceneMigrationSynchronization = false;
+
+                // Root In-scene placed NetworkObjects have to either have the SessionOwner or Distributable permission flag set.
+                if (transform.parent == null)
+                {
+                    if (!Ownership.HasFlag(OwnershipStatus.SessionOwner) && !Ownership.HasFlag(OwnershipStatus.Distributable))
+                    {
+                        Ownership |= OwnershipStatus.Distributable;
+                    }
+                }
             }
         }
 #endif // UNITY_EDITOR
@@ -493,6 +502,7 @@ namespace Unity.Netcode
         /// <see cref="Transferable"/>: When set, a non-owner can obtain ownership immediately (without requesting and as long as it is not locked).
         /// <see cref="RequestRequired"/>: When set, a non-owner must request ownership from the owner (will always get locked once ownership is transferred).
         /// <see cref="SessionOwner"/>: When set, only the current session owner may have ownership over this object.
+        /// <see cref="All"/>: Used within the inspector view only. When selected it will set the Distributable, Transferable, and RequestRequired flags or if those flags are already set it will select the SessionOwner flag by itself.
         /// </summary>
         // Ranges from 1 to 8 bits
         [Flags]
@@ -503,6 +513,7 @@ namespace Unity.Netcode
             Transferable = 1 << 1,
             RequestRequired = 1 << 2,
             SessionOwner = 1 << 3,
+            All = ~0,
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1967,9 +1967,12 @@ namespace Unity.Netcode
                                 {
                                     continue;
                                 }
-                                if ((!child.IsOwnershipDistributable || !child.IsOwnershipTransferable) && NetworkManager.LogLevel == LogLevel.Developer)
+                                if (!child.IsOwnershipDistributable || !child.IsOwnershipTransferable)
                                 {
-                                    NetworkLog.LogWarning($"Sibling {child.name} of root parent {ownerList.Value[i].name} is neither transferrable or distributable! Object distribution skipped and could lead to a potentially un-owned or owner-mismatched {nameof(NetworkObject)}!");
+                                    if (NetworkManager.LogLevel == LogLevel.Developer)
+                                    {
+                                        NetworkLog.LogWarning($"Sibling {child.name} of root parent {ownerList.Value[i].name} is neither transferrable or distributable! Object distribution skipped and could lead to a potentially un-owned or owner-mismatched {nameof(NetworkObject)}!");
+                                    }
                                     continue;
                                 }
                                 // Transfer ownership of all distributable =or= transferrable children with the same owner to the same client to preserve the sibling ownership tree.


### PR DESCRIPTION
This PR addresses:

- An issue where selecting "Everything" would include the SessionOwner and end up with a value of -1 (i.e. the default value for "Everything" with an enum used as flags).
- Root in-scene placed `NetworkObject` instances' not defaulting ownership permissions to `Distributable` unless it already has the `SessionOwner` flag set.
- A yet-to-be-released issue in the develop-2.0.0 branch.


## Changelog

- Fixed: Issue where the `NetworkObject.Ownership` custom editor did not take the default "Everything" flag into consideration.
- Changed: Root in-scene placed `NetworkObject` instances will now always have either the `Distributable` permission set unless the `SessionOwer` permission is set.

## Testing and Documentation

- No tests have been added.
- Documentation changes or additions were necessary ([PR-1423](https://github.com/Unity-Technologies/com.unity.multiplayer.docs/pull/1423))

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
