### PR TITLE
ci: [2.X] Turn off title validation for single commit PRs

### DIFF
--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -1,6 +1,6 @@
 name: Conventional PR
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   pull_request:
     branches:
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: semantic-pull-request
         # Internal Unity mirror available at jesseo/action-semantic-pull-request, but actions from private repos aren't supported, so continue to use the public one below
-        uses: amannn/action-semantic-pull-request@40166f00814508ec3201fc8595b393d451c8cd80
+        uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -35,4 +35,4 @@ jobs:
           # For work-in-progress PRs you can typically use draft pull requests from Github. However, private repositories on the free plan don't have this option and therefore this action allows you to opt-in to using the special '[WIP]' prefix to indicate this state. This will avoid the validation of the PR title and the pull request checks remain pending. Note that a second check will be reported if this is enabled.
           #wip: # optional
           # When using "Squash and merge" on a PR with only one commit, GitHub will suggest using that commit message instead of the PR title for the merge commit, and it's easy to commit this by mistake. Enable this option to also validate the commit message for one commit PRs.
-          validateSingleCommit: true # optional
+          # validateSingleCommit: true # optional


### PR DESCRIPTION
<!-- Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

## 2.x

When the semantic commit action was added into the branch, the default squash commit for a pr with only a single commit was the commit name and not the PR title. Since then, Github has [added a feature to allow configuration of the default](https://github.com/orgs/community/discussions/16271) and we have that setting set in our repo.

This PR turns off the validation of commits as the check is not valid anymore.
