### PR TITLE
fix: NetworkEndPoint simplify to NetworkEndpoint in 2021.3 editor

### DIFF
--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -42,7 +42,7 @@ develop_nightly:
   dependencies:
     # Run project standards to verify package/default project
     - .yamato/project-standards.yml#standards_ubuntu_testproject_trunk
-#    - .yamato/project-standards.yml#standards_ubuntu_testproject_2021.3  # Tracked in MTT-11382
+    - .yamato/project-standards.yml#standards_ubuntu_testproject_2021.3
     # Run APV jobs to make sure the change won't break any dependants
     - .yamato/wrench/preview-a-p-v.yml#all_preview_apv_jobs
     # Run package EditMode and Playmode tests on desktop platforms on trunk and 2021.3

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1250,7 +1250,7 @@ namespace Unity.Netcode.Transports.UTP
         /// </remarks>
         /// <param name="clientId">NGO client identifier to get endpoint information about.</param>
         /// <returns><see cref="NetworkEndPoint"/></returns>
-        public NetworkEndPoint GetEndpoint(ulong clientId)
+        public NetworkEndpoint GetEndpoint(ulong clientId)
         {
             if (m_Driver.IsCreated && NetworkManager != null && NetworkManager.IsListening)
             {
@@ -1261,7 +1261,7 @@ namespace Unity.Netcode.Transports.UTP
                     return m_Driver.RemoteEndPoint(networkConnection);
                 }
             }
-            return new NetworkEndPoint();
+            return new NetworkEndpoint();
         }
 #endif
 

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1241,7 +1241,7 @@ namespace Unity.Netcode.Transports.UTP
         }
 #else
         /// <summary>
-        /// Provides the <see cref="NetworkEndPoint"/> for the NGO client identifier specified.
+        /// Provides the <see cref="NetworkEndpoint"/> for the NGO client identifier specified.
         /// </summary>
         /// <remarks>
         /// - This is only really useful for direct connections.
@@ -1249,7 +1249,7 @@ namespace Unity.Netcode.Transports.UTP
         /// - For LAN topologies this should work as long as it is a direct connection and not a relay connection.
         /// </remarks>
         /// <param name="clientId">NGO client identifier to get endpoint information about.</param>
-        /// <returns><see cref="NetworkEndPoint"/></returns>
+        /// <returns><see cref="NetworkEndpoint"/></returns>
         public NetworkEndpoint GetEndpoint(ulong clientId)
         {
             if (m_Driver.IsCreated && NetworkManager != null && NetworkManager.IsListening)


### PR DESCRIPTION
This PR resolves some standards test issues regarding the simplification of `NetworkEndPoint` to `NetworkEndpoint`.

[MTT-11382](https://jira.unity3d.com/browse/MTT-11382)

## Changelog

NA

## Testing and Documentation

- No tests have been added.
- Includes edits to existing public API documentation.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
