### PR TITLE
fix: fastbufferreader does not honor arraysegment configuration

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -9,8 +9,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ## [Unreleased]
 
 ### Added
-- Added `FastBufferReader(ArraySegment<byte> buffer, Allocator copyAllocator)` constructor that uses the `ArraySegment.Offset` as the `FastBufferReader` offset and the `ArraySegment.Count` as the `FastBufferReader` length.
-- Added `FastBufferReader(ArraySegment<byte> buffer, Allocator copyAllocator, int length = -1)` constructor that uses the `ArraySegment.Offset` as the `FastBufferReader` offset.
+- Added `FastBufferReader(ArraySegment<byte> buffer, Allocator copyAllocator)` constructor that uses the `ArraySegment.Offset` as the `FastBufferReader` offset and the `ArraySegment.Count` as the `FastBufferReader` length. (#3320)
+- Added `FastBufferReader(ArraySegment<byte> buffer, Allocator copyAllocator, int length = -1)` constructor that uses the `ArraySegment.Offset` as the `FastBufferReader` offset. (#3320)
 
 ### Fixed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -9,6 +9,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ## [Unreleased]
 
 ### Added
+- Added `FastBufferReader(ArraySegment<byte> buffer, Allocator copyAllocator)` constructor that uses the `ArraySegment.Offset` as the `FastBufferReader` offset and the `ArraySegment.Count` as the `FastBufferReader` length.
+- Added `FastBufferReader(ArraySegment<byte> buffer, Allocator copyAllocator, int length = -1)` constructor that uses the `ArraySegment.Offset` as the `FastBufferReader` offset.
 
 ### Fixed
 

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
@@ -136,7 +136,58 @@ namespace Unity.Netcode
             }
             fixed (byte* data = buffer.Array)
             {
+
                 Handle = CreateHandle(data, length == -1 ? buffer.Count : length, offset, copyAllocator, Allocator.Temp);
+            }
+        }
+
+        /// <summary>
+        /// Create a FastBufferReader from an ArraySegment that uses the ArraySegment.Offset for the reader's offset.
+        ///
+        /// A new buffer will be created using the given allocator and the value will be copied in.
+        /// FastBufferReader will then own the data.
+        ///
+        /// Allocator.None is not supported for byte[]. If you need this functionality, use a fixed() block
+        /// and ensure the FastBufferReader isn't used outside that block.
+        /// </summary>
+        /// <param name="buffer">The buffer to copy from</param>
+        /// <param name="copyAllocator">The allocator type used for internal data when copying an existing buffer if other than Allocator.None is specified, that memory will be owned by this FastBufferReader instance</param>
+        /// <param name="length">The number of bytes to copy (all if this is -1)</param>
+        /// <exception cref="NotSupportedException"></exception>
+        public unsafe FastBufferReader(ArraySegment<byte> buffer, Allocator copyAllocator, int length = -1)
+        {
+            if (copyAllocator == Allocator.None)
+            {
+                throw new NotSupportedException("Allocator.None cannot be used with managed source buffers.");
+            }
+            fixed (byte* data = buffer.Array)
+            {
+
+                Handle = CreateHandle(data, length == -1 ? buffer.Count : length, buffer.Offset, copyAllocator, Allocator.Temp);
+            }
+        }
+
+        /// <summary>
+        /// Create a FastBufferReader from an ArraySegment that uses the ArraySegment.Offset for the reader's offset and the ArraySegment.Count for the reader's length.
+        ///
+        /// A new buffer will be created using the given allocator and the value will be copied in.
+        /// FastBufferReader will then own the data.
+        ///
+        /// Allocator.None is not supported for byte[]. If you need this functionality, use a fixed() block
+        /// and ensure the FastBufferReader isn't used outside that block.
+        /// </summary>
+        /// <param name="buffer">The buffer to copy from</param>
+        /// <param name="copyAllocator">The allocator type used for internal data when copying an existing buffer if other than Allocator.None is specified, that memory will be owned by this FastBufferReader instance</param>
+        /// <exception cref="NotSupportedException"></exception>
+        public unsafe FastBufferReader(ArraySegment<byte> buffer, Allocator copyAllocator)
+        {
+            if (copyAllocator == Allocator.None)
+            {
+                throw new NotSupportedException("Allocator.None cannot be used with managed source buffers.");
+            }
+            fixed (byte* data = buffer.Array)
+            {
+                Handle = CreateHandle(data, buffer.Count, buffer.Offset, copyAllocator, Allocator.Temp);
             }
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
@@ -153,7 +153,6 @@ namespace Unity.Netcode
         /// <param name="buffer">The buffer to copy from</param>
         /// <param name="copyAllocator">The allocator type used for internal data when copying an existing buffer if other than Allocator.None is specified, that memory will be owned by this FastBufferReader instance</param>
         /// <param name="length">The number of bytes to copy (all if this is -1)</param>
-        /// <exception cref="NotSupportedException"></exception>
         public unsafe FastBufferReader(ArraySegment<byte> buffer, Allocator copyAllocator, int length = -1)
         {
             if (copyAllocator == Allocator.None)
@@ -178,7 +177,6 @@ namespace Unity.Netcode
         /// </summary>
         /// <param name="buffer">The buffer to copy from</param>
         /// <param name="copyAllocator">The allocator type used for internal data when copying an existing buffer if other than Allocator.None is specified, that memory will be owned by this FastBufferReader instance</param>
-        /// <exception cref="NotSupportedException"></exception>
         public unsafe FastBufferReader(ArraySegment<byte> buffer, Allocator copyAllocator)
         {
             if (copyAllocator == Allocator.None)

--- a/com.unity.netcode.gameobjects/Tests/Editor/Serialization/FastBufferReaderTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Serialization/FastBufferReaderTests.cs
@@ -1579,5 +1579,21 @@ namespace Unity.Netcode.EditorTests
                 Assert.AreEqual(reader.Handle->AllowedReadMark, 25);
             }
         }
+
+        [Test]
+        public unsafe void WhenUsingArraySegment_ConstructorHonorsArraySegmentConfiguration()
+        {
+            var bytes = new byte[] { 0, 1, 2, 3 };
+            var segment = new ArraySegment<byte>(bytes, 1, 3);
+            var reader = new FastBufferReader(segment, Allocator.Temp);
+
+            var readerArray = reader.ToArray();
+            Assert.True(readerArray.Length == bytes.Length - 1, $"Array of reader should have a length of {bytes.Length - 1} but was {readerArray.Length}!");
+            for(int i = 0; i < readerArray.Length; i++)
+            {
+                Assert.True(bytes[i + 1] == readerArray[i], $"Value of {nameof(readerArray)} at index {i} is {readerArray[i]} but should be {bytes[i + 1]}!");
+            }
+            reader.Dispose();
+        }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Editor/Serialization/FastBufferReaderTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Serialization/FastBufferReaderTests.cs
@@ -1589,7 +1589,7 @@ namespace Unity.Netcode.EditorTests
 
             var readerArray = reader.ToArray();
             Assert.True(readerArray.Length == bytes.Length - 1, $"Array of reader should have a length of {bytes.Length - 1} but was {readerArray.Length}!");
-            for(int i = 0; i < readerArray.Length; i++)
+            for (int i = 0; i < readerArray.Length; i++)
             {
                 Assert.True(bytes[i + 1] == readerArray[i], $"Value of {nameof(readerArray)} at index {i} is {readerArray[i]} but should be {bytes[i + 1]}!");
             }

--- a/pvpExceptions.json
+++ b/pvpExceptions.json
@@ -731,6 +731,7 @@
           "Unity.Netcode.EditorTests.FastBufferReaderTests: void WhenCallingTryBeginRead_TheAllowedReadPositionIsMarkedRelativeToCurrentPosition(): undocumented",
           "Unity.Netcode.EditorTests.FastBufferReaderTests: void WhenReadingAfterSeeking_TheNewReadComesFromTheCorrectPosition(): undocumented",
           "Unity.Netcode.EditorTests.FastBufferReaderTests: void WhenCallingTryBeginReadInternal_AllowedReadPositionDoesNotMoveBackward(): undocumented",
+          "Unity.Netcode.EditorTests.FastBufferReaderTests: void WhenUsingArraySegment_ConstructorHonorsArraySegmentConfiguration(): undocumented",
           "Unity.Netcode.EditorTests.FastBufferWriterTests: undocumented",
           "Unity.Netcode.EditorTests.FastBufferWriterTests: void RunTypeTest(T): undocumented",
           "Unity.Netcode.EditorTests.FastBufferWriterTests: void RunTypeTestSafe(T): undocumented",


### PR DESCRIPTION
This PR resolves the issue where `FastBufferReader` did not provide constructors that would automatically use an `ArraySegment`'s configuration (Count and Offset) to define the `FastBufferReader`.

[MTTB-34](https://jira.unity3d.com/browse/MTTB-34)

fix: #2885

up-port: #3321

## Changelog

- Added `FastBufferReader(ArraySegment<byte> buffer, Allocator copyAllocator)` constructor that uses the `ArraySegment.Offset` as the `FastBufferReader` offset and the `ArraySegment.Count` as the `FastBufferReader` length.
- Added `FastBufferReader(ArraySegment<byte> buffer, Allocator copyAllocator, int length = -1)` constructor that uses the `ArraySegment.Offset` as the `FastBufferReader` offset.

## Testing and Documentation

- Includes unit test.
- Includes public API documentation.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
