### PR TITLE
fix: AnticipatedNetworkVariable not updating previous value [MTTB-1036] (back port)

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where `AnticipatedNetworkVariable` previous value returned by `AnticipatedNetworkVariable.OnAuthoritativeValueChanged` is updated correctly on the non-authoritative side. (#3322)
+
 ### Changed
 
 

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/AnticipatedNetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/AnticipatedNetworkVariable.cs
@@ -387,6 +387,9 @@ namespace Unity.Netcode
         public override void ReadDelta(FastBufferReader reader, bool keepDirtyDelta)
         {
             m_AuthoritativeValue.ReadDelta(reader, keepDirtyDelta);
+            // Assure that the post delta read is invoked in order to update
+            // previous value.
+            m_AuthoritativeValue.PostDeltaRead();
         }
     }
 }


### PR DESCRIPTION
Back-port of #3306.

This fixes the issue where the `AnticipatedNetworkVariable` previous value was never updated on the non-authority/write permission instances when the `OnAuthoritativeValueChanged` callback was invoked.

[MTTB-1036](https://jira.unity3d.com/browse/MTTB-1036)

<!-- Add RFC link here if applicable. -->

## Changelog

- Fixed: Issue where the `AnticipatedNetworkVariable` previous value was never updated on the non-authority/write permission instances when the `OnAuthoritativeValueChanged` callback was invoked.

## Testing and Documentation

- Includes integration test `NetworkVariableAnticipationTests.PreviousValueIsMaintainedProperly`.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
