### PR TITLE
fix: Never distribute an object to a client who is not an observer

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -15,6 +15,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed `ChangeOwnership` changing ownership to clients that are not observers. This also happened with automated object distribution. (#3323)
 - Fixed `OnClientConnectedCallback` passing incorrect `clientId` when scene management is disabled. (#3312)
 - Fixed issue where the `NetworkObject.Ownership` custom editor did not take the default "Everything" flag into consideration. (#3305)
 - Fixed DestroyObject flow on non-authority game clients. (#3291)

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -1211,25 +1211,22 @@ namespace Unity.Netcode
                                 }
 
                                 var targetOwner = NetworkManager.ServerClientId;
-                                if (predictedClientCount > 1)
+                                // Cycle through the full count of clients to find
+                                // the next viable owner. If none are found, then
+                                // the DAHost defaults to the owner.
+                                for (int j = 0; j < remainingClients.Count; j++)
                                 {
                                     clientCounter++;
-                                    clientCounter %= predictedClientCount;
-                                    targetOwner = remainingClients[clientCounter].ClientId;
+                                    clientCounter = clientCounter % predictedClientCount;
+                                    if (ownedObject.Observers.Contains(remainingClients[clientCounter].ClientId))
+                                    {
+                                        targetOwner = remainingClients[clientCounter].ClientId;
+                                        break;
+                                    }
                                 }
                                 if (EnableDistributeLogging)
                                 {
                                     Debug.Log($"[Disconnected][Client-{clientId}][NetworkObjectId-{ownedObject.NetworkObjectId} Distributed to Client-{targetOwner}");
-                                }
-
-                                if (!ownedObject.Observers.Contains(targetOwner))
-                                {
-                                    targetOwner = NetworkManager.ServerClientId;
-                                }
-
-                                if (!ownedObject.Observers.Contains(targetOwner))
-                                {
-                                    targetOwner = ownedObject.Observers.First();
                                 }
 
                                 NetworkManager.SpawnManager.ChangeOwnership(ownedObject, targetOwner, true);

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -1122,18 +1122,16 @@ namespace Unity.Netcode
                 {
                     if (!playerObject.DontDestroyWithOwner)
                     {
-                        // DANGO-TODO: This is something that would be best for CMB Service to handle as it is part of the disconnection process
                         // If a player NetworkObject is being despawned, make sure to remove all children if they are marked to not be destroyed
                         // with the owner.
-                        if (NetworkManager.DistributedAuthorityMode && NetworkManager.DAHost)
+                        if (NetworkManager.DAHost)
                         {
                             // Remove any children from the player object if they are not going to be destroyed with the owner
                             var childNetworkObjects = playerObject.GetComponentsInChildren<NetworkObject>();
                             foreach (var child in childNetworkObjects)
                             {
-                                // TODO: We have always just removed all children, but we might think about changing this to preserve the nested child
-                                // hierarchy.
-                                if (child.DontDestroyWithOwner && child.transform.transform.parent != null)
+                                // TODO: We have always just removed all children, but we might think about changing this to preserve the nested child hierarchy.
+                                if (child.DontDestroyWithOwner && child.transform.transform.parent)
                                 {
                                     // If we are here, then we are running in DAHost mode and have the authority to remove the child from its parent
                                     child.AuthorityAppliedParenting = true;
@@ -1158,10 +1156,7 @@ namespace Unity.Netcode
                     }
                     else if (!NetworkManager.ShutdownInProgress)
                     {
-                        if (!NetworkManager.ShutdownInProgress)
-                        {
-                            playerObject.RemoveOwnership();
-                        }
+                        playerObject.RemoveOwnership();
                     }
                 }
 
@@ -1175,7 +1170,7 @@ namespace Unity.Netcode
                 for (int i = clientOwnedObjects.Count - 1; i >= 0; i--)
                 {
                     var ownedObject = clientOwnedObjects[i];
-                    if (ownedObject != null)
+                    if (ownedObject)
                     {
                         // If destroying with owner, then always despawn and destroy (or defer destroying to prefab handler)
                         if (!ownedObject.DontDestroyWithOwner)
@@ -1196,68 +1191,86 @@ namespace Unity.Netcode
                         }
                         else if (!NetworkManager.ShutdownInProgress)
                         {
+                            // DANGO-TODO: We will want to match how the CMB service handles this. For now, we just try to evenly distribute
+                            // ownership.
                             // NOTE: All of the below code only handles ownership transfer.
                             // For client-server, we just remove the ownership.
                             // For distributed authority, we need to change ownership based on parenting
                             if (NetworkManager.DistributedAuthorityMode)
                             {
-                                // Only NetworkObjects that have the OwnershipStatus.Distributable flag set and no parent
-                                // (ownership is transferred to all children) will have their ownership redistributed.
-                                if (ownedObject.IsOwnershipDistributable && ownedObject.GetCachedParent() == null && !ownedObject.IsOwnershipSessionOwner)
+                                // Only NetworkObjects that have the OwnershipStatus.Distributable flag set and are not OwnershipSessionOwner are distributed.
+                                // If the object has a parent - skip it for now, it will be distributed when its root parent is distributed.
+                                if (!ownedObject.IsOwnershipDistributable || ownedObject.IsOwnershipSessionOwner || ownedObject.GetCachedParent())
                                 {
-                                    if (ownedObject.IsOwnershipLocked)
+                                    continue;
+                                }
+
+                                if (ownedObject.IsOwnershipLocked)
+                                {
+                                    ownedObject.SetOwnershipLock(false);
+                                }
+
+                                var targetOwner = NetworkManager.ServerClientId;
+                                if (predictedClientCount > 1)
+                                {
+                                    clientCounter++;
+                                    clientCounter %= predictedClientCount;
+                                    targetOwner = remainingClients[clientCounter].ClientId;
+                                }
+                                if (EnableDistributeLogging)
+                                {
+                                    Debug.Log($"[Disconnected][Client-{clientId}][NetworkObjectId-{ownedObject.NetworkObjectId} Distributed to Client-{targetOwner}");
+                                }
+
+                                if (!ownedObject.Observers.Contains(targetOwner))
+                                {
+                                    targetOwner = NetworkManager.ServerClientId;
+                                }
+
+                                if (!ownedObject.Observers.Contains(targetOwner))
+                                {
+                                    targetOwner = ownedObject.Observers.First();
+                                }
+
+                                NetworkManager.SpawnManager.ChangeOwnership(ownedObject, targetOwner, true);
+
+                                // Ownership gets passed down to all children that have the same owner.
+                                var childNetworkObjects = ownedObject.GetComponentsInChildren<NetworkObject>();
+                                foreach (var childObject in childNetworkObjects)
+                                {
+                                    // We already changed ownership for this
+                                    if (childObject == ownedObject)
                                     {
-                                        ownedObject.SetOwnershipLock(false);
+                                        continue;
+                                    }
+                                    // If the client owner disconnected, it is ok to unlock this at this point in time.
+                                    if (childObject.IsOwnershipLocked)
+                                    {
+                                        childObject.SetOwnershipLock(false);
                                     }
 
-                                    // DANGO-TODO: We will want to match how the CMB service handles this. For now, we just try to evenly distribute
-                                    // ownership.
-                                    var targetOwner = NetworkManager.ServerClientId;
-                                    if (predictedClientCount > 1)
+                                    // Ignore session owner marked objects
+                                    if (childObject.IsOwnershipSessionOwner)
                                     {
-                                        clientCounter++;
-                                        clientCounter = clientCounter % predictedClientCount;
-                                        targetOwner = remainingClients[clientCounter].ClientId;
+                                        continue;
                                     }
+
+                                    // If the child's owner is not the client disconnected and the objects are marked with either distributable or transferable, then
+                                    // do not change ownership.
+                                    if (childObject.OwnerClientId != clientId && (childObject.IsOwnershipDistributable || childObject.IsOwnershipTransferable))
+                                    {
+                                        continue;
+                                    }
+
+                                    if (!ownedObject.Observers.Contains(targetOwner))
+                                    {
+                                        targetOwner = ownedObject.Observers.First();
+                                    }
+
+                                    NetworkManager.SpawnManager.ChangeOwnership(childObject, targetOwner, true);
                                     if (EnableDistributeLogging)
                                     {
-                                        Debug.Log($"[Disconnected][Client-{clientId}][NetworkObjectId-{ownedObject.NetworkObjectId} Distributed to Client-{targetOwner}");
-                                    }
-                                    NetworkManager.SpawnManager.ChangeOwnership(ownedObject, targetOwner, true);
-                                    // DANGO-TODO: Should we try handling inactive NetworkObjects?
-                                    // Ownership gets passed down to all children that have the same owner.
-                                    var childNetworkObjects = ownedObject.GetComponentsInChildren<NetworkObject>();
-                                    foreach (var childObject in childNetworkObjects)
-                                    {
-                                        // We already changed ownership for this
-                                        if (childObject == ownedObject)
-                                        {
-                                            continue;
-                                        }
-                                        // If the client owner disconnected, it is ok to unlock this at this point in time.
-                                        if (childObject.IsOwnershipLocked)
-                                        {
-                                            childObject.SetOwnershipLock(false);
-                                        }
-
-                                        // Ignore session owner marked objects
-                                        if (childObject.IsOwnershipSessionOwner)
-                                        {
-                                            continue;
-                                        }
-
-                                        // If the child's owner is not the client disconnected and the objects are marked with either distributable or transferable, then
-                                        // do not change ownership.
-                                        if (childObject.OwnerClientId != clientId && (childObject.IsOwnershipDistributable || childObject.IsOwnershipTransferable))
-                                        {
-                                            continue;
-                                        }
-
-                                        NetworkManager.SpawnManager.ChangeOwnership(childObject, targetOwner, true);
-                                        if (EnableDistributeLogging)
-                                        {
-                                            Debug.Log($"[Disconnected][Client-{clientId}][Child of {ownedObject.NetworkObjectId}][NetworkObjectId-{ownedObject.NetworkObjectId} Distributed to Client-{targetOwner}");
-                                        }
+                                        Debug.Log($"[Disconnected][Client-{clientId}][Child of {ownedObject.NetworkObjectId}][NetworkObjectId-{ownedObject.NetworkObjectId} Distributed to Client-{targetOwner}");
                                     }
                                 }
                             }

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -1259,12 +1259,22 @@ namespace Unity.Netcode
                                         continue;
                                     }
 
-                                    if (!ownedObject.Observers.Contains(targetOwner))
+                                    var childOwner = targetOwner;
+                                    if (!childObject.Observers.Contains(childOwner))
                                     {
-                                        targetOwner = ownedObject.Observers.First();
+                                        for (int j = 0; j < remainingClients.Count; j++)
+                                        {
+                                            clientCounter++;
+                                            clientCounter = clientCounter % predictedClientCount;
+                                            if (ownedObject.Observers.Contains(remainingClients[clientCounter].ClientId))
+                                            {
+                                                childOwner = remainingClients[clientCounter].ClientId;
+                                                break;
+                                            }
+                                        }
                                     }
 
-                                    NetworkManager.SpawnManager.ChangeOwnership(childObject, targetOwner, true);
+                                    NetworkManager.SpawnManager.ChangeOwnership(childObject, childOwner, true);
                                     if (EnableDistributeLogging)
                                     {
                                         Debug.Log($"[Disconnected][Client-{clientId}][Child of {ownedObject.NetworkObjectId}][NetworkObjectId-{ownedObject.NetworkObjectId} Distributed to Client-{targetOwner}");

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -435,20 +435,15 @@ namespace Unity.Netcode
             // For client-server:
             // If ownership changes faster than the latency between the client-server and there are NetworkVariables being updated during ownership changes,
             // then notify the user they could potentially lose state updates if developer logging is enabled.
-            if (!NetworkManager.DistributedAuthorityMode && m_LastChangeInOwnership.ContainsKey(networkObject.NetworkObjectId) && m_LastChangeInOwnership[networkObject.NetworkObjectId] > Time.realtimeSinceStartup)
+            if (NetworkManager.LogLevel == LogLevel.Developer && !NetworkManager.DistributedAuthorityMode && m_LastChangeInOwnership.ContainsKey(networkObject.NetworkObjectId) && m_LastChangeInOwnership[networkObject.NetworkObjectId] > Time.realtimeSinceStartup)
             {
-                var hasNetworkVariables = false;
                 for (int i = 0; i < networkObject.ChildNetworkBehaviours.Count; i++)
                 {
-                    hasNetworkVariables = networkObject.ChildNetworkBehaviours[i].NetworkVariableFields.Count > 0;
-                    if (hasNetworkVariables)
+                    if (networkObject.ChildNetworkBehaviours[i].NetworkVariableFields.Count > 0)
                     {
+                        NetworkLog.LogWarningServer($"[Rapid Ownership Change Detected][Potential Loss in State] Detected a rapid change in ownership that exceeds a frequency less than {k_MaximumTickOwnershipChangeMultiplier}x the current network tick rate! Provide at least {k_MaximumTickOwnershipChangeMultiplier}x the current network tick rate between ownership changes to avoid NetworkVariable state loss.");
                         break;
                     }
-                }
-                if (hasNetworkVariables && NetworkManager.LogLevel == LogLevel.Developer)
-                {
-                    NetworkLog.LogWarningServer($"[Rapid Ownership Change Detected][Potential Loss in State] Detected a rapid change in ownership that exceeds a frequency less than {k_MaximumTickOwnershipChangeMultiplier}x the current network tick rate! Provide at least {k_MaximumTickOwnershipChangeMultiplier}x the current network tick rate between ownership changes to avoid NetworkVariable state loss.");
                 }
             }
 
@@ -517,12 +512,20 @@ namespace Unity.Netcode
                 throw new SpawnStateException("Object is not spawned");
             }
 
-
             if (networkObject.OwnerClientId == clientId && networkObject.PreviousOwnerId == clientId)
             {
                 if (NetworkManager.LogLevel == LogLevel.Developer)
                 {
                     NetworkLog.LogWarningServer($"[Already Owner] Unnecessary ownership change for {networkObject.name} as it is already the owned by client-{clientId}");
+                }
+                return;
+            }
+
+            if (!networkObject.Observers.Contains(clientId))
+            {
+                if (NetworkManager.LogLevel == LogLevel.Developer)
+                {
+                    NetworkLog.LogWarningServer($"[Invalid Owner] Cannot send Ownership change as client-{clientId} cannot see {networkObject.name}! Use {nameof(NetworkObject.NetworkShow)} first.");
                 }
                 return;
             }
@@ -1877,6 +1880,12 @@ namespace Unity.Netcode
             }
         }
 
+        /// <summary>
+        /// Distributes an even portion of spawned NetworkObjects to the given client.
+        /// This is called as part of the client connection process to ensure that all clients have a fair share of the spawned NetworkObjects.
+        /// DANGO-TODO: This will be handled by the CMB Service in the future.
+        /// </summary>
+        /// <param name="clientId">Client to distribute NetworkObjects to</param>
         internal void DistributeNetworkObjects(ulong clientId)
         {
             if (!NetworkManager.DistributedAuthorityMode)
@@ -1888,7 +1897,6 @@ namespace Unity.Netcode
             {
                 return;
             }
-
 
             // DA-NGO CMB SERVICE NOTES:
             // The most basic object distribution should be broken up into a table of spawned object types
@@ -1956,6 +1964,11 @@ namespace Unity.Netcode
                     {
                         if ((i % offsetCount) == 0)
                         {
+                            while (!ownerList.Value[i].Observers.Contains(clientId))
+                            {
+                                i++;
+                            }
+
                             var children = ownerList.Value[i].GetComponentsInChildren<NetworkObject>();
                             // Since the ownerList.Value[i] has to be distributable, then transfer all child NetworkObjects
                             // with the same owner clientId and are marked as distributable also to the same client to keep
@@ -1969,13 +1982,10 @@ namespace Unity.Netcode
                                 }
                                 if (!child.IsOwnershipDistributable || !child.IsOwnershipTransferable)
                                 {
-                                    if (NetworkManager.LogLevel == LogLevel.Developer)
-                                    {
-                                        NetworkLog.LogWarning($"Sibling {child.name} of root parent {ownerList.Value[i].name} is neither transferrable or distributable! Object distribution skipped and could lead to a potentially un-owned or owner-mismatched {nameof(NetworkObject)}!");
-                                    }
+                                    NetworkLog.LogWarning($"Sibling {child.name} of root parent {ownerList.Value[i].name} is neither transferable or distributable! Object distribution skipped and could lead to a potentially un-owned or owner-mismatched {nameof(NetworkObject)}!");
                                     continue;
                                 }
-                                // Transfer ownership of all distributable =or= transferrable children with the same owner to the same client to preserve the sibling ownership tree.
+                                // Transfer ownership of all distributable =or= transferable children with the same owner to the same client to preserve the sibling ownership tree.
                                 ChangeOwnership(child, clientId, true);
                                 // Note: We don't increment the distributed count for these children as they are skipped when getting the object distribution
                             }


### PR DESCRIPTION
<!-- Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->
[MTTB-1041](https://jira.unity3d.com/browse/MTTB-1041)

<!-- Add RFC link here if applicable. -->

## Changelog

- Fixed: ChangeOwnership should never distribute to a client that is not an observer of that object.

## Testing and Documentation

- No tests have been added.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

Closes #3299 
