### PR TITLE
fix: Block websocket use in dedicated server builds

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -31,6 +31,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+- Ensured that a useful error is thrown when attempting to build a dedicated server with Unity Transport that uses websockets. (#3336)
 - Changed root in-scene placed `NetworkObject` instances now will always have either the `Distributable` permission set unless the `SessionOwner` permission is set. (#3305)
 - Changed the `DestroyObject` message to reduce the serialized message size and remove the unnecessary message field. (#3304)
 - Changed the `NetworkTimeSystem.Sync` method to use half RTT to calculate the desired local time offset as opposed to the full RTT. (#3212)

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1728,22 +1728,24 @@ namespace Unity.Netcode.Transports.UTP
 #endif
 
 #if UTP_TRANSPORT_2_1_ABOVE
-            if (m_UseWebSockets && m_RelayServerData.IsWebSocket == 0)
+            if (m_ProtocolType == ProtocolType.RelayUnityTransport)
             {
-                Debug.LogError("Transport is configured to use WebSockets, but Relay server data isn't. Be sure to use \"wss\" as the connection type when creating the server data (instead of \"dtls\" or \"udp\").");
-            }
+                if (m_UseWebSockets && m_RelayServerData.IsWebSocket == 0)
+                {
+                    Debug.LogError("Transport is configured to use WebSockets, but Relay server data isn't. Be sure to use \"wss\" as the connection type when creating the server data (instead of \"dtls\" or \"udp\").");
+                }
 
-            if (!m_UseWebSockets && m_RelayServerData.IsWebSocket != 0)
-            {
-                Debug.LogError("Relay server data indicates usage of WebSockets, but \"Use WebSockets\" checkbox isn't checked under \"Unity Transport\" component.");
+                if (!m_UseWebSockets && m_RelayServerData.IsWebSocket != 0)
+                {
+                    Debug.LogError("Relay server data indicates usage of WebSockets, but \"Use WebSockets\" checkbox isn't checked under \"Unity Transport\" component.");
+                }
             }
-        }
 #endif
 
 #if UTP_TRANSPORT_2_0_ABOVE
             if (m_UseWebSockets)
             {
-                driver = NetworkDriver.Create(private new WebSocketNetworkInterface(), m_NetworkSettings);
+                driver = NetworkDriver.Create(new WebSocketNetworkInterface(), m_NetworkSettings);
             }
             else
             {
@@ -1751,7 +1753,7 @@ namespace Unity.Netcode.Transports.UTP
                 Debug.LogWarning($"WebSockets were used even though they're not selected in NetworkManager. You should check {nameof(UseWebSockets)}', on the Unity Transport component, to silence this warning.");
                 driver = NetworkDriver.Create(new WebSocketNetworkInterface(), m_NetworkSettings);
 #else
-                driver = NetworkDriver.Create(private new UDPNetworkInterface(), m_NetworkSettings);
+                driver = NetworkDriver.Create(new UDPNetworkInterface(), m_NetworkSettings);
 #endif
             }
 #else
@@ -1768,10 +1770,10 @@ namespace Unity.Netcode.Transports.UTP
                 out unreliableSequencedFragmentedPipeline,
                 out reliableSequencedPipeline);
 #else
-SetupPipelinesForUtp2(driver,
-    out unreliableFragmentedPipeline,
-    out unreliableSequencedFragmentedPipeline,
-    out reliableSequencedPipeline);
+            SetupPipelinesForUtp2(driver,
+                out unreliableFragmentedPipeline,
+                out unreliableSequencedFragmentedPipeline,
+                out reliableSequencedPipeline);
 #endif
         }
 
@@ -1839,74 +1841,74 @@ SetupPipelinesForUtp2(driver,
             out NetworkPipeline unreliableFragmentedPipeline,
             out NetworkPipeline unreliableSequencedFragmentedPipeline,
             out NetworkPipeline reliableSequencedPipeline)
-{
-
-    unreliableFragmentedPipeline = driver.CreatePipeline(
-        typeof(FragmentationPipelineStage)
-#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
-        , typeof(SimulatorPipelineStage)
-#endif
-#if MULTIPLAYER_TOOLS_1_0_0_PRE_7
-                , typeof(NetworkMetricsPipelineStage)
-#endif
-    );
-
-    unreliableSequencedFragmentedPipeline = driver.CreatePipeline(
-        typeof(FragmentationPipelineStage),
-        typeof(UnreliableSequencedPipelineStage)
-#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
-        , typeof(SimulatorPipelineStage)
-#endif
-#if MULTIPLAYER_TOOLS_1_0_0_PRE_7
-                , typeof(NetworkMetricsPipelineStage)
-#endif
-    );
-
-    reliableSequencedPipeline = driver.CreatePipeline(
-        typeof(ReliableSequencedPipelineStage)
-#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
-        , typeof(SimulatorPipelineStage)
-#endif
-#if MULTIPLAYER_TOOLS_1_0_0_PRE_7
-                , typeof(NetworkMetricsPipelineStage)
-#endif
-    );
-}
-#endif
-// -------------- Utility Types -------------------------------------------------------------------------------
-
-
-/// <summary>
-/// Cached information about reliability mode with a certain client
-/// </summary>
-private struct SendTarget : IEquatable<SendTarget>
-{
-    public readonly ulong ClientId;
-    public readonly NetworkPipeline NetworkPipeline;
-
-    public SendTarget(ulong clientId, NetworkPipeline networkPipeline)
-    {
-        ClientId = clientId;
-        NetworkPipeline = networkPipeline;
-    }
-
-    public bool Equals(SendTarget other)
-    {
-        return ClientId == other.ClientId && NetworkPipeline.Equals(other.NetworkPipeline);
-    }
-
-    public override bool Equals(object obj)
-    {
-        return obj is SendTarget other && Equals(other);
-    }
-
-    public override int GetHashCode()
-    {
-        unchecked
         {
-            return (ClientId.GetHashCode() * 397) ^ NetworkPipeline.GetHashCode();
+
+            unreliableFragmentedPipeline = driver.CreatePipeline(
+                typeof(FragmentationPipelineStage)
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
+                , typeof(SimulatorPipelineStage)
+#endif
+#if MULTIPLAYER_TOOLS_1_0_0_PRE_7
+                , typeof(NetworkMetricsPipelineStage)
+#endif
+            );
+
+            unreliableSequencedFragmentedPipeline = driver.CreatePipeline(
+                typeof(FragmentationPipelineStage),
+                typeof(UnreliableSequencedPipelineStage)
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
+                , typeof(SimulatorPipelineStage)
+#endif
+#if MULTIPLAYER_TOOLS_1_0_0_PRE_7
+                , typeof(NetworkMetricsPipelineStage)
+#endif
+            );
+
+            reliableSequencedPipeline = driver.CreatePipeline(
+                typeof(ReliableSequencedPipelineStage)
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
+                , typeof(SimulatorPipelineStage)
+#endif
+#if MULTIPLAYER_TOOLS_1_0_0_PRE_7
+                , typeof(NetworkMetricsPipelineStage)
+#endif
+            );
         }
-    }
-}
+#endif
+        // -------------- Utility Types -------------------------------------------------------------------------------
+
+
+        /// <summary>
+        /// Cached information about reliability mode with a certain client
+        /// </summary>
+        private struct SendTarget : IEquatable<SendTarget>
+        {
+            public readonly ulong ClientId;
+            public readonly NetworkPipeline NetworkPipeline;
+
+            public SendTarget(ulong clientId, NetworkPipeline networkPipeline)
+            {
+                ClientId = clientId;
+                NetworkPipeline = networkPipeline;
+            }
+
+            public bool Equals(SendTarget other)
+            {
+                return ClientId == other.ClientId && NetworkPipeline.Equals(other.NetworkPipeline);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is SendTarget other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return (ClientId.GetHashCode() * 397) ^ NetworkPipeline.GetHashCode();
+                }
+            }
+        }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1668,6 +1668,21 @@ namespace Unity.Netcode.Transports.UTP
             }
 #endif
 
+#if UNITY_SERVER
+            if (m_ProtocolType == ProtocolType.RelayUnityTransport)
+            {
+                if (m_UseWebSockets)
+                {
+                    Debug.LogError("Transport is configured to use Websockets, but websockets are not available on server builds. Ensure that the \"Use WebSockets\" checkbox is checked under \"Unity Transport\" component.");
+                }
+
+                if (m_RelayServerData.IsWebSocket != 0)
+                {
+                    Debug.LogError("Relay server data indicates usage of WebSockets, but websockets are not available on server builds. Be sure to use \"dtls\" or \"udp\" as the connection type when creating the server data");
+                }
+            }
+#endif
+
 #if UTP_TRANSPORT_2_0_ABOVE
             if (m_UseEncryption)
             {
@@ -1713,24 +1728,22 @@ namespace Unity.Netcode.Transports.UTP
 #endif
 
 #if UTP_TRANSPORT_2_1_ABOVE
-            if (m_ProtocolType == ProtocolType.RelayUnityTransport)
+            if (m_UseWebSockets && m_RelayServerData.IsWebSocket == 0)
             {
-                if (m_UseWebSockets && m_RelayServerData.IsWebSocket == 0)
-                {
-                    Debug.LogError("Transport is configured to use WebSockets, but Relay server data isn't. Be sure to use \"wss\" as the connection type when creating the server data (instead of \"dtls\" or \"udp\").");
-                }
-
-                if (!m_UseWebSockets && m_RelayServerData.IsWebSocket != 0)
-                {
-                    Debug.LogError("Relay server data indicates usage of WebSockets, but \"Use WebSockets\" checkbox isn't checked under \"Unity Transport\" component.");
-                }
+                Debug.LogError("Transport is configured to use WebSockets, but Relay server data isn't. Be sure to use \"wss\" as the connection type when creating the server data (instead of \"dtls\" or \"udp\").");
             }
+
+            if (!m_UseWebSockets && m_RelayServerData.IsWebSocket != 0)
+            {
+                Debug.LogError("Relay server data indicates usage of WebSockets, but \"Use WebSockets\" checkbox isn't checked under \"Unity Transport\" component.");
+            }
+        }
 #endif
 
 #if UTP_TRANSPORT_2_0_ABOVE
             if (m_UseWebSockets)
             {
-                driver = NetworkDriver.Create(new WebSocketNetworkInterface(), m_NetworkSettings);
+                driver = NetworkDriver.Create(private new WebSocketNetworkInterface(), m_NetworkSettings);
             }
             else
             {
@@ -1738,7 +1751,7 @@ namespace Unity.Netcode.Transports.UTP
                 Debug.LogWarning($"WebSockets were used even though they're not selected in NetworkManager. You should check {nameof(UseWebSockets)}', on the Unity Transport component, to silence this warning.");
                 driver = NetworkDriver.Create(new WebSocketNetworkInterface(), m_NetworkSettings);
 #else
-                driver = NetworkDriver.Create(new UDPNetworkInterface(), m_NetworkSettings);
+                driver = NetworkDriver.Create(private new UDPNetworkInterface(), m_NetworkSettings);
 #endif
             }
 #else
@@ -1755,10 +1768,10 @@ namespace Unity.Netcode.Transports.UTP
                 out unreliableSequencedFragmentedPipeline,
                 out reliableSequencedPipeline);
 #else
-            SetupPipelinesForUtp2(driver,
-                out unreliableFragmentedPipeline,
-                out unreliableSequencedFragmentedPipeline,
-                out reliableSequencedPipeline);
+SetupPipelinesForUtp2(driver,
+    out unreliableFragmentedPipeline,
+    out unreliableSequencedFragmentedPipeline,
+    out reliableSequencedPipeline);
 #endif
         }
 
@@ -1826,74 +1839,74 @@ namespace Unity.Netcode.Transports.UTP
             out NetworkPipeline unreliableFragmentedPipeline,
             out NetworkPipeline unreliableSequencedFragmentedPipeline,
             out NetworkPipeline reliableSequencedPipeline)
+{
+
+    unreliableFragmentedPipeline = driver.CreatePipeline(
+        typeof(FragmentationPipelineStage)
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
+        , typeof(SimulatorPipelineStage)
+#endif
+#if MULTIPLAYER_TOOLS_1_0_0_PRE_7
+                , typeof(NetworkMetricsPipelineStage)
+#endif
+    );
+
+    unreliableSequencedFragmentedPipeline = driver.CreatePipeline(
+        typeof(FragmentationPipelineStage),
+        typeof(UnreliableSequencedPipelineStage)
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
+        , typeof(SimulatorPipelineStage)
+#endif
+#if MULTIPLAYER_TOOLS_1_0_0_PRE_7
+                , typeof(NetworkMetricsPipelineStage)
+#endif
+    );
+
+    reliableSequencedPipeline = driver.CreatePipeline(
+        typeof(ReliableSequencedPipelineStage)
+#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
+        , typeof(SimulatorPipelineStage)
+#endif
+#if MULTIPLAYER_TOOLS_1_0_0_PRE_7
+                , typeof(NetworkMetricsPipelineStage)
+#endif
+    );
+}
+#endif
+// -------------- Utility Types -------------------------------------------------------------------------------
+
+
+/// <summary>
+/// Cached information about reliability mode with a certain client
+/// </summary>
+private struct SendTarget : IEquatable<SendTarget>
+{
+    public readonly ulong ClientId;
+    public readonly NetworkPipeline NetworkPipeline;
+
+    public SendTarget(ulong clientId, NetworkPipeline networkPipeline)
+    {
+        ClientId = clientId;
+        NetworkPipeline = networkPipeline;
+    }
+
+    public bool Equals(SendTarget other)
+    {
+        return ClientId == other.ClientId && NetworkPipeline.Equals(other.NetworkPipeline);
+    }
+
+    public override bool Equals(object obj)
+    {
+        return obj is SendTarget other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
         {
-
-            unreliableFragmentedPipeline = driver.CreatePipeline(
-                typeof(FragmentationPipelineStage)
-#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
-                , typeof(SimulatorPipelineStage)
-#endif
-#if MULTIPLAYER_TOOLS_1_0_0_PRE_7
-                , typeof(NetworkMetricsPipelineStage)
-#endif
-            );
-
-            unreliableSequencedFragmentedPipeline = driver.CreatePipeline(
-                typeof(FragmentationPipelineStage),
-                typeof(UnreliableSequencedPipelineStage)
-#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
-                , typeof(SimulatorPipelineStage)
-#endif
-#if MULTIPLAYER_TOOLS_1_0_0_PRE_7
-                , typeof(NetworkMetricsPipelineStage)
-#endif
-            );
-
-            reliableSequencedPipeline = driver.CreatePipeline(
-                typeof(ReliableSequencedPipelineStage)
-#if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED
-                , typeof(SimulatorPipelineStage)
-#endif
-#if MULTIPLAYER_TOOLS_1_0_0_PRE_7
-                , typeof(NetworkMetricsPipelineStage)
-#endif
-            );
+            return (ClientId.GetHashCode() * 397) ^ NetworkPipeline.GetHashCode();
         }
-#endif
-        // -------------- Utility Types -------------------------------------------------------------------------------
-
-
-        /// <summary>
-        /// Cached information about reliability mode with a certain client
-        /// </summary>
-        private struct SendTarget : IEquatable<SendTarget>
-        {
-            public readonly ulong ClientId;
-            public readonly NetworkPipeline NetworkPipeline;
-
-            public SendTarget(ulong clientId, NetworkPipeline networkPipeline)
-            {
-                ClientId = clientId;
-                NetworkPipeline = networkPipeline;
-            }
-
-            public bool Equals(SendTarget other)
-            {
-                return ClientId == other.ClientId && NetworkPipeline.Equals(other.NetworkPipeline);
-            }
-
-            public override bool Equals(object obj)
-            {
-                return obj is SendTarget other && Equals(other);
-            }
-
-            public override int GetHashCode()
-            {
-                unchecked
-                {
-                    return (ClientId.GetHashCode() * 397) ^ NetworkPipeline.GetHashCode();
-                }
-            }
-        }
+    }
+}
     }
 }


### PR DESCRIPTION
<!-- Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

Ensure users are not using websockets when building dedicated game server builds

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->
[MTT-11522](https://jira.unity3d.com/browse/MTT-11522)
[MTTB-613](https://jira.unity3d.com/browse/MTTB-613)

<!-- Add RFC link here if applicable. -->

## Changelog

- Fixed: Blocks trying to create a dedicated server build with a websocket connection on Unity Transport.

## Testing and Documentation

- No tests have been added.

