### PR TITLE
chore: Update the port of the codec tests

### DIFF
--- a/.yamato/desktop-standalone-tests.yml
+++ b/.yamato/desktop-standalone-tests.yml
@@ -95,9 +95,9 @@ desktop_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}_{{ 
     # Install rust
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     # Build the echo server
-    - cd ./mps-common-multiplayer-backend && $HOME/.cargo/bin/cargo build --example ngo_echo_server
+    - cd ./mps-common-multiplayer-backend/runtime && $HOME/.cargo/bin/cargo build --example ngo_echo_server
     # Run the echo server in the background - this will reuse the artifacts from the build
-    - cd ./mps-common-multiplayer-backend && $HOME/.cargo/bin/cargo run --example ngo_echo_server &
+    - cd ./mps-common-multiplayer-backend/runtime && $HOME/.cargo/bin/cargo run --example ngo_echo_server &
 {% endif %}
 
 # Run Standalone tests

--- a/.yamato/desktop-standalone-tests.yml
+++ b/.yamato/desktop-standalone-tests.yml
@@ -77,12 +77,11 @@ desktop_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}_{{ 
     image: {{ platform.image }}
     flavor: {{ platform.flavor }}
   variables:
-{% if platform.name != "win" %}
     ECHO_SERVER_PORT: "7788"
     # Ensure the DA codec tests will fail if they cannot connect to the echo-server
     # The default is to ignore the codec tests if the echo-server fails to connect
-    ENSURE_CODEC_TESTS: "true"
-{% endif %}
+    ENSURE_CODEC_TESTS: {% if platform.name != "win" %} "true" {% endif %}
+
   commands:
 # Platform specific UTR setup
     - |

--- a/.yamato/desktop-standalone-tests.yml
+++ b/.yamato/desktop-standalone-tests.yml
@@ -7,7 +7,7 @@
 # Builds are made on each supported editor as in project.metafile declaration
 # Builds are made with different scripting backends as in project.metafile declaration
 # ARM64 architectures are for now not considered since Windows_arm64 is recommended to use only after builds (would require separation here) and when it comes to macOS_arm64 there is problem with OpenCL not being available
-  
+
 # Build phase
 {% for project in projects.default -%}
 {% for platform in test_platforms.desktop -%}
@@ -24,9 +24,10 @@ desktop_standalone_build_{{ project.name }}_{{ platform.name }}_{{ backend }}_{{
 {% if platform.name == "ubuntu" %}
     - sudo apt-get update -q
     - sudo apt install -qy imagemagick
+
 {% endif %}
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
-  
+
 # Platform specific UTR setup
     - |
 {% if platform.name == "win" %}
@@ -34,10 +35,10 @@ desktop_standalone_build_{{ project.name }}_{{ platform.name }}_{{ backend }}_{{
 {% else %}
       curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr && chmod +x utr
 {% endif %}
-  
+
 # Installing editor
     - unity-downloader-cli -u {{ editor }} -c Editor {% if backend == "il2cpp" %} -c il2cpp {% endif %} --fast --wait
-  
+
 # Build Player
     - |
 {% if platform.name == "win" %}
@@ -53,17 +54,17 @@ desktop_standalone_build_{{ project.name }}_{{ platform.name }}_{{ backend }}_{{
     logs:
       paths:
         - "artifacts/**/*"
-        
+
   dependencies:
     - .yamato/project-pack.yml#project_pack_-_{{ project.name }}_{{ platform.name }}
 {% endfor -%}
 {% endfor -%}
 {% endfor -%}
 {% endfor -%}
-  
-  
-  
-  
+
+
+
+
 # Run phase
 {% for project in projects.default -%}
 {% for platform in test_platforms.desktop -%}
@@ -86,7 +87,20 @@ desktop_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}_{{ 
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
 
     - unity-downloader-cli -u {{ editor }} -c Editor {% if backend == "il2cpp" %} -c il2cpp {% endif %} --fast --wait
-  
+
+# If ubuntu, run rust echo server
+{% if platform.name == "ubuntu" %}
+    - git clone https://github.com/Unity-Technologies/mps-common-multiplayer-backend.git
+    - pushd mps-common-multiplayer-backend/runtime
+    # Install rust
+    - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+    # Build the echo server
+    - cargo build --example ngo_echo_server
+    # Run the echo server in the background - this will reuse the artifacts from the build
+    - cargo run --example ngo_echo_server &
+    - popd
+{% endif %}
+
 # Run Standalone tests
     - |
 {% if platform.name == "win" %}

--- a/.yamato/desktop-standalone-tests.yml
+++ b/.yamato/desktop-standalone-tests.yml
@@ -76,11 +76,15 @@ desktop_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}_{{ 
     type: {% if platform.name == "mac" %} {{ platform.type }} {% else %} {{ platform.type }}::GPU {% endif %}
     image: {{ platform.image }}
     flavor: {{ platform.flavor }}
+
+# Set additional variables for running the echo server
+{% if platform.name != "win" %}
   variables:
     ECHO_SERVER_PORT: "7788"
-    # Ensure the DA codec tests will fail if they cannot connect to the echo-server
+    # Set this to ensure the DA codec tests will fail if they cannot connect to the echo-server
     # The default is to ignore the codec tests if the echo-server fails to connect
-    ENSURE_CODEC_TESTS: {% if platform.name != "win" %} "true" {% else %} "" {% endif %}
+    ENSURE_CODEC_TESTS: "true"
+{% endif %}
 
   commands:
 # Platform specific UTR setup

--- a/.yamato/desktop-standalone-tests.yml
+++ b/.yamato/desktop-standalone-tests.yml
@@ -76,6 +76,8 @@ desktop_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}_{{ 
     type: {% if platform.name == "mac" %} {{ platform.type }} {% else %} {{ platform.type }}::GPU {% endif %}
     image: {{ platform.image }}
     flavor: {{ platform.flavor }}
+  variables:
+    ECHO_SERVER_PORT: "7788"
   commands:
 # Platform specific UTR setup
     - |
@@ -97,7 +99,7 @@ desktop_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}_{{ 
     # Build the echo server
     - cd ./mps-common-multiplayer-backend/runtime && $HOME/.cargo/bin/cargo build --example ngo_echo_server
     # Run the echo server in the background - this will reuse the artifacts from the build
-    - cd ./mps-common-multiplayer-backend/runtime && $HOME/.cargo/bin/cargo run --example ngo_echo_server &
+    - cd ./mps-common-multiplayer-backend/runtime && $HOME/.cargo/bin/cargo run --example ngo_echo_server -- --port $ECHO_SERVER_PORT &
 {% endif %}
 
 # Run Standalone tests

--- a/.yamato/desktop-standalone-tests.yml
+++ b/.yamato/desktop-standalone-tests.yml
@@ -90,15 +90,14 @@ desktop_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}_{{ 
 
 # If ubuntu, run rust echo server
 {% if platform.name == "ubuntu" %}
-    - git clone https://github.com/Unity-Technologies/mps-common-multiplayer-backend.git
-    - pushd mps-common-multiplayer-backend/runtime
+    - |
+      git clone https://github.com/Unity-Technologies/mps-common-multiplayer-backend.git
     # Install rust
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     # Build the echo server
-    - $HOME/.cargo/bin/cargo build --example ngo_echo_server
+    - cd ./mps-common-multiplayer-backend && $HOME/.cargo/bin/cargo build --example ngo_echo_server
     # Run the echo server in the background - this will reuse the artifacts from the build
-    - $HOME/.cargo/bin/cargo run --example ngo_echo_server &
-    - popd
+    - cd ./mps-common-multiplayer-backend && $HOME/.cargo/bin/cargo run --example ngo_echo_server &
 {% endif %}
 
 # Run Standalone tests

--- a/.yamato/desktop-standalone-tests.yml
+++ b/.yamato/desktop-standalone-tests.yml
@@ -78,9 +78,6 @@ desktop_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}_{{ 
     flavor: {{ platform.flavor }}
   variables:
     ECHO_SERVER_PORT: "7788"
-    # Ensure the DA codec tests will fail if they cannot connect to the echo-server
-    # The default is to ignore the codec tests if the echo-server fails to connect
-    ENSURE_CODEC_TESTS: {% if platform.name != "win" %} "true" {% endif %}
 
   commands:
 # Platform specific UTR setup

--- a/.yamato/desktop-standalone-tests.yml
+++ b/.yamato/desktop-standalone-tests.yml
@@ -93,7 +93,7 @@ desktop_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}_{{ 
     - git clone https://github.com/Unity-Technologies/mps-common-multiplayer-backend.git
     - pushd mps-common-multiplayer-backend/runtime
     # Install rust
-    - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+    - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     # Build the echo server
     - cargo build --example ngo_echo_server
     # Run the echo server in the background - this will reuse the artifacts from the build

--- a/.yamato/desktop-standalone-tests.yml
+++ b/.yamato/desktop-standalone-tests.yml
@@ -78,6 +78,9 @@ desktop_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}_{{ 
     flavor: {{ platform.flavor }}
   variables:
     ECHO_SERVER_PORT: "7788"
+    # Ensure the DA codec tests will fail if they cannot connect to the echo-server
+    # The default is to ignore the codec tests if the echo-server fails to connect
+    ENSURE_CODEC_TESTS: {% if platform.name != "win" %} "true" {% else %} "" {% endif %}
 
   commands:
 # Platform specific UTR setup

--- a/.yamato/desktop-standalone-tests.yml
+++ b/.yamato/desktop-standalone-tests.yml
@@ -77,7 +77,12 @@ desktop_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}_{{ 
     image: {{ platform.image }}
     flavor: {{ platform.flavor }}
   variables:
+{% if platform.name != "win" %}
     ECHO_SERVER_PORT: "7788"
+    # Ensure the DA codec tests will fail if they cannot connect to the echo-server
+    # The default is to ignore the codec tests if the echo-server fails to connect
+    ENSURE_CODEC_TESTS: "true"
+{% endif %}
   commands:
 # Platform specific UTR setup
     - |
@@ -91,9 +96,8 @@ desktop_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}_{{ 
     - unity-downloader-cli -u {{ editor }} -c Editor {% if backend == "il2cpp" %} -c il2cpp {% endif %} --fast --wait
 
 # If ubuntu, run rust echo server
-{% if platform.name == "ubuntu" %}
-    - |
-      git clone https://github.com/Unity-Technologies/mps-common-multiplayer-backend.git
+{% if platform.name != "win" %}
+    - git clone https://github.com/Unity-Technologies/mps-common-multiplayer-backend.git
     # Install rust
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     # Build the echo server

--- a/.yamato/desktop-standalone-tests.yml
+++ b/.yamato/desktop-standalone-tests.yml
@@ -95,9 +95,9 @@ desktop_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}_{{ 
     # Install rust
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     # Build the echo server
-    - cargo build --example ngo_echo_server
+    - $HOME/.cargo/bin/cargo build --example ngo_echo_server
     # Run the echo server in the background - this will reuse the artifacts from the build
-    - cargo run --example ngo_echo_server &
+    - $HOME/.cargo/bin/cargo run --example ngo_echo_server &
     - popd
 {% endif %}
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
@@ -76,7 +76,7 @@ namespace Unity.Netcode.RuntimeTests
 #else
             if (!CanConnectToServer(m_TransportHost, k_TransportPort))
             {
-                Assert.Ignore("ignoring DA codec tests because UTP transport cannot connect to the runtime");
+                Assert.Ignore($"ignoring DA codec tests because UTP transport cannot connect to the rust echo-server at ${m_TransportHost}:{k_TransportPort}");
             }
 #endif
             base.OnOneTimeSetup();

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
@@ -79,13 +79,13 @@ namespace Unity.Netcode.RuntimeTests
             if (!CanConnectToServer(m_TransportHost, k_TransportPort))
             {
                 var shouldFail = Environment.GetEnvironmentVariable("ENSURE_CODEC_TESTS");
-                if (!string.IsNullOrEmpty(shouldFail))
+                if (string.IsNullOrEmpty(shouldFail) || shouldFail.ToLower == "false")
                 {
-                    Assert.Fail($"Failed to connect to the rust echo-server at {m_TransportHost}:{k_TransportPort}");
+                    Assert.Ignore($"ignoring DA codec tests because UTP transport cannot connect to the rust echo-server at {m_TransportHost}:{k_TransportPort}");
                 }
                 else
                 {
-                    Assert.Ignore($"ignoring DA codec tests because UTP transport cannot connect to the rust echo-server at {m_TransportHost}:{k_TransportPort}");
+                    Assert.Fail($"Failed to connect to the rust echo-server at {m_TransportHost}:{k_TransportPort}");
                 }
             }
 #endif

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
@@ -27,6 +27,8 @@ namespace Unity.Netcode.RuntimeTests
     /// The tests check if they can bind to a rust echo-server at the given address and port, if all tests are ignored.
     /// The rust echo-server is run using `cargo run --example ngo_echo_server -- --port {port}`
     /// The C# port can be configured using the environment variable "ECHO_SERVER_PORT"
+    /// The default behaviour when unity fails to connect to the echo-server is to ignore all tests in this class.
+    /// This can be overridden by setting the environment variable "ENSURE_CODEC_TESTS" to any value - then the tests will fail.
     /// </remarks>
     internal class DistributedAuthorityCodecTests : NetcodeIntegrationTest
     {
@@ -60,7 +62,7 @@ namespace Unity.Netcode.RuntimeTests
         internal class TestNetworkComponent : NetworkBehaviour
         {
             public NetworkList<int> MyNetworkList = new NetworkList<int>(new List<int> { 1, 2, 3 });
-            public NetworkVariable<int> MyNetworkVar = new NetworkVariable<int>(3);
+            public NetworkVariable<int> myNetworkVar = new NetworkVariable<int>(3);
 
             [Rpc(SendTo.Authority)]
             public void TestAuthorityRpc(byte[] _)
@@ -76,7 +78,15 @@ namespace Unity.Netcode.RuntimeTests
 #else
             if (!CanConnectToServer(m_TransportHost, k_TransportPort))
             {
-                Assert.Ignore($"ignoring DA codec tests because UTP transport cannot connect to the rust echo-server at ${m_TransportHost}:{k_TransportPort}");
+                var shouldFail = Environment.GetEnvironmentVariable("ENSURE_CODEC_TESTS");
+                if (!string.IsNullOrEmpty(shouldFail))
+                {
+                    Assert.Fail($"Failed to connect to the rust echo-server at {m_TransportHost}:{k_TransportPort}");
+                }
+                else
+                {
+                    Assert.Ignore($"ignoring DA codec tests because UTP transport cannot connect to the rust echo-server at {m_TransportHost}:{k_TransportPort}");
+                }
             }
 #endif
             base.OnOneTimeSetup();
@@ -250,9 +260,9 @@ namespace Unity.Netcode.RuntimeTests
             var component = instance.GetComponent<TestNetworkComponent>();
 
             var newValue = 5;
-            component.MyNetworkVar.Value = newValue;
+            component.myNetworkVar.Value = newValue;
             yield return m_ClientCodecHook.WaitForMessageReceived<NetworkVariableDeltaMessage>();
-            Assert.AreEqual(newValue, component.MyNetworkVar.Value);
+            Assert.AreEqual(newValue, component.myNetworkVar.Value);
         }
 
         [UnityTest]

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
@@ -16,6 +16,18 @@ using UnityEngine.TestTools;
 
 namespace Unity.Netcode.RuntimeTests
 {
+    /// <summary>
+    /// This class tests the NGO message codec between the C# SDK and the Rust runtime.
+    /// </summary>
+    /// <remarks>
+    /// These tests are run against a rust echo-server.
+    /// This server decodes incoming messages, and then re-encodes them before sending them back to the client.
+    /// Any errors in decoding or encoding messages will not echo the messages back, causing the tests to fail
+    /// No message handling logic is tested in these tests. They are only testing the codec.
+    /// The tests check if they can bind to a rust echo-server at the given address and port, if all tests are ignored.
+    /// The rust echo-server is run using `cargo run --example ngo_echo_server -- --port {port}`
+    /// The C# port can be configured using the environment variable "ECHO_SERVER_PORT"
+    /// </remarks>
     internal class DistributedAuthorityCodecTests : NetcodeIntegrationTest
     {
         protected override int NumberOfClients => 1;
@@ -30,13 +42,17 @@ namespace Unity.Netcode.RuntimeTests
         private NetworkManager Client => m_ClientNetworkManagers[0];
 
         private string m_TransportHost = Environment.GetEnvironmentVariable("NGO_HOST") ?? "127.0.0.1";
-        private static readonly ushort k_TransportPort = GetPortToBind(7777);
+        private static readonly ushort k_TransportPort = GetPortToBind();
         private const int k_ClientId = 0;
 
-        private static ushort GetPortToBind(ushort defaultPort)
+        /// <summary>
+        /// Configures the port to look for the rust echo-server.
+        /// </summary>
+        /// <returns>The port from the environment variable "ECHO_SERVER_PORT" if it is set and valid; otherwise uses port 7777</returns>
+        private static ushort GetPortToBind()
         {
             var value = Environment.GetEnvironmentVariable("ECHO_SERVER_PORT");
-            return ushort.TryParse(value, out var configuredPort) ? configuredPort : defaultPort;
+            return ushort.TryParse(value, out var configuredPort) ? configuredPort : (ushort)7777;
         }
 
         private GameObject m_SpawnObject;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
@@ -62,7 +62,7 @@ namespace Unity.Netcode.RuntimeTests
         internal class TestNetworkComponent : NetworkBehaviour
         {
             public NetworkList<int> MyNetworkList = new NetworkList<int>(new List<int> { 1, 2, 3 });
-            public NetworkVariable<int> myNetworkVar = new NetworkVariable<int>(3);
+            public NetworkVariable<int> MyNetworkVar = new NetworkVariable<int>(3);
 
             [Rpc(SendTo.Authority)]
             public void TestAuthorityRpc(byte[] _)
@@ -260,9 +260,9 @@ namespace Unity.Netcode.RuntimeTests
             var component = instance.GetComponent<TestNetworkComponent>();
 
             var newValue = 5;
-            component.myNetworkVar.Value = newValue;
+            component.MyNetworkVar.Value = newValue;
             yield return m_ClientCodecHook.WaitForMessageReceived<NetworkVariableDeltaMessage>();
-            Assert.AreEqual(newValue, component.myNetworkVar.Value);
+            Assert.AreEqual(newValue, component.MyNetworkVar.Value);
         }
 
         [UnityTest]

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
@@ -79,7 +79,7 @@ namespace Unity.Netcode.RuntimeTests
             if (!CanConnectToServer(m_TransportHost, k_TransportPort))
             {
                 var shouldFail = Environment.GetEnvironmentVariable("ENSURE_CODEC_TESTS");
-                if (string.IsNullOrEmpty(shouldFail) || shouldFail.ToLower == "false")
+                if (string.IsNullOrEmpty(shouldFail) || shouldFail.ToLower() == "false")
                 {
                     Assert.Ignore($"ignoring DA codec tests because UTP transport cannot connect to the rust echo-server at {m_TransportHost}:{k_TransportPort}");
                 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
@@ -30,8 +30,14 @@ namespace Unity.Netcode.RuntimeTests
         private NetworkManager Client => m_ClientNetworkManagers[0];
 
         private string m_TransportHost = Environment.GetEnvironmentVariable("NGO_HOST") ?? "127.0.0.1";
-        private const int k_TransportPort = 7788;
+        private static readonly ushort k_TransportPort = GetPortToBind(7777);
         private const int k_ClientId = 0;
+
+        private static ushort GetPortToBind(ushort defaultPort)
+        {
+            var value = Environment.GetEnvironmentVariable("ECHO_SERVER_PORT");
+            return ushort.TryParse(value, out var configuredPort) ? configuredPort : defaultPort;
+        }
 
         private GameObject m_SpawnObject;
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
@@ -30,7 +30,7 @@ namespace Unity.Netcode.RuntimeTests
         private NetworkManager Client => m_ClientNetworkManagers[0];
 
         private string m_TransportHost = Environment.GetEnvironmentVariable("NGO_HOST") ?? "127.0.0.1";
-        private const int k_TransportPort = 7777;
+        private const int k_TransportPort = 7788;
         private const int k_ClientId = 0;
 
         private GameObject m_SpawnObject;


### PR DESCRIPTION
<!-- Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

- Add a configurable port for the DA codec tests (env variable: `ECHO_SERVER_PORT`)
- Add an environment variable (`ENSURE_CODEC_TESTS`) that when set, will fail the codec tests if they fail to connect to an echo-server. The current/default behaviour is to ignore the tests when no echo-server is available
- Run the rust echo-server inside yamato so that we can run the codec tests in our yamato tests
- Ensure when running the codec tests that the `ENSURE_CODEC_TESTS` variable is set to ensure a test failure if the tests fail to connect to the echo-server

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->
[MTT-11549](https://jira.unity3d.com/browse/MTT-11549)

<!-- Add RFC link here if applicable. -->

## Changelog

- Added: Automated testing of the `DistributedAuthorityCodecTests` that run against a rust echo server built off the latest commit on their main branch

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
