### PR TITLE
fix: Objects without observers are DestroyWithOwner

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -1173,16 +1173,17 @@ namespace Unity.Netcode
                     if (ownedObject)
                     {
                         // If destroying with owner, then always despawn and destroy (or defer destroying to prefab handler)
-                        if (!ownedObject.DontDestroyWithOwner)
+                        // Handle an object with no observers other than the current disconnecting client as destroying with owner
+                        if (!ownedObject.DontDestroyWithOwner || ownedObject.Observers.Count == 0 || (ownedObject.Observers.Count == 1 && ownedObject.Observers.Contains(clientId)))
                         {
-                            if (NetworkManager.PrefabHandler.ContainsHandler(clientOwnedObjects[i].GlobalObjectIdHash))
+                            if (NetworkManager.PrefabHandler.ContainsHandler(ownedObject.GlobalObjectIdHash))
                             {
                                 if (ownedObject.IsSpawned)
                                 {
                                     // Don't destroy (prefab handler will determine this, but always notify
                                     NetworkManager.SpawnManager.DespawnObject(ownedObject, false, true);
                                 }
-                                NetworkManager.PrefabHandler.HandleNetworkPrefabDestroy(clientOwnedObjects[i]);
+                                NetworkManager.PrefabHandler.HandleNetworkPrefabDestroy(ownedObject);
                             }
                             else
                             {
@@ -1237,6 +1238,12 @@ namespace Unity.Netcode
                                 {
                                     // We already changed ownership for this
                                     if (childObject == ownedObject)
+                                    {
+                                        continue;
+                                    }
+
+                                    // Skip destroy with owner objects as they will be processed by the outer loop
+                                    if (!childObject.DontDestroyWithOwner || childObject.Observers.Count == 0 || (childObject.Observers.Count == 1 && childObject.Observers.Contains(clientId)))
                                     {
                                         continue;
                                     }

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1975,8 +1975,8 @@ namespace Unity.Netcode
                             // the owned distributable parent with the owned distributable children
                             foreach (var child in children)
                             {
-                                // Ignore the parent and any child that does not have the same owner or that is already owned by the currently targeted client
-                                if (child == ownerList.Value[i] || child.OwnerClientId != ownerList.Value[i].OwnerClientId || child.OwnerClientId == clientId)
+                                // Ignore any child that does not have the same owner, that is already owned by the currently targeted client, or that doesn't have the targeted client as an observer
+                                if (child == ownerList.Value[i] || child.OwnerClientId != ownerList.Value[i].OwnerClientId || child.OwnerClientId == clientId || !child.Observers.Contains(clientId))
                                 {
                                     continue;
                                 }


### PR DESCRIPTION
<!-- Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

 - Ensure objects with no observers (or only current owner as observer) are treated as if `DontDestroyWithOwner = true` on client disconnect
 - Explicitly check if childObject has new client as observer on client connect

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->
[MTTB-1041](https://jira.unity3d.com/browse/MTTB-1041)
Changelog for this is in #3323.

<!-- Add RFC link here if applicable. -->

## Changelog

- Fixed: Ensure objects with no observers are treated as if `DontDestroyWithOwner = true` on client disconnect

## Testing and Documentation

- No tests have been added.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
