### PR TITLE
chore: turn on verbose for world position stays test

### DIFF
--- a/testproject/Assets/Tests/Runtime/ObjectParenting/ParentingWorldPositionStaysTests.cs
+++ b/testproject/Assets/Tests/Runtime/ObjectParenting/ParentingWorldPositionStaysTests.cs
@@ -158,6 +158,7 @@ namespace TestProject.RuntimeTests
 
         protected override IEnumerator OnSetup()
         {
+            m_EnableVerboseDebug = true;
             TestComponentHelper.ClientsRegistered.Clear();
             TestComponentHelper.NetworkObjectIdToIndex.Clear();
             for (int i = 0; i < k_NestedChildren; i++)
@@ -169,6 +170,7 @@ namespace TestProject.RuntimeTests
 
         protected override IEnumerator OnTearDown()
         {
+            m_EnableVerboseDebug = false;
             if (m_ServerSideParent != null && m_ServerSideParent.GetComponent<NetworkObject>().IsSpawned)
             {
                 // Clean up in reverse order (also makes sure we can despawn parents before children)

--- a/testproject/Assets/Tests/Runtime/ObjectParenting/ParentingWorldPositionStaysTests.cs
+++ b/testproject/Assets/Tests/Runtime/ObjectParenting/ParentingWorldPositionStaysTests.cs
@@ -158,6 +158,7 @@ namespace TestProject.RuntimeTests
 
         protected override IEnumerator OnSetup()
         {
+            //TODO: Remove this when we determine what the random failure is
             m_EnableVerboseDebug = true;
             TestComponentHelper.ClientsRegistered.Clear();
             TestComponentHelper.NetworkObjectIdToIndex.Clear();
@@ -170,6 +171,7 @@ namespace TestProject.RuntimeTests
 
         protected override IEnumerator OnTearDown()
         {
+            //TODO: Remove this when we determine what the random failure is
             m_EnableVerboseDebug = false;
             if (m_ServerSideParent != null && m_ServerSideParent.GetComponent<NetworkObject>().IsSpawned)
             {


### PR DESCRIPTION
Turning on verbose debug for the WorldPositionStays integration test.


## Changelog

NA

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
