### PR TITLE
fix: android time test failures due to edge case float precision errors

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Runtime/Timing/NetworkTimeSystemTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Timing/NetworkTimeSystemTests.cs
@@ -79,7 +79,6 @@ namespace Unity.Netcode.RuntimeTests
                     previous_localTickCalculated++;
                 }
 
-
                 tickCalculated = NetworkManager.Singleton.ServerTime.Time / delta;
                 previous_serverTickCalculated = (int)tickCalculated;
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Timing/NetworkTimeSystemTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Timing/NetworkTimeSystemTests.cs
@@ -62,7 +62,7 @@ namespace Unity.Netcode.RuntimeTests
         public IEnumerator CorrectAmountTicksTest()
         {
             NetworkTickSystem tickSystem = NetworkManager.Singleton.NetworkTickSystem;
-            float delta = tickSystem.LocalTime.FixedDeltaTime;
+            double delta = tickSystem.LocalTime.FixedDeltaTimeAsDouble;
             int previous_localTickCalculated = 0;
             int previous_serverTickCalculated = 0;
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeInitializationTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeInitializationTest.cs
@@ -49,7 +49,11 @@ namespace Unity.Netcode.RuntimeTests
 
             var ticksPassed = server.NetworkTickSystem.ServerTime.Tick - serverTick;
             Assert.AreEqual(doubleExpectedServerTickCount, ticksPassed, $"Double calculated tick count failed: DTick ({doubleExpectedServerTickCount}) TicksPassed ({ticksPassed}) Server Tick ({server.NetworkTickSystem.ServerTime.Tick}) Prev-Server Tick ({serverTick})");
-            Assert.AreEqual(expectedServerTickCount, ticksPassed, $"FloorToInt calculated tick count failed: DTick ({expectedServerTickCount}) TicksPassed ({ticksPassed}) Server Tick ({server.NetworkTickSystem.ServerTime.Tick}) Prev-Server Tick ({serverTick})");
+            if (expectedServerTickCount != ticksPassed)
+            {
+                Debug.Log($"FloorToInt calculated tick count failed: DTick ({expectedServerTickCount}) TicksPassed ({ticksPassed}) Server Tick ({server.NetworkTickSystem.ServerTime.Tick}) Prev-Server Tick ({serverTick})");
+            }
+            //Assert.AreEqual(expectedServerTickCount, ticksPassed, $"FloorToInt calculated tick count failed: DTick ({expectedServerTickCount}) TicksPassed ({ticksPassed}) Server Tick ({server.NetworkTickSystem.ServerTime.Tick}) Prev-Server Tick ({serverTick})");
 
             yield return new WaitForSeconds(clientStartDelay);
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeInitializationTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeInitializationTest.cs
@@ -42,18 +42,11 @@ namespace Unity.Netcode.RuntimeTests
             yield return new WaitUntil(() => server.NetworkTickSystem.ServerTime.Tick > 2);
 
             var serverTimePassed = server.NetworkTickSystem.ServerTime.Time;
-            var doubleExpectedServerTickCount = (int)System.Math.Floor(serverTimePassed / server.ServerTime.FixedDeltaTimeAsDouble);
-            var expectedServerTickCount = Mathf.FloorToInt((float)(serverTimePassed * 30));
 
-            Debug.Log($"Server Tick: {server.NetworkTickSystem.ServerTime.Tick} Prev-ServerTick: {serverTick} Server Time: {server.NetworkTickSystem.ServerTime.Time} ExpDoubTick: {doubleExpectedServerTickCount} ExpTick: {expectedServerTickCount}");
-
+            // Use FixedDeltaTimeAsDouble and divide the tick frequency into the time passed to get the accurate tick count
+            var expectedServerTickCount = (int)System.Math.Floor(serverTimePassed / server.ServerTime.FixedDeltaTimeAsDouble);
             var ticksPassed = server.NetworkTickSystem.ServerTime.Tick - serverTick;
-            Assert.AreEqual(doubleExpectedServerTickCount, ticksPassed, $"Double calculated tick count failed: DTick ({doubleExpectedServerTickCount}) TicksPassed ({ticksPassed}) Server Tick ({server.NetworkTickSystem.ServerTime.Tick}) Prev-Server Tick ({serverTick})");
-            if (expectedServerTickCount != ticksPassed)
-            {
-                Debug.Log($"FloorToInt calculated tick count failed: DTick ({expectedServerTickCount}) TicksPassed ({ticksPassed}) Server Tick ({server.NetworkTickSystem.ServerTime.Tick}) Prev-Server Tick ({serverTick})");
-            }
-            //Assert.AreEqual(expectedServerTickCount, ticksPassed, $"FloorToInt calculated tick count failed: DTick ({expectedServerTickCount}) TicksPassed ({ticksPassed}) Server Tick ({server.NetworkTickSystem.ServerTime.Tick}) Prev-Server Tick ({serverTick})");
+            Assert.AreEqual(expectedServerTickCount, ticksPassed, $"Calculated tick failed: Tick ({expectedServerTickCount}) TicksPassed ({ticksPassed}) Server Tick ({server.NetworkTickSystem.ServerTime.Tick}) Prev-Server Tick ({serverTick})");
 
             yield return new WaitForSeconds(clientStartDelay);
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeInitializationTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeInitializationTest.cs
@@ -42,10 +42,14 @@ namespace Unity.Netcode.RuntimeTests
             yield return new WaitUntil(() => server.NetworkTickSystem.ServerTime.Tick > 2);
 
             var serverTimePassed = server.NetworkTickSystem.ServerTime.Time;
+            var doubleExpectedServerTickCount = (int)System.Math.Floor(serverTimePassed / server.ServerTime.FixedDeltaTimeAsDouble);
             var expectedServerTickCount = Mathf.FloorToInt((float)(serverTimePassed * 30));
 
+            Debug.Log($"Server Tick: {server.NetworkTickSystem.ServerTime.Tick} Server Time: {server.NetworkTickSystem.ServerTime.Time} ExpDoubTick: {doubleExpectedServerTickCount} ExpTick: {expectedServerTickCount}");
+
             var ticksPassed = server.NetworkTickSystem.ServerTime.Tick - serverTick;
-            Assert.AreEqual(expectedServerTickCount, ticksPassed);
+            Assert.AreEqual(doubleExpectedServerTickCount, ticksPassed, "Double calculated tick count failed.");
+            Assert.AreEqual(expectedServerTickCount, ticksPassed, "FloorToInt calculated tick count failed.");
 
             yield return new WaitForSeconds(clientStartDelay);
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeInitializationTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeInitializationTest.cs
@@ -45,11 +45,11 @@ namespace Unity.Netcode.RuntimeTests
             var doubleExpectedServerTickCount = (int)System.Math.Floor(serverTimePassed / server.ServerTime.FixedDeltaTimeAsDouble);
             var expectedServerTickCount = Mathf.FloorToInt((float)(serverTimePassed * 30));
 
-            Debug.Log($"Server Tick: {server.NetworkTickSystem.ServerTime.Tick} Server Time: {server.NetworkTickSystem.ServerTime.Time} ExpDoubTick: {doubleExpectedServerTickCount} ExpTick: {expectedServerTickCount}");
+            Debug.Log($"Server Tick: {server.NetworkTickSystem.ServerTime.Tick} Prev-ServerTick: {serverTick} Server Time: {server.NetworkTickSystem.ServerTime.Time} ExpDoubTick: {doubleExpectedServerTickCount} ExpTick: {expectedServerTickCount}");
 
             var ticksPassed = server.NetworkTickSystem.ServerTime.Tick - serverTick;
-            Assert.AreEqual(doubleExpectedServerTickCount, ticksPassed, "Double calculated tick count failed.");
-            Assert.AreEqual(expectedServerTickCount, ticksPassed, "FloorToInt calculated tick count failed.");
+            Assert.AreEqual(doubleExpectedServerTickCount, ticksPassed, $"Double calculated tick count failed: DTick ({doubleExpectedServerTickCount}) TicksPassed ({ticksPassed}) Server Tick ({server.NetworkTickSystem.ServerTime.Tick}) Prev-Server Tick ({serverTick})");
+            Assert.AreEqual(expectedServerTickCount, ticksPassed, $"FloorToInt calculated tick count failed: DTick ({expectedServerTickCount}) TicksPassed ({ticksPassed}) Server Tick ({server.NetworkTickSystem.ServerTime.Tick}) Prev-Server Tick ({serverTick})");
 
             yield return new WaitForSeconds(clientStartDelay);
 


### PR DESCRIPTION
`NetworkTimeSystemTests.CorrectAmountTicksTest`
Using the double version of tick frequency to calculate number of ticks passed.

`TimeInitializationTest.TestClientTimeInitializationOnConnect`
Dividing the double version of tick frequency to calculate number of ticks passed and using the double version of `Math.Floor` before casting that to an integer.

## Changelog

NA

## Testing and Documentation

- Includes integration test updates.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
