### PR TITLE
docs: [NGOv2.X] Correction of API Reference link

### DIFF
--- a/com.unity.netcode.gameobjects/Documentation~/index.md
+++ b/com.unity.netcode.gameobjects/Documentation~/index.md
@@ -9,7 +9,7 @@ See guides below to install Unity Netcode for GameObjects, set up your project, 
 - [Documentation](https://docs-multiplayer.unity3d.com/netcode/current/about)
 - [Installation](https://docs-multiplayer.unity3d.com/netcode/current/installation)
 - [First Steps](https://docs-multiplayer.unity3d.com/netcode/current/tutorials/get-started-ngo)
-- [API Reference](https://docs.unity3d.com/Packages/com.unity.netcode.gameobjects@1.6/api/index.html)
+- [API Reference](https://docs.unity3d.com/Packages/com.unity.netcode.gameobjects@latest)
 
 # Technical details
 

--- a/com.unity.netcode.gameobjects/Documentation~/index.md
+++ b/com.unity.netcode.gameobjects/Documentation~/index.md
@@ -9,7 +9,7 @@ See guides below to install Unity Netcode for GameObjects, set up your project, 
 - [Documentation](https://docs-multiplayer.unity3d.com/netcode/current/about)
 - [Installation](https://docs-multiplayer.unity3d.com/netcode/current/installation)
 - [First Steps](https://docs-multiplayer.unity3d.com/netcode/current/tutorials/get-started-ngo)
-- [API Reference](https://docs.unity3d.com/Packages/com.unity.netcode.gameobjects@latest)
+- [API Reference](https://docs.unity3d.com/Packages/com.unity.netcode.gameobjects@2.2/api/index.html)
 
 # Technical details
 


### PR DESCRIPTION
This PR builds on https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/2579 and updates link for API Reference in **Documentation~** folder so it's up to date