### PR TITLE
fix: Add OnPreShutdown to NetworkManager

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -478,6 +478,12 @@ namespace Unity.Netcode
         public event Action OnClientStarted = null;
 
         /// <summary>
+        /// Subscribe to this static event to get notifications before a <see cref="NetworkManager"/> instance is being destroyed.
+        /// This is useful if you want to use the state of anything the NetworkManager cleans up during its shutdown.
+        /// </summary>
+        public event Action OnPreShutdown = null;
+
+        /// <summary>
         /// This callback is invoked once the local server is stopped.
         /// </summary>
         /// <remarks>
@@ -1197,6 +1203,8 @@ namespace Unity.Netcode
             {
                 NetworkLog.LogInfo(nameof(ShutdownInternal));
             }
+
+            OnPreShutdown?.Invoke();
 
             this.UnregisterAllNetworkUpdates();
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -478,7 +478,7 @@ namespace Unity.Netcode
         public event Action OnClientStarted = null;
 
         /// <summary>
-        /// Subscribe to this static event to get notifications before a <see cref="NetworkManager"/> instance is being destroyed.
+        /// Subscribe to this event to get notifications before a <see cref="NetworkManager"/> instance is being destroyed.
         /// This is useful if you want to use the state of anything the NetworkManager cleans up during its shutdown.
         /// </summary>
         public event Action OnPreShutdown = null;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerEventsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerEventsTests.cs
@@ -237,6 +237,46 @@ namespace Unity.Netcode.RuntimeTests
             Assert.AreEqual(2, callbacksInvoked, "either OnServerStarted or OnClientStarted wasn't invoked");
         }
 
+        [UnityTest]
+        public IEnumerator OnPreShutdownCalledWhenShuttingDown()
+        {
+            bool preShutdownInvoked = false;
+            bool shutdownInvoked = false;
+            var gameObject = new GameObject(nameof(OnPreShutdownCalledWhenShuttingDown));
+            m_ServerManager = gameObject.AddComponent<NetworkManager>();
+
+            // Set dummy transport that does nothing
+            var transport = gameObject.AddComponent<DummyTransport>();
+            m_ServerManager.NetworkConfig = new NetworkConfig() { NetworkTransport = transport };
+
+            Action onPreShutdown = () =>
+            {
+                preShutdownInvoked = true;
+                Assert.IsFalse(shutdownInvoked, "OnPreShutdown was invoked after OnServerStopped");
+            };
+
+            Action<bool> onServerStopped = (bool wasAlsoClient) =>
+            {
+                shutdownInvoked = true;
+                Assert.IsTrue(preShutdownInvoked, "OnPreShutdown wasn't invoked before OnServerStopped");
+            };
+
+            // Start server to cause initialization process
+            Assert.True(m_ServerManager.StartServer());
+            Assert.True(m_ServerManager.IsListening);
+
+            m_ServerManager.OnPreShutdown += onPreShutdown;
+            m_ServerManager.OnServerStopped += onServerStopped;
+            m_ServerManager.Shutdown();
+            Object.DestroyImmediate(gameObject);
+
+            yield return WaitUntilManagerShutsdown();
+
+            Assert.False(m_ServerManager.IsListening);
+            Assert.True(preShutdownInvoked, "OnPreShutdown wasn't invoked");
+            Assert.True(shutdownInvoked, "OnServerStopped wasn't invoked");
+        }
+
         private IEnumerator WaitUntilManagerShutsdown()
         {
             /* Need two updates to actually shut down. First one to see the transport failing, which

--- a/pvpExceptions.json
+++ b/pvpExceptions.json
@@ -928,6 +928,7 @@
           "Unity.Netcode.RuntimeTests.NetworkManagerEventsTests: IEnumerator OnServerStartedCalledWhenServerStarts(): undocumented",
           "Unity.Netcode.RuntimeTests.NetworkManagerEventsTests: IEnumerator OnClientStartedCalledWhenClientStarts(): undocumented",
           "Unity.Netcode.RuntimeTests.NetworkManagerEventsTests: IEnumerator OnClientAndServerStartedCalledWhenHostStarts(): undocumented",
+	  "Unity.Netcode.RuntimeTests.NetworkManagerEventsTests: IEnumerator OnPreShutdownCalledWhenShuttingDown(): undocumented",
           "Unity.Netcode.RuntimeTests.NetworkManagerEventsTests: IEnumerator Teardown(): undocumented",
           "Unity.Netcode.RuntimeTests.NetworkManagerSceneManagerTests: undocumented",
           "Unity.Netcode.RuntimeTests.NetworkManagerSceneManagerTests: void SceneManagerAssigned(): undocumented",


### PR DESCRIPTION
This PR adds a `NetworkManager.OnPreShutdown` callback that happens before the internal shutdown is done. This is to allow accessing any state that is cleaned up by the `NetworkManager` during shutdown, such as accessing dynamically spawned NetworkObjects.

fix: #3145 
close: #3145 

## Changelog

- Added: The event NetworkManager.OnPreShutdown has been added which is called before the NetworkManager cleans up and shuts down.

## Testing and Documentation

- A test has been added to ensure this is being called, and called before OnServerStopped.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
