### PR TITLE
fix: Sync transform position on spawn

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -14,6 +14,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed initial `NetworkTransform` spawn, ensure it uses world space. (#3361)
 - Fixed issue where `AnticipatedNetworkVariable` previous value returned by `AnticipatedNetworkVariable.OnAuthoritativeValueChanged` is updated correctly on the non-authoritative side. (#3322)
 
 ### Changed

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -2785,7 +2785,7 @@ namespace Unity.Netcode.Components
 
             Initialize();
 
-            if (CanCommitToTransform && UseHalfFloatPrecision)
+            if (CanCommitToTransform)
             {
                 SetState(GetSpaceRelativePosition(), GetSpaceRelativeRotation(), GetScale(), false);
             }


### PR DESCRIPTION
<!-- Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->
[MTTB-90](https://jira.unity3d.com/browse/MTTB-90)
[MTTB-1131](https://jira.unity3d.com/browse/MTTB-1131)

<!-- Add RFC link here if applicable. -->

## Changelog

- Fixed: Correctly sync network transform using world space on spawn

## Testing and Documentation

- No tests have been added.

