### PR TITLE
fix: OnGainedOwnership and OnLostOwnership XML API updates

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -826,7 +826,7 @@ namespace Unity.Netcode
 
         /// <summary>
         /// In client-server contexts, this method is invoked on both the server and the local client of the owner when <see cref="Netcode.NetworkObject"/> ownership is assigned.
-        /// In distributed authority contexts, this method is only invoked on the local client that has been assigned ownership of the associated <see cref="Netcode.NetworkObject"/>.
+        /// In distributed authority contexts, this method is invoked on all clients connected to the session./>.
         /// </summary>
         public virtual void OnGainedOwnership() { }
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -826,7 +826,7 @@ namespace Unity.Netcode
 
         /// <summary>
         /// In client-server contexts, this method is invoked on both the server and the local client of the owner when <see cref="Netcode.NetworkObject"/> ownership is assigned.
-        /// In distributed authority contexts, this method is invoked on all clients connected to the session./>.
+        /// In distributed authority contexts, this method is invoked on all clients connected to the session.
         /// </summary>
         public virtual void OnGainedOwnership() { }
 
@@ -863,7 +863,7 @@ namespace Unity.Netcode
         /// <summary>
         /// In client-server contexts, this method is invoked on the local client when it loses ownership of the associated <see cref="Netcode.NetworkObject"/>
         /// and on the server when any client loses ownership.
-        /// In distributed authority contexts, this method is only invoked on the local client that has lost ownership of the associated <see cref="Netcode.NetworkObject"/>.
+        /// In distributed authority contexts, this method is invoked on all clients connected to the session.
         /// </summary>
         public virtual void OnLostOwnership() { }
 


### PR DESCRIPTION
Correcting the XML API documentation for OnGainedOwnership and OnLostOwnership when using a distributed authority network topology.

[MTTB-1086](https://jira.unity3d.com/browse/MTTB-1086)

fix: #3345

## Changelog
NA

## Testing and Documentation

- No tests have been added.
- Includes edits to existing public API documentation.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
