### PR TITLE
chore: [1.x] Add NetworkTransform parenting test

### DIFF
--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -524,6 +524,14 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// <param name="networkManager">The NetworkManager instance of the client.</param>
         protected virtual void OnNewClientCreated(NetworkManager networkManager)
         {
+            // Ensure any late joining client has all NetworkPrefabs required to connect.
+            foreach (var networkPrefab in m_ServerNetworkManager.NetworkConfig.Prefabs.Prefabs)
+            {
+                if (!networkManager.NetworkConfig.Prefabs.Contains(networkPrefab.Prefab))
+                {
+                    networkManager.NetworkConfig.Prefabs.Add(networkPrefab);
+                }
+            }
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DeferredMessagingTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DeferredMessagingTests.cs
@@ -256,8 +256,7 @@ namespace Unity.Netcode.RuntimeTests
             {
                 AddPrefabsToClient(networkManager);
             }
-
-            base.OnNewClientCreated(networkManager);
+            // Don't call base as this will synchronize the prefabs
         }
 
         private void SpawnClients(bool clearTestDeferredMessageManagerCallFlags = true)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourPrePostSpawnTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourPrePostSpawnTests.cs
@@ -88,12 +88,6 @@ namespace Unity.Netcode.RuntimeTests
             return base.OnSetup();
         }
 
-        protected override void OnNewClientCreated(NetworkManager networkManager)
-        {
-            networkManager.NetworkConfig.Prefabs = m_ServerNetworkManager.NetworkConfig.Prefabs;
-            base.OnNewClientCreated(networkManager);
-        }
-
         /// <summary>
         /// This validates that pre spawn can be used to instantiate and assign a NetworkVariable (or other prespawn tasks)
         /// which can be useful for assigning a NetworkVariable value on the server side when the NetworkVariable has owner write permissions.

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOnSpawnTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOnSpawnTests.cs
@@ -62,18 +62,10 @@ namespace Unity.Netcode.RuntimeTests
         }
 
         /// <summary>
-        /// Assures the <see cref="ObserverSpawnTests"/> late joining client has all
-        /// NetworkPrefabs required to connect.
+        /// Set up late joining client
         /// </summary>
         protected override void OnNewClientCreated(NetworkManager networkManager)
         {
-            foreach (var networkPrefab in m_ServerNetworkManager.NetworkConfig.Prefabs.Prefabs)
-            {
-                if (!networkManager.NetworkConfig.Prefabs.Contains(networkPrefab.Prefab))
-                {
-                    networkManager.NetworkConfig.Prefabs.Add(networkPrefab);
-                }
-            }
             networkManager.NetworkConfig.EnableSceneManagement = m_ServerNetworkManager.NetworkConfig.EnableSceneManagement;
             base.OnNewClientCreated(networkManager);
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectSynchronizationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectSynchronizationTests.cs
@@ -76,21 +76,18 @@ namespace Unity.Netcode.RuntimeTests
 
         protected override void OnNewClientCreated(NetworkManager networkManager)
         {
+            // Setup late joining client prefabs first
+            base.OnNewClientCreated(networkManager);
+
             networkManager.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
             networkManager.NetworkConfig.EnsureNetworkVariableLengthSafety = m_VariableLengthSafety == VariableLengthSafety.EnabledNetVarSafety;
-            foreach (var networkPrefab in m_ServerNetworkManager.NetworkConfig.Prefabs.Prefabs)
-            {
-                // To simulate a failure, we exclude the m_InValidNetworkPrefab from the connecting
-                // client's side.
-                if (networkPrefab.Prefab.name != m_InValidNetworkPrefab.name)
-                {
-                    networkManager.NetworkConfig.Prefabs.Add(networkPrefab);
-                }
-            }
+
             // Disable forcing the same prefabs to avoid failed connections
             networkManager.NetworkConfig.ForceSamePrefabs = false;
             networkManager.LogLevel = m_CurrentLogLevel;
-            base.OnNewClientCreated(networkManager);
+
+            // To simulate a failure, we exclude the m_InValidNetworkPrefab from the connecting client's side.
+            networkManager.NetworkConfig.Prefabs.Remove(m_InValidNetworkPrefab);
         }
 
         [UnityTest]

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectSynchronizationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectSynchronizationTests.cs
@@ -85,8 +85,7 @@ namespace Unity.Netcode.RuntimeTests
             // Disable forcing the same prefabs to avoid failed connections
             networkManager.NetworkConfig.ForceSamePrefabs = false;
             networkManager.LogLevel = m_CurrentLogLevel;
-
-            // To simulate a failure, we exclude the m_InValidNetworkPrefab from the connecting client's side.
+            // To simulate a failure, exclude the m_InValidNetworkPrefab from the connecting client's side.
             networkManager.NetworkConfig.Prefabs.Remove(m_InValidNetworkPrefab);
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformBase.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformBase.cs
@@ -339,7 +339,6 @@ namespace Unity.Netcode.RuntimeTests
         /// </summary>
         protected override void OnNewClientCreated(NetworkManager networkManager)
         {
-            networkManager.NetworkConfig.Prefabs = m_ServerNetworkManager.NetworkConfig.Prefabs;
             networkManager.NetworkConfig.TickRate = GetTickRate();
             if (m_EnableVerboseDebug)
             {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
@@ -46,20 +46,6 @@ namespace Unity.Netcode.RuntimeTests
             base.OnServerAndClientsCreated();
         }
 
-        /// <summary>
-        /// Clients created during a test need to have their prefabs list updated to
-        /// match the server's prefab list.
-        /// </summary>
-        protected override void OnNewClientCreated(NetworkManager networkManager)
-        {
-            foreach (var networkPrefab in m_ServerNetworkManager.NetworkConfig.Prefabs.Prefabs)
-            {
-                networkManager.NetworkConfig.Prefabs.Add(networkPrefab);
-            }
-
-            base.OnNewClientCreated(networkManager);
-        }
-
         private bool ClientIsOwner()
         {
             var clientId = m_ClientNetworkManagers[0].LocalClientId;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformParentingTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformParentingTests.cs
@@ -1,0 +1,191 @@
+using System.Collections;
+using Unity.Netcode.Components;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    internal class NetworkTransformParentingTests : IntegrationTestWithApproximation
+    {
+        /// <summary>
+        /// A NetworkBehaviour that moves in space.
+        /// When spawned on the client, an RPC is sent to the server to spawn a player object for that client.
+        /// The server parents the player object to the spawner object. This gives a moving parent object and a non-moving child object.
+        /// The child object should always be at {0,0,0} local space, while the parent object moves around.
+        /// This NetworkBehaviour tests that parenting to a moving object works as expected.
+        /// </summary>
+        internal class PlayerSpawner : NetworkBehaviour
+        {
+            /// <summary>
+            /// Prefab for the player
+            /// </summary>
+            public NetworkObject playerPrefab;
+
+            /// <summary>
+            /// The server side NetworkObject that was spawned when the client connected.
+            /// </summary>
+            public NetworkObject spawnedPlayer;
+
+            /// <summary>
+            /// Represents the different movement states of the PlayerSpawner during the test lifecycle.
+            /// </summary>
+            public enum MoveState
+            {
+                // Initial state, PlayerSpawner will move without counting frames
+                NotStarted,
+                // The player object has been spawned, start counting frames
+                PlayerSpawned,
+                // We have moved far enough to test location
+                ReachedPeak,
+            }
+            public MoveState moveState = MoveState.NotStarted;
+
+            // A count of the number of updates since the player object was spawned.
+            private int m_Count;
+
+            // Movement offsets and targets.
+            private const float k_PositionOffset = 5.0f;
+            private const float k_RotationOffset = 25.0f;
+            private readonly Vector3 m_PositionTarget = Vector3.one * k_PositionOffset * 10;
+            private readonly Vector3 m_RotationTarget = Vector3.one * k_RotationOffset * 10;
+
+            private void Update()
+            {
+                if (!IsServer)
+                {
+                    return;
+                }
+
+                transform.position = Vector3.Lerp(transform.position, m_PositionTarget, Time.deltaTime * 2);
+                var rotation = transform.rotation;
+                rotation.eulerAngles = Vector3.Slerp(rotation.eulerAngles, m_RotationTarget, Time.deltaTime * 2);
+                transform.rotation = rotation;
+
+                if (moveState != MoveState.PlayerSpawned)
+                {
+                    return;
+                }
+
+                // Move self for some time after player object is spawned
+                // This ensures the parent object is moving throughout the spawn process.
+                m_Count++;
+                if (m_Count > 10)
+                {
+                    // Mark PlayerSpawner as having moved far enough to test.
+                    moveState = MoveState.ReachedPeak;
+                }
+            }
+
+            public override void OnNetworkSpawn()
+            {
+                if (IsOwner)
+                {
+                    // Owner initialises PlayerSpawner movement on spawn
+                    transform.position = Vector3.one * k_PositionOffset;
+                    var rotation = transform.rotation;
+                    rotation.eulerAngles = Vector3.one * k_RotationOffset;
+                    transform.rotation = rotation;
+                }
+                else
+                {
+                    // When spawned on a client, send the RPC to spawn the player object
+                    // Using an RPC ensures the PlayerSpawner is moving for the entire spawning of the player object.
+                    RequestPlayerObjectSpawnServerRpc();
+                }
+            }
+
+            /// <summary>
+            /// A ServerRpc that requests the server to spawn a player object for the client that invoked this RPC.
+            /// </summary>
+            /// <param name="rpcParams">Parameters for the ServerRpc, including the sender's client ID.</param>
+            [ServerRpc(RequireOwnership = false)]
+            private void RequestPlayerObjectSpawnServerRpc(ServerRpcParams rpcParams = default)
+            {
+                spawnedPlayer = Instantiate(playerPrefab);
+                spawnedPlayer.SpawnAsPlayerObject(rpcParams.Receive.SenderClientId);
+                spawnedPlayer.TrySetParent(NetworkObject, false);
+                moveState = MoveState.PlayerSpawned;
+            }
+        }
+
+        // Client Authoritative NetworkTransform
+        internal class ClientNetworkTransform : NetworkTransform
+        {
+            protected override bool OnIsServerAuthoritative()
+            {
+                return false;
+            }
+        }
+
+        // Don't start with any clients, we will manually spawn a client inside the test
+        protected override int NumberOfClients => 0;
+
+        // Parent prefab with moving PlayerSpawner which will spawn the childPrefab
+        private GameObject m_PlayerSpawnerPrefab;
+
+        // Client and server instances
+        private PlayerSpawner m_ServerPlayerSpawner;
+        private NetworkObject m_NewClientPlayer;
+
+        protected override void OnServerAndClientsCreated()
+        {
+            m_PlayerSpawnerPrefab = CreateNetworkObjectPrefab("Parent");
+            var parentPlayerSpawner = m_PlayerSpawnerPrefab.AddComponent<PlayerSpawner>();
+            m_PlayerSpawnerPrefab.AddComponent<NetworkTransform>();
+
+            var playerPrefab = CreateNetworkObjectPrefab("Child");
+            var childNetworkTransform = playerPrefab.AddComponent<ClientNetworkTransform>();
+            childNetworkTransform.InLocalSpace = true;
+
+            parentPlayerSpawner.playerPrefab = playerPrefab.GetComponent<NetworkObject>();
+
+            base.OnServerAndClientsCreated();
+        }
+
+        private bool NewPlayerObjectSpawned()
+        {
+            return m_ServerPlayerSpawner.spawnedPlayer &&
+                   m_ClientNetworkManagers[0].SpawnManager.SpawnedObjects.ContainsKey(m_ServerPlayerSpawner.spawnedPlayer.NetworkObjectId);
+        }
+
+        private bool HasServerInstanceReachedPeakPoint()
+        {
+            VerboseDebug($"Client Local: {m_NewClientPlayer.transform.localPosition} Server Local: {m_ServerPlayerSpawner.spawnedPlayer.transform.localPosition}");
+            return m_ServerPlayerSpawner.moveState == PlayerSpawner.MoveState.ReachedPeak;
+        }
+
+        private bool ServerClientPositionMatches()
+        {
+            return Approximately(m_NewClientPlayer.transform.localPosition, m_ServerPlayerSpawner.spawnedPlayer.transform.localPosition) &&
+                Approximately(m_NewClientPlayer.transform.position, m_ServerPlayerSpawner.spawnedPlayer.transform.position);
+        }
+
+        [UnityTest]
+        public IEnumerator TestParentedPlayerUsingLocalSpace()
+        {
+            // Spawn the PlayerSpawner object and save the instantiated component
+            // The PlayerSpawner object will start moving.
+            m_ServerPlayerSpawner = SpawnObject(m_PlayerSpawnerPrefab, m_ServerNetworkManager).GetComponent<PlayerSpawner>();
+
+            // Create a new client and connect to the server
+            // The client will prompt the server to spawn a player object and parent it to the PlayerSpawner object.
+            yield return CreateAndStartNewClient();
+
+            yield return WaitForConditionOrTimeOut(NewPlayerObjectSpawned);
+            AssertOnTimeout($"Client did not spawn new player object!");
+
+            // Save the spawned player object
+            m_NewClientPlayer = m_ClientNetworkManagers[0].SpawnManager.SpawnedObjects[m_ServerPlayerSpawner.spawnedPlayer.NetworkObjectId];
+
+            // Let the parent PlayerSpawner move for several ticks to get an offset
+            yield return WaitForConditionOrTimeOut(HasServerInstanceReachedPeakPoint);
+            AssertOnTimeout($"Server instance never reached peak point!");
+
+            // Check that the client and server local positions match (they should both be at {0,0,0} local space)
+            yield return WaitForConditionOrTimeOut(ServerClientPositionMatches);
+            AssertOnTimeout($"Client local position {m_NewClientPlayer.transform.localPosition} does not match" +
+                $" server local position {m_ServerPlayerSpawner.spawnedPlayer.transform.localPosition}");
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformParentingTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformParentingTests.cs
@@ -20,12 +20,12 @@ namespace Unity.Netcode.RuntimeTests
             /// <summary>
             /// Prefab for the player
             /// </summary>
-            public NetworkObject playerPrefab;
+            public NetworkObject PlayerPrefab;
 
             /// <summary>
             /// The server side NetworkObject that was spawned when the client connected.
             /// </summary>
-            public NetworkObject spawnedPlayer;
+            public NetworkObject SpawnedPlayer;
 
             /// <summary>
             /// Represents the different movement states of the PlayerSpawner during the test lifecycle.
@@ -39,7 +39,7 @@ namespace Unity.Netcode.RuntimeTests
                 // We have moved far enough to test location
                 ReachedPeak,
             }
-            public MoveState moveState = MoveState.NotStarted;
+            public MoveState State = MoveState.NotStarted;
 
             // A count of the number of updates since the player object was spawned.
             private int m_Count;
@@ -62,7 +62,7 @@ namespace Unity.Netcode.RuntimeTests
                 rotation.eulerAngles = Vector3.Slerp(rotation.eulerAngles, m_RotationTarget, Time.deltaTime * 2);
                 transform.rotation = rotation;
 
-                if (moveState != MoveState.PlayerSpawned)
+                if (State != MoveState.PlayerSpawned)
                 {
                     return;
                 }
@@ -73,7 +73,7 @@ namespace Unity.Netcode.RuntimeTests
                 if (m_Count > 10)
                 {
                     // Mark PlayerSpawner as having moved far enough to test.
-                    moveState = MoveState.ReachedPeak;
+                    State = MoveState.ReachedPeak;
                 }
             }
 
@@ -102,10 +102,10 @@ namespace Unity.Netcode.RuntimeTests
             [ServerRpc(RequireOwnership = false)]
             private void RequestPlayerObjectSpawnServerRpc(ServerRpcParams rpcParams = default)
             {
-                spawnedPlayer = Instantiate(playerPrefab);
-                spawnedPlayer.SpawnAsPlayerObject(rpcParams.Receive.SenderClientId);
-                spawnedPlayer.TrySetParent(NetworkObject, false);
-                moveState = MoveState.PlayerSpawned;
+                SpawnedPlayer = Instantiate(PlayerPrefab);
+                SpawnedPlayer.SpawnAsPlayerObject(rpcParams.Receive.SenderClientId);
+                SpawnedPlayer.TrySetParent(NetworkObject, false);
+                State = MoveState.PlayerSpawned;
             }
         }
 
@@ -138,27 +138,27 @@ namespace Unity.Netcode.RuntimeTests
             var childNetworkTransform = playerPrefab.AddComponent<ClientNetworkTransform>();
             childNetworkTransform.InLocalSpace = true;
 
-            parentPlayerSpawner.playerPrefab = playerPrefab.GetComponent<NetworkObject>();
+            parentPlayerSpawner.PlayerPrefab = playerPrefab.GetComponent<NetworkObject>();
 
             base.OnServerAndClientsCreated();
         }
 
         private bool NewPlayerObjectSpawned()
         {
-            return m_ServerPlayerSpawner.spawnedPlayer &&
-                   m_ClientNetworkManagers[0].SpawnManager.SpawnedObjects.ContainsKey(m_ServerPlayerSpawner.spawnedPlayer.NetworkObjectId);
+            return m_ServerPlayerSpawner.SpawnedPlayer &&
+                   m_ClientNetworkManagers[0].SpawnManager.SpawnedObjects.ContainsKey(m_ServerPlayerSpawner.SpawnedPlayer.NetworkObjectId);
         }
 
         private bool HasServerInstanceReachedPeakPoint()
         {
-            VerboseDebug($"Client Local: {m_NewClientPlayer.transform.localPosition} Server Local: {m_ServerPlayerSpawner.spawnedPlayer.transform.localPosition}");
-            return m_ServerPlayerSpawner.moveState == PlayerSpawner.MoveState.ReachedPeak;
+            VerboseDebug($"Client Local: {m_NewClientPlayer.transform.localPosition} Server Local: {m_ServerPlayerSpawner.SpawnedPlayer.transform.localPosition}");
+            return m_ServerPlayerSpawner.State == PlayerSpawner.MoveState.ReachedPeak;
         }
 
         private bool ServerClientPositionMatches()
         {
-            return Approximately(m_NewClientPlayer.transform.localPosition, m_ServerPlayerSpawner.spawnedPlayer.transform.localPosition) &&
-                Approximately(m_NewClientPlayer.transform.position, m_ServerPlayerSpawner.spawnedPlayer.transform.position);
+            return Approximately(m_NewClientPlayer.transform.localPosition, m_ServerPlayerSpawner.SpawnedPlayer.transform.localPosition) &&
+                Approximately(m_NewClientPlayer.transform.position, m_ServerPlayerSpawner.SpawnedPlayer.transform.position);
         }
 
         [UnityTest]
@@ -176,7 +176,7 @@ namespace Unity.Netcode.RuntimeTests
             AssertOnTimeout($"Client did not spawn new player object!");
 
             // Save the spawned player object
-            m_NewClientPlayer = m_ClientNetworkManagers[0].SpawnManager.SpawnedObjects[m_ServerPlayerSpawner.spawnedPlayer.NetworkObjectId];
+            m_NewClientPlayer = m_ClientNetworkManagers[0].SpawnManager.SpawnedObjects[m_ServerPlayerSpawner.SpawnedPlayer.NetworkObjectId];
 
             // Let the parent PlayerSpawner move for several ticks to get an offset
             yield return WaitForConditionOrTimeOut(HasServerInstanceReachedPeakPoint);
@@ -185,7 +185,7 @@ namespace Unity.Netcode.RuntimeTests
             // Check that the client and server local positions match (they should both be at {0,0,0} local space)
             yield return WaitForConditionOrTimeOut(ServerClientPositionMatches);
             AssertOnTimeout($"Client local position {m_NewClientPlayer.transform.localPosition} does not match" +
-                $" server local position {m_ServerPlayerSpawner.spawnedPlayer.transform.localPosition}");
+                $" server local position {m_ServerPlayerSpawner.SpawnedPlayer.transform.localPosition}");
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformParentingTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformParentingTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 51591ff70c654563a1d8aa2f83bc023f
+timeCreated: 1743177289

--- a/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
@@ -626,19 +626,6 @@ namespace TestProject.RuntimeTests
             VerboseDebug($" ------------------ Trigger Test [{TriggerTest.Iteration}][{ownerShipMode}] Stopping ------------------ ");
         }
 
-        protected override void OnNewClientCreated(NetworkManager networkManager)
-        {
-            var networkPrefab = new NetworkPrefab() { Prefab = m_AnimationTestPrefab };
-            networkManager.NetworkConfig.Prefabs.Add(networkPrefab);
-            networkPrefab = new NetworkPrefab() { Prefab = m_AnimationOwnerTestPrefab };
-            networkManager.NetworkConfig.Prefabs.Add(networkPrefab);
-
-            networkPrefab = new NetworkPrefab() { Prefab = m_AnimationCheerTestPrefab };
-            networkManager.NetworkConfig.Prefabs.Add(networkPrefab);
-            networkPrefab = new NetworkPrefab() { Prefab = m_AnimationCheerOwnerTestPrefab };
-            networkManager.NetworkConfig.Prefabs.Add(networkPrefab);
-        }
-
         /// <summary>
         /// Verifies that triggers are synchronized with currently connected clients
         /// </summary>

--- a/testproject/Assets/Tests/Runtime/DontDestroyOnLoadTests.cs
+++ b/testproject/Assets/Tests/Runtime/DontDestroyOnLoadTests.cs
@@ -22,12 +22,6 @@ namespace TestProject.RuntimeTests
             base.OnServerAndClientsCreated();
         }
 
-        protected override void OnNewClientCreated(NetworkManager networkManager)
-        {
-            networkManager.NetworkConfig.Prefabs = m_ServerNetworkManager.NetworkConfig.Prefabs;
-            base.OnNewClientCreated(networkManager);
-        }
-
         private ulong m_SpawnedNetworkObjectId;
         private StringBuilder m_ErrorLog = new StringBuilder();
 

--- a/testproject/Assets/Tests/Runtime/NetworkManagerTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkManagerTests.cs
@@ -108,16 +108,12 @@ namespace TestProject.RuntimeTests
         protected override void OnNewClientCreated(NetworkManager networkManager)
         {
             networkManager.NetworkConfig.EnableSceneManagement = m_UseSceneManagement;
-            foreach (var prefab in m_ServerNetworkManager.NetworkConfig.Prefabs.Prefabs)
-            {
-                networkManager.NetworkConfig.Prefabs.Add(prefab);
-            }
             base.OnNewClientCreated(networkManager);
         }
 
         /// <summary>
         /// Validate shutting down a second time does not cause an exception.
-        /// </summary>        
+        /// </summary>
         [UnityTest]
         public IEnumerator ValidateShutdown([Values] ShutdownChecks shutdownCheck)
         {
@@ -132,7 +128,7 @@ namespace TestProject.RuntimeTests
             }
             else
             {
-                // For this test (simplify the complexity) with a late joining client, just remove the 
+                // For this test (simplify the complexity) with a late joining client, just remove the
                 // in-scene placed NetworkObject prior to the client connecting
                 // (We are testing the shutdown sequence)
                 var spawnedObjects = m_ServerNetworkManager.SpawnManager.SpawnedObjectsList.ToList();

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectSceneMigrationTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectSceneMigrationTests.cs
@@ -59,19 +59,6 @@ namespace TestProject.RuntimeTests
             base.OnServerAndClientsCreated();
         }
 
-        protected override void OnNewClientCreated(NetworkManager networkManager)
-        {
-            foreach (var networkPrfab in m_ServerNetworkManager.NetworkConfig.Prefabs.Prefabs)
-            {
-                if (networkPrfab.Prefab == null)
-                {
-                    continue;
-                }
-                networkManager.NetworkConfig.Prefabs.Add(networkPrfab);
-            }
-            base.OnNewClientCreated(networkManager);
-        }
-
         private bool DidClientsSpawnInstance(NetworkObject serverObject, bool checkDestroyWithScene = false)
         {
             foreach (var networkManager in m_ClientNetworkManagers)

--- a/testproject/Assets/Tests/Runtime/ObjectParenting/ParentDynamicUnderInScenePlaced.cs
+++ b/testproject/Assets/Tests/Runtime/ObjectParenting/ParentDynamicUnderInScenePlaced.cs
@@ -46,15 +46,6 @@ namespace TestProject.RuntimeTests
             return base.OnStartedServerAndClients();
         }
 
-        protected override void OnNewClientCreated(NetworkManager networkManager)
-        {
-            foreach (var networkPrefab in m_ServerNetworkManager.NetworkConfig.Prefabs.Prefabs)
-            {
-                networkManager.NetworkConfig.Prefabs.Add(networkPrefab);
-            }
-            base.OnNewClientCreated(networkManager);
-        }
-
         protected override void OnNewClientStarted(NetworkManager networkManager)
         {
             m_ServerNetworkManager.SceneManager.SetClientSynchronizationMode(LoadSceneMode.Additive);

--- a/testproject/Assets/Tests/Runtime/ObjectParenting/ParentingWorldPositionStaysTests.cs
+++ b/testproject/Assets/Tests/Runtime/ObjectParenting/ParentingWorldPositionStaysTests.cs
@@ -218,14 +218,6 @@ namespace TestProject.RuntimeTests
             base.OnServerAndClientsCreated();
         }
 
-        protected override void OnNewClientCreated(NetworkManager networkManager)
-        {
-            foreach (var networkPrefab in m_ServerNetworkManager.NetworkConfig.Prefabs.Prefabs)
-            {
-                networkManager.NetworkConfig.Prefabs.Add(networkPrefab);
-            }
-        }
-
         private bool HaveAllClientsSpawnedObjects()
         {
             foreach (var client in m_ClientNetworkManagers)

--- a/testproject/Assets/Tests/Runtime/PrefabExtendedTests.cs
+++ b/testproject/Assets/Tests/Runtime/PrefabExtendedTests.cs
@@ -129,11 +129,10 @@ namespace TestProject.RuntimeTests
         {
             networkManager.NetworkConfig.EnableSceneManagement = m_SceneManagementEnabled;
             networkManager.NetworkConfig.Prefabs.NetworkPrefabsLists.Add(PrefabTestConfig.Instance.TestPrefabs);
-            base.OnNewClientCreated(networkManager);
         }
 
         /// <summary>
-        /// Validates that all spawned NetworkObjects are present and their corresponding 
+        /// Validates that all spawned NetworkObjects are present and their corresponding
         /// GlobalObjectIdHash values match
         /// </summary>
         private bool ValidateAllClientsSpawnedObjects()
@@ -227,7 +226,7 @@ namespace TestProject.RuntimeTests
             yield return CreateAndStartNewClient();
 
             var spawnManager = m_ServerNetworkManager.SpawnManager;
-            // If scene management is enabled, then we want to verify against the editor 
+            // If scene management is enabled, then we want to verify against the editor
             // assigned in-scene placed NetworkObjects
             if (m_SceneManagementEnabled)
             {
@@ -303,7 +302,7 @@ namespace TestProject.RuntimeTests
         [UnityTest]
         public IEnumerator TestsInstantiateAndSpawnErrors([Values] InstantiateAndSpawnMethods instantiateAndSpawnType)
         {
-            // If scene management is enabled, then we want to verify against the editor 
+            // If scene management is enabled, then we want to verify against the editor
             // assigned in-scene placed NetworkObjects
             if (m_SceneManagementEnabled)
             {
@@ -344,7 +343,7 @@ namespace TestProject.RuntimeTests
             m_ServerNetworkManager.Shutdown();
             LogAssert.Expect(LogType.Warning, NetworkSpawnManager.InstantiateAndSpawnErrors[NetworkSpawnManager.InstantiateAndSpawnErrorTypes.InvokedWhenShuttingDown]);
             InstantiateAndSpawn(m_ObjectsToSpawn[0], instantiateAndSpawnType);
-            // The not listening error can only happen when trying to instantiate and spawn on a Network Prefab 
+            // The not listening error can only happen when trying to instantiate and spawn on a Network Prefab
             if (instantiateAndSpawnType == InstantiateAndSpawnMethods.NetworkObject)
             {
                 LogAssert.Expect(LogType.Error, NetworkSpawnManager.InstantiateAndSpawnErrors[NetworkSpawnManager.InstantiateAndSpawnErrorTypes.NoActiveSession]);


### PR DESCRIPTION
Adds a test replicating the bug fixed in #3361 

Move the code to sync prefabs for late joining clients into the `NetcodeIntegrationTest`

## Changelog

- Added: Test for #3361 

## Testing and Documentation

- Adds Unit test

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
