### PR TITLE
ci: [2.X] disabling WebGL Build job on macOS due to "Light baking could not be started because no valid OpenCL device could be found" error.

### DIFF
--- a/.yamato/_run-all.yml
+++ b/.yamato/_run-all.yml
@@ -81,9 +81,11 @@ run_all_webgl_builds:
   dependencies:
 {% for project in projects.default -%}
 {% for platform in test_platforms.desktop -%}
+{% if platform.name != "mac" -%} # There is an error about "Light baking could not be started because no valid OpenCL device could be found". Tracked in MTT-11726
 {% for editor in validation_editors.all -%}
     - .yamato/webgl-build.yml#webgl_build_{{ project.name }}_{{ platform.name }}_{{ editor }}
 {% endfor -%}
+{% endif -%}
 {% endfor -%}
 {% endfor -%}
 
@@ -94,9 +96,11 @@ run_all_webgl_builds_trunk:
   dependencies:
 {% for project in projects.default -%}
 {% for platform in test_platforms.desktop -%}
+{% if platform.name != "mac" -%} # There is an error about "Light baking could not be started because no valid OpenCL device could be found". Tracked in MTT-11726
 {% for editor in validation_editors.default -%}
     - .yamato/webgl-build.yml#webgl_build_{{ project.name }}_{{ platform.name }}_{{ editor }}
 {% endfor -%}
+{% endif -%}
 {% endfor -%}
 {% endfor -%}
 

--- a/.yamato/webgl-build.yml
+++ b/.yamato/webgl-build.yml
@@ -25,7 +25,7 @@
   
 {% for project in projects.default -%}
 {% for platform in test_platforms.desktop -%}
-{% if platform.name != "mac" -%} # There is an error about "Light baking could not be started because no valid OpenCL device could be found". Tracked in MTT-
+{% if platform.name != "mac" -%} # There is an error about "Light baking could not be started because no valid OpenCL device could be found". Tracked in MTT-11726
 {% for editor in validation_editors.all -%}
 webgl_build_{{ project.name }}_{{ platform.name }}_{{ editor }}:
   name: WebGl Build - {{ project.name }} [{{ platform.name }}, {{ editor }}, il2cpp]

--- a/.yamato/webgl-build.yml
+++ b/.yamato/webgl-build.yml
@@ -44,7 +44,7 @@ webgl_build_{{ project.name }}_{{ platform.name }}_{{ editor }}:
       # Engine is initialized in ‘nographics’ mode since we don't need any graphics for this case (--extra-editor-arg=-nographics)
       # In case of failure the job will be rerunned once (--reruncount=1) with clean library (--clean-library-on-rerun) 
       # This will perform only building phase (--build-only) with a timeout of 3m (--timeout=1800)
-    - UnifiedTestRunner --suite=playmode --platform=WebGL --scripting-backend=il2cpp --testproject={{ project.path }} --editor-location=.Editor --artifacts_path=artifacts --player-save-path=build/players --extra-editor-arg=-batchmode --extra-editor-arg=-nolightmap --extra-editor-arg=-nographics --reruncount=1 --clean-library-on-rerun --build-only --timeout=1800
+    - UnifiedTestRunner --suite=playmode --platform=WebGL --scripting-backend=il2cpp --testproject={{ project.path }} --editor-location=.Editor --artifacts_path=artifacts --player-save-path=build/players --extra-editor-arg=-batchmode --extra-editor-arg=-nolightmap --extra-editor-arg=-nographics -extra-editor-arg=-automated --reruncount=1 --clean-library-on-rerun --build-only --timeout=1800
   artifacts:
     logs:
       paths:

--- a/.yamato/webgl-build.yml
+++ b/.yamato/webgl-build.yml
@@ -44,7 +44,7 @@ webgl_build_{{ project.name }}_{{ platform.name }}_{{ editor }}:
       # Engine is initialized in ‘nographics’ mode since we don't need any graphics for this case (--extra-editor-arg=-nographics)
       # In case of failure the job will be rerunned once (--reruncount=1) with clean library (--clean-library-on-rerun) 
       # This will perform only building phase (--build-only) with a timeout of 3m (--timeout=1800)
-    - UnifiedTestRunner --suite=playmode --platform=WebGL --scripting-backend=il2cpp --testproject={{ project.path }} --editor-location=.Editor --artifacts_path=artifacts --player-save-path=build/players --extra-editor-arg=-batchmode --extra-editor-arg=-nographics --reruncount=1 --clean-library-on-rerun --build-only --timeout=1800
+    - UnifiedTestRunner --suite=playmode --platform=WebGL --scripting-backend=il2cpp --testproject={{ project.path }} --editor-location=.Editor --artifacts_path=artifacts --player-save-path=build/players --extra-editor-arg=-batchmode --extra-editor-arg=-nolightmap --extra-editor-arg=-nographics --reruncount=1 --clean-library-on-rerun --build-only --timeout=1800
   artifacts:
     logs:
       paths:

--- a/.yamato/webgl-build.yml
+++ b/.yamato/webgl-build.yml
@@ -44,7 +44,7 @@ webgl_build_{{ project.name }}_{{ platform.name }}_{{ editor }}:
       # Engine is initialized in ‘nographics’ mode since we don't need any graphics for this case (--extra-editor-arg=-nographics)
       # In case of failure the job will be rerunned once (--reruncount=1) with clean library (--clean-library-on-rerun) 
       # This will perform only building phase (--build-only) with a timeout of 3m (--timeout=1800)
-    - UnifiedTestRunner --suite=playmode --platform=WebGL --scripting-backend=il2cpp --testproject={{ project.path }} --editor-location=.Editor --artifacts_path=artifacts --player-save-path=build/players --extra-editor-arg=-batchmode --extra-editor-arg=-nolightmap --extra-editor-arg=-nographics -extra-editor-arg=-automated --reruncount=1 --clean-library-on-rerun --build-only --timeout=1800
+    - UnifiedTestRunner --suite=playmode --platform=WebGL --scripting-backend=il2cpp --testproject={{ project.path }} --editor-location=.Editor --artifacts_path=artifacts --player-save-path=build/players --extra-editor-arg=-batchmode --category=!RequiresGPU --extra-editor-arg=-nolightmap --extra-editor-arg=-nographics -extra-editor-arg=-automated --reruncount=1 --clean-library-on-rerun --build-only --timeout=1800
   artifacts:
     logs:
       paths:

--- a/.yamato/webgl-build.yml
+++ b/.yamato/webgl-build.yml
@@ -25,6 +25,7 @@
   
 {% for project in projects.default -%}
 {% for platform in test_platforms.desktop -%}
+{% if platform.name != "mac" -%} # There is an error about "Light baking could not be started because no valid OpenCL device could be found". Tracked in MTT-
 {% for editor in validation_editors.all -%}
 webgl_build_{{ project.name }}_{{ platform.name }}_{{ editor }}:
   name: WebGl Build - {{ project.name }} [{{ platform.name }}, {{ editor }}, il2cpp]
@@ -44,12 +45,13 @@ webgl_build_{{ project.name }}_{{ platform.name }}_{{ editor }}:
       # Engine is initialized in ‘nographics’ mode since we don't need any graphics for this case (--extra-editor-arg=-nographics)
       # In case of failure the job will be rerunned once (--reruncount=1) with clean library (--clean-library-on-rerun) 
       # This will perform only building phase (--build-only) with a timeout of 3m (--timeout=1800)
-    - UnifiedTestRunner --suite=playmode --platform=WebGL --scripting-backend=il2cpp --testproject={{ project.path }} --editor-location=.Editor --artifacts_path=artifacts --player-save-path=build/players --extra-editor-arg=-batchmode --category=!RequiresGPU --extra-editor-arg=-nolightmap --extra-editor-arg=-nographics -extra-editor-arg=-automated --reruncount=1 --clean-library-on-rerun --build-only --timeout=1800
+    - UnifiedTestRunner --suite=playmode --platform=WebGL --scripting-backend=il2cpp --testproject={{ project.path }} --editor-location=.Editor --artifacts_path=artifacts --player-save-path=build/players --extra-editor-arg=-batchmode --extra-editor-arg=-nographics --reruncount=1 --clean-library-on-rerun --build-only --timeout=1800
   artifacts:
     logs:
       paths:
         - "artifacts/**/*"
         - "build/players/**/*"
 {% endfor -%}
+{% endif -%}
 {% endfor -%}
 {% endfor -%}


### PR DESCRIPTION
After switching from Intel macOS to Apple Silicon due to the common problem with bit-flipping on Intel macOS the WebGL build job started failing due to "Light baking could not be started because no valid OpenCL device could be found" error.
We need to figure out if this can be fixed or how to proceed with it.
* PR that switched macOS device --> [NGOv1.X](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3326), [NGOv2.X](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3329)

The issue exists on both NGO branches (*develop* and *develop-2.0.0*) so the solution needs to be applied on both. For now I'm disabling this job and tracking it in MTT-11726