### PR TITLE
chore: Issues marked by "stat:import" OR "stat:imported" labels won't be marked as "Stale" by automation

### DIFF
--- a/.github/workflows/mark-stale-issue.yaml
+++ b/.github/workflows/mark-stale-issue.yaml
@@ -25,6 +25,7 @@ jobs:
           days-before-stale: 30
           days-before-close: 30
           stale-issue-label: 'Stale'
+          exempt-issue-labels: 'stat:import', 'stat:imported'
           stale-issue-message: >
             This issue has been automatically marked as stale because it has been awaiting 
             response for over 30 days without any activity.


### PR DESCRIPTION
This quick PR add labels that can be assigned to issues to exclude them from being marked as stale as per https://github.com/actions/stale?tab=readme-ov-file#exempt-issue-labels. We don't want imported issues to get Stale and potentially automatically closed