### PR TITLE
fix: LegacyLerp was using ticklatency as opposed to legacy ticksAgo

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Components/Interpolator/BufferedLinearInterpolator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Interpolator/BufferedLinearInterpolator.cs
@@ -199,7 +199,6 @@ namespace Unity.Netcode
         /// The current buffered items received by the authority.
         /// </summary>
         protected internal readonly Queue<BufferedItem> m_BufferQueue = new Queue<BufferedItem>(k_BufferCountLimit);
-        protected internal readonly List<BufferedItem> m_BufferList = new List<BufferedItem>(k_BufferCountLimit);
 
         /// <summary>
         /// The current interpolation state

--- a/com.unity.netcode.gameobjects/Runtime/Components/Interpolator/BufferedLinearInterpolator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Interpolator/BufferedLinearInterpolator.cs
@@ -443,7 +443,6 @@ namespace Unity.Netcode
             {
                 BufferedItem? previousItem = null;
                 var alreadyHasBufferItem = false;
-                var count = 0;
                 while (m_BufferQueue.TryPeek(out BufferedItem potentialItem))
                 {
                     // If we are still on the same buffered item (FIFO Queue), then exit early as there is nothing

--- a/com.unity.netcode.gameobjects/Runtime/Components/Interpolator/BufferedLinearInterpolator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Interpolator/BufferedLinearInterpolator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using UnityEngine;
 
 namespace Unity.Netcode
@@ -14,8 +15,15 @@ namespace Unity.Netcode
         // Constant absolute value for max buffer count instead of dynamic time based value. This is in case we have very low tick rates, so
         // that we don't have a very small buffer because of this.
         private const int k_BufferCountLimit = 100;
-        private const float k_AproximatePrecision = 0.0001f;
+        private const float k_ApproximateLowPrecision = 0.000001f;
+        private const float k_ApproximateHighPrecision = 1E-10f;
         private const double k_SmallValue = 9.999999439624929E-11; // copied from Vector3's equal operator
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private float GetPrecision()
+        {
+            return m_BufferQueue.Count == 0 ? k_ApproximateHighPrecision : k_ApproximateLowPrecision;
+        }
 
         #region Legacy notes
         // Buffer consumption scenarios
@@ -132,6 +140,7 @@ namespace Unity.Netcode
             public float CurrentDeltaTime => m_CurrentDeltaTime;
             public double FinalTimeToTarget => Math.Max(0.0, TimeToTargetValue - DeltaTime);
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void AddDeltaTime(float deltaTime)
             {
                 m_CurrentDeltaTime = deltaTime;
@@ -139,6 +148,7 @@ namespace Unity.Netcode
                 LerpT = (float)(TimeToTargetValue == 0.0 ? 1.0 : DeltaTime / TimeToTargetValue);
             }
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void SetTimeToTarget(double timeToTarget)
             {
                 LerpT = 0.0f;
@@ -146,6 +156,7 @@ namespace Unity.Netcode
                 TimeToTargetValue = timeToTarget;
             }
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public bool TargetTimeAproximatelyReached()
             {
                 if (!Target.HasValue)
@@ -188,6 +199,7 @@ namespace Unity.Netcode
         /// The current buffered items received by the authority.
         /// </summary>
         protected internal readonly Queue<BufferedItem> m_BufferQueue = new Queue<BufferedItem>(k_BufferCountLimit);
+        protected internal readonly List<BufferedItem> m_BufferList = new List<BufferedItem>(k_BufferCountLimit);
 
         /// <summary>
         /// The current interpolation state
@@ -237,6 +249,7 @@ namespace Unity.Netcode
             InternalReset(targetValue, serverTime);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void InternalReset(T targetValue, double serverTime, bool addMeasurement = true)
         {
             m_RateOfChange = default;
@@ -271,7 +284,7 @@ namespace Unity.Netcode
             {
                 if (!InterpolateState.TargetReached)
                 {
-                    InterpolateState.TargetReached = IsAproximately(InterpolateState.CurrentValue, InterpolateState.Target.Value.Item);
+                    InterpolateState.TargetReached = IsApproximately(InterpolateState.CurrentValue, InterpolateState.Target.Value.Item, GetPrecision());
                 }
                 return;
             }
@@ -291,7 +304,7 @@ namespace Unity.Netcode
                     potentialItemNeedsProcessing = ((potentialItem.TimeSent <= renderTime) && potentialItem.TimeSent > InterpolateState.Target.Value.TimeSent);
                     if (!InterpolateState.TargetReached)
                     {
-                        InterpolateState.TargetReached = IsAproximately(InterpolateState.CurrentValue, InterpolateState.Target.Value.Item);
+                        InterpolateState.TargetReached = IsApproximately(InterpolateState.CurrentValue, InterpolateState.Target.Value.Item, GetPrecision());
                     }
                 }
 
@@ -424,23 +437,27 @@ namespace Unity.Netcode
         /// This version of TryConsumeFromBuffer adheres to the original BufferedLinearInterpolator buffer consumption pattern.
         /// </remarks>
         /// <param name="renderTime"></param>
+        /// <param name="serverTime"></param>
         private void TryConsumeFromBuffer(double renderTime, double serverTime)
         {
             if (!InterpolateState.Target.HasValue || (InterpolateState.Target.Value.TimeSent <= renderTime))
             {
                 BufferedItem? previousItem = null;
                 var alreadyHasBufferItem = false;
+                var count = 0;
                 while (m_BufferQueue.TryPeek(out BufferedItem potentialItem))
                 {
                     // If we are still on the same buffered item (FIFO Queue), then exit early as there is nothing
-                    // to consume.
+                    // to consume. (just a safety check but this scenario should never happen based on the below legacy approach of
+                    // consuming until the most current state)
                     if (previousItem.HasValue && previousItem.Value.TimeSent == potentialItem.TimeSent)
                     {
                         break;
                     }
 
-                    if ((potentialItem.TimeSent <= serverTime) &&
-                        (!InterpolateState.Target.HasValue || InterpolateState.Target.Value.TimeSent < potentialItem.TimeSent))
+                    // Continue to processing until we reach the most current state
+                    if ((potentialItem.TimeSent <= serverTime) && // Inverted logic (below) from original since we have to go from past to present
+                        (!InterpolateState.Target.HasValue || potentialItem.TimeSent > InterpolateState.Target.Value.TimeSent))
                     {
                         if (m_BufferQueue.TryDequeue(out BufferedItem target))
                         {
@@ -449,6 +466,7 @@ namespace Unity.Netcode
                                 InterpolateState.Target = target;
                                 alreadyHasBufferItem = true;
                                 InterpolateState.NextValue = InterpolateState.CurrentValue;
+                                InterpolateState.PreviousValue = InterpolateState.CurrentValue;
                                 InterpolateState.StartTime = target.TimeSent;
                                 InterpolateState.EndTime = target.TimeSent;
                             }
@@ -458,18 +476,14 @@ namespace Unity.Netcode
                                 {
                                     alreadyHasBufferItem = true;
                                     InterpolateState.StartTime = InterpolateState.Target.Value.TimeSent;
-                                    InterpolateState.NextValue = InterpolateState.CurrentValue;
+                                    InterpolateState.PreviousValue = InterpolateState.NextValue;
                                     InterpolateState.TargetReached = false;
                                 }
                                 InterpolateState.EndTime = target.TimeSent;
-                                InterpolateState.Target = target;
                                 InterpolateState.TimeToTargetValue = InterpolateState.EndTime - InterpolateState.StartTime;
+                                InterpolateState.Target = target;
                             }
                         }
-                    }
-                    else
-                    {
-                        break;
                     }
 
                     if (!InterpolateState.Target.HasValue)
@@ -505,19 +519,20 @@ namespace Unity.Netcode
                     InterpolateState.LerpT = Math.Clamp((float)((renderTime - InterpolateState.StartTime) / InterpolateState.TimeToTargetValue), 0.0f, 1.0f);
                 }
 
-                var target = Interpolate(InterpolateState.NextValue, InterpolateState.Target.Value.Item, InterpolateState.LerpT);
+                InterpolateState.NextValue = Interpolate(InterpolateState.PreviousValue, InterpolateState.Target.Value.Item, InterpolateState.LerpT);
 
                 if (LerpSmoothEnabled)
                 {
                     // Assure our MaximumInterpolationTime is valid and that the second lerp time ranges between deltaTime and 1.0f.
-                    InterpolateState.CurrentValue = Interpolate(InterpolateState.CurrentValue, target, deltaTime / MaximumInterpolationTime);
+                    InterpolateState.CurrentValue = Interpolate(InterpolateState.CurrentValue, InterpolateState.NextValue, deltaTime / MaximumInterpolationTime);
                 }
                 else
                 {
-                    InterpolateState.CurrentValue = target;
+                    InterpolateState.CurrentValue = InterpolateState.NextValue;
                 }
+
                 // Determine if we have reached our target
-                InterpolateState.TargetReached = IsAproximately(InterpolateState.CurrentValue, InterpolateState.Target.Value.Item);
+                InterpolateState.TargetReached = IsApproximately(InterpolateState.CurrentValue, InterpolateState.Target.Value.Item, GetPrecision());
             }
             else // If the target is reached and we have no more state updates, we want to check to see if we need to reset.
             if (m_BufferQueue.Count == 0 && InterpolateState.TargetReached)
@@ -601,6 +616,7 @@ namespace Unity.Netcode
         /// Gets latest value from the interpolator. This is updated every update as time goes by.
         /// </summary>
         /// <returns>The current interpolated value of type 'T'</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public T GetInterpolatedValue()
         {
             return InterpolateState.CurrentValue;
@@ -638,6 +654,7 @@ namespace Unity.Netcode
         /// <param name="deltaTime">The increasing delta time from when start to finish.</param>
         /// <param name="maxSpeed">Maximum rate of change per pass.</param>
         /// <returns>The smoothed <see cref="T"/> value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private protected virtual T SmoothDamp(T current, T target, ref T rateOfChange, float duration, float deltaTime, float maxSpeed = Mathf.Infinity)
         {
             return target;
@@ -653,7 +670,8 @@ namespace Unity.Netcode
         /// <param name="second">Second value of type <see cref="T"/>.</param>
         /// <param name="precision">The precision of the aproximation.</param>
         /// <returns>true if the two values are aproximately the same and false if they are not</returns>
-        private protected virtual bool IsAproximately(T first, T second, float precision = k_AproximatePrecision)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private protected virtual bool IsApproximately(T first, T second, float precision = k_ApproximateLowPrecision)
         {
             return false;
         }
@@ -665,6 +683,7 @@ namespace Unity.Netcode
         /// <param name="item">The item to convert.</param>
         /// <param name="inLocalSpace">local or world space (true or false).</param>
         /// <returns>The converted value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected internal virtual T OnConvertTransformSpace(Transform transform, T item, bool inLocalSpace)
         {
             return default;
@@ -675,6 +694,7 @@ namespace Unity.Netcode
         /// </summary>
         /// <param name="transform">The transform that the <see cref="Components.NetworkTransform"/> is associated with.</param>
         /// <param name="inLocalSpace">Whether the <see cref="Components.NetworkTransform"/> is now being tracked in local or world spaced.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void ConvertTransformSpace(Transform transform, bool inLocalSpace)
         {
             var count = m_BufferQueue.Count;

--- a/com.unity.netcode.gameobjects/Runtime/Components/Interpolator/BufferedLinearInterpolatorFloat.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Interpolator/BufferedLinearInterpolatorFloat.cs
@@ -25,7 +25,7 @@ namespace Unity.Netcode
 
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private protected override bool IsAproximately(float first, float second, float precision = 1E-07F)
+        private protected override bool IsApproximately(float first, float second, float precision = 1E-06F)
         {
             return Mathf.Approximately(first, second);
         }

--- a/com.unity.netcode.gameobjects/Runtime/Components/Interpolator/BufferedLinearInterpolatorQuaternion.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Interpolator/BufferedLinearInterpolatorQuaternion.cs
@@ -66,7 +66,7 @@ namespace Unity.Netcode
 
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private protected override bool IsAproximately(Quaternion first, Quaternion second, float precision)
+        private protected override bool IsApproximately(Quaternion first, Quaternion second, float precision = 1E-06F)
         {
             return Mathf.Abs(first.x - second.x) <= precision &&
                 Mathf.Abs(first.y - second.y) <= precision &&

--- a/com.unity.netcode.gameobjects/Runtime/Components/Interpolator/BufferedLinearInterpolatorVector3.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Interpolator/BufferedLinearInterpolatorVector3.cs
@@ -59,7 +59,7 @@ namespace Unity.Netcode
 
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private protected override bool IsAproximately(Vector3 first, Vector3 second, float precision = 0.0001F)
+        private protected override bool IsApproximately(Vector3 first, Vector3 second, float precision = 1E-06F)
         {
             return Math.Round(Mathf.Abs(first.x - second.x), 2) <= precision &&
                 Math.Round(Mathf.Abs(first.y - second.y), 2) <= precision &&

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
@@ -968,6 +968,8 @@ namespace Unity.Netcode.Components
             /// <item><description>The first phase lerps from the previous state update value to the next state update value.</description></item>
             /// <item><description>The second phase (optional) performs lerp smoothing where the current respective transform value is lerped towards the result of the first phase at a rate of delta time divided by the respective max interpolation time.</description></item>
             /// </list>
+            /// !!! NOTE !!!<br />
+            /// The legacy lerp interpolation type does not use <see cref="NetworkTimeSystem.TickLatency"/> to determine the buffer depth. This is to preserve the same interpolation results when lerp smoothing is enabled.<br />
             /// </summary>
             /// <remarks>
             /// For more information:<br />
@@ -4085,6 +4087,17 @@ namespace Unity.Netcode.Components
                 }
             }
 
+            // Note: This is for the legacy lerp type in order to maintain the same end result for any games under development that have tuned their
+            // project's to match the legacy lerp's end result. This will not allow changes
+            var cachedRenderTime = 0.0;
+            if (PositionInterpolationType == InterpolationTypes.LegacyLerp || RotationInterpolationType == InterpolationTypes.LegacyLerp || ScaleInterpolationType == InterpolationTypes.LegacyLerp)
+            {
+                // Since InterpolationBufferTickOffset defaults to zero, this should not impact exist projects but still provides users with the ability to tweak
+                // their ticks ago time. 
+                var ticksAgo = (!IsServerAuthoritative() && !IsServer ? 2 : 1) + InterpolationBufferTickOffset;
+                cachedRenderTime = timeSystem.TimeTicksAgo(ticksAgo).Time;
+            }
+
             // Get the tick latency (ticks ago) as time (in the past) to process state updates in the queue.
             var tickLatencyAsTime = timeSystem.TimeTicksAgo(tickLatency).Time;
 
@@ -4127,7 +4140,7 @@ namespace Unity.Netcode.Components
 
                 if (PositionInterpolationType == InterpolationTypes.LegacyLerp)
                 {
-                    m_PositionInterpolator.Update(cachedDeltaTime, tickLatencyAsTime, currentTime);
+                    m_PositionInterpolator.Update(cachedDeltaTime, cachedRenderTime, currentTime);
                 }
                 else
                 {
@@ -4158,7 +4171,7 @@ namespace Unity.Netcode.Components
                 m_RotationInterpolator.IsSlerp = !UseHalfFloatPrecision;
                 if (RotationInterpolationType == InterpolationTypes.LegacyLerp)
                 {
-                    m_RotationInterpolator.Update(cachedDeltaTime, tickLatencyAsTime, currentTime);
+                    m_RotationInterpolator.Update(cachedDeltaTime, cachedRenderTime, currentTime);
                 }
                 else
                 {
@@ -4186,7 +4199,7 @@ namespace Unity.Netcode.Components
 
                 if (ScaleInterpolationType == InterpolationTypes.LegacyLerp)
                 {
-                    m_ScaleInterpolator.Update(cachedDeltaTime, tickLatencyAsTime, currentTime);
+                    m_ScaleInterpolator.Update(cachedDeltaTime, cachedRenderTime, currentTime);
                 }
                 else
                 {


### PR DESCRIPTION
This update resolves the issue where the legacy lerp result was not yielding the same result as the original lerp. This update also resolves a secondary issue discovered by the services group where the final interpolation (i.e. last measurement in the queue) was not using a high enough precision value when determining if it reached its final destination point. This update also includes some inlining additions along with a spelling mistake with the IsApproximately method. It also updates the XML API regarding Legacy lerp to let users know that it does not use the tick latency value when calculating the ticksAgo value.


## Changelog
NA

## Testing and Documentation

- No tests have been added.
- Includes edits to existing API XML documentation.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
