### PR TITLE
fix: Don't accept invalid connections in UnityTransport.Send

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -22,6 +22,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed an issue in `UnityTransport` where the transport would accept sends on invalid connections, leading to a useless memory allocation and confusing error message.
 - Fixed issue where the time delta that interpolators used would not be properly updated during multiple fixed update invocations within the same player loop frame. (#3355)
 - Fixed issue when using a distributed authority network topology and many clients attempt to connect simultaneously the session owner could max-out the maximum in-flight reliable messages allowed, start dropping packets, and some of the connecting clients would fail to fully synchronize. (#3350)
 - Fixed issue when using a distributed authority network topology and scene management was disabled clients would not be able to spawn any new network prefab instances until synchronization was complete. (#3350)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -22,7 +22,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed an issue in `UnityTransport` where the transport would accept sends on invalid connections, leading to a useless memory allocation and confusing error message.
+- Fixed an issue in `UnityTransport` where the transport would accept sends on invalid connections, leading to a useless memory allocation and confusing error message. (#3382)
 - Fixed issue where the time delta that interpolators used would not be properly updated during multiple fixed update invocations within the same player loop frame. (#3355)
 - Fixed issue when using a distributed authority network topology and many clients attempt to connect simultaneously the session owner could max-out the maximum in-flight reliable messages allowed, start dropping packets, and some of the connecting clients would fail to fully synchronize. (#3350)
 - Fixed issue when using a distributed authority network topology and scene management was disabled clients would not be able to spawn any new network prefab instances until synchronization was complete. (#3350)

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -1347,8 +1347,13 @@ namespace Unity.Netcode.Transports.UTP
         /// <param name="networkDelivery">The delivery type (QoS) to send data with</param>
         public override void Send(ulong clientId, ArraySegment<byte> payload, NetworkDelivery networkDelivery)
         {
-            var pipeline = SelectSendPipeline(networkDelivery);
+            var connection = ParseClientId(clientId);
+            if (!m_Driver.IsCreated || m_Driver.GetConnectionState(connection) != NetworkConnection.State.Connected)
+            {
+                return;
+            }
 
+            var pipeline = SelectSendPipeline(networkDelivery);
             if (pipeline != m_ReliableSequencedPipeline && payload.Count > m_MaxPayloadSize)
             {
                 Debug.LogError($"Unreliable payload of size {payload.Count} larger than configured 'Max Payload Size' ({m_MaxPayloadSize}).");

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
@@ -483,5 +483,22 @@ namespace Unity.Netcode.RuntimeTests
                 yield return EnsureNoNetworkEvent(m_Client1Events);
             }
         }
+
+        [UnityTest]
+        public IEnumerator DoesNotAttemptToSendOnInvalidConnections()
+        {
+            InitializeTransport(out m_Server, out m_ServerEvents);
+            InitializeTransport(out m_Client1, out m_Client1Events);
+
+            m_Server.StartServer();
+            m_Client1.StartClient();
+
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_Client1Events);
+
+            var data = new ArraySegment<byte>(new byte[42]);
+            m_Server.Send(m_Client1.ServerClientId, data, NetworkDelivery.Reliable);
+
+            yield return EnsureNoNetworkEvent(m_Client1Events);
+        }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
@@ -496,7 +496,7 @@ namespace Unity.Netcode.RuntimeTests
             yield return WaitForNetworkEvent(NetworkEvent.Connect, m_Client1Events);
 
             var data = new ArraySegment<byte>(new byte[42]);
-            m_Server.Send(m_Client1.ServerClientId, data, NetworkDelivery.Reliable);
+            m_Server.Send(0, data, NetworkDelivery.Reliable);
 
             yield return EnsureNoNetworkEvent(m_Client1Events);
         }


### PR DESCRIPTION
This avoids the error message reported in [MTTB-1143](https://jira.unity3d.com/browse/MTTB-1143).

The `UnityTransport.Send` method would happily accept invalid or stale connections, which would lead to the allocation of a `BatchedSendQueue` structure and to an error message when the batched sends are passed on to the driver.

In MTTB-1143 we'd get a send on client ID 0, but that's not a valid client ID in `UnityTransport`. My guess is that there's something somewhere (possibly in Boss Room) triggering a send to the server after the connection has closed (which reverts `UnityTransport.ServerClientId` to its default value of 0). Of course, ideally there'd never be such a send-after-disconnect and that's what should be ultimately addressed. But the bug is quite hard to reproduce, so as a stopgap until we have something better I'm making a fix that only avoids the last and more user-visible consequences of the issue.

## Changelog

- Fixed: Fixed an issue in `UnityTransport` where the transport would accept sends on invalid connections, leading to a useless memory allocation and confusing error message.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.