### PR TITLE
fix: NetworkAnimator logging error when a state has no destination information

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -16,6 +16,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where `NetworkAnimator` would log an error if there was no destination transition information. (#3384)
 - Fixed initial `NetworkTransform` spawn, ensure it uses world space. (#3361)
 - Fixed issue where `AnticipatedNetworkVariable` previous value returned by `AnticipatedNetworkVariable.OnAuthoritativeValueChanged` is updated correctly on the non-authoritative side. (#3322)
 

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -1226,10 +1226,11 @@ namespace Unity.Netcode.Components
                         NetworkLog.LogError($"[DestinationState To Transition Info] Layer ({animationState.Layer}) sub-table does not contain destination state ({animationState.DestinationStateHash})!");
                     }
                 }
-                else if (NetworkManager.LogLevel == LogLevel.Developer)
-                {
-                    NetworkLog.LogError($"[DestinationState To Transition Info] Layer ({animationState.Layer}) does not exist!");
-                }
+                // For reference, it is valid to have no transition information
+                //else if (NetworkManager.LogLevel == LogLevel.Developer)
+                //{
+                //    NetworkLog.LogError($"[DestinationState To Transition Info] Layer ({animationState.Layer}) does not exist!");
+                //}
             }
             else if (animationState.Transition && animationState.CrossFade)
             {


### PR DESCRIPTION
This PR remove the error log when a state has no transition information associated with it.

[MTTB-1153](https://jira.unity3d.com/browse/MTTB-1153)

## Changelog

- Fixed: Issue where `NetworkAnimator` would log an error if there was no destination transition information.

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->
