### PR TITLE
ci: backport-verification test

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,7 @@
 - [ ] The users can understand why this API was removed and what they should use instead.
 -->
 
-## Backports
+## Backport
 
 Link to the backport to develop branch (NGOv1.X) if applicable. If this is a backport, please add the following to the PR title: "\[Backport\] ..." .
 If the backport is not needed please provide the reason why.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,6 +27,10 @@
 
 ## Backport
 
-Link to the backport to develop branch (NGOv1.X) if applicable. If this is a backport, please add the following to the PR title: "\[Backport\] ..." .
-If the backport is not needed please provide the reason why.
-If "Backports" section will not be present it will lead to CI test failure
+<!-- If this is a backport:
+ - Add the following to the PR title: "\[Backport\] ..." .
+ - Link to the original PR.
+If this needs a backport - state this here
+If a backport is not needed please provide the reason why.
+If the "Backports" section is not present it will lead to a CI test failure. 
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,6 @@
 
 <!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->
 
-<!-- Add RFC link here if applicable. -->
-
 ## Changelog
 
 - Added: The package whose Changelog should be added to should be in the header. Delete the changelog section entirely if it's not needed.
@@ -26,3 +24,9 @@
 - [ ] Deprecation of the API is explained in the CHANGELOG.
 - [ ] The users can understand why this API was removed and what they should use instead.
 -->
+
+## Backports
+
+Link to the backport to develop branch (NGOv1.X) if applicable. If this is a backport, please add the following to the PR title: "\[Backport\] ..." .
+If the backport is not needed please provide the reason why.
+If "Backports" section will not be present it will lead to CI test failure

--- a/.github/workflows/backport-verification.yml
+++ b/.github/workflows/backport-verification.yml
@@ -1,0 +1,32 @@
+﻿# This workflow is designed to verify that the pull request description contains a "## Backport" section, which is important as a reminder to account for backports for anyone that works with NGO repository.
+# We have 2 development branches (develop and develop-2.0.0) and we need to ensure that relevant changes are landing in only one or both of them
+# If the "##Backport" section is missing, the workflow will fail and block the PR from merging, prompting the developer to add this section.
+
+# The workflow is configured to run when PR is created as well as when it is edited which also counts simple description edits.
+
+name: "NGO - Backport Verification"
+  
+on:
+  pull_request:
+    types: [opened, edited]
+    branches:
+      - develop
+      - develop-2.0.0
+
+jobs:
+  backport-verification:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Check PR description
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+
+            if (!body.includes('## Backport')) {
+              core.setFailed('PR description must include a "## Backport" section. Please add this section and provide information about this PR backport to develop or develop-2.0.0 branch respectively or explain why backport is not needed.');
+            }


### PR DESCRIPTION
Due to nature of NGO of having 2 development branches (`develop` for NGOv1.X and `develop-2.0.0` for NGOv2.X) we need to ensure that relevant changes are landing in only one branch (when it's relevant to only develop-2.0.0 for example) or both of them.

For people not familiar with NGO structure (but also for us) it might be easy to omit the fact of making a backport (or forward port) so this PR includes a GitHub workflow that will check if "**## Backport**" section exist in the PR thus making it mandatory. This will add a bit of work to each PR but it will ensure that developers get reminded about backports and hopefully this will lead to 

- Easier PR tracking since every PR will contain a description of a backport or reasoning why a backport is not needed
- Reduction of potential forgotten backports which in turn could increase overall quality of NGO 

I tested this workflow on my fork of NGO repo and seems to be working as expected

## Backport
Backport created in https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3393. After this PR gets approved I will modify branch protection rules to block PRs from merging if this check fails.