### PR TITLE
ci: webgl build job timeout extended

### DIFF
--- a/.yamato/webgl-build.yml
+++ b/.yamato/webgl-build.yml
@@ -45,7 +45,7 @@ webgl_build_{{ project.name }}_{{ platform.name }}_{{ editor }}:
       # Engine is initialized in ‘nographics’ mode since we don't need any graphics for this case (--extra-editor-arg=-nographics)
       # In case of failure the job will be rerunned once (--reruncount=1) with clean library (--clean-library-on-rerun) 
       # This will perform only building phase (--build-only) with a timeout of 3m (--timeout=1800)
-    - UnifiedTestRunner --suite=playmode --platform=WebGL --scripting-backend=il2cpp --testproject={{ project.path }} --editor-location=.Editor --artifacts_path=artifacts --player-save-path=build/players --extra-editor-arg=-batchmode --extra-editor-arg=-nographics --reruncount=1 --clean-library-on-rerun --build-only --timeout=1800
+    - UnifiedTestRunner --suite=playmode --platform=WebGL --scripting-backend=il2cpp --testproject={{ project.path }} --editor-location=.Editor --artifacts_path=artifacts --player-save-path=build/players --extra-editor-arg=-batchmode --extra-editor-arg=-nographics --reruncount=1 --clean-library-on-rerun --build-only --timeout=2400
   artifacts:
     logs:
       paths:


### PR DESCRIPTION
It was noted that webgl builds started timing out more often in the span of the last month so this PR aims to increase the timeout for this job