### PR TITLE
chore: Updated support template to redirect users to Discord or Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -7,6 +7,7 @@ assignees: ''
 
 ---
 
-Post your questions or problems here.
+For support related questions we HIGHLY recommend to post a message either on the [Unity Discussions](https://discussions.unity.com/tag/netcode-for-gameobjects) or on our [Discord Community](https://discord.gg/TqNeJTtC) where you can get help from the community and the developers.
+Those forums will get you the fastest response and are the best place to ask for help.
 
-For general questions, networking advice or discussions about the Netcode for GameObjects, you can also reach us on our [Discord Community](https://discord.gg/FM8SE9E) or create a post in the [Unity Multiplayer Forum](https://forum.unity.com/forums/multiplayer.26/).
+If you still feel like you want to open a support issue as an GitHub Issue, please make sure to include as much information as possible (also including any relevant code/project) to help us understand your problem.


### PR DESCRIPTION
This PR aims to modify the template when user wants to create support related issue. The goal is to redirect those to either DIscord or Unity Discussions where user would get much more (and faster) support and by doing this we may minimize the amount of GitHub Issues we need to take care of

## Backport
PR is also backported to develop branch in https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3392