### PR TITLE
chore: [Backport] Updated support template to redirect users to Discord or Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -2,11 +2,12 @@
 name: Support
 about: Have a question or need help with anything?
 title: ''
-labels: stat:awaiting-triage, stat:reply-needed, type:support
+labels: stat:awaiting triage, type:support
 assignees: ''
 
 ---
 
-Post your questions or problems here.
+For support related questions we HIGHLY recommend to post a message either on the [Unity Discussions](https://discussions.unity.com/tag/netcode-for-gameobjects) or on our [Discord Community](https://discord.gg/TqNeJTtC) where you can get help from the community and the developers.
+Those forums will get you the fastest response and are the best place to ask for help.
 
-For general questions, networking advice or discussions about the Netcode for GameObjects, you can also reach us on our [Discord Community](https://discord.gg/FM8SE9E) or create a post in the [Unity Multiplayer Forum](https://forum.unity.com/forums/multiplayer.26/).
+If you still feel like you want to open a support issue as an GitHub Issue, please make sure to include as much information as possible (also including any relevant code/project) to help us understand your problem.

--- a/.github/workflows/assignee-management.yaml
+++ b/.github/workflows/assignee-management.yaml
@@ -21,7 +21,7 @@ env:
 jobs:
   handle_assignment:
     name: Handle Issue Assignment Changes
-    if: ${{ !github.event.issue.pull_request  }} && ${{ github.event.issue.state == 'open' }}
+    if: ${{ !github.event.issue.pull_request && github.event.issue.state == 'open' }}
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
## Backport
This PR is a backport of https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3391. 

This PR aims to modify the template when user wants to create support related issue. The goal is to redirect those to either DIscord or Unity Discussions where user would get much more (and faster) support and by doing this we may minimize the amount of GitHub Issues we need to take care of