### PR TITLE
chore: [Backport] GitHub actions mirrored from develop

### DIFF
--- a/.github/workflows/assignee-management.yaml
+++ b/.github/workflows/assignee-management.yaml
@@ -1,0 +1,70 @@
+﻿# This workflow manages issue assignments and related label changes:
+# 1. When someone is assigned to an issue:
+#    - Removes "stat:awaiting-triage" label
+#    - Adds "stat:Investigating" label
+# 2. When all assignees are removed from an issue:
+#    - Adds "stat:awaiting-triage" label
+#    - Removes "stat:Investigating" label
+# 3. When "stat:Investigating" label is added:
+#    - Automatically assigns the issue to the person who added the label
+
+name: Handle Issue Assignment and Labels
+
+on:
+  issues:
+    types: [assigned, unassigned, labeled]
+
+env:
+  AWAITING-TRIAGE_LABEL: stat:awaiting-triage
+  INVESTIGATING_LABEL: stat:Investigating
+
+jobs:
+  handle_assignment:
+    name: Handle Issue Assignment Changes
+    if: ${{ !github.event.issue.pull_request && github.event.issue.state == 'open' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Handle Assignment Changes
+        run: |
+          if [[ "${{ github.event.action }}" == "assigned" ]]; then
+            # Someone was assigned - remove awaiting-triage, add investigating
+            echo "ADD=${{ env.INVESTIGATING_LABEL }}" >> $GITHUB_ENV
+            echo "REMOVE=${{ env.AWAITING-TRIAGE_LABEL }}" >> $GITHUB_ENV
+          elif [[ "${{ github.event.action }}" == "unassigned" ]]; then
+            # Check if there are any remaining assignees
+            ASSIGNEES=$(echo '${{ toJson(github.event.issue.assignees) }}' | jq length)
+            if [[ "$ASSIGNEES" == "0" ]]; then
+              # No assignees left - add awaiting-triage, remove investigating
+              echo "ADD=${{ env.AWAITING-TRIAGE_LABEL }}" >> $GITHUB_ENV
+              echo "REMOVE=${{ env.INVESTIGATING_LABEL }}" >> $GITHUB_ENV
+            fi
+          fi
+
+      - name: Update Labels
+        if: env.ADD != '' || env.REMOVE != ''
+        run: gh issue edit "$NUMBER" --add-label "$ADD" --remove-label "$REMOVE"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+
+  handle_investigating_label:
+    name: Handle Investigating Label Addition
+    if: ${{ github.event.action == 'labeled' && github.event.label.name == 'stat:Investigating' && !github.event.issue.pull_request && github.event.issue.state == 'open' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Assign Issue to person that added Investigating Label
+        run: |
+          # Assign the issue to the person who added the label
+          gh issue edit "$NUMBER" --add-assignee "$ACTOR"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          ACTOR: ${{ github.actor }}

--- a/.github/workflows/backport-verification.yml
+++ b/.github/workflows/backport-verification.yml
@@ -5,7 +5,7 @@
 # The workflow is configured to run when PR is created as well as when it is edited which also counts simple description edits.
 
 name: "NGO - Backport Verification"
-  
+
 on:
   pull_request:
     types: [opened, edited]

--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -6,7 +6,6 @@ on:
     branches:
     - develop
     - develop-2.0.0
-
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"

--- a/.github/workflows/conversation-labels.yaml
+++ b/.github/workflows/conversation-labels.yaml
@@ -1,0 +1,51 @@
+# This workflow will update issues with proper "conversation related" labels. This mean that stat:awaiting-repsonse label will be present after Unity account made comments and stat:reply-needed will be present when user made latest comment
+
+name: Update conversation labels of the issue
+
+# Trigger for the workflow
+# This trigger will populate the github.event object
+# Details on properties are here: https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=created#issue_comment
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+# Define labels here
+env:
+  AWAITING_RESPONSE: stat:awaiting-response
+  REPLY_NEEDED: stat:reply-needed
+
+jobs:
+  conversation_labels:
+    name: Calculate and update conversation labels of the issue
+    if: ${{ !github.event.issue.pull_request && github.event.issue.state == 'open' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Calculate labels
+        run: |
+
+          if [[ "${{ github.event.comment.author_association }}" == "MEMBER" ]]; then
+            # Unity member commented - add awaiting-response, remove reply-needed
+            echo "ADD=${{ env.AWAITING_RESPONSE }}" >> $GITHUB_ENV
+            echo "REMOVE=${{ env.REPLY_NEEDED }}" >> $GITHUB_ENV
+          else
+            # Non-Unity member commented - add reply-needed, remove awaiting-response
+            echo "ADD=${{ env.REPLY_NEEDED }}" >> $GITHUB_ENV
+            echo "REMOVE=${{ env.AWAITING_RESPONSE }}" >> $GITHUB_ENV
+          fi
+
+      - name: Update labels
+        # This runs a command using the github cli: https://cli.github.com/manual/gh_issue_edit
+        # If $ADD is set, it will add the label, otherwise it will remove the label
+        # There is no need to check if $ADD or $REMOVE is set, as the command will ignore it if it is empty
+        run: gh issue edit "$NUMBER" --add-label "$ADD" --remove-label "$REMOVE"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/mark-stale-issue.yaml
+++ b/.github/workflows/mark-stale-issue.yaml
@@ -1,0 +1,39 @@
+﻿# This workflow utilises an existing implementation (https://github.com/actions/stale) that performs the following actions:
+#   1) Adds "stale" label to issues that have "stat:awaiting-response" for more than 30 days meaning that since we don't have enough information we may potentially close such issue
+#   2) Closes issues that have been marked as "stale" for more than 30 days
+
+# This affects only Issues but at some point we may also consider rules for PRs
+
+name: Mark or Close Stale Issues
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'  # Runs daily at midnight
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Only mark issues (not PRs) as stale
+          any-of-labels: 'stat:awaiting-response'
+          days-before-stale: 30
+          days-before-close: 30
+          stale-issue-label: 'Stale'
+          exempt-issue-labels: 'stat:import,stat:imported'
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has been awaiting 
+            response for over 30 days without any activity.
+
+            Please update the issue with any new information or it may be closed in 30 days.
+          close-issue-message: >
+            This issue has been automatically closed because it has been stale for 30 days 
+            without any activity. Feel free to reopen if you have new information to add.
+          # Prevent the action from marking/closing PRs
+          days-before-pr-stale: -1
+          days-before-pr-close: -1

--- a/.github/workflows/remove-labels-on-issue-close.yaml
+++ b/.github/workflows/remove-labels-on-issue-close.yaml
@@ -1,0 +1,40 @@
+# This workflow will remove almost all labels from closed issues beside ones that could be relevant for future tracking like: "port:", "type:", "priority:", "regression" and "stat:imported"
+
+name: Remove labels when issue is closed
+
+on:
+  issues:
+    types: [closed] # We want it to run on closed issues
+
+jobs:
+  remove_labels:
+    name: Calculate and remove issue labels
+    if: ${{ !github.event.issue.pull_request  }} # This is needed to distinguish from PRs (which we don't want to affect)
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Find labels to remove
+        id: data
+        run: |
+          # Convert labels to array and filter out type: labels
+          LABELS_TO_REMOVE=($(echo "$EXISTING_LABELS" | jq -r '.[] | select(startswith("type:") or startswith("port:") or startswith("priority:") or . == "regression" or . == "stat:imported" | not)'))
+          
+          # Only proceed if we have labels to remove
+          if [ ${#LABELS_TO_REMOVE[@]} -gt 0 ]; then
+            echo "REMOVE_LABELS=$(IFS=,; echo "${LABELS_TO_REMOVE[*]}")" >> $GITHUB_ENV
+            echo "HAS_LABELS=true" >> $GITHUB_ENV
+          else
+            echo "HAS_LABELS=false" >> $GITHUB_ENV
+          fi
+        env:
+          EXISTING_LABELS: ${{ toJson(github.event.issue.labels.*.name) }}
+
+      - name: Remove labels
+        if: ${{ env.REMOVE_LABELS != '' }}
+        run: gh issue edit "$NUMBER" --remove-label "$REMOVE_LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
This PR ports all new GitHub Actions that were added to develop branch. This will not have any temporary effect since GitHub Actions utilizes configuration from main branch (currently develop) but this ensures that when we will change main branch to be develop-2.0.0 everything will be working in the same way

## Backport
This PR ports changes that were included in https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3194 and https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3380