### PR TITLE
ci: Increased WebGL job timeout

### DIFF
--- a/.yamato/webgl-build.yml
+++ b/.yamato/webgl-build.yml
@@ -20,6 +20,7 @@
 # QUALITY CONSIDERATIONS--------------------------------------------------------------------
   # In the future we could try to implement an infrastructure to run test in webgl context but this could be quite complicated and would need to be evaluated if it's worth it
   # To see where this job is included (in trigger job definitions) look into _triggers.yml file
+  # WebGL jobs were timing up more often in develop-2.0.0 branch (especially on trunk) so we increased the timeout from 1800 to 3600. We should investigate why it times more often in develop-2.0.0/ubuntu/trunk
   
 #-------------------------------------------------------------------------------------- 
   

--- a/.yamato/webgl-build.yml
+++ b/.yamato/webgl-build.yml
@@ -45,7 +45,7 @@ webgl_build_{{ project.name }}_{{ platform.name }}_{{ editor }}:
       # Engine is initialized in ‘nographics’ mode since we don't need any graphics for this case (--extra-editor-arg=-nographics)
       # In case of failure the job will be rerunned once (--reruncount=1) with clean library (--clean-library-on-rerun) 
       # This will perform only building phase (--build-only) with a timeout of 3m (--timeout=1800)
-    - UnifiedTestRunner --suite=playmode --platform=WebGL --scripting-backend=il2cpp --testproject={{ project.path }} --editor-location=.Editor --artifacts_path=artifacts --player-save-path=build/players --extra-editor-arg=-batchmode --extra-editor-arg=-nographics --reruncount=1 --clean-library-on-rerun --build-only --timeout=2400
+    - UnifiedTestRunner --suite=playmode --platform=WebGL --scripting-backend=il2cpp --testproject={{ project.path }} --editor-location=.Editor --artifacts_path=artifacts --player-save-path=build/players --extra-editor-arg=-batchmode --extra-editor-arg=-nographics --reruncount=1 --clean-library-on-rerun --build-only --timeout=3600
   artifacts:
     logs:
       paths:


### PR DESCRIPTION
This PR follows up on https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3389 and increases the timeout even more because it was noted that the issue is still happening. After some testing it seems that this timeout is sufficient but some investigation should be performed in the future to see why the job times out more often in such configuration (develop-2.0.0/ubuntu/trunk)

## Backport
Since this PR is targeting an Issue that happens mostly in develop-2.0.0, ubuntu/trunk configuration no backport is needed (there is no that big of a problem in develop branch)