### PR TITLE
ci: Updating WhenManyObjectsAreSpawnedAtOnce_AllAreReceived test

### DIFF
--- a/.yamato/package-tests.yml
+++ b/.yamato/package-tests.yml
@@ -47,7 +47,7 @@ package_test_-_ngo_{{ editor }}_{{ platform.name }}:
 
     # Run UTR to test packages.
     - upm-pvp create-test-project test-project --packages "upm-ci~/packages/*.tgz" --filter "com.unity.netcode.gameobjects" --unity .Editor
-    - UnifiedTestRunner --suite=editor --suite=playmode --editor-location=.Editor --testproject=test-project --artifacts-path=test-results "--ff={ops.upmpvpevidence.enable=true}" --extra-editor-arg=-batchmode --extra-editor-arg=-nographics --reruncount=1 --testfilter=WhenManyObjectsAreSpawnedAtOnce_AllAreReceived --clean-library-on-rerun
+    - UnifiedTestRunner --suite=editor --suite=playmode --editor-location=.Editor --testproject=test-project --artifacts-path=test-results "--ff={ops.upmpvpevidence.enable=true}" --extra-editor-arg=-batchmode --extra-editor-arg=-nographics --reruncount=1 --clean-library-on-rerun
   artifacts:
     logs:
       paths:

--- a/.yamato/package-tests.yml
+++ b/.yamato/package-tests.yml
@@ -47,7 +47,7 @@ package_test_-_ngo_{{ editor }}_{{ platform.name }}:
 
     # Run UTR to test packages.
     - upm-pvp create-test-project test-project --packages "upm-ci~/packages/*.tgz" --filter "com.unity.netcode.gameobjects" --unity .Editor
-    - UnifiedTestRunner --suite=editor --suite=playmode --editor-location=.Editor --testproject=test-project --artifacts-path=test-results "--ff={ops.upmpvpevidence.enable=true}" --extra-editor-arg=-batchmode --extra-editor-arg=-nographics --reruncount=1 --clean-library-on-rerun
+    - UnifiedTestRunner --suite=editor --suite=playmode --editor-location=.Editor --testproject=test-project --artifacts-path=test-results "--ff={ops.upmpvpevidence.enable=true}" --extra-editor-arg=-batchmode --extra-editor-arg=-nographics --reruncount=1 --testfilter=WhenManyObjectsAreSpawnedAtOnce_AllAreReceived --clean-library-on-rerun
   artifacts:
     logs:
       paths:

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectSpawnManyObjectsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectSpawnManyObjectsTests.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using NUnit.Framework;
 using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
 using UnityEngine.TestTools;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectSpawnManyObjectsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectSpawnManyObjectsTests.cs
@@ -47,19 +47,23 @@ namespace Unity.Netcode.RuntimeTests
         }
 
         [UnityTest]
-        // When this test fails it does so without an exception and will wait the default ~6 minutes
-        [Timeout(360000)] // Tracked in MTT-11360
         public IEnumerator WhenManyObjectsAreSpawnedAtOnce_AllAreReceived()
         {
+            var timeStarted = Time.realtimeSinceStartup;
             for (int x = 0; x < k_SpawnedObjects; x++)
             {
                 NetworkObject serverObject = Object.Instantiate(m_PrefabToSpawn.Prefab).GetComponent<NetworkObject>();
                 serverObject.NetworkManagerOwner = m_ServerNetworkManager;
                 serverObject.Spawn();
             }
+
+            var timeSpawned = Time.realtimeSinceStartup - timeStarted;
+            // Provide plenty of time to spawn all 1500 objects in case the CI VM is running slow
+            var timeoutHelper = new TimeoutHelper(30);
             // ensure all objects are replicated
-            yield return WaitForConditionOrTimeOut(() => SpawnObjecTrackingComponent.SpawnedObjects == k_SpawnedObjects);
-            AssertOnTimeout($"Timed out waiting for the client to spawn {k_SpawnedObjects} objects!");
+            yield return WaitForConditionOrTimeOut(() => SpawnObjecTrackingComponent.SpawnedObjects == k_SpawnedObjects, timeoutHelper);
+
+            AssertOnTimeout($"Timed out waiting for the client to spawn {k_SpawnedObjects} objects! Time to spawn: {timeSpawned} | Time to timeout: {timeStarted - Time.realtimeSinceStartup}", timeoutHelper);
         }
     }
 }


### PR DESCRIPTION
Starting investigation with MTT-8973 I noted that it relates to MTT-11360 and this specific test (WhenManyObjectsAreSpawnedAtOnce_AllAreReceived) was updated in develop-2.0.0 branch to account for this timeout.

This PR aims to update the test on develop branch to the same definition which will allow to remove the [Timeout] parameter and fix both pointed tickets

## Backport
As this issue exists only in develop branch (NGOv1.X) no backport is needed