### PR TITLE
fix: distributable or sessionowner flag always defaults for in-scene placed NetworkObjects

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -13,6 +13,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where root level in-scene placed `NetworkObject`s would only allow the ownership permission to be no less than distributable or sessionowner. (#3407)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -1195,16 +1195,13 @@ namespace Unity.Netcode
                         }
                         else if (!NetworkManager.ShutdownInProgress)
                         {
-                            // DANGO-TODO: We will want to match how the CMB service handles this. For now, we just try to evenly distribute
-                            // ownership.
-                            // NOTE: All of the below code only handles ownership transfer.
+                            // NOTE: All of the below code only handles ownership transfer
                             // For client-server, we just remove the ownership.
-                            // For distributed authority, we need to change ownership based on parenting
+                            // For distributed authority (DAHost only), we only transfer objects that are not parented or belong to the session owner.
+                            // Rust server handles the object redistribution on its end.
                             if (NetworkManager.DistributedAuthorityMode)
                             {
-                                // Only NetworkObjects that have the OwnershipStatus.Distributable flag set and are not OwnershipSessionOwner are distributed.
-                                // If the object has a parent - skip it for now, it will be distributed when its root parent is distributed.
-                                if (!ownedObject.IsOwnershipDistributable || ownedObject.IsOwnershipSessionOwner || ownedObject.GetCachedParent())
+                                if (ownedObject.IsOwnershipSessionOwner || ownedObject.GetCachedParent())
                                 {
                                     continue;
                                 }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -325,15 +325,6 @@ namespace Unity.Netcode
 
                 // Default scene migration synchronization to false for in-scene placed NetworkObjects
                 SceneMigrationSynchronization = false;
-
-                // Root In-scene placed NetworkObjects have to either have the SessionOwner or Distributable permission flag set.
-                if (transform.parent == null)
-                {
-                    if (!Ownership.HasFlag(OwnershipStatus.SessionOwner) && !Ownership.HasFlag(OwnershipStatus.Distributable))
-                    {
-                        Ownership |= OwnershipStatus.Distributable;
-                    }
-                }
             }
         }
 #endif // UNITY_EDITOR


### PR DESCRIPTION
This PR removes the opinionated restrictions to permissions with in-scene placed NetworkObjects and matches the DAHost redistribution logic to mirror the rust server's when a client disconnects.

[MTT-11973](https://jira.unity3d.com/browse/MTT-11973)

## Changelog

- Fixed: Issue where root level in-scene placed `NetworkObject`s would only allow the ownership permission to be no less than distributable or sessionowner.

## Testing and Documentation

- No tests have been added (requires manually testing in-editor)
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Backport

No backport is needed since this is a distributed authority specific fix.