### PR TITLE
ci: Improving trigger jobs coverage

### DIFF
--- a/.yamato/_run-all.yml
+++ b/.yamato/_run-all.yml
@@ -10,6 +10,13 @@
 
 #-----------------------------------------------------------------------------------
 
+# This job runs the fastest checks (PVP and code standards)
+# This is mainly used to quickly validate the easy mistakes before for example running PR trigger jobs (see _triggers.yml)
+run_quick_checks:
+  name: Run Quick Initial Checks
+  dependencies:
+    - .yamato/package-pack.yml#package_pack_-_ngo_ubuntu
+    - .yamato/project-standards.yml#standards_win_testproject_trunk
 
 # Runs all package tests
 run_all_package_tests:

--- a/.yamato/_run-all.yml
+++ b/.yamato/_run-all.yml
@@ -16,7 +16,7 @@ run_quick_checks:
   name: Run Quick Initial Checks
   dependencies:
     - .yamato/package-pack.yml#package_pack_-_ngo_ubuntu
-    - .yamato/project-standards.yml#standards_win_testproject_trunk
+    - .yamato/project-standards.yml#standards_ubuntu_testproject_trunk
 
 # Runs all package tests
 run_all_package_tests:

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -103,9 +103,6 @@ develop_nightly:
     # Build player for webgl platform on trunk and 2021 editors
     - .yamato/project-updated-dependencies-test.yml#updated-dependencies_testproject_NGO_ubuntu_trunk
     - .yamato/project-updated-dependencies-test.yml#updated-dependencies_testproject_NGO_win_2021.3
-    # Clean import test
-    - .yamato/clean-import-job.yml#clean_import_testproject_trunk
-    - .yamato/clean-import-job.yml#clean_import_testproject_2021.3
 
 
 # Run all tests on weekly bases

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -78,7 +78,7 @@ develop_nightly:
         rerun: always
   dependencies:
     # Run project standards to verify package/default project
-    - .yamato/project-standards.yml#standards_win_testproject_trunk
+    - .yamato/project-standards.yml#standards_ubuntu_testproject_trunk
     - .yamato/project-standards.yml#standards_ubuntu_testproject_2021.3
     # Run APV jobs to make sure the change won't break any dependants
     - .yamato/wrench/preview-a-p-v.yml#all_preview_apv_jobs

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -53,7 +53,7 @@ pull_request_trigger:
     # Run project EditMode and PLaymode project tests on minimum supported editor (2021.3 in case of NGOv1.X)
     - .yamato/_run-all.yml#run_all_project_tests_2021
     # Run one standalone test to make sure there are no obvious issues with most common platform (for example --fail-on-assert option is not present with package/project tests). We run 2 different combinations (platform/editor)
-    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_win_il2cpp_trunk
+    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_mac_il2cpp_trunk
     - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_win_mono_2021.3
   triggers:
     cancel_old_ci: true

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -39,6 +39,7 @@
 #-----------------------------------------------------------------------------------
 
 # Run all relevant tasks when a pull request targeting the develop or release branch is created or updated.
+# In order to have better coverage we run desktop standalone tests with different configurations which allows to mostly cover for different platforms, scripting backends and editor versions.
 pull_request_trigger:
   name: Pull Request Trigger (develop, develop-2.0.0, & release branches)
   dependencies:
@@ -52,7 +53,7 @@ pull_request_trigger:
     - .yamato/_run-all.yml#run_all_project_tests_trunk
     # Run project EditMode and PLaymode project tests on minimum supported editor (2021.3 in case of NGOv1.X)
     - .yamato/_run-all.yml#run_all_project_tests_2021
-    # Run one standalone test to make sure there are no obvious issues with most common platform (for example --fail-on-assert option is not present with package/project tests). We run 2 different combinations (platform/editor)
+    # Run standalone test with mixture of parameters to make sure there are no obvious issues with most common platform (for example --fail-on-assert option is not present with package/project tests). We run 2 different combinations with different platform/editor/scripting backend.
     - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_mac_il2cpp_trunk
     - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_win_mono_2021.3
   triggers:
@@ -78,7 +79,7 @@ develop_nightly:
         rerun: always
   dependencies:
     # Run project standards to verify package/default project
-    - .yamato/project-standards.yml#standards_ubuntu_testproject_trunk
+    - .yamato/project-standards.yml#standards_win_testproject_trunk
     - .yamato/project-standards.yml#standards_ubuntu_testproject_2021.3
     # Run APV jobs to make sure the change won't break any dependants
     - .yamato/wrench/preview-a-p-v.yml#all_preview_apv_jobs

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -40,11 +40,10 @@
 
 # Run all relevant tasks when a pull request targeting the develop or release branch is created or updated.
 # In order to have better coverage we run desktop standalone tests with different configurations which allows to mostly cover for different platforms, scripting backends and editor versions.
+# Since standards job is a part of initial checks it's not present as direct dependency here
 pull_request_trigger:
   name: Pull Request Trigger (develop, develop-2.0.0, & release branches)
   dependencies:
-    # Run project standards to verify package/default project. This is fine to just run for trunk
-    - .yamato/project-standards.yml#standards_ubuntu_testproject_trunk
     # Run package EditMode and Playmode package tests on trunk
     - .yamato/_run-all.yml#run_all_package_tests_trunk
     # Run package EditMode and Playmode package tests on minimum supported editor (2021.3 in case of NGOv1.X)

--- a/.yamato/package-tests.yml
+++ b/.yamato/package-tests.yml
@@ -54,6 +54,7 @@ package_test_-_ngo_{{ editor }}_{{ platform.name }}:
         - "upm-ci~/test-results/**/*"
         - "pvp-results/*"
   dependencies:
+    - .yamato/_run-all.yml#run_quick_checks # initial checks to perform fast validation of common errors
     - .yamato/package-pack.yml#package_pack_-_ngo_{{ platform.name }}
 {% endfor -%}
 {% endfor -%}

--- a/.yamato/project-pack.yml
+++ b/.yamato/project-pack.yml
@@ -35,6 +35,8 @@ project_pack_-_{{ project.name }}_{{ platform.name }}:
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm # upm-ci is not preinstalled on the image so we need to download it
     - upm-ci project pack --project-path {{ project.path }}
+  dependencies:
+    - .yamato/_run-all.yml#run_quick_checks # initial checks to perform fast validation of common errors
   artifacts:
     packages:
       paths:

--- a/.yamato/project-standards.yml
+++ b/.yamato/project-standards.yml
@@ -28,7 +28,7 @@
 #------------------------------------------------------------------------------------
   
 {% for project in projects.all -%}
-{% for platform in test_platforms.default -%}
+{% for platform in test_platforms.all -%}
 {% for editor in validation_editors.all -%}
 standards_{{ platform.name }}_{{ project.name }}_{{ editor }}:
   name: Standards Check - NGO {{ project.name }} [{{ platform.name }}, {{ editor }}]

--- a/.yamato/project-standards.yml
+++ b/.yamato/project-standards.yml
@@ -28,7 +28,7 @@
 #------------------------------------------------------------------------------------
   
 {% for project in projects.all -%}
-{% for platform in test_platforms.desktop -%}
+{% for platform in test_platforms.default -%}
 {% for editor in validation_editors.all -%}
 standards_{{ platform.name }}_{{ project.name }}_{{ editor }}:
   name: Standards Check - NGO {{ project.name }} [{{ platform.name }}, {{ editor }}]

--- a/.yamato/project-standards.yml
+++ b/.yamato/project-standards.yml
@@ -28,7 +28,7 @@
 #------------------------------------------------------------------------------------
   
 {% for project in projects.all -%}
-{% for platform in test_platforms.all -%}
+{% for platform in test_platforms.desktop -%}
 {% for editor in validation_editors.all -%}
 standards_{{ platform.name }}_{{ project.name }}_{{ editor }}:
   name: Standards Check - NGO {{ project.name }} [{{ platform.name }}, {{ editor }}]


### PR DESCRIPTION
This PR aims to fix an oversight of having invalid dependency in Nightly trigger as well as adding more variations to PR trigger job.

Additionally it introduces _**run_quick_checks**_  job that was added as a requirement for package_pack and project_pack jobs. It will run as a first check (also on PR trigger) to catch any basic errors (PVP and project standards) and ONLY IF this job will pass, the rest of PR trigger job dependencies will be executed.
This way provides faster feedback loop for developers and allow to minimize resource usage when unnecessary

Failing result may look like this
![image](https://github.com/user-attachments/assets/bc89acc7-1fad-4330-92df-407bef45c308)
Where we can see that many jobs failed but in reality we can see that only PVP jobs failed and others were never executed and failed due to their dependencies

## Backport
This is specific change to develop branch but it's somewhat reflected in https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3409