### PR TITLE
fix: [Backport] NetworkBehaviour and NetworkVariable length safety checks

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -16,6 +16,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issues with the `NetworkBehaviour` and `NetworkVariable` length safety checks. (#3415)
 - Fixed issue where during a `NetworkObject`'s spawn if you instantiated, spawned, and parented another network prefab under the currently spawning `NetworkObject` the parenting message would not properly defer until the parent `NetworkObject` was spawned. (#3403)
 - Fixed issue where in-scene placed `NetworkObjects` could fail to synchronize its transform properly (especially without a `NetworkTransform`) if their parenting changes from the default when the scene is loaded and if the same scene remains loaded between network sessions while the parenting is completely different from the original hierarchy. (#3388)
 - Fixed an issue in `UnityTransport` where the transport would accept sends on invalid connections, leading to a useless memory allocation and confusing error message. (#3383)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -1112,49 +1112,33 @@ namespace Unity.Netcode
         /// </remarks>
         internal void WriteNetworkVariableData(FastBufferWriter writer, ulong targetClientId)
         {
-            if (NetworkVariableFields.Count == 0)
+            foreach (var field in NetworkVariableFields)
             {
-                return;
-            }
-
-            for (int j = 0; j < NetworkVariableFields.Count; j++)
-            {
-
-                if (NetworkVariableFields[j].CanClientRead(targetClientId))
+                if (field.CanClientRead(targetClientId))
                 {
                     if (NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
                     {
                         var writePos = writer.Position;
                         // Note: This value can't be packed because we don't know how large it will be in advance
-                        // we reserve space for it, then write the data, then come back and fill in the space
-                        // to pack here, we'd have to write data to a temporary buffer and copy it in - which
-                        // isn't worth possibly saving one byte if and only if the data is less than 63 bytes long...
-                        // The way we do packing, any value > 63 in a ushort will use the full 2 bytes to represent.
-                        writer.WriteValueSafe((ushort)0);
+                        writer.WriteValueSafe(0);
                         var startPos = writer.Position;
                         // Write the NetworkVariable field value
-                        // WriteFieldSynchronization will write the current value only if there are no pending changes.
-                        // Otherwise, it will write the previous value if there are pending changes since the pending
-                        // changes will be sent shortly after the client's synchronization.
-                        NetworkVariableFields[j].WriteFieldSynchronization(writer);
+                        field.WriteFieldSynchronization(writer);
                         var size = writer.Position - startPos;
                         writer.Seek(writePos);
-                        writer.WriteValueSafe((ushort)size);
+                        writer.WriteValueSafe(size);
                         writer.Seek(startPos + size);
                     }
                     else
                     {
                         // Write the NetworkVariable field value
-                        // WriteFieldSynchronization will write the current value only if there are no pending changes.
-                        // Otherwise, it will write the previous value if there are pending changes since the pending
-                        // changes will be sent shortly after the client's synchronization.
-                        NetworkVariableFields[j].WriteFieldSynchronization(writer);
+                        field.WriteFieldSynchronization(writer);
                     }
                 }
                 else // Only if EnsureNetworkVariableLengthSafety, otherwise just skip
                 if (NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
                 {
-                    writer.WriteValueSafe((ushort)0);
+                    writer.WriteValueSafe(0);
                 }
             }
         }
@@ -1169,51 +1153,37 @@ namespace Unity.Netcode
         /// </remarks>
         internal void SetNetworkVariableData(FastBufferReader reader, ulong clientId)
         {
-            if (NetworkVariableFields.Count == 0)
+            foreach (var field in NetworkVariableFields)
             {
-                return;
-            }
-
-            for (int j = 0; j < NetworkVariableFields.Count; j++)
-            {
-                var varSize = (ushort)0;
+                int expectedBytesToRead = 0;
                 var readStartPos = 0;
                 if (NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
                 {
-                    reader.ReadValueSafe(out varSize);
-                    if (varSize == 0)
+                    reader.ReadValueSafe(out expectedBytesToRead);
+                    if (expectedBytesToRead == 0)
                     {
                         continue;
                     }
                     readStartPos = reader.Position;
                 }
                 else // If the client cannot read this field, then skip it
-                if (!NetworkVariableFields[j].CanClientRead(clientId))
+                if (!field.CanClientRead(clientId))
                 {
                     continue;
                 }
 
-                NetworkVariableFields[j].ReadField(reader);
+                field.ReadField(reader);
 
                 if (NetworkManager.NetworkConfig.EnsureNetworkVariableLengthSafety)
                 {
-                    if (reader.Position > (readStartPos + varSize))
+                    var totalBytesRead = reader.Position - readStartPos;
+                    if (totalBytesRead != expectedBytesToRead)
                     {
-                        if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
+                        if (NetworkManager.LogLevel <= LogLevel.Normal)
                         {
-                            NetworkLog.LogWarning($"Var data read too far. {reader.Position - (readStartPos + varSize)} bytes.");
+                            NetworkLog.LogWarning($"[{name}][NetworkObjectId: {NetworkObjectId}][NetworkBehaviourId: {NetworkBehaviourId}][{field.Name}] NetworkVariable read {totalBytesRead} bytes but was expected to read {expectedBytesToRead} bytes during synchronization deserialization!");
                         }
-
-                        reader.Seek(readStartPos + varSize);
-                    }
-                    else if (reader.Position < (readStartPos + varSize))
-                    {
-                        if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
-                        {
-                            NetworkLog.LogWarning($"Var data read too little. {(readStartPos + varSize) - reader.Position} bytes.");
-                        }
-
-                        reader.Seek(readStartPos + varSize);
+                        reader.Seek(readStartPos + expectedBytesToRead);
                     }
                 }
             }
@@ -1295,7 +1265,7 @@ namespace Unity.Netcode
                 // Save our position where we will write the final size being written so we can skip over it in the
                 // event an exception occurs when deserializing.
                 var sizePosition = writer.Position;
-                writer.WriteValueSafe((ushort)0);
+                writer.WriteValueSafe(0);
 
                 // Save our position before synchronizing to determine how much was written
                 var positionBeforeSynchronize = writer.Position;
@@ -1333,7 +1303,7 @@ namespace Unity.Netcode
                     // Write the number of bytes serialized to handle exceptions on the deserialization side
                     var bytesWritten = finalPosition - positionBeforeSynchronize;
                     writer.Seek(sizePosition);
-                    writer.WriteValueSafe((ushort)bytesWritten);
+                    writer.WriteValueSafe(bytesWritten);
                     writer.Seek(finalPosition);
                 }
                 return true;
@@ -1342,7 +1312,7 @@ namespace Unity.Netcode
             {
                 var reader = serializer.GetFastBufferReader();
                 // We will always read the expected byte count
-                reader.ReadValueSafe(out ushort expectedBytesToRead);
+                reader.ReadValueSafe(out int expectedBytesToRead);
 
                 // Save our position before we begin synchronization deserialization
                 var positionBeforeSynchronize = reader.Position;

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
@@ -108,11 +108,15 @@ namespace Unity.Netcode
                 }
 
                 // Now, reset all the no-longer-dirty variables
-                foreach (var dirtyobj in m_DirtyNetworkObjects)
+                foreach (var dirtyObj in m_DirtyNetworkObjects)
                 {
-                    dirtyobj.PostNetworkVariableWrite(forceSend);
+                    foreach (var behaviour in dirtyObj.ChildNetworkBehaviours)
+                    {
+                        behaviour.PostNetworkVariableWrite(forceSend);
+                    }
+
                     // Once done processing, we set the previous owner id to the current owner id
-                    dirtyobj.PreviousOwnerId = dirtyobj.OwnerClientId;
+                    dirtyObj.PreviousOwnerId = dirtyObj.OwnerClientId;
                 }
                 m_DirtyNetworkObjects.Clear();
             }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1476,16 +1476,6 @@ namespace Unity.Netcode
             }
         }
 
-        internal void WriteNetworkVariableData(FastBufferWriter writer, ulong targetClientId)
-        {
-            for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
-            {
-                var behavior = ChildNetworkBehaviours[i];
-                behavior.InitializeVariables();
-                behavior.WriteNetworkVariableData(writer, targetClientId);
-            }
-        }
-
         internal void MarkVariablesDirty(bool dirty)
         {
             for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
@@ -1525,18 +1515,6 @@ namespace Unity.Netcode
             }
         }
 
-        /// <summary>
-        /// Only invoked during first synchronization of a NetworkObject (late join or newly spawned)
-        /// </summary>
-        internal void SetNetworkVariableData(FastBufferReader reader, ulong clientId)
-        {
-            for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
-            {
-                var behaviour = ChildNetworkBehaviours[i];
-                behaviour.InitializeVariables();
-                behaviour.SetNetworkVariableData(reader, clientId);
-            }
-        }
 
         internal ushort GetNetworkBehaviourOrderIndex(NetworkBehaviour instance)
         {
@@ -1744,14 +1722,6 @@ namespace Unity.Netcode
             }
         }
 
-        internal void PostNetworkVariableWrite(bool forceSend)
-        {
-            for (int k = 0; k < ChildNetworkBehaviours.Count; k++)
-            {
-                ChildNetworkBehaviours[k].PostNetworkVariableWrite(forceSend);
-            }
-        }
-
         /// <summary>
         /// Handles synchronizing NetworkVariables and custom synchronization data for NetworkBehaviours.
         /// </summary>
@@ -1769,7 +1739,12 @@ namespace Unity.Netcode
                 var sizeToSkipCalculationPosition = writer.Position;
 
                 // Synchronize NetworkVariables
-                WriteNetworkVariableData(writer, targetClientId);
+                foreach (var behavior in ChildNetworkBehaviours)
+                {
+                    behavior.InitializeVariables();
+                    behavior.WriteNetworkVariableData(writer, targetClientId);
+                }
+
                 // Reserve the NetworkBehaviour synchronization count position
                 var networkBehaviourCountPosition = writer.Position;
                 writer.WriteValueSafe((byte)0);
@@ -1803,23 +1778,35 @@ namespace Unity.Netcode
             else
             {
                 var reader = serializer.GetFastBufferReader();
-
                 reader.ReadValueSafe(out ushort sizeOfSynchronizationData);
                 var seekToEndOfSynchData = reader.Position + sizeOfSynchronizationData;
-                // Apply the network variable synchronization data
-                SetNetworkVariableData(reader, targetClientId);
-                // Read the number of NetworkBehaviours to synchronize
-                reader.ReadValueSafe(out byte numberSynchronized);
-                var networkBehaviourId = (ushort)0;
 
-                // If a NetworkBehaviour writes synchronization data, it will first
-                // write its NetworkBehaviourId so when deserializing the client-side
-                // can find the right NetworkBehaviour to deserialize the synchronization data.
-                for (int i = 0; i < numberSynchronized; i++)
+                try
                 {
-                    serializer.SerializeValue(ref networkBehaviourId);
-                    var networkBehaviour = GetNetworkBehaviourAtOrderIndex(networkBehaviourId);
-                    networkBehaviour.Synchronize(ref serializer, targetClientId);
+                    // Apply the network variable synchronization data
+                    foreach (var behaviour in ChildNetworkBehaviours)
+                    {
+                        behaviour.InitializeVariables();
+                        behaviour.SetNetworkVariableData(reader, targetClientId);
+                    }
+
+                    // Read the number of NetworkBehaviours to synchronize
+                    reader.ReadValueSafe(out byte numberSynchronized);
+                    var networkBehaviourId = (ushort)0;
+
+                    // If a NetworkBehaviour writes synchronization data, it will first
+                    // write its NetworkBehaviourId so when deserializing the client-side
+                    // can find the right NetworkBehaviour to deserialize the synchronization data.
+                    for (int i = 0; i < numberSynchronized; i++)
+                    {
+                        serializer.SerializeValue(ref networkBehaviourId);
+                        var networkBehaviour = GetNetworkBehaviourAtOrderIndex(networkBehaviourId);
+                        networkBehaviour.Synchronize(ref serializer, targetClientId);
+                    }
+                }
+                catch
+                {
+                    reader.Seek(seekToEndOfSynchData);
                 }
             }
         }
@@ -1916,7 +1903,7 @@ namespace Unity.Netcode
                 try
                 {
                     // If we failed to load this NetworkObject, then skip past the Network Variable and (if any) synchronization data
-                    reader.ReadValueSafe(out ushort networkBehaviourSynchronizationDataLength);
+                    reader.ReadValueSafe(out int networkBehaviourSynchronizationDataLength);
                     reader.Seek(reader.Position + networkBehaviourSynchronizationDataLength);
                 }
                 catch (Exception ex)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1735,7 +1735,7 @@ namespace Unity.Netcode
             {
                 var writer = serializer.GetFastBufferWriter();
                 var positionBeforeSynchronizing = writer.Position;
-                writer.WriteValueSafe((ushort)0);
+                writer.WriteValueSafe(0);
                 var sizeToSkipCalculationPosition = writer.Position;
 
                 // Synchronize NetworkVariables
@@ -1766,7 +1766,7 @@ namespace Unity.Netcode
                 // synchronization.
                 writer.Seek(positionBeforeSynchronizing);
                 // We want the size of everything after our size to skip calculation position
-                var size = (ushort)(currentPosition - sizeToSkipCalculationPosition);
+                var size = currentPosition - sizeToSkipCalculationPosition;
                 writer.WriteValueSafe(size);
                 // Write the number of NetworkBehaviours synchronized
                 writer.Seek(networkBehaviourCountPosition);
@@ -1778,7 +1778,7 @@ namespace Unity.Netcode
             else
             {
                 var reader = serializer.GetFastBufferReader();
-                reader.ReadValueSafe(out ushort sizeOfSynchronizationData);
+                reader.ReadValueSafe(out int sizeOfSynchronizationData);
                 var seekToEndOfSynchData = reader.Position + sizeOfSynchronizationData;
 
                 try
@@ -1792,14 +1792,13 @@ namespace Unity.Netcode
 
                     // Read the number of NetworkBehaviours to synchronize
                     reader.ReadValueSafe(out byte numberSynchronized);
-                    var networkBehaviourId = (ushort)0;
 
                     // If a NetworkBehaviour writes synchronization data, it will first
                     // write its NetworkBehaviourId so when deserializing the client-side
                     // can find the right NetworkBehaviour to deserialize the synchronization data.
                     for (int i = 0; i < numberSynchronized; i++)
                     {
-                        serializer.SerializeValue(ref networkBehaviourId);
+                        reader.ReadValueSafe(out ushort networkBehaviourId);
                         var networkBehaviour = GetNetworkBehaviourAtOrderIndex(networkBehaviourId);
                         networkBehaviour.Synchronize(ref serializer, targetClientId);
                     }

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
@@ -97,7 +97,7 @@ namespace Unity.Netcode
             if (!m_NetworkBehaviour.NetworkObject.NetworkManagerOwner)
             {
                 // Exit early if there has yet to be a NetworkManagerOwner assigned
-                // to the NetworkObject. This is ok because Initialize is invoked 
+                // to the NetworkObject. This is ok because Initialize is invoked
                 // multiple times until it is considered "initialized".
                 return;
             }
@@ -374,7 +374,7 @@ namespace Unity.Netcode
         /// This should be always invoked (client & server) to assure the previous values are set
         /// !! IMPORTANT !!
         /// When a server forwards delta updates to connected clients, it needs to preserve the previous dirty value(s)
-        /// until it is done serializing all valid NetworkVariable field deltas (relative to each client). This is invoked 
+        /// until it is done serializing all valid NetworkVariable field deltas (relative to each client). This is invoked
         /// after it is done forwarding the deltas at the end of the <see cref="NetworkVariableDeltaMessage.Handle(ref NetworkContext)"/> method.
         /// </summary>
         internal virtual void PostDeltaRead()
@@ -382,12 +382,16 @@ namespace Unity.Netcode
         }
 
         /// <summary>
+        /// WriteFieldSynchronization will write the current value only if there are no pending changes.
+        /// Otherwise, it will write the previous value if there are pending changes since the pending
+        /// changes will be sent shortly after the client's synchronization.
+        /// <br/><br/>
         /// There are scenarios, specifically with collections, where a client could be synchronizing and
         /// some NetworkVariables have pending updates. To avoid duplicating entries, this is invoked only
         /// when sending the full synchronization information.
         /// </summary>
         /// <remarks>
-        /// Derrived classes should send the previous value for synchronization so when the updated value
+        /// Derived classes should send the previous value for synchronization so when the updated value
         /// is sent (after synchronizing the client) it will apply the updates.
         /// </remarks>
         /// <param name="writer"></param>

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -1467,6 +1467,21 @@ namespace Unity.Netcode.TestHelpers.Runtime
         }
 
         /// <summary>
+        /// Validation for clients connected.
+        /// </summary>
+        private bool CheckClientsConnected(NetworkManager[] clientsToCheck)
+        {
+            if (clientsToCheck.Any(client => !client.IsConnectedClient))
+            {
+                return false;
+            }
+            var expectedCount = m_ServerNetworkManager.IsHost ? clientsToCheck.Length + 1 : clientsToCheck.Length;
+            var currentCount = m_ServerNetworkManager.ConnectedClients.Count;
+
+            return currentCount == expectedCount;
+        }
+
+        /// <summary>
         /// Validates that all remote clients (i.e. non-server) detect they are connected
         /// to the server and that the server reflects the appropriate number of clients
         /// have connected or it will time out.
@@ -1475,11 +1490,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// <returns>An IEnumerator for use with Unity's coroutine system.</returns>
         protected IEnumerator WaitForClientsConnectedOrTimeOut(NetworkManager[] clientsToCheck)
         {
-            var remoteClientCount = clientsToCheck.Length;
-            var serverClientCount = m_ServerNetworkManager.IsHost ? remoteClientCount + 1 : remoteClientCount;
-
-            yield return WaitForConditionOrTimeOut(() => clientsToCheck.Where((c) => c.IsConnectedClient).Count() == remoteClientCount &&
-                                                         m_ServerNetworkManager.ConnectedClients.Count == serverClientCount);
+            yield return WaitForConditionOrTimeOut(() => CheckClientsConnected(clientsToCheck));
         }
 
         /// <summary>
@@ -1492,11 +1503,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// <returns>True if all clients are connected within the specified number of frames; otherwise, false.</returns>
         protected bool WaitForClientsConnectedOrTimeOutWithTimeTravel(NetworkManager[] clientsToCheck)
         {
-            var remoteClientCount = clientsToCheck.Length;
-            var serverClientCount = m_ServerNetworkManager.IsHost ? remoteClientCount + 1 : remoteClientCount;
-
-            return WaitForConditionOrTimeOutWithTimeTravel(() => clientsToCheck.Where((c) => c.IsConnectedClient).Count() == remoteClientCount &&
-                                                                 m_ServerNetworkManager.ConnectedClients.Count == serverClientCount);
+            return WaitForConditionOrTimeOutWithTimeTravel(() => CheckClientsConnected(clientsToCheck));
         }
         /// <summary>
         /// Overloaded method that just passes in all clients to

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTestsHelperTypes.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariableTestsHelperTypes.cs
@@ -889,12 +889,12 @@ namespace Unity.Netcode.RuntimeTests
 
     public class TemplateNetworkBehaviourType<T> : NetworkBehaviour
     {
-        public NetworkVariable<T> TheVar;
+        public NetworkVariable<T> TheVar = new NetworkVariable<T>();
     }
 
     public class IntermediateNetworkBehavior<T> : TemplateNetworkBehaviourType<T>
     {
-        public NetworkVariable<T> TheVar2;
+        public NetworkVariable<T> TheVar2 = new NetworkVariable<T>();
     }
 
     public class ClassHavingNetworkBehaviour : IntermediateNetworkBehavior<TestClass>


### PR DESCRIPTION
<!-- Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->
[MTTB-1080](https://jira.unity3d.com/browse/MTTB-1080)

1.x for #3335 

## Changelog

- Fixed: NetworkBehaviour length safety checks use `int` instead of `ushort`
- Fixed: NetworkVariable `EnsureNetworkVariableLengthSafety` checks use `int` instead of `ushort`

## Testing and Documentation

- No tests have been added.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Backport

<!-- If this is a backport:
 - Add the following to the PR title: "\[Backport\] ..." .
 - Link to the original PR.
If this needs a backport - state this here
If a backport is not needed please provide the reason why.
If the "Backports" section is not present it will lead to a CI test failure. 
-->

This is a backport of #3405 