### PR TITLE
chore: [Backport] Add test for unregistering custom message handlers

### DIFF
--- a/pvpExceptions.json
+++ b/pvpExceptions.json
@@ -860,6 +860,7 @@
           "Unity.Netcode.RuntimeTests.NamedMessageTests: IEnumerator WhenSendingNamedMessageToAll_AllClientsReceiveIt(): undocumented",
           "Unity.Netcode.RuntimeTests.NamedMessageTests: void WhenSendingNamedMessageToNullClientList_ArgumentNullExceptionIsThrown(): undocumented",
           "Unity.Netcode.RuntimeTests.NamedMessageTests: void ErrorMessageIsPrintedWhenAttemptingToSendNamedMessageWithTooBigBuffer(): undocumented",
+          "Unity.Netcode.RuntimeTests.NamedMessageTests: void NamedMessageHandlerIsUnregisteredWithoutException(): undocumented",
           "Unity.Netcode.RuntimeTests.UnnamedMessageTests: undocumented",
           "Unity.Netcode.RuntimeTests.UnnamedMessageTests: NumberOfClients: undocumented",
           "Unity.Netcode.RuntimeTests.UnnamedMessageTests: IEnumerator UnnamedMessageIsReceivedOnClientWithContent(): undocumented",


### PR DESCRIPTION
<!-- Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->
[MTTB-1229](https://jira.unity3d.com/browse/MTTB-1229)

## Changelog

- Added: A test for unregistering named message handlers within the handler itself

## Testing and Documentation

- Includes a unit test.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Backport

<!-- If this is a backport:
 - Add the following to the PR title: "\[Backport\] ..." .
 - Link to the original PR.
If this needs a backport - state this here
If a backport is not needed please provide the reason why.
If the "Backports" section is not present it will lead to a CI test failure. 
-->
Backport of #3417 