### PR TITLE
fix: tools metrics dispatcher related memory leak

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -13,6 +13,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed memory leaks when domain reload is disabled. (#3427)
 - Fixed an exception being thrown when unregistering a custom message handler from within the registered callback. (#3417)
 
 ### Changed

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1629,6 +1629,10 @@ namespace Unity.Netcode
             {
                 Singleton = null;
             }
+
+#if UNITY_EDITOR
+            EditorApplication.playModeStateChanged -= ModeChanged;
+#endif
         }
 
         // Command line options


### PR DESCRIPTION
playModeStateChanged never gets unsubscribed in NetworkManager and keeps Multiplayer Tools MetricsDispatcher instances alive through NetworkMetrics when domain reload is disabled.

Jira ticket: [MTT-11638](https://jira.unity3d.com/browse/MTT-11638)

## Changelog

- Fixed: Memory leaks when domain reload is disabled.

## Testing and Documentation

- No tests have been added.

## Backport

Requires backport to v1.x. (#3428)