### PR TITLE
fix: tools metrics dispatcher related memory leak [Backport]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -16,6 +16,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed: Memory leaks when domain reload is disabled. (#3428)
 - Fixed issue where during a `NetworkObject`'s spawn if you instantiated, spawned, and parented another network prefab under the currently spawning `NetworkObject` the parenting message would not properly defer until the parent `NetworkObject` was spawned. (#3403)
 - Fixed issue where in-scene placed `NetworkObjects` could fail to synchronize its transform properly (especially without a `NetworkTransform`) if their parenting changes from the default when the scene is loaded and if the same scene remains loaded between network sessions while the parenting is completely different from the original hierarchy. (#3388)
 - Fixed an issue in `UnityTransport` where the transport would accept sends on invalid connections, leading to a useless memory allocation and confusing error message. (#3383)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -16,7 +16,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed: Memory leaks when domain reload is disabled. (#3428)
+- Fixed memory leaks when domain reload is disabled. (#3428)
 - Fixed issue where during a `NetworkObject`'s spawn if you instantiated, spawned, and parented another network prefab under the currently spawning `NetworkObject` the parenting message would not properly defer until the parent `NetworkObject` was spawned. (#3403)
 - Fixed issue where in-scene placed `NetworkObjects` could fail to synchronize its transform properly (especially without a `NetworkTransform`) if their parenting changes from the default when the scene is loaded and if the same scene remains loaded between network sessions while the parenting is completely different from the original hierarchy. (#3388)
 - Fixed an issue in `UnityTransport` where the transport would accept sends on invalid connections, leading to a useless memory allocation and confusing error message. (#3383)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1303,6 +1303,9 @@ namespace Unity.Netcode
             {
                 Singleton = null;
             }
+#if UNITY_EDITOR
+            EditorApplication.playModeStateChanged -= ModeChanged;
+#endif            
         }
 
         // Command line options


### PR DESCRIPTION
playModeStateChanged never gets unsubscribed in NetworkManager and keeps Multiplayer Tools MetricsDispatcher instances alive through NetworkMetrics when domain reload is disabled.

Jira ticket: [MTT-11638](https://jira.unity3d.com/browse/MTT-11638)

## Changelog

- Fixed: Memory leaks when domain reload is disabled.

## Testing and Documentation

- No tests have been added.

## Backport

This is a backport of #3427