### PR TITLE
ci: Changed standalone tests trigger on PRs to use only Ubuntu

### DIFF
--- a/.yamato/_run-all.yml
+++ b/.yamato/_run-all.yml
@@ -138,11 +138,11 @@ run_all_webgl_builds_6000:
   name: Run All WebGl Build [6000.0]
   dependencies:
 {% for project in projects.default -%}
-{% if platform.name != "mac" -%} # There is an error about "Light baking could not be started because no valid OpenCL device could be found". Tracked in MTT-11726
 {% for platform in test_platforms.desktop -%}
+{% if platform.name != "mac" -%} # There is an error about "Light baking could not be started because no valid OpenCL device could be found". Tracked in MTT-11726
     - .yamato/webgl-build.yml#webgl_build_{{ project.name }}_{{ platform.name }}_6000.0
-{% endfor -%}
 {% endif -%}
+{% endfor -%}
 {% endfor -%}
 
 

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -47,7 +47,7 @@ pull_request_trigger:
   name: Pull Request Trigger (develop, develop-2.0.0, & release branches)
   dependencies:
     # Run project standards to verify package/default project
-    - .yamato/project-standards.yml#standards_ubuntu_testproject_6000.0
+    - .yamato/project-standards.yml#standards_ubuntu_testproject_trunk
     # Run package EditMode and Playmode package tests on trunk
     - .yamato/_run-all.yml#run_all_package_tests_trunk
     # Run package EditMode and Playmode package tests on minimum supported editor (6000.0 in case of NGOv2.X)
@@ -83,7 +83,6 @@ develop_nightly:
   dependencies:
     # Run project standards to verify package/default project
     - .yamato/project-standards.yml#standards_ubuntu_testproject_trunk
-    - .yamato/project-standards.yml#standards_ubuntu_testproject_6000.0
     # Run APV jobs to make sure the change won't break any dependants
     - .yamato/wrench/preview-a-p-v.yml#all_preview_apv_jobs
     # Run package EditMode and Playmode tests on desktop platforms on trunk and 6000.0

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -46,6 +46,8 @@
 pull_request_trigger:
   name: Pull Request Trigger (develop, develop-2.0.0, & release branches)
   dependencies:
+    # Run project standards to verify package/default project
+    - .yamato/project-standards.yml#standards_ubuntu_testproject_6000.0
     # Run package EditMode and Playmode package tests on trunk
     - .yamato/_run-all.yml#run_all_package_tests_trunk
     # Run package EditMode and Playmode package tests on minimum supported editor (6000.0 in case of NGOv2.X)
@@ -54,9 +56,9 @@ pull_request_trigger:
     - .yamato/_run-all.yml#run_all_project_tests_trunk
     # Run project EditMode and PLaymode project tests on minimum supported editor (6000.0 in case of NGOv2.X)
     - .yamato/_run-all.yml#run_all_project_tests_6000
-    # Run standalone test with mixture of parameters to make sure there are no obvious issues with most common platform (for example --fail-on-assert option is not present with package/project tests). We run 2 different combinations with different platform/editor/scripting backend.
-    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_mac_il2cpp_trunk
-    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_win_mono_6000.0
+    # Run standalone test. We run it only on Ubuntu since it's the fastest machine, and it was noted that for example distribution on macOS is taking 40m since we switched to Apple Silicon
+    # Coverage on other standalone machines is present in Nightly job so it's enough to not run all of them for PRs
+    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_ubuntu_il2cpp_trunk
   triggers:
     cancel_old_ci: true
     pull_requests:

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -58,7 +58,7 @@ pull_request_trigger:
     - .yamato/_run-all.yml#run_all_project_tests_6000
     # Run standalone test. We run it only on Ubuntu since it's the fastest machine, and it was noted that for example distribution on macOS is taking 40m since we switched to Apple Silicon
     # Coverage on other standalone machines is present in Nightly job so it's enough to not run all of them for PRs
-    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_ubuntu_il2cpp_trunk
+    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_ubuntu_il2cpp_6000.0
   triggers:
     cancel_old_ci: true
     pull_requests:

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -42,12 +42,10 @@
 # In order to have better coverage we run desktop standalone tests with different configurations which allows to mostly cover for different platforms, scripting backends and editor versions.
 # This job will FIRST run "run_quick_checks" jobs (defined in _run-all.yml) since it's the dependency of project pack jobs which is on the lowest dependency tier. This runs the fastest checks (like PVP or code standards) and ONLY IF those pass it will run the rest of the tests.
 # This optimization allows to speed up feedback look for any "obvious" errors and save resources.
-# Since standards job is a part of initial checks it's not present as direct dependency here
+# Since standards job is a part of initial checks it's not present as direct dependency here!!!!!!!!!!!!!!!!!!!!
 pull_request_trigger:
   name: Pull Request Trigger (develop, develop-2.0.0, & release branches)
   dependencies:
-    # Run project standards to verify package/default project
-    - .yamato/project-standards.yml#standards_ubuntu_testproject_trunk
     # Run package EditMode and Playmode package tests on trunk
     - .yamato/_run-all.yml#run_all_package_tests_trunk
     # Run package EditMode and Playmode package tests on minimum supported editor (6000.0 in case of NGOv2.X)


### PR DESCRIPTION
It was noted that after we switched macOS from x64 to Apple Silicon the distribution times started taking up to 40m which is fine for Nightly jobs but it's frustrating for PRs triggers. 
We decided that coverage on Ubuntu is enough for PR trigger since all other standalone desktop devices are being tested during Nightly.

## Backport
Backport present in https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3432