### PR TITLE
fix: authority changing ownership via rpc can result in the same previous and current clientid values [BackPort]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -12,6 +12,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where when a client changes ownership via RPC the `NetworkBehaviour.OnOwnershipChanged` can result in identical previous and current owner identifiers. (#3434)
+
 ### Changed
 
 ## [1.13.0] - 2025-04-29

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -1091,13 +1091,22 @@ namespace Unity.Netcode
             }
         }
 
-        internal void MarkOwnerReadVariablesDirty()
+        /// <summary>
+        /// For owner read permissions, when changing ownership we need to do a full synchronization
+        /// of all NetworkVariables that are owner read permission based since the owner is the only
+        /// instance that knows what the most current values are.
+        /// </summary>
+        internal void MarkOwnerReadDirtyAndCheckOwnerWriteIsDirty()
         {
             for (int j = 0; j < NetworkVariableFields.Count; j++)
             {
                 if (NetworkVariableFields[j].ReadPerm == NetworkVariableReadPermission.Owner)
                 {
                     NetworkVariableFields[j].SetDirty(true);
+                }
+                if (NetworkVariableFields[j].WritePerm == NetworkVariableWritePermission.Owner)
+                {
+                    NetworkVariableFields[j].OnCheckIsDirtyState();
                 }
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
@@ -114,9 +114,6 @@ namespace Unity.Netcode
                     {
                         behaviour.PostNetworkVariableWrite(forceSend);
                     }
-
-                    // Once done processing, we set the previous owner id to the current owner id
-                    dirtyObj.PreviousOwnerId = dirtyObj.OwnerClientId;
                 }
                 m_DirtyNetworkObjects.Clear();
             }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1485,12 +1485,39 @@ namespace Unity.Netcode
             }
         }
 
-        internal void MarkOwnerReadVariablesDirty()
+        /// <summary>
+        /// Used when changing ownership, this will mark any owner read permission base NetworkVariables as dirty
+        /// and will check if any owner write permission NetworkVariables are dirty (primarily for collections) so
+        /// the new owner will get a full state update prior to changing ownership.
+        /// </summary>
+        /// <remarks>
+        /// We have to pass in the original owner and previous owner to "reset" back to the current state of this
+        /// NetworkObject in order to preserve the same ownership change flow. By the time this is invoked, the
+        /// new and previous owner ids have already been set.
+        /// </remarks>
+        /// <param name="originalOwnerId">the owner prior to beginning the change in ownership change.</param>
+        /// <param name="originalPreviousOwnerId">the previous owner prior to beginning the change in ownership change.</param>
+        internal void SynchronizeOwnerNetworkVariables(ulong originalOwnerId, ulong originalPreviousOwnerId)
         {
+            var currentOwnerId = OwnerClientId;
+            OwnerClientId = originalOwnerId;
+            PreviousOwnerId = originalPreviousOwnerId;
             for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
             {
-                ChildNetworkBehaviours[i].MarkOwnerReadVariablesDirty();
+                ChildNetworkBehaviours[i].MarkOwnerReadDirtyAndCheckOwnerWriteIsDirty();
             }
+
+            // Now set the new owner and previous owner identifiers back to their original new values
+            // before we run the NetworkBehaviourUpdate. For owner read only permissions this order of
+            // operations is **particularly important** as we need to first (above) mark things as dirty
+            // from the context of the original owner and then second (below) we need to send the messages
+            // which requires the new owner to be set for owner read permission NetworkVariables.
+            OwnerClientId = currentOwnerId;
+            PreviousOwnerId = originalOwnerId;
+
+            // Force send a state update for all owner read NetworkVariables  and any currently dirty
+            // owner write NetworkVariables.
+            NetworkManager.BehaviourUpdater.NetworkBehaviourUpdate(true);
         }
 
         // NGO currently guarantees that the client will receive spawn data for all objects in one network tick.

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ChangeOwnershipMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ChangeOwnershipMessage.cs
@@ -62,11 +62,7 @@ namespace Unity.Netcode
 
             if (originalOwner == networkManager.LocalClientId)
             {
-                // Mark any owner read variables as dirty
-                networkObject.MarkOwnerReadVariablesDirty();
-                // Immediately queue any pending deltas and order the message before the
-                // change in ownership message.
-                networkManager.BehaviourUpdater.NetworkBehaviourUpdate(true);
+                networkObject.SynchronizeOwnerNetworkVariables(originalOwner, networkObject.PreviousOwnerId);
             }
 
             networkObject.InvokeOwnershipChanged(originalOwner, OwnerClientId);

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -166,6 +166,13 @@ namespace Unity.Netcode
             return isDirty;
         }
 
+        /// <inheritdoc/>
+        internal override void OnCheckIsDirtyState()
+        {
+            CheckDirtyState();
+            base.OnCheckIsDirtyState();
+        }
+
         internal ref T RefValue()
         {
             return ref m_InternalValue;

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
@@ -346,6 +346,15 @@ namespace Unity.Netcode
         }
 
         /// <summary>
+        /// Primarily to check for collections dirty states when doing
+        /// a fully owner read/write NetworkVariable update.
+        /// </summary>
+        internal virtual void OnCheckIsDirtyState()
+        {
+
+        }
+
+        /// <summary>
         /// Writes the dirty changes, that is, the changes since the variable was last dirty, to the writer
         /// </summary>
         /// <param name="writer">The stream to write the dirty changes to</param>

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -250,6 +250,17 @@ namespace Unity.Netcode
 
         internal void ChangeOwnership(NetworkObject networkObject, ulong clientId)
         {
+
+            if (clientId == networkObject.OwnerClientId)
+            {
+                if (NetworkManager.LogLevel <= LogLevel.Developer)
+                {
+                    Debug.LogWarning($"[{nameof(NetworkSpawnManager)}][{nameof(ChangeOwnership)}] Attempting to change ownership to Client-{clientId} when the owner is already {networkObject.OwnerClientId}! (Ignoring)");
+
+                }
+                return;
+            }
+
             // If ownership changes faster than the latency between the client-server and there are NetworkVariables being updated during ownership changes,
             // then notify the user they could potentially lose state updates if developer logging is enabled.
             if (m_LastChangeInOwnership.ContainsKey(networkObject.NetworkObjectId) && m_LastChangeInOwnership[networkObject.NetworkObjectId] > Time.realtimeSinceStartup)
@@ -278,6 +289,8 @@ namespace Unity.Netcode
             {
                 throw new SpawnStateException("Object is not spawned");
             }
+            var originalPreviousOwnerId = networkObject.PreviousOwnerId;
+            var originalOwner = networkObject.OwnerClientId;
 
             // Used to distinguish whether a new owner should receive any currently dirty NetworkVariable updates
             networkObject.PreviousOwnerId = networkObject.OwnerClientId;
@@ -294,13 +307,10 @@ namespace Unity.Netcode
             // Always notify locally on the server when a new owner is assigned
             networkObject.InvokeBehaviourOnGainedOwnership();
 
+            // If we are the original owner, then we want to synchronize owner read & write NetworkVariables.
             if (networkObject.PreviousOwnerId == NetworkManager.LocalClientId)
             {
-                // Mark any owner read variables as dirty
-                networkObject.MarkOwnerReadVariablesDirty();
-                // Immediately queue any pending deltas and order the message before the
-                // change in ownership message.
-                NetworkManager.BehaviourUpdater.NetworkBehaviourUpdate(true);
+                networkObject.SynchronizeOwnerNetworkVariables(originalOwner, originalPreviousOwnerId);
             }
 
             var message = new ChangeOwnershipMessage

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DeferredMessagingTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DeferredMessagingTests.cs
@@ -1269,7 +1269,9 @@ namespace Unity.Netcode.RuntimeTests
                 Assert.AreEqual(0, manager.DeferredMessageCountForKey(IDeferredNetworkMessageManager.TriggerType.OnSpawn, serverObject2.GetComponent<NetworkObject>().NetworkObjectId));
             }
 
-            serverObject2.GetComponent<NetworkObject>().ChangeOwnership(m_ServerNetworkManager.LocalClientId);
+            // Changing ownership when the owner specified is already an owner should not send any messages
+            // The original test was changing ownership to the server when the object was spawned with the server being an owner.            
+            serverObject2.GetComponent<NetworkObject>().ChangeOwnership(m_ClientNetworkManagers[1].LocalClientId);
             WaitForAllClientsToReceive<ChangeOwnershipMessage>();
 
             foreach (var client in m_ClientNetworkManagers)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOwnershipTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOwnershipTests.cs
@@ -385,6 +385,7 @@ namespace Unity.Netcode.RuntimeTests
         /// ends up always being the server, but for distributed authority the authority changes when
         /// ownership changes.
         /// </summary>
+        /// <returns><see cref="IEnumerator"/></returns>
         [UnityTest]
         public IEnumerator TestAuthorityChangingOwnership()
         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOwnershipTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOwnershipTests.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using Unity.Netcode.Components;
 using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -23,10 +24,22 @@ namespace Unity.Netcode.RuntimeTests
             OnGainedOwnershipFired = true;
         }
 
+        protected override void OnOwnershipChanged(ulong previous, ulong current)
+        {
+            Assert.True(previous != current, $"[{nameof(OnOwnershipChanged)}][Invalid Parameters] Invoked and the previous ({previous}) equals the current ({current})!");
+            base.OnOwnershipChanged(previous, current);
+        }
+
         public void ResetFlags()
         {
             OnLostOwnershipFired = false;
             OnGainedOwnershipFired = false;
+        }
+
+        [Rpc(SendTo.Server)]
+        public void ChangeOwnershipRpc(RpcParams rpcParams = default)
+        {
+            NetworkObject.ChangeOwnership(rpcParams.Receive.SenderClientId);
         }
     }
 
@@ -52,6 +65,7 @@ namespace Unity.Netcode.RuntimeTests
         {
             m_OwnershipPrefab = CreateNetworkObjectPrefab("OnwershipPrefab");
             m_OwnershipPrefab.AddComponent<NetworkObjectOwnershipComponent>();
+            m_OwnershipPrefab.AddComponent<NetworkTransform>();
             base.OnServerAndClientsCreated();
         }
 
@@ -357,6 +371,76 @@ namespace Unity.Netcode.RuntimeTests
             yield return WaitForConditionOrTimeOut(ServerHasCorrectClientOwnedObjectCount);
             AssertOnTimeout($"Server does not have the correct count for all clients spawned {k_NumberOfSpawnedObjects} {nameof(NetworkObject)}s!");
 
+        }
+
+        /// <summary>
+        /// Validates that when changing ownership NetworkTransform does not enter into a bad state
+        /// because the previous and current owner identifiers are the same. For client-server this
+        /// ends up always being the server, but for distributed authority the authority changes when
+        /// ownership changes.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestAuthorityChangingOwnership()
+        {
+            var authorityManager = m_ServerNetworkManager; ;
+            var allNetworkManagers = m_ClientNetworkManagers.ToList();
+            allNetworkManagers.Add(m_ServerNetworkManager);
+
+            m_OwnershipObject = SpawnObject(m_OwnershipPrefab, m_ServerNetworkManager);
+            m_OwnershipNetworkObject = m_OwnershipObject.GetComponent<NetworkObject>();
+            var ownershipNetworkObjectId = m_OwnershipNetworkObject.NetworkObjectId;
+            bool WaitForClientsToSpawnNetworkObject()
+            {
+                foreach (var clientNetworkManager in m_ClientNetworkManagers)
+                {
+                    if (!clientNetworkManager.SpawnManager.SpawnedObjects.ContainsKey(ownershipNetworkObjectId))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            yield return WaitForConditionOrTimeOut(WaitForClientsToSpawnNetworkObject);
+            AssertOnTimeout($"Timed out waiting for all clients to spawn the {m_OwnershipNetworkObject.name} {nameof(NetworkObject)} instance!");
+
+            var currentTargetOwner = (ulong)0;
+            bool WaitForAllInstancesToChangeOwnership()
+            {
+                foreach (var clientNetworkManager in m_ClientNetworkManagers)
+                {
+                    if (!clientNetworkManager.SpawnManager.SpawnedObjects.ContainsKey(ownershipNetworkObjectId))
+                    {
+                        return false;
+                    }
+                    if (clientNetworkManager.SpawnManager.SpawnedObjects[ownershipNetworkObjectId].OwnerClientId != currentTargetOwner)
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            // Change ownership a few times and as long as the previous and current owners are not the same when
+            // OnOwnershipChanged is invoked then the test passed.
+            foreach (var networkManager in allNetworkManagers)
+            {
+                if (networkManager == authorityManager)
+                {
+                    continue;
+                }
+                var clonedObject = networkManager.SpawnManager.SpawnedObjects[ownershipNetworkObjectId];
+
+                if (clonedObject.OwnerClientId == networkManager.LocalClientId)
+                {
+                    continue;
+                }
+
+                var testComponent = clonedObject.GetComponent<NetworkObjectOwnershipComponent>();
+                testComponent.ChangeOwnershipRpc();
+                yield return WaitForAllInstancesToChangeOwnership();
+                AssertOnTimeout($"Timed out waiting for all instances to change ownership to Client-{networkManager.LocalClientId}!");
+            }
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOwnershipTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOwnershipTests.cs
@@ -14,16 +14,22 @@ namespace Unity.Netcode.RuntimeTests
         public bool OnLostOwnershipFired = false;
         public bool OnGainedOwnershipFired = false;
 
+
+        /// <inheritdoc/>
         public override void OnLostOwnership()
         {
             OnLostOwnershipFired = true;
         }
 
+
+        /// <inheritdoc/>
         public override void OnGainedOwnership()
         {
             OnGainedOwnershipFired = true;
         }
 
+
+        /// <inheritdoc/>
         protected override void OnOwnershipChanged(ulong previous, ulong current)
         {
             Assert.True(previous != current, $"[{nameof(OnOwnershipChanged)}][Invalid Parameters] Invoked and the previous ({previous}) equals the current ({current})!");
@@ -37,7 +43,7 @@ namespace Unity.Netcode.RuntimeTests
         }
 
         [Rpc(SendTo.Server)]
-        public void ChangeOwnershipRpc(RpcParams rpcParams = default)
+        internal void ChangeOwnershipRpc(RpcParams rpcParams = default)
         {
             NetworkObject.ChangeOwnership(rpcParams.Receive.SenderClientId);
         }


### PR DESCRIPTION
This fixes an issue with the synchronization of NetworkVariables when changing ownership where it was possible to have the previous owner be equal to the current owner when a client used an RPC to change ownership.

This includes an additional check for dirty states of any collections base NetworkVariables.

## Changelog

- Fixed: Issue where when a client changes ownership via RPC the `NetworkBehaviour.OnOwnershipChanged` can result in identical previous and current owner identifiers.

## Testing and Documentation

- Includes integration test `NetworkObjectOwnershipTests.TestAuthorityChangingOwnership`.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Backport

This is a backport of #3347.