### PR TITLE
fix: NetcodeIntegrationTest updates and fixes

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
@@ -275,6 +275,8 @@ namespace Unity.Netcode
 
             foreach (var clientId in ConnectedClientIds)
             {
+                // DANGO-TODO: Revisit the entire connection sequence and determine why we would need to check both cases as we shouldn't have to =or= we could
+                // try removing this after the Rust server connection sequence stuff is resolved. (Might be only needed if scene management is disabled)
                 // If there is any disconnect between the connection sequence of Ids vs ConnectedClients, then add the client.
                 if (!networkManager.ConnectionManager.ConnectedClientIds.Contains(clientId) || !networkManager.ConnectionManager.ConnectedClients.ContainsKey(clientId))
                 {

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using Unity.Collections;
 
 namespace Unity.Netcode
@@ -273,10 +274,10 @@ namespace Unity.Netcode
             // Stop the client-side approval timeout coroutine since we are approved.
             networkManager.ConnectionManager.StopClientApprovalCoroutine();
 
-            networkManager.ConnectionManager.ConnectedClientIds.Clear();
             foreach (var clientId in ConnectedClientIds)
             {
-                if (!networkManager.ConnectionManager.ConnectedClientIds.Contains(clientId))
+                // If there is any disconnect between the connection sequence of Ids vs ConnectedClients, then add the client.
+                if (!networkManager.ConnectionManager.ConnectedClientIds.Contains(clientId) || !networkManager.ConnectionManager.ConnectedClients.ContainsKey(clientId))
                 {
                     networkManager.ConnectionManager.AddClient(clientId);
                 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Diagnostics;
 using Unity.Collections;
 
 namespace Unity.Netcode

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -2595,42 +2595,26 @@ namespace Unity.Netcode
                 case SceneEventType.SynchronizeComplete:
                     {
                         // At this point the client is considered fully "connected"
-                        if ((NetworkManager.DistributedAuthorityMode && NetworkManager.LocalClient.IsSessionOwner) || !NetworkManager.DistributedAuthorityMode)
+                        // Make sure we have a NetworkClient for this synchronized client
+                        if (!NetworkManager.ConnectedClients.ContainsKey(clientId))
                         {
-                            // Notify the local server that a client has finished synchronizing
-                            OnSceneEvent?.Invoke(new SceneEvent()
-                            {
-                                SceneEventType = sceneEventData.SceneEventType,
-                                SceneName = string.Empty,
-                                ClientId = clientId
-                            });
-
-                            // Make sure we have a NetworkClient for this synchronized client
-                            if (!NetworkManager.ConnectedClients.ContainsKey(clientId))
-                            {
-                                NetworkManager.ConnectionManager.AddClient(clientId);
-                            }
-                            // Mark this client as being connected
-                            NetworkManager.ConnectedClients[clientId].IsConnected = true;
+                            NetworkManager.ConnectionManager.AddClient(clientId);
                         }
-                        else
+                        // Mark this client as being connected
+                        NetworkManager.ConnectedClients[clientId].IsConnected = true;
+
+                        // Notify the local server that a client has finished synchronizing
+                        OnSceneEvent?.Invoke(new SceneEvent()
                         {
-                            // Notify the local server that a client has finished synchronizing
-                            OnSceneEvent?.Invoke(new SceneEvent()
-                            {
-                                SceneEventType = sceneEventData.SceneEventType,
-                                SceneName = string.Empty,
-                                ClientId = clientId
-                            });
+                            SceneEventType = sceneEventData.SceneEventType,
+                            SceneName = string.Empty,
+                            ClientId = clientId
+                        });
 
-                            // Make sure we have a NetworkClient for this synchronized client
-                            if (!NetworkManager.ConnectedClients.ContainsKey(clientId))
-                            {
-                                NetworkManager.ConnectionManager.AddClient(clientId);
-                            }
-                            // Mark this client as being connected
-                            NetworkManager.ConnectedClients[clientId].IsConnected = true;
-
+                        // For non-authority clients in a distributed authority session, we show hidden objects,
+                        // we distribute NetworkObjects, and then we end the scene event.
+                        if (NetworkManager.DistributedAuthorityMode && !NetworkManager.LocalClient.IsSessionOwner)
+                        {
                             // Show any NetworkObjects that are:
                             // - Hidden from the session owner
                             // - Owned by this client

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -2604,8 +2604,15 @@ namespace Unity.Netcode
                                 SceneName = string.Empty,
                                 ClientId = clientId
                             });
-                            if (NetworkManager.ConnectedClients.ContainsKey(clientId))
+
+                            if (NetworkManager.DistributedAuthorityMode)
                             {
+                                // Make sure we have a NetworkClient for this synchronized client
+                                if (!NetworkManager.ConnectedClients.ContainsKey(clientId))
+                                {
+                                    NetworkManager.ConnectionManager.AddClient(clientId);
+                                }
+                                // Mark this client as being connected
                                 NetworkManager.ConnectedClients[clientId].IsConnected = true;
                             }
                         }
@@ -2618,6 +2625,14 @@ namespace Unity.Netcode
                                 SceneName = string.Empty,
                                 ClientId = clientId
                             });
+
+                            // Make sure we have a NetworkClient for this synchronized client
+                            if (!NetworkManager.ConnectedClients.ContainsKey(clientId))
+                            {
+                                NetworkManager.ConnectionManager.AddClient(clientId);
+                            }
+                            // Mark this client as being connected
+                            NetworkManager.ConnectedClients[clientId].IsConnected = true;
 
                             // Show any NetworkObjects that are:
                             // - Hidden from the session owner

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -2605,16 +2605,13 @@ namespace Unity.Netcode
                                 ClientId = clientId
                             });
 
-                            if (NetworkManager.DistributedAuthorityMode)
+                            // Make sure we have a NetworkClient for this synchronized client
+                            if (!NetworkManager.ConnectedClients.ContainsKey(clientId))
                             {
-                                // Make sure we have a NetworkClient for this synchronized client
-                                if (!NetworkManager.ConnectedClients.ContainsKey(clientId))
-                                {
-                                    NetworkManager.ConnectionManager.AddClient(clientId);
-                                }
-                                // Mark this client as being connected
-                                NetworkManager.ConnectedClients[clientId].IsConnected = true;
+                                NetworkManager.ConnectionManager.AddClient(clientId);
                             }
+                            // Mark this client as being connected
+                            NetworkManager.ConnectedClients[clientId].IsConnected = true;
                         }
                         else
                         {

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -831,7 +831,7 @@ namespace Unity.Netcode
                 {
                     if (NetworkLog.CurrentLogLevel <= LogLevel.Error)
                     {
-                        NetworkLog.LogError($"Failed to create object locally. [{nameof(globalObjectIdHash)}={globalObjectIdHash}]. {nameof(NetworkPrefab)} could not be found. Is the prefab registered with {nameof(NetworkManager)}?");
+                        NetworkLog.LogError($"Failed to create object locally. [{nameof(globalObjectIdHash)}={globalObjectIdHash}]. {nameof(NetworkPrefab)} could not be found. Is the prefab registered with {NetworkManager.name}?");
                     }
                 }
                 else

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -96,13 +96,27 @@ namespace Unity.Netcode.TestHelpers.Runtime
             }
         }
 
+        private int GetTotalClients()
+        {
+            if (m_DistributedAuthority)
+            {
+                // If not connecting to a CMB service then we are using a DAHost and we add 1 to this count.
+                return !UseCMBService() && m_UseHost ? m_NumberOfClients + 1 : m_NumberOfClients;
+            }
+            else
+            {
+                // If using a host then we add one to this count.
+                return m_UseHost ? m_NumberOfClients + 1 : m_NumberOfClients;
+            }
+        }
+
         /// <summary>
         /// Total number of clients that should be connected at any point during a test.
         /// </summary>
         /// <remarks>
         /// When using the CMB Service, we ignore if <see cref="m_UseHost"/> is true.
         /// </remarks>
-        protected int TotalClients => m_UseHost && !UseCMBService() ? m_NumberOfClients + 1 : m_NumberOfClients;
+        protected int TotalClients => GetTotalClients();
 
         protected const uint k_DefaultTickRate = 30;
 
@@ -212,7 +226,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         protected Dictionary<ulong, Dictionary<ulong, NetworkObject>> m_PlayerNetworkObjects = new Dictionary<ulong, Dictionary<ulong, NetworkObject>>();
 
         protected bool m_UseHost = true;
-        protected bool m_DistributedAuthority;
+        protected bool m_DistributedAuthority => m_NetworkTopologyType == NetworkTopologyTypes.DistributedAuthority;
         protected NetworkTopologyTypes m_NetworkTopologyType = NetworkTopologyTypes.ClientServer;
 
         /// <summary>
@@ -233,14 +247,14 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// check the environment variable once per test set.
         /// </remarks>
         /// <returns>true/false</returns>
-        private bool UseCMBServiceEnviromentVariableSet()
+        private bool GetServiceEnviromentVariable()
         {
             if (!m_UseCmbServiceEnv && m_UseCmbServiceEnvString == null)
             {
                 var useCmbService = Environment.GetEnvironmentVariable("USE_CMB_SERVICE") ?? "false";
                 if (bool.TryParse(useCmbService.ToLower(), out bool isTrue))
                 {
-                    m_UseCmbService = isTrue;
+                    m_UseCmbServiceEnv = isTrue;
                 }
                 else
                 {
@@ -261,7 +275,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
 #if USE_CMB_SERVICE
             return true;
 #else
-            return UseCMBServiceEnviromentVariableSet();
+            return m_UseCmbService;
 #endif
         }
 
@@ -409,6 +423,24 @@ namespace Unity.Netcode.TestHelpers.Runtime
         [OneTimeSetUp]
         public void OneTimeSetup()
         {
+            // Only For CMB Server Tests:
+            // If the environment variable is set (i.e. doing a CMB server run) but UseCMBservice returns false, then ignore the test.
+            // Note: This will prevent us from re-running all of the non-DA integration tests that have already run multiple times on
+            // multiple platforms
+            if (GetServiceEnviromentVariable() && !UseCMBService())
+            {
+                Assert.Ignore("[CMB-Server Test Run] Skipping non-distributed authority test.");
+                return;
+            }
+            else
+            {
+                // Otherwise, continue with the test
+                InternalOnOneTimeSetup();
+            }
+        }
+
+        private void InternalOnOneTimeSetup()
+        {
             Application.runInBackground = true;
             m_NumberOfClients = NumberOfClients;
             IsRunning = true;
@@ -515,7 +547,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
                 }
             }
-
             VerboseDebug($"Exiting {nameof(SetUp)}");
         }
 
@@ -1983,23 +2014,45 @@ namespace Unity.Netcode.TestHelpers.Runtime
             InitializeTestConfiguration(m_NetworkTopologyType, hostOrServer);
         }
 
+        /// <summary>
+        /// Override this virtual method to execute script that runs before the base class constructor has finished executing.<br />
+        /// </summary>
+        /// <remarks>
+        /// ***NOTE***
+        /// When this method is invoked there will have been no properties set (i.e. nothing is configured). <br />
+        /// Primarily this is to set things like environemnt variables or other more external configurations that could
+        /// determine how the <see cref="NetcodeIntegrationTest"/> is configured.
+        /// </remarks>
+        protected virtual void OnPreInitializeConfiguration()
+        {
+        }
+
         private void InitializeTestConfiguration(NetworkTopologyTypes networkTopologyType, HostOrServer? hostOrServer)
         {
-            if (!hostOrServer.HasValue)
-            {
-                // Always default to hosting, set the type of host based on the topology type
-                hostOrServer = networkTopologyType == NetworkTopologyTypes.DistributedAuthority ? HostOrServer.DAHost : HostOrServer.Host;
-            }
+            OnPreInitializeConfiguration();
 
             NetworkMessageManager.EnableMessageOrderConsoleLog = false;
 
+            // Set m_NetworkTopologyType first because m_DistributedAuthority is calculated from it.
             m_NetworkTopologyType = networkTopologyType;
-            m_DistributedAuthority = m_NetworkTopologyType == NetworkTopologyTypes.DistributedAuthority;
+
+            if (!hostOrServer.HasValue)
+            {
+                // Always default to hosting, set the type of host based on the topology type.
+                // Note: For m_DistributedAuthority to be true, the m_NetworkTopologyType must be set to NetworkTopologyTypes.DistributedAuthority
+                hostOrServer = m_DistributedAuthority ? HostOrServer.DAHost : HostOrServer.Host;
+            }
             m_UseHost = hostOrServer == HostOrServer.Host || hostOrServer == HostOrServer.DAHost;
 
-            if (UseCMBService())
+            // If we are using a distributed authority network topology and the environment variable
+            // to use the CMBService is set, then perform the m_UseCmbService check.
+            if (m_DistributedAuthority && GetServiceEnviromentVariable())
             {
-                m_UseCmbService = m_DistributedAuthority && hostOrServer == HostOrServer.DAHost;
+                m_UseCmbService = hostOrServer == HostOrServer.DAHost;
+                // In the event UseCMBService is overridden, we apply the value returned.
+                // If it is, then whatever UseCMBService returns is the setting for m_UseCmbService.
+                // If it is not, then it will return whatever m_UseCmbService's setting is from the above check.
+                m_UseCmbService = UseCMBService();
             }
         }
 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -1700,10 +1700,10 @@ namespace Unity.Netcode.TestHelpers.Runtime
         {
             var remoteClientCount = clientsToCheck.Length;
             var authorityNetworkManager = GetAuthorityNetworkManager();
-            var serverClientCount = authorityNetworkManager.IsHost ? remoteClientCount + 1 : remoteClientCount;
+            var authorityClientCount = authorityNetworkManager.IsHost ? remoteClientCount + 1 : remoteClientCount;
 
             return WaitForConditionOrTimeOutWithTimeTravel(() => clientsToCheck.Where((c) => c.IsConnectedClient).Count() == remoteClientCount &&
-                                                                 authorityNetworkManager.ConnectedClients.Count == serverClientCount);
+                                                                 authorityNetworkManager.ConnectedClients.Count == authorityClientCount);
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -1058,6 +1058,14 @@ namespace Unity.Netcode.TestHelpers.Runtime
         }
 
         /// <summary>
+        /// Determines whether the session owner will be auto-started prior to any other client
+        /// </summary>
+        internal virtual bool ShouldAutoStartSessionOwner()
+        {
+            return true;
+        }
+
+        /// <summary>
         /// This starts the server and clients as long as <see cref="CanStartServerAndClients"/>
         /// returns true.
         /// </summary>
@@ -1067,7 +1075,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             {
                 VerboseDebug($"Entering {nameof(StartServerAndClients)}");
 
-                if (m_UseCmbService)
+                if (m_UseCmbService && ShouldAutoStartSessionOwner())
                 {
                     VerboseDebug("Using a distributed authority CMB Server for connection.");
                     yield return StartSessionOwner();

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -244,7 +244,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 }
                 else
                 {
-                    Debug.LogWarning($"USE_CMB_SERVICE value ({useCmbService}) is not a valid bool value. {m_UseCmbService} is being set to false.");
+                    Debug.LogWarning($"The USE_CMB_SERVICE ({useCmbService}) value is an invalid bool string. {m_UseCmbService} is being set to false.");
                     m_UseCmbServiceEnv = false;
                 }
             }

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -194,18 +194,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
                         return client;
                     }
                 }
-
-                // If we have not found a session owner and we are not
-                // auto-starting the session owner, then return the first 
-                // client NetworkManager.
-                if (!ShouldAutoStartSessionOwner())
-                {
-                    return m_NetworkManagers[0];
-                }
-                else
-                {
-                    Assert.Fail("No DA session owner found!");
-                }
+                Assert.Fail("No DA session owner found!");
             }
 
             return m_ServerNetworkManager;
@@ -255,7 +244,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         {
             if (!m_UseCmbServiceEnv && m_UseCmbServiceEnvString == null)
             {
-                m_UseCmbServiceEnvString = Environment.GetEnvironmentVariable("USE_CMB_SERVICE") ?? "false";
+                m_UseCmbServiceEnvString = NetcodeIntegrationTestHelpers.GetCMBServiceEnvironentVariable();
                 if (bool.TryParse(m_UseCmbServiceEnvString.ToLower(), out bool isTrue))
                 {
                     m_UseCmbServiceEnv = isTrue;
@@ -276,11 +265,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// <returns>true if a DAHost test should run against a hosted CMB service instance; otherwise false</returns>
         protected virtual bool UseCMBService()
         {
-#if USE_CMB_SERVICE
-            return true;
-#else
             return m_UseCmbService;
-#endif
         }
 
         protected virtual NetworkTopologyTypes OnGetNetworkTopologyType()
@@ -983,13 +968,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 m_PlayerNetworkObjects.Add(networkManager.LocalClientId, new Dictionary<ulong, NetworkObject>());
             }
 
-#if UNITY_2023_1_OR_NEWER
             // Get all player instances for the current client NetworkManager instance
             var clientPlayerClones = Object.FindObjectsByType<NetworkObject>(FindObjectsSortMode.None).Where((c) => c.IsPlayerObject && c.OwnerClientId == networkManager.LocalClientId).ToList();
-#else
-            // Get all player instances for the current client NetworkManager instance
-            var clientPlayerClones = Object.FindObjectsOfType<NetworkObject>().Where((c) => c.IsPlayerObject && c.OwnerClientId == networkManager.LocalClientId).ToList();
-#endif
             // Add this player instance to each client player entry
             foreach (var playerNetworkObject in clientPlayerClones)
             {
@@ -1004,13 +984,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
                     m_PlayerNetworkObjects[playerNetworkObject.NetworkManager.LocalClientId].Add(networkManager.LocalClientId, playerNetworkObject);
                 }
             }
-#if UNITY_2023_1_OR_NEWER
             // For late joining clients, add the remaining (if any) cloned versions of each client's player
             clientPlayerClones = Object.FindObjectsByType<NetworkObject>(FindObjectsSortMode.None).Where((c) => c.IsPlayerObject && c.NetworkManager == networkManager).ToList();
-#else
-            // For late joining clients, add the remaining (if any) cloned versions of each client's player
-            clientPlayerClones = Object.FindObjectsOfType<NetworkObject>().Where((c) => c.IsPlayerObject && c.NetworkManager == networkManager).ToList();
-#endif
             foreach (var playerNetworkObject in clientPlayerClones)
             {
                 if (!m_PlayerNetworkObjects[networkManager.LocalClientId].ContainsKey(playerNetworkObject.OwnerClientId))
@@ -1058,6 +1033,10 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// <summary>
         /// Starts the session owner and awaits for it to connect before starting the remaining clients.
         /// </summary>
+        /// <remarks>
+        /// DANGO-TODO: Renove this when the Rust server connection sequence is fixed and we don't have to pre-start
+        /// the session owner.
+        /// </remarks>
         private IEnumerator StartSessionOwner()
         {
             VerboseDebug("Starting session owner...");
@@ -1066,14 +1045,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
             AssertOnTimeout($"Timed out waiting for the session owner to connect to CMB Server!");
             Assert.True(m_ClientNetworkManagers[0].LocalClient.IsSessionOwner, $"Client-{m_ClientNetworkManagers[0].LocalClientId} started session but was not set to be the session owner!");
             VerboseDebug("Session owner connected and approved.");
-        }
-
-        /// <summary>
-        /// Determines whether the session owner will be auto-started prior to any other client
-        /// </summary>
-        internal virtual bool ShouldAutoStartSessionOwner()
-        {
-            return true;
         }
 
         /// <summary>
@@ -1086,7 +1057,9 @@ namespace Unity.Netcode.TestHelpers.Runtime
             {
                 VerboseDebug($"Entering {nameof(StartServerAndClients)}");
 
-                if (m_UseCmbService && ShouldAutoStartSessionOwner())
+                // DANGO-TODO: Renove this when the Rust server connection sequence is fixed and we don't have to pre-start
+                // the session owner.
+                if (m_UseCmbService)
                 {
                     VerboseDebug("Using a distributed authority CMB Server for connection.");
                     yield return StartSessionOwner();
@@ -2018,23 +1991,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
             InitializeTestConfiguration(m_NetworkTopologyType, hostOrServer);
         }
 
-        /// <summary>
-        /// Override this virtual method to execute script that runs before the base class constructor has finished executing.<br />
-        /// </summary>
-        /// <remarks>
-        /// ***NOTE***
-        /// When this method is invoked there will have been no properties set (i.e. nothing is configured). <br />
-        /// Primarily this is to set things like environemnt variables or other more external configurations that could
-        /// determine how the <see cref="NetcodeIntegrationTest"/> is configured.
-        /// </remarks>
-        protected virtual void OnPreInitializeConfiguration()
-        {
-        }
-
         private void InitializeTestConfiguration(NetworkTopologyTypes networkTopologyType, HostOrServer? hostOrServer)
         {
-            OnPreInitializeConfiguration();
-
             NetworkMessageManager.EnableMessageOrderConsoleLog = false;
 
             // Set m_NetworkTopologyType first because m_DistributedAuthority is calculated from it.

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -194,7 +194,18 @@ namespace Unity.Netcode.TestHelpers.Runtime
                         return client;
                     }
                 }
-                Assert.Fail("No DA session owner found!");
+
+                // If we have not found a session owner and we are not
+                // auto-starting the session owner, then return the first 
+                // client NetworkManager.
+                if (!ShouldAutoStartSessionOwner())
+                {
+                    return m_NetworkManagers[0];
+                }
+                else
+                {
+                    Assert.Fail("No DA session owner found!");
+                }
             }
 
             return m_ServerNetworkManager;

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -237,8 +237,16 @@ namespace Unity.Netcode.TestHelpers.Runtime
         {
             if (!m_UseCmbServiceEnv && m_UseCmbServiceEnvString == null)
             {
-                var useCmbService = Environment.GetEnvironmentVariable("USE_CMB_SERVICE") ?? "unset";
-                m_UseCmbServiceEnv = bool.Parse(useCmbService.ToLower());
+                var useCmbService = Environment.GetEnvironmentVariable("USE_CMB_SERVICE") ?? "false";
+                if (bool.TryParse(useCmbService.ToLower(), out bool isTrue))
+                {
+                    m_UseCmbService = isTrue;
+                }
+                else
+                {
+                    Debug.LogWarning($"USE_CMB_SERVICE value ({useCmbService}) is not a valid bool value. {m_UseCmbService} is being set to false.");
+                    m_UseCmbServiceEnv = false;
+                }
             }
             return m_UseCmbServiceEnv;
         }

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -99,7 +99,10 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// <summary>
         /// Total number of clients that should be connected at any point during a test.
         /// </summary>
-        protected int TotalClients => m_UseHost ? m_NumberOfClients + 1 : m_NumberOfClients;
+        /// <remarks>
+        /// When using the CMB Service, we ignore if <see cref="m_UseHost"/> is true.
+        /// </remarks>
+        protected int TotalClients => m_UseHost && !UseCMBService() ? m_NumberOfClients + 1 : m_NumberOfClients;
 
         protected const uint k_DefaultTickRate = 30;
 
@@ -222,15 +225,20 @@ namespace Unity.Netcode.TestHelpers.Runtime
         private bool m_UseCmbServiceEnv;
 
         /// <summary>
-        /// Will set itself once and if already set then return true
+        /// Will check the environment variable once and then always return the results
+        /// of the first check.
         /// </summary>
+        /// <remarks>
+        /// This resets its properties during <see cref="OnOneTimeTearDown"/>, so it will
+        /// check the environment variable once per test set.
+        /// </remarks>
         /// <returns>true/false</returns>
-        internal bool UseCMBServiceEnviromentVariableSet()
+        private bool UseCMBServiceEnviromentVariableSet()
         {
             if (!m_UseCmbServiceEnv && m_UseCmbServiceEnvString == null)
             {
                 var useCmbService = Environment.GetEnvironmentVariable("USE_CMB_SERVICE") ?? "unset";
-                m_UseCmbServiceEnv = useCmbService.ToLower() == "true";
+                m_UseCmbServiceEnv = bool.Parse(useCmbService.ToLower());
             }
             return m_UseCmbServiceEnv;
         }

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -164,6 +164,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
         /// <summary>The Server <see cref="NetworkManager"/> instance instantiated and tracked within the current test</summary>
         protected NetworkManager m_ServerNetworkManager;
+
         /// <summary>All the client <see cref="NetworkManager"/> instances instantiated and tracked within the current test</summary>
         protected NetworkManager[] m_ClientNetworkManagers;
         /// <summary>All the <see cref="NetworkManager"/> instances instantiated and tracked within the current test</summary>
@@ -251,14 +252,14 @@ namespace Unity.Netcode.TestHelpers.Runtime
         {
             if (!m_UseCmbServiceEnv && m_UseCmbServiceEnvString == null)
             {
-                var useCmbService = Environment.GetEnvironmentVariable("USE_CMB_SERVICE") ?? "false";
-                if (bool.TryParse(useCmbService.ToLower(), out bool isTrue))
+                m_UseCmbServiceEnvString = Environment.GetEnvironmentVariable("USE_CMB_SERVICE") ?? "false";
+                if (bool.TryParse(m_UseCmbServiceEnvString.ToLower(), out bool isTrue))
                 {
                     m_UseCmbServiceEnv = isTrue;
                 }
                 else
                 {
-                    Debug.LogWarning($"The USE_CMB_SERVICE ({useCmbService}) value is an invalid bool string. {m_UseCmbService} is being set to false.");
+                    Debug.LogWarning($"The USE_CMB_SERVICE ({m_UseCmbServiceEnvString}) value is an invalid bool string. {m_UseCmbService} is being set to false.");
                     m_UseCmbServiceEnv = false;
                 }
             }
@@ -592,21 +593,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
         {
         }
 
-        /// <summary>
-        /// Will create <see cref="NumberOfClients"/> number of clients.
-        /// To create a specific number of clients <see cref="CreateServerAndClients(int)"/>
-        /// </summary>
-        protected void CreateServerAndClients()
-        {
-            // If we are connecting to a CMB server and we have a zero client count,
-            // then we must make m_NumberOfClients = 1 for the session owner.
-            if (m_UseCmbService && NumberOfClients == 0 && m_NumberOfClients == 0)
-            {
-                m_NumberOfClients = 1;
-            }
-            CreateServerAndClients(m_NumberOfClients);
-        }
-
         private void AddRemoveNetworkManager(NetworkManager networkManager, bool addNetworkManager)
         {
             var clientNetworkManagersList = new List<NetworkManager>(m_ClientNetworkManagers);
@@ -878,6 +864,15 @@ namespace Unity.Netcode.TestHelpers.Runtime
         }
 
         /// <summary>
+        /// Will create <see cref="NumberOfClients"/> number of clients.
+        /// To create a specific number of clients <see cref="CreateServerAndClients(int)"/>
+        /// </summary>
+        protected void CreateServerAndClients()
+        {
+            CreateServerAndClients(NumberOfClients);
+        }
+
+        /// <summary>
         /// Creates the server and clients
         /// </summary>
         /// <param name="numberOfClients">The number of client instances to create</param>
@@ -892,23 +887,10 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 m_TargetFrameRate = -1;
             }
 
-            // In the event this is invoked within a derived integration test and
-            // the number of clients is 0, then we need to have at least 1 client
-            // to be the session owner.
-            if (m_UseCmbService && numberOfClients == 0)
+            // If we are connecting to a CMB server we add +1 for the session owner
+            if (m_UseCmbService)
             {
-                numberOfClients = 1;
-                // If m_NumberOfCleints == 0, then we should increment it.
-                if (m_NumberOfClients == 0)
-                {
-                    m_NumberOfClients = 1;
-                }
-                else
-                {
-                    // Otherwise, log a warning to the developer that they may be doing something bad.
-                    Debug.LogWarning($"[{nameof(CreateServerAndClients)}] Invoked with number of clients set to zero but m_NumberOfClients was {m_NumberOfClients}. " +
-                        $"Unless this was intended, this could cause issues with the {nameof(NetcodeIntegrationTest)}!");
-                }
+                numberOfClients++;
             }
 
             // Create multiple NetworkManager instances
@@ -917,7 +899,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 Debug.LogError("Failed to create instances");
                 Assert.Fail("Failed to create instances");
             }
-
+            m_NumberOfClients = numberOfClients;
             m_ClientNetworkManagers = clients;
             m_ServerNetworkManager = server;
 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -218,6 +218,23 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// <remarks>Can only be true if <see cref="UseCMBService"/> returns true.</remarks>
         protected bool m_UseCmbService { get; private set; }
 
+        private string m_UseCmbServiceEnvString = null;
+        private bool m_UseCmbServiceEnv;
+
+        /// <summary>
+        /// Will set itself once and if already set then return true
+        /// </summary>
+        /// <returns>true/false</returns>
+        internal bool UseCMBServiceEnviromentVariableSet()
+        {
+            if (!m_UseCmbServiceEnv && m_UseCmbServiceEnvString == null)
+            {
+                var useCmbService = Environment.GetEnvironmentVariable("USE_CMB_SERVICE") ?? "unset";
+                m_UseCmbServiceEnv = useCmbService.ToLower() == "true";
+            }
+            return m_UseCmbServiceEnv;
+        }
+
         /// <summary>
         /// Indicates whether a hosted CMB service is available.
         /// </summary>
@@ -228,8 +245,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
 #if USE_CMB_SERVICE
             return true;
 #else
-            var useCmbService = Environment.GetEnvironmentVariable("USE_CMB_SERVICE") ?? "unset";
-            return useCmbService.ToLower() == "true";
+            return UseCMBServiceEnviromentVariableSet();
 #endif
         }
 
@@ -1438,6 +1454,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
 #endif
 
             IsRunning = false;
+            m_UseCmbServiceEnvString = null;
+            m_UseCmbServiceEnv = false;
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -162,10 +162,23 @@ namespace Unity.Netcode.TestHelpers.Runtime
         {
             if (m_UseCmbService)
             {
+                // TODO: Because we start the NetworkManagers back-to-back, the service can make a NetworkManager
+                // (other than the very first one) the session owner. This could lead to test instabilities and
+                // we need to add additional code during the start process that will start the very 1st instance
+                // and wait for it to be approved and assigned the session owner before we assume anything.
+                // Otherwise, any pick from the m_NetworkManagers could result in that specific instance not being
+                // the first session owner.
+                // If we haven't even started any NetworkManager, then just return the first
+                // instance until we resolve the above issue.
+                if (!NetcodeIntegrationTestHelpers.IsStarted)
+                {
+                    return m_NetworkManagers[0];
+                }
+
                 foreach (var client in m_NetworkManagers)
                 {
-                    // If client isn't approved we are still in setup and want to return the first client
-                    // otherwise look for the session owner
+                    // See above notes.
+                    // TODO: Once the above is resolved, just check for client.LocalClient.IsSessionOwner
                     if (!client.LocalClient.IsApproved || client.LocalClient.IsSessionOwner)
                     {
                         return client;
@@ -203,7 +216,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// Indicates whether the currently running tests are targeting the hosted CMB Service
         /// </summary>
         /// <remarks>Can only be true if <see cref="UseCMBService"/> returns true.</remarks>
-        protected bool m_UseCmbService;
+        protected bool m_UseCmbService { get; private set; }
 
         /// <summary>
         /// Indicates whether a hosted CMB service is available.
@@ -419,6 +432,9 @@ namespace Unity.Netcode.TestHelpers.Runtime
         [UnitySetUp]
         public IEnumerator SetUp()
         {
+            // In addition to setting the number of clients in the OneTimeSetup, we need to re-apply the number of clients for each unique test
+            // in the event that a previous test stopped a client.
+            m_NumberOfClients = NumberOfClients;
             VerboseDebugLog.Clear();
             VerboseDebug($"Entering {nameof(SetUp)}");
             NetcodeLogAssert = new NetcodeLogAssert();
@@ -521,7 +537,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         {
             // If we are connecting to a CMB server and we have a zero client count,
             // then we must make m_NumberOfClients = 1 for the session owner.
-            if (UseCMBService() && NumberOfClients == 0 && m_NumberOfClients == 0)
+            if (m_UseCmbService && NumberOfClients == 0 && m_NumberOfClients == 0)
             {
                 m_NumberOfClients = 1;
             }
@@ -816,7 +832,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             // In the event this is invoked within a derived integration test and
             // the number of clients is 0, then we need to have at least 1 client
             // to be the session owner.
-            if (UseCMBService() && numberOfClients == 0)
+            if (m_UseCmbService && numberOfClients == 0)
             {
                 numberOfClients = 1;
                 // If m_NumberOfCleints == 0, then we should increment it.
@@ -995,7 +1011,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
             return true;
         }
 
-
         /// <summary>
         /// This starts the server and clients as long as <see cref="CanStartServerAndClients"/>
         /// returns true.
@@ -1009,15 +1024,15 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 // Start the instances and pass in our SceneManagerInitialization action that is invoked immediately after host-server
                 // is started and after each client is started.
 
-                // When using the CMBService, we don't have a server, so get the appropriate authority network manager
-                var authorityManager = GetAuthorityNetworkManager();
-
                 VerboseDebug($"Starting with useCmbService: {m_UseCmbService}");
                 if (!NetcodeIntegrationTestHelpers.Start(m_UseHost, !m_UseCmbService, m_ServerNetworkManager, m_ClientNetworkManagers))
                 {
                     Debug.LogError("Failed to start instances");
                     Assert.Fail("Failed to start instances");
                 }
+
+                // When using the CMBService, we don't have a server, so get the appropriate authority network manager
+                var authorityManager = GetAuthorityNetworkManager();
 
                 // When scene management is enabled, we need to re-apply the scenes populated list since we have overriden the ISceneManagerHandler
                 // imeplementation at this point. This assures any pre-loaded scenes will be automatically assigned to the server and force clients
@@ -1382,9 +1397,11 @@ namespace Unity.Netcode.TestHelpers.Runtime
             var networkManagers = Object.FindObjectsByType<NetworkManager>(FindObjectsSortMode.None);
             foreach (var networkManager in networkManagers)
             {
-
                 Object.DestroyImmediate(networkManager.gameObject);
             }
+            m_NetworkManagers = null;
+            m_ClientNetworkManagers = null;
+            m_ServerNetworkManager = null;
         }
 
         /// <summary>
@@ -1949,7 +1966,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
             if (UseCMBService())
             {
                 m_UseCmbService = m_DistributedAuthority && hostOrServer == HostOrServer.DAHost;
-
             }
         }
 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -180,14 +180,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
         {
             if (m_UseCmbService)
             {
-                // TODO: Because we start the NetworkManagers back-to-back, the service can make a NetworkManager
-                // (other than the very first one) the session owner. This could lead to test instabilities and
-                // we need to add additional code during the start process that will start the very 1st instance
-                // and wait for it to be approved and assigned the session owner before we assume anything.
-                // Otherwise, any pick from the m_NetworkManagers could result in that specific instance not being
-                // the first session owner.
-                // If we haven't even started any NetworkManager, then just return the first
-                // instance until we resolve the above issue.
+                // If we haven't even started any NetworkManager, then return the first instance
+                // since it will be the session owner.
                 if (!NetcodeIntegrationTestHelpers.IsStarted)
                 {
                     return m_NetworkManagers[0];
@@ -195,9 +189,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
                 foreach (var client in m_NetworkManagers)
                 {
-                    // See above notes.
-                    // TODO: Once the above is resolved, just check for client.LocalClient.IsSessionOwner
-                    if (!client.LocalClient.IsApproved || client.LocalClient.IsSessionOwner)
+                    if (client.LocalClient.IsSessionOwner)
                     {
                         return client;
                     }
@@ -584,15 +576,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
             VerboseDebug($"Exiting {nameof(CreatePlayerPrefab)}");
         }
 
-        /// <summary>
-        /// This is invoked before the server and client(s) are started.
-        /// Override this method if you want to make any adjustments to their
-        /// NetworkManager instances.
-        /// </summary>
-        protected virtual void OnServerAndClientsCreated()
-        {
-        }
-
         private void AddRemoveNetworkManager(NetworkManager networkManager, bool addNetworkManager)
         {
             var clientNetworkManagersList = new List<NetworkManager>(m_ClientNetworkManagers);
@@ -613,6 +596,78 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 clientNetworkManagersList.Insert(0, m_ServerNetworkManager);
             }
             m_NetworkManagers = clientNetworkManagersList.ToArray();
+        }
+
+        /// <summary>
+        /// This is invoked before the server and client(s) are started.
+        /// Override this method if you want to make any adjustments to their
+        /// NetworkManager instances.
+        /// </summary>
+        protected virtual void OnServerAndClientsCreated()
+        {
+        }
+
+        /// <summary>
+        /// Will create <see cref="NumberOfClients"/> number of clients.
+        /// To create a specific number of clients <see cref="CreateServerAndClients(int)"/>
+        /// </summary>
+        protected void CreateServerAndClients()
+        {
+            CreateServerAndClients(NumberOfClients);
+        }
+
+        /// <summary>
+        /// Creates the server and clients
+        /// </summary>
+        /// <param name="numberOfClients">The number of client instances to create</param>
+        protected void CreateServerAndClients(int numberOfClients)
+        {
+            VerboseDebug($"Entering {nameof(CreateServerAndClients)}");
+
+            CreatePlayerPrefab();
+
+            if (m_EnableTimeTravel)
+            {
+                m_TargetFrameRate = -1;
+            }
+
+            // If we are connecting to a CMB server we add +1 for the session owner
+            if (m_UseCmbService)
+            {
+                numberOfClients++;
+            }
+
+            // Create multiple NetworkManager instances
+            if (!NetcodeIntegrationTestHelpers.Create(numberOfClients, out NetworkManager server, out NetworkManager[] clients, m_TargetFrameRate, m_CreateServerFirst, m_EnableTimeTravel, m_UseCmbService))
+            {
+                Debug.LogError("Failed to create instances");
+                Assert.Fail("Failed to create instances");
+            }
+            m_NumberOfClients = numberOfClients;
+            m_ClientNetworkManagers = clients;
+            m_ServerNetworkManager = server;
+
+            var managers = clients.ToList();
+            if (!m_UseCmbService)
+            {
+                managers.Insert(0, m_ServerNetworkManager);
+            }
+            m_NetworkManagers = managers.ToArray();
+
+            s_DefaultWaitForTick = new WaitForSecondsRealtime(1.0f / GetAuthorityNetworkManager().NetworkConfig.TickRate);
+
+            // Set the player prefab for the server and clients
+            foreach (var manager in m_NetworkManagers)
+            {
+                manager.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
+                SetDistributedAuthorityProperties(manager);
+            }
+
+            // Provides opportunity to allow child derived classes to
+            // modify the NetworkManager's configuration before starting.
+            OnServerAndClientsCreated();
+
+            VerboseDebug($"Exiting {nameof(CreateServerAndClients)}");
         }
 
         /// <summary>
@@ -864,69 +919,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
         }
 
         /// <summary>
-        /// Will create <see cref="NumberOfClients"/> number of clients.
-        /// To create a specific number of clients <see cref="CreateServerAndClients(int)"/>
-        /// </summary>
-        protected void CreateServerAndClients()
-        {
-            CreateServerAndClients(NumberOfClients);
-        }
-
-        /// <summary>
-        /// Creates the server and clients
-        /// </summary>
-        /// <param name="numberOfClients">The number of client instances to create</param>
-        protected void CreateServerAndClients(int numberOfClients)
-        {
-            VerboseDebug($"Entering {nameof(CreateServerAndClients)}");
-
-            CreatePlayerPrefab();
-
-            if (m_EnableTimeTravel)
-            {
-                m_TargetFrameRate = -1;
-            }
-
-            // If we are connecting to a CMB server we add +1 for the session owner
-            if (m_UseCmbService)
-            {
-                numberOfClients++;
-            }
-
-            // Create multiple NetworkManager instances
-            if (!NetcodeIntegrationTestHelpers.Create(numberOfClients, out NetworkManager server, out NetworkManager[] clients, m_TargetFrameRate, m_CreateServerFirst, m_EnableTimeTravel, m_UseCmbService))
-            {
-                Debug.LogError("Failed to create instances");
-                Assert.Fail("Failed to create instances");
-            }
-            m_NumberOfClients = numberOfClients;
-            m_ClientNetworkManagers = clients;
-            m_ServerNetworkManager = server;
-
-            var managers = clients.ToList();
-            if (!m_UseCmbService)
-            {
-                managers.Insert(0, m_ServerNetworkManager);
-            }
-            m_NetworkManagers = managers.ToArray();
-
-            s_DefaultWaitForTick = new WaitForSecondsRealtime(1.0f / GetAuthorityNetworkManager().NetworkConfig.TickRate);
-
-            // Set the player prefab for the server and clients
-            foreach (var manager in m_NetworkManagers)
-            {
-                manager.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
-                SetDistributedAuthorityProperties(manager);
-            }
-
-            // Provides opportunity to allow child derived classes to
-            // modify the NetworkManager's configuration before starting.
-            OnServerAndClientsCreated();
-
-            VerboseDebug($"Exiting {nameof(CreateServerAndClients)}");
-        }
-
-        /// <summary>
         /// Override this method and return false in order to be able
         /// to manually control when the server and clients are started.
         /// </summary>
@@ -1028,11 +1020,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
             if (m_UseHost)
             {
-#if UNITY_2023_1_OR_NEWER
                 var clientSideServerPlayerClones = Object.FindObjectsByType<NetworkObject>(FindObjectsSortMode.None).Where((c) => c.IsPlayerObject && c.OwnerClientId == NetworkManager.ServerClientId);
-#else
-                var clientSideServerPlayerClones = Object.FindObjectsOfType<NetworkObject>().Where((c) => c.IsPlayerObject && c.OwnerClientId == m_ServerNetworkManager.LocalClientId);
-#endif
                 foreach (var playerNetworkObject in clientSideServerPlayerClones)
                 {
                     // When the server is not the host this needs to be done
@@ -1057,6 +1045,19 @@ namespace Unity.Netcode.TestHelpers.Runtime
         }
 
         /// <summary>
+        /// Starts the session owner and awaits for it to connect before starting the remaining clients.
+        /// </summary>
+        private IEnumerator StartSessionOwner()
+        {
+            VerboseDebug("Starting session owner...");
+            NetcodeIntegrationTestHelpers.StartOneClient(m_ClientNetworkManagers[0]);
+            yield return WaitForConditionOrTimeOut(() => m_ClientNetworkManagers[0].IsConnectedClient);
+            AssertOnTimeout($"Timed out waiting for the session owner to connect to CMB Server!");
+            Assert.True(m_ClientNetworkManagers[0].LocalClient.IsSessionOwner, $"Client-{m_ClientNetworkManagers[0].LocalClientId} started session but was not set to be the session owner!");
+            VerboseDebug("Session owner connected and approved.");
+        }
+
+        /// <summary>
         /// This starts the server and clients as long as <see cref="CanStartServerAndClients"/>
         /// returns true.
         /// </summary>
@@ -1066,17 +1067,21 @@ namespace Unity.Netcode.TestHelpers.Runtime
             {
                 VerboseDebug($"Entering {nameof(StartServerAndClients)}");
 
+                if (m_UseCmbService)
+                {
+                    VerboseDebug("Using a distributed authority CMB Server for connection.");
+                    yield return StartSessionOwner();
+                }
+
                 // Start the instances and pass in our SceneManagerInitialization action that is invoked immediately after host-server
                 // is started and after each client is started.
-
-                VerboseDebug($"Starting with useCmbService: {m_UseCmbService}");
                 if (!NetcodeIntegrationTestHelpers.Start(m_UseHost, !m_UseCmbService, m_ServerNetworkManager, m_ClientNetworkManagers))
                 {
                     Debug.LogError("Failed to start instances");
                     Assert.Fail("Failed to start instances");
                 }
 
-                // When using the CMBService, we don't have a server, so get the appropriate authority network manager
+                // Get the authority NetworkMananger (Server, Host, or Session Owner)
                 var authorityManager = GetAuthorityNetworkManager();
 
                 // When scene management is enabled, we need to re-apply the scenes populated list since we have overriden the ISceneManagerHandler
@@ -1108,13 +1113,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
                     if (m_UseHost || authorityManager.IsHost)
                     {
-#if UNITY_2023_1_OR_NEWER
                         // Add the server player instance to all m_ClientSidePlayerNetworkObjects entries
                         var serverPlayerClones = Object.FindObjectsByType<NetworkObject>(FindObjectsSortMode.None).Where((c) => c.IsPlayerObject && c.OwnerClientId == authorityManager.LocalClientId);
-#else
-                        // Add the server player instance to all m_ClientSidePlayerNetworkObjects entries
-                        var serverPlayerClones = Object.FindObjectsOfType<NetworkObject>().Where((c) => c.IsPlayerObject && c.OwnerClientId == authorityManager.LocalClientId);
-#endif
                         foreach (var playerNetworkObject in serverPlayerClones)
                         {
                             if (!m_PlayerNetworkObjects.ContainsKey(playerNetworkObject.NetworkManager.LocalClientId))
@@ -1128,6 +1128,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
                             }
                         }
                     }
+
+                    // With distributed authority, we check that all players have spawned on all NetworkManager instances
                     if (m_DistributedAuthority)
                     {
                         foreach (var networkManager in m_NetworkManagers)
@@ -1137,8 +1139,10 @@ namespace Unity.Netcode.TestHelpers.Runtime
                         }
                     }
 
-                    if (ShouldCheckForSpawnedPlayers())
+                    // Client-Server or DAHost
+                    if (ShouldCheckForSpawnedPlayers() && !m_UseCmbService)
                     {
+                        // Check for players being spawned on server instance
                         ClientNetworkManagerPostStartInit();
                     }
 
@@ -1698,13 +1702,12 @@ namespace Unity.Netcode.TestHelpers.Runtime
             }
 
             var manager = GetAuthorityNetworkManager();
-            var expectedCount = manager.IsHost ? clientsToCheck.Length + 1 : clientsToCheck.Length;
             var currentCount = manager.ConnectedClients.Count;
 
-            if (currentCount != expectedCount)
+            if (currentCount != TotalClients)
             {
                 allClientsConnected = false;
-                m_InternalErrorLog.AppendLine($"[Server-Side] Expected {expectedCount} clients to connect but only {currentCount} connected!");
+                m_InternalErrorLog.AppendLine($"[Server-Side] Expected {TotalClients} clients to connect but only {currentCount} connected!");
             }
 
             return allClientsConnected;

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -97,7 +97,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         }
 
         /// <summary>
-        /// Total number of clients that should be connected at any point during a test
+        /// Total number of clients that should be connected at any point during a test.
         /// </summary>
         protected int TotalClients => m_UseHost ? m_NumberOfClients + 1 : m_NumberOfClients;
 
@@ -107,15 +107,21 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// Specifies the number of client instances to be created for the integration test.
         /// </summary>
         /// <remarks>
-        /// When running with a hosted CMB Service, NumberOfClients + 1 clients are created.
-        /// This holds assumptions throughout the test suite that when running with a host, there is an extra client.
-        /// For example, see the calculation for <see cref="TotalClients"/>.
+        /// Client-Server network topology:<br />
+        /// When running as a host the total number of clients will be NumberOfClients + 1.<br />
+        /// See the calculation for <see cref="TotalClients"/>.
+        /// Distributed Authority network topology:<br />
+        /// When connecting to a CMB server, if the <see cref="NumberOfClients"/> == 0 then a session owner client will
+        /// be automatically added in order to start the session and the private internal m_NumberOfClients value, which 
+        /// is initialized as <see cref="NumberOfClients"/>, will be incremented by 1 making <see cref="TotalClients"/> yield the
+        /// same results as if we were running a Host where it will effectively be <see cref="NumberOfClients"/>
+        /// + 1.
         /// </remarks>
         protected abstract int NumberOfClients { get; }
         private int m_NumberOfClients;
 
         /// <summary>
-        /// Set this to false to create the clients first.
+        /// Set this to false to create the clients first.<br />
         /// Note: If you are using scene placed NetworkObjects or doing any form of scene testing and
         /// get prefab hash id "soft synchronization" errors, then set this to false and run your test
         /// again.  This is a work-around until we can resolve some issues with NetworkManagerOwner and
@@ -513,7 +519,13 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// </summary>
         protected void CreateServerAndClients()
         {
-            CreateServerAndClients(NumberOfClients);
+            // If we are connecting to a CMB server and we have a zero client count,
+            // then we must make m_NumberOfClients = 1 for the session owner.
+            if (UseCMBService() && NumberOfClients == 0 && m_NumberOfClients == 0)
+            {
+                m_NumberOfClients = 1;
+            }
+            CreateServerAndClients(m_NumberOfClients);
         }
 
         private void AddRemoveNetworkManager(NetworkManager networkManager, bool addNetworkManager)
@@ -546,7 +558,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         protected virtual void OnNewClientCreated(NetworkManager networkManager)
         {
             // Ensure any late joining client has all NetworkPrefabs required to connect.
-            foreach (var networkPrefab in m_ServerNetworkManager.NetworkConfig.Prefabs.Prefabs)
+            foreach (var networkPrefab in GetAuthorityNetworkManager().NetworkConfig.Prefabs.Prefabs)
             {
                 if (!networkManager.NetworkConfig.Prefabs.Contains(networkPrefab.Prefab))
                 {
@@ -761,7 +773,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
         protected void SetTimeTravelSimulatedLatency(float latencySeconds)
         {
-            ((MockTransport)m_ServerNetworkManager.NetworkConfig.NetworkTransport).SimulatedLatencySeconds = latencySeconds;
+            ((MockTransport)GetAuthorityNetworkManager().NetworkConfig.NetworkTransport).SimulatedLatencySeconds = latencySeconds;
             foreach (var client in m_ClientNetworkManagers)
             {
                 ((MockTransport)client.NetworkConfig.NetworkTransport).SimulatedLatencySeconds = latencySeconds;
@@ -770,7 +782,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
         protected void SetTimeTravelSimulatedDropRate(float dropRatePercent)
         {
-            ((MockTransport)m_ServerNetworkManager.NetworkConfig.NetworkTransport).PacketDropRate = dropRatePercent;
+            ((MockTransport)GetAuthorityNetworkManager().NetworkConfig.NetworkTransport).PacketDropRate = dropRatePercent;
             foreach (var client in m_ClientNetworkManagers)
             {
                 ((MockTransport)client.NetworkConfig.NetworkTransport).PacketDropRate = dropRatePercent;
@@ -779,7 +791,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
         protected void SetTimeTravelSimulatedLatencyJitter(float jitterSeconds)
         {
-            ((MockTransport)m_ServerNetworkManager.NetworkConfig.NetworkTransport).LatencyJitter = jitterSeconds;
+            ((MockTransport)GetAuthorityNetworkManager().NetworkConfig.NetworkTransport).LatencyJitter = jitterSeconds;
             foreach (var client in m_ClientNetworkManagers)
             {
                 ((MockTransport)client.NetworkConfig.NetworkTransport).LatencyJitter = jitterSeconds;
@@ -801,10 +813,23 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 m_TargetFrameRate = -1;
             }
 
-            // Add an extra session owner client when using the cmb service
-            if (m_UseCmbService)
+            // In the event this is invoked within a derived integration test and
+            // the number of clients is 0, then we need to have at least 1 client
+            // to be the session owner.
+            if (UseCMBService() && numberOfClients == 0)
             {
-                numberOfClients += 1;
+                numberOfClients = 1;
+                // If m_NumberOfCleints == 0, then we should increment it.
+                if (m_NumberOfClients == 0)
+                {
+                    m_NumberOfClients = 1;
+                }
+                else
+                {
+                    // Otherwise, log a warning to the developer that they may be doing something bad.
+                    Debug.LogWarning($"[{nameof(CreateServerAndClients)}] Invoked with number of clients set to zero but m_NumberOfClients was {m_NumberOfClients}. " +
+                        $"Unless this was intended, this could cause issues with the {nameof(NetcodeIntegrationTest)}!");
+                }
             }
 
             // Create multiple NetworkManager instances
@@ -824,7 +849,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             }
             m_NetworkManagers = managers.ToArray();
 
-            s_DefaultWaitForTick = new WaitForSecondsRealtime(1.0f / m_ServerNetworkManager.NetworkConfig.TickRate);
+            s_DefaultWaitForTick = new WaitForSecondsRealtime(1.0f / GetAuthorityNetworkManager().NetworkConfig.TickRate);
 
             // Set the player prefab for the server and clients
             foreach (var manager in m_NetworkManagers)
@@ -943,7 +968,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             if (m_UseHost)
             {
 #if UNITY_2023_1_OR_NEWER
-                var clientSideServerPlayerClones = Object.FindObjectsByType<NetworkObject>(FindObjectsSortMode.None).Where((c) => c.IsPlayerObject && c.OwnerClientId == m_ServerNetworkManager.LocalClientId);
+                var clientSideServerPlayerClones = Object.FindObjectsByType<NetworkObject>(FindObjectsSortMode.None).Where((c) => c.IsPlayerObject && c.OwnerClientId == NetworkManager.ServerClientId);
 #else
                 var clientSideServerPlayerClones = Object.FindObjectsOfType<NetworkObject>().Where((c) => c.IsPlayerObject && c.OwnerClientId == m_ServerNetworkManager.LocalClientId);
 #endif
@@ -955,9 +980,9 @@ namespace Unity.Netcode.TestHelpers.Runtime
                         m_PlayerNetworkObjects.Add(playerNetworkObject.NetworkManager.LocalClientId, new Dictionary<ulong, NetworkObject>());
                     }
 
-                    if (!m_PlayerNetworkObjects[playerNetworkObject.NetworkManager.LocalClientId].ContainsKey(m_ServerNetworkManager.LocalClientId))
+                    if (!m_PlayerNetworkObjects[playerNetworkObject.NetworkManager.LocalClientId].ContainsKey(NetworkManager.ServerClientId))
                     {
-                        m_PlayerNetworkObjects[playerNetworkObject.NetworkManager.LocalClientId].Add(m_ServerNetworkManager.LocalClientId, playerNetworkObject);
+                        m_PlayerNetworkObjects[playerNetworkObject.NetworkManager.LocalClientId].Add(NetworkManager.ServerClientId, playerNetworkObject);
                     }
                 }
             }
@@ -1021,7 +1046,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
                     AssertOnTimeout($"{nameof(StartServerAndClients)} timed out waiting for all clients to be connected!\n {m_InternalErrorLog}");
 
-                    if (m_UseHost || m_ServerNetworkManager.IsHost)
+                    if (m_UseHost || authorityManager.IsHost)
                     {
 #if UNITY_2023_1_OR_NEWER
                         // Add the server player instance to all m_ClientSidePlayerNetworkObjects entries
@@ -1039,7 +1064,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
                             if (!m_UseCmbService)
                             {
-                                m_PlayerNetworkObjects[playerNetworkObject.NetworkManager.LocalClientId].Add(m_ServerNetworkManager.LocalClientId, playerNetworkObject);
+                                m_PlayerNetworkObjects[playerNetworkObject.NetworkManager.LocalClientId].Add(authorityManager.LocalClientId, playerNetworkObject);
                             }
                         }
                     }
@@ -1111,7 +1136,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
                     AssertOnTimeout($"{nameof(StartServerAndClients)} timed out waiting for all clients to be connected!");
 
-                    if (m_UseHost || m_ServerNetworkManager.IsHost)
+                    if (m_UseHost || authorityManager.IsHost)
                     {
 #if UNITY_2023_1_OR_NEWER
                         // Add the server player instance to all m_ClientSidePlayerNetworkObjects entries
@@ -1129,7 +1154,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
                             if (!m_UseCmbService)
                             {
-                                m_PlayerNetworkObjects[playerNetworkObject.NetworkManager.LocalClientId].Add(m_ServerNetworkManager.LocalClientId, playerNetworkObject);
+                                m_PlayerNetworkObjects[playerNetworkObject.NetworkManager.LocalClientId].Add(authorityManager.LocalClientId, playerNetworkObject);
                             }
                         }
                     }
@@ -1449,10 +1474,9 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// </summary>
         protected void EnableMessageLogging()
         {
-            m_ServerNetworkManager.ConnectionManager.MessageManager.Hook(new DebugNetworkHooks());
-            foreach (var client in m_ClientNetworkManagers)
+            foreach (var networkManager in m_NetworkManagers)
             {
-                client.ConnectionManager.MessageManager.Hook(new DebugNetworkHooks());
+                networkManager.ConnectionManager.MessageManager.Hook(new DebugNetworkHooks());
             }
         }
 
@@ -1632,10 +1656,11 @@ namespace Unity.Netcode.TestHelpers.Runtime
         protected bool WaitForClientsConnectedOrTimeOutWithTimeTravel(NetworkManager[] clientsToCheck)
         {
             var remoteClientCount = clientsToCheck.Length;
-            var serverClientCount = m_ServerNetworkManager.IsHost ? remoteClientCount + 1 : remoteClientCount;
+            var authorityNetworkManager = GetAuthorityNetworkManager();
+            var serverClientCount = authorityNetworkManager.IsHost ? remoteClientCount + 1 : remoteClientCount;
 
             return WaitForConditionOrTimeOutWithTimeTravel(() => clientsToCheck.Where((c) => c.IsConnectedClient).Count() == remoteClientCount &&
-                                                                 m_ServerNetworkManager.ConnectedClients.Count == serverClientCount);
+                                                                 authorityNetworkManager.ConnectedClients.Count == serverClientCount);
         }
 
         /// <summary>
@@ -1746,9 +1771,10 @@ namespace Unity.Netcode.TestHelpers.Runtime
         {
             var prefabCreateAssertError = $"You can only invoke this method during {nameof(OnServerAndClientsCreated)} " +
                                           $"but before {nameof(OnStartedServerAndClients)}!";
-            Assert.IsNotNull(m_ServerNetworkManager, prefabCreateAssertError);
-            Assert.IsFalse(m_ServerNetworkManager.IsListening, prefabCreateAssertError);
-            var prefabObject = NetcodeIntegrationTestHelpers.CreateNetworkObjectPrefab(baseName, m_ServerNetworkManager, m_ClientNetworkManagers);
+            var authorityNetworkManager = GetAuthorityNetworkManager();
+            Assert.IsNotNull(authorityNetworkManager, prefabCreateAssertError);
+            Assert.IsFalse(authorityNetworkManager.IsListening, prefabCreateAssertError);
+            var prefabObject = NetcodeIntegrationTestHelpers.CreateNetworkObjectPrefab(baseName, authorityNetworkManager, m_ClientNetworkManagers);
             // DANGO-TODO: Ownership flags could require us to change this
             // For testing purposes, we default to true for the distribute ownership property when in a distirbuted authority network topology.
             prefabObject.GetComponent<NetworkObject>().Ownership |= NetworkObject.OwnershipStatus.Distributable;

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -247,7 +247,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// check the environment variable once per test set.
         /// </remarks>
         /// <returns>true/false</returns>
-        private bool GetServiceEnviromentVariable()
+        private bool GetServiceEnvironmentVariable()
         {
             if (!m_UseCmbServiceEnv && m_UseCmbServiceEnvString == null)
             {
@@ -427,7 +427,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             // If the environment variable is set (i.e. doing a CMB server run) but UseCMBservice returns false, then ignore the test.
             // Note: This will prevent us from re-running all of the non-DA integration tests that have already run multiple times on
             // multiple platforms
-            if (GetServiceEnviromentVariable() && !UseCMBService())
+            if (GetServiceEnvironmentVariable() && !UseCMBService())
             {
                 Assert.Ignore("[CMB-Server Test Run] Skipping non-distributed authority test.");
                 return;

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -2046,7 +2046,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
             // If we are using a distributed authority network topology and the environment variable
             // to use the CMBService is set, then perform the m_UseCmbService check.
-            if (m_DistributedAuthority && GetServiceEnviromentVariable())
+            if (m_DistributedAuthority && GetServiceEnvironmentVariable())
             {
                 m_UseCmbService = hostOrServer == HostOrServer.DAHost;
                 // In the event UseCMBService is overridden, we apply the value returned.

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
@@ -172,6 +172,18 @@ namespace Unity.Netcode.TestHelpers.Runtime
             }
         }
 
+        /// <summary>
+        /// Use for non <see cref="NetcodeIntegrationTest"/> derived integration tests to automatically ignore the
+        /// test is the USE_CMB_SERVICE is set. 
+        /// </summary>
+        internal static void IgnoreIfServiceEnviromentVariableSet()
+        {
+            if (bool.TryParse(Environment.GetEnvironmentVariable("USE_CMB_SERVICE") ?? "false", out bool isTrue) ? isTrue : false)
+            {
+                Assert.Ignore("[CMB-Server Test Run] Skipping non-distributed authority test.");
+            }
+        }
+
         private static readonly string k_TransportHost = GetAddressToBind();
         private static readonly ushort k_TransportPort = GetPortToBind();
 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
@@ -173,12 +173,25 @@ namespace Unity.Netcode.TestHelpers.Runtime
         }
 
         /// <summary>
+        /// Gets the CMB_SERVICE environemnt variable or returns "false" if it does not exist
+        /// </summary>
+        /// <returns>string</returns>
+        internal static string GetCMBServiceEnvironentVariable()
+        {
+#if USE_CMB_SERVICE
+            return "true";
+#else
+            return Environment.GetEnvironmentVariable("USE_CMB_SERVICE") ?? "false";
+#endif
+        }
+
+        /// <summary>
         /// Use for non <see cref="NetcodeIntegrationTest"/> derived integration tests to automatically ignore the
         /// test if running against a CMB server.
         /// </summary>
         internal static void IgnoreIfServiceEnviromentVariableSet()
         {
-            if (bool.TryParse(Environment.GetEnvironmentVariable("USE_CMB_SERVICE") ?? "false", out bool isTrue) ? isTrue : false)
+            if (bool.TryParse(GetCMBServiceEnvironentVariable(), out bool isTrue) ? isTrue : false)
             {
                 Assert.Ignore("[CMB-Server Test Run] Skipping non-distributed authority test.");
             }
@@ -327,7 +340,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         public static bool CreateNewClients(int clientCount, out NetworkManager[] clients, bool useMockTransport = false, bool useCmbService = false)
         {
             clients = new NetworkManager[clientCount];
-            // Pre-identify NetworkManager identifiers based on network topology type
+            // Pre-identify NetworkManager identifiers based on network topology type (Rust server starts at client identifier 1 and considers itself 0)
             var startCount = useCmbService ? 1 : 0;
             for (int i = 0; i < clientCount; i++)
             {
@@ -549,6 +562,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
             foreach (var client in clients)
             {
+                // DANGO-TODO: Renove this entire check when the Rust server connection sequence is fixed and we don't have to pre-start
+                // the session owner.
                 if (client.IsConnectedClient)
                 {
                     // Skip starting the session owner

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
@@ -174,7 +174,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
         /// <summary>
         /// Use for non <see cref="NetcodeIntegrationTest"/> derived integration tests to automatically ignore the
-        /// test is the USE_CMB_SERVICE is set. 
+        /// test if running against a CMB server.
         /// </summary>
         internal static void IgnoreIfServiceEnviromentVariableSet()
         {

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
@@ -265,16 +265,18 @@ namespace Unity.Netcode.TestHelpers.Runtime
         {
             s_NetworkManagerInstances = new List<NetworkManager>();
             server = null;
-            if (serverFirst)
+            // Only if we are not connecting to a CMB server
+            if (serverFirst && !useCmbService)
             {
-                server = CreateServer(useMockTransport || useCmbService);
+                server = CreateServer(useMockTransport);
             }
 
             CreateNewClients(clientCount, out clients, useMockTransport, useCmbService);
 
-            if (!serverFirst)
+            // Only if we are not connecting to a CMB server
+            if (!serverFirst && !useCmbService)
             {
-                server = CreateServer(useMockTransport || useCmbService);
+                server = CreateServer(useMockTransport);
             }
 
             s_OriginalTargetFrameRate = Application.targetFrameRate;
@@ -627,7 +629,19 @@ namespace Unity.Netcode.TestHelpers.Runtime
             return gameObject;
         }
 
-        public static GameObject CreateNetworkObjectPrefab(string baseName, NetworkManager server, params NetworkManager[] clients)
+        /// <summary>
+        /// This will create and register a <see cref="NetworkPrefab"/> instance for all <see cref="NetworkManager"/> instances.<br />
+        /// *** Invoke this method before starting any of the <see cref="NetworkManager"/> instances ***.
+        /// </summary>
+        /// <remarks>
+        /// When using a <see cref="NetworkTopologyTypes.DistributedAuthority"/> network topology, the authority <see cref="NetworkManager"/>
+        /// can be within the clients array of <see cref="NetworkManager"/> instances.
+        /// </remarks>
+        /// <param name="baseName">The base name of the network prefab. Keep it short as additional information will be added to this name.</param>
+        /// <param name="authorityNetworkManager">The authority <see cref="NetworkManager"/> (i.e. server, host, or session owner)</param>
+        /// <param name="clients">The clients that should also have this <see cref="NetworkPrefab"/> instance added to their network prefab list.</param>
+        /// <returns>The prefab's root <see cref="GameObject"/></returns>
+        public static GameObject CreateNetworkObjectPrefab(string baseName, NetworkManager authorityNetworkManager, params NetworkManager[] clients)
         {
             void AddNetworkPrefab(NetworkConfig config, NetworkPrefab prefab)
             {
@@ -635,17 +649,21 @@ namespace Unity.Netcode.TestHelpers.Runtime
             }
 
             var prefabCreateAssertError = $"You can only invoke this method before starting the network manager(s)!";
-            Assert.IsNotNull(server, prefabCreateAssertError);
-            Assert.IsFalse(server.IsListening, prefabCreateAssertError);
+            Assert.IsNotNull(authorityNetworkManager, prefabCreateAssertError);
+            Assert.IsFalse(authorityNetworkManager.IsListening, prefabCreateAssertError);
 
-            var gameObject = CreateNetworkObject(baseName, server);
+            var gameObject = CreateNetworkObject(baseName, authorityNetworkManager);
             var networkPrefab = new NetworkPrefab() { Prefab = gameObject };
 
             // We could refactor this test framework to share a NetworkPrefabList instance, but at this point it's
             // probably more trouble than it's worth to verify these lists stay in sync across all tests...
-            AddNetworkPrefab(server.NetworkConfig, networkPrefab);
+            AddNetworkPrefab(authorityNetworkManager.NetworkConfig, networkPrefab);
             foreach (var clientNetworkManager in clients)
             {
+                if (clientNetworkManager == authorityNetworkManager)
+                {
+                    continue;
+                }
                 AddNetworkPrefab(clientNetworkManager.NetworkConfig, networkPrefab);
             }
             return gameObject;

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
@@ -327,10 +327,13 @@ namespace Unity.Netcode.TestHelpers.Runtime
         public static bool CreateNewClients(int clientCount, out NetworkManager[] clients, bool useMockTransport = false, bool useCmbService = false)
         {
             clients = new NetworkManager[clientCount];
+            // Pre-identify NetworkManager identifiers based on network topology type
+            var startCount = useCmbService ? 1 : 0;
             for (int i = 0; i < clientCount; i++)
             {
                 // Create networkManager component
-                clients[i] = CreateNewClient(i, useMockTransport, useCmbService);
+                clients[i] = CreateNewClient(startCount, useMockTransport, useCmbService);
+                startCount++;
             }
 
             NetworkManagerInstances.AddRange(clients);
@@ -546,6 +549,18 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
             foreach (var client in clients)
             {
+                if (client.IsConnectedClient)
+                {
+                    // Skip starting the session owner
+                    if (client.DistributedAuthorityMode && client.CMBServiceConnection && client.LocalClient.IsSessionOwner)
+                    {
+                        continue;
+                    }
+                    else
+                    {
+                        throw new Exception("Client NetworkManager is already connected when starting clients!");
+                    }
+                }
                 client.StartClient();
                 hooks = new MultiInstanceHooks();
                 client.ConnectionManager.MessageManager.Hook(hooks);

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
@@ -21,6 +21,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         private static List<NetworkManager> s_NetworkManagerInstances = new List<NetworkManager>();
         private static Dictionary<NetworkManager, MultiInstanceHooks> s_Hooks = new Dictionary<NetworkManager, MultiInstanceHooks>();
         private static bool s_IsStarted;
+        internal static bool IsStarted => s_IsStarted;
         private static int s_ClientCount;
         private static int s_OriginalTargetFrameRate = -1;
 
@@ -643,11 +644,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// <returns>The prefab's root <see cref="GameObject"/></returns>
         public static GameObject CreateNetworkObjectPrefab(string baseName, NetworkManager authorityNetworkManager, params NetworkManager[] clients)
         {
-            void AddNetworkPrefab(NetworkConfig config, NetworkPrefab prefab)
-            {
-                config.Prefabs.Add(prefab);
-            }
-
             var prefabCreateAssertError = $"You can only invoke this method before starting the network manager(s)!";
             Assert.IsNotNull(authorityNetworkManager, prefabCreateAssertError);
             Assert.IsFalse(authorityNetworkManager.IsListening, prefabCreateAssertError);
@@ -657,14 +653,14 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
             // We could refactor this test framework to share a NetworkPrefabList instance, but at this point it's
             // probably more trouble than it's worth to verify these lists stay in sync across all tests...
-            AddNetworkPrefab(authorityNetworkManager.NetworkConfig, networkPrefab);
+            authorityNetworkManager.NetworkConfig.Prefabs.Add(networkPrefab);
             foreach (var clientNetworkManager in clients)
             {
                 if (clientNetworkManager == authorityNetworkManager)
                 {
                     continue;
                 }
-                AddNetworkPrefab(clientNetworkManager.NetworkConfig, networkPrefab);
+                clientNetworkManager.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Prefab = gameObject });
             }
             return gameObject;
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ClientOnlyConnectionTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ClientOnlyConnectionTests.cs
@@ -15,6 +15,13 @@ namespace Unity.Netcode.RuntimeTests
         private bool m_WasDisconnected;
         private TimeoutHelper m_TimeoutHelper;
 
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // TODO: [CmbServiceTests] if this test is deemed needed to test against the CMB server then update this test.
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
+
         [SetUp]
         public void Setup()
         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributeObjectsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributeObjectsTests.cs
@@ -161,6 +161,11 @@ namespace Unity.Netcode.RuntimeTests
                 {
                     foreach (var client in clients)
                     {
+                        if (!DistributeObjectsTestHelper.DistributedObjects.ContainsKey(client))
+                        {
+                            m_ErrorLog.AppendLine($"[Client-{client}] Does not have an entry in the root of the {nameof(DistributeObjectsTestHelper.DistributedObjects)} table!");
+                            return false;
+                        }
                         var clientOwnerTable = DistributeObjectsTestHelper.DistributedObjects[client];
                         if (!clientOwnerTable.ContainsKey(hostClientEntry.Key))
                         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
@@ -45,8 +45,6 @@ namespace Unity.Netcode.RuntimeTests
         private static readonly ushort k_TransportPort = GetPortToBind();
         private const int k_ClientId = 0;
 
-        private GameObject m_TestPrefab;
-
         /// <summary>
         /// Configures the port to look for the rust echo-server.
         /// </summary>

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
@@ -30,7 +30,7 @@ namespace Unity.Netcode.RuntimeTests
     /// </remarks>
     internal class DistributedAuthorityCodecTests : NetcodeIntegrationTest
     {
-        protected override int NumberOfClients => 1;
+        protected override int NumberOfClients => 0;
 
         // Use the CMB Service for all tests
         protected override bool UseCMBService() => true;
@@ -66,14 +66,6 @@ namespace Unity.Netcode.RuntimeTests
             public void TestAuthorityRpc(byte[] _)
             {
             }
-        }
-
-        /// <summary>
-        /// Don't auto start the session owner for codec tests
-        /// </summary>
-        internal override bool ShouldAutoStartSessionOwner()
-        {
-            return false;
         }
 
         protected override void OnOneTimeSetup()

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
@@ -45,6 +45,8 @@ namespace Unity.Netcode.RuntimeTests
         private static readonly ushort k_TransportPort = GetPortToBind();
         private const int k_ClientId = 0;
 
+        private GameObject m_TestPrefab;
+
         /// <summary>
         /// Configures the port to look for the rust echo-server.
         /// </summary>
@@ -247,9 +249,7 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator NetworkVariableDelta_WithValueUpdate()
         {
-            var networkObj = CreateNetworkObjectPrefab("TestObject");
-            networkObj.AddComponent<TestNetworkComponent>();
-            var instance = SpawnObject(networkObj, Client);
+            var instance = SpawnObject(m_SpawnObject, Client);
             yield return m_ClientCodecHook.WaitForMessageReceived<CreateObjectMessage>();
             var component = instance.GetComponent<TestNetworkComponent>();
 
@@ -262,9 +262,7 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator NetworkListDelta_WithValueUpdate()
         {
-            var networkObj = CreateNetworkObjectPrefab("TestObject");
-            networkObj.AddComponent<TestNetworkComponent>();
-            var instance = SpawnObject(networkObj, Client);
+            var instance = SpawnObject(m_SpawnObject, Client);
             yield return m_ClientCodecHook.WaitForMessageReceived<CreateObjectMessage>();
             var component = instance.GetComponent<TestNetworkComponent>();
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
@@ -39,7 +39,7 @@ namespace Unity.Netcode.RuntimeTests
         protected override NetworkTopologyTypes OnGetNetworkTopologyType() => NetworkTopologyTypes.DistributedAuthority;
 
         private CodecTestHooks m_ClientCodecHook;
-        private NetworkManager Client => m_ClientNetworkManagers[0];
+        private NetworkManager m_Client;
 
         private string m_TransportHost = Environment.GetEnvironmentVariable("NGO_HOST") ?? "127.0.0.1";
         private static readonly ushort k_TransportPort = GetPortToBind();
@@ -100,48 +100,48 @@ namespace Unity.Netcode.RuntimeTests
         /// </summary>
         protected override void OnServerAndClientsCreated()
         {
-            var utpTransport = Client.gameObject.AddComponent<UnityTransport>();
-            Client.NetworkConfig.NetworkTransport = utpTransport;
-            Client.NetworkConfig.EnableSceneManagement = false;
-            Client.NetworkConfig.AutoSpawnPlayerPrefabClientSide = true;
+            m_Client = GetAuthorityNetworkManager();
+
+            var utpTransport = m_Client.gameObject.AddComponent<UnityTransport>();
+            m_Client.NetworkConfig.NetworkTransport = utpTransport;
+            m_Client.NetworkConfig.EnableSceneManagement = false;
+            m_Client.NetworkConfig.AutoSpawnPlayerPrefabClientSide = true;
             utpTransport.ConnectionData.Address = Dns.GetHostAddresses(m_TransportHost).First().ToString();
             utpTransport.ConnectionData.Port = k_TransportPort;
-            Client.LogLevel = LogLevel.Developer;
+            m_Client.LogLevel = LogLevel.Developer;
 
             // Validate we are in distributed authority mode with client side spawning and using CMB Service
-            Assert.True(Client.NetworkConfig.NetworkTopology == NetworkTopologyTypes.DistributedAuthority, "Distributed authority topology is not set!");
-            Assert.True(Client.AutoSpawnPlayerPrefabClientSide, "Client side spawning is not set!");
-            Assert.True(Client.CMBServiceConnection, "CMBServiceConnection is not set!");
+            Assert.True(m_Client.NetworkConfig.NetworkTopology == NetworkTopologyTypes.DistributedAuthority, "Distributed authority topology is not set!");
+            Assert.True(m_Client.AutoSpawnPlayerPrefabClientSide, "Client side spawning is not set!");
+            Assert.True(m_Client.CMBServiceConnection, "CMBServiceConnection is not set!");
 
             // Create a prefab for creating and destroying tests (auto-registers with NetworkManagers)
             m_SpawnObject = CreateNetworkObjectPrefab("TestObject");
             m_SpawnObject.AddComponent<TestNetworkComponent>();
-
-            // Ignore the client connection timeout after starting the client
-            m_BypassConnectionTimeout = true;
         }
 
         protected override IEnumerator OnStartedServerAndClients()
         {
             // Validate the NetworkManager are in distributed authority mode
-            Assert.True(Client.DistributedAuthorityMode, "Distributed authority is not set!");
+            Assert.True(m_Client.DistributedAuthorityMode, "Distributed authority is not set!");
 
-            // Register hooks after starting clients and server (in this case just the one client)
-            // We do this at this point in time because the MessageManager exists (happens within the same call stack when starting NetworkManagers)
-            m_ClientCodecHook = new CodecTestHooks();
-            Client.MessageManager.Hook(m_ClientCodecHook);
             yield return base.OnStartedServerAndClients();
 
             // wait for client to connect since m_BypassConnectionTimeout
-            yield return WaitForConditionOrTimeOut(() => Client.LocalClient.PlayerObject != null);
+            yield return WaitForConditionOrTimeOut(() => m_Client.LocalClient.PlayerObject != null);
             AssertOnTimeout($"Timed out waiting for the client's player to be spanwed!");
+
+            // Register hooks after starting clients and server (in this case just the one client)
+            // We do this at this after all the setup has finished in order to ensure our hooks are only catching messages from the tests
+            m_ClientCodecHook = new CodecTestHooks();
+            m_Client.MessageManager.Hook(m_ClientCodecHook);
         }
 
         [UnityTest]
         public IEnumerator AuthorityRpc()
         {
-            var player = Client.LocalClient.PlayerObject;
-            player.OwnerClientId = Client.LocalClientId + 1;
+            var player = m_Client.LocalClient.PlayerObject;
+            player.OwnerClientId = m_Client.LocalClientId + 1;
 
             var networkComponent = player.GetComponent<TestNetworkComponent>();
             networkComponent.UpdateNetworkProperties();
@@ -189,14 +189,14 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator CreateObject()
         {
-            SpawnObject(m_SpawnObject, Client);
+            SpawnObject(m_SpawnObject, m_Client);
             yield return m_ClientCodecHook.WaitForMessageReceived<CreateObjectMessage>();
         }
 
         [UnityTest]
         public IEnumerator DestroyObject()
         {
-            var spawnedObject = SpawnObject(m_SpawnObject, Client);
+            var spawnedObject = SpawnObject(m_SpawnObject, m_Client);
             yield return m_ClientCodecHook.WaitForMessageReceived<CreateObjectMessage>();
             spawnedObject.GetComponent<NetworkObject>().Despawn();
             yield return m_ClientCodecHook.WaitForMessageReceived<DestroyObjectMessage>();
@@ -231,10 +231,10 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator NetworkVariableDelta()
         {
-            var component = Client.LocalClient.PlayerObject.GetComponent<TestNetworkComponent>();
+            var component = m_Client.LocalClient.PlayerObject.GetComponent<TestNetworkComponent>();
             var message = new NetworkVariableDeltaMessage
             {
-                NetworkObjectId = Client.LocalClient.PlayerObject.NetworkObjectId,
+                NetworkObjectId = m_Client.LocalClient.PlayerObject.NetworkObjectId,
                 NetworkBehaviourIndex = component.NetworkBehaviourId,
                 DeliveryMappedNetworkVariableIndex = new HashSet<int> { 0, 1 },
                 TargetClientId = 5,
@@ -247,7 +247,7 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator NetworkVariableDelta_WithValueUpdate()
         {
-            var instance = SpawnObject(m_SpawnObject, Client);
+            var instance = SpawnObject(m_SpawnObject, m_Client);
             yield return m_ClientCodecHook.WaitForMessageReceived<CreateObjectMessage>();
             var component = instance.GetComponent<TestNetworkComponent>();
 
@@ -260,7 +260,7 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator NetworkListDelta_WithValueUpdate()
         {
-            var instance = SpawnObject(m_SpawnObject, Client);
+            var instance = SpawnObject(m_SpawnObject, m_Client);
             yield return m_ClientCodecHook.WaitForMessageReceived<CreateObjectMessage>();
             var component = instance.GetComponent<TestNetworkComponent>();
 
@@ -337,8 +337,8 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator SceneEventMessageLoad()
         {
-            Client.SceneManager.SkipSceneHandling = true;
-            var eventData = new SceneEventData(Client)
+            m_Client.SceneManager.SkipSceneHandling = true;
+            var eventData = new SceneEventData(m_Client)
             {
                 SceneEventType = SceneEventType.Load,
                 LoadSceneMode = LoadSceneMode.Single,
@@ -357,14 +357,14 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator SceneEventMessageLoadWithObjects()
         {
-            Client.SceneManager.SkipSceneHandling = true;
+            m_Client.SceneManager.SkipSceneHandling = true;
             var prefabNetworkObject = m_SpawnObject.GetComponent<NetworkObject>();
 
-            Client.SceneManager.ScenePlacedObjects.Add(0, new Dictionary<int, NetworkObject>()
+            m_Client.SceneManager.ScenePlacedObjects.Add(0, new Dictionary<int, NetworkObject>()
             {
                 { 1, prefabNetworkObject }
             });
-            var eventData = new SceneEventData(Client)
+            var eventData = new SceneEventData(m_Client)
             {
                 SceneEventType = SceneEventType.Load,
                 LoadSceneMode = LoadSceneMode.Single,
@@ -383,8 +383,8 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator SceneEventMessageUnload()
         {
-            Client.SceneManager.SkipSceneHandling = true;
-            var eventData = new SceneEventData(Client)
+            m_Client.SceneManager.SkipSceneHandling = true;
+            var eventData = new SceneEventData(m_Client)
             {
                 SceneEventType = SceneEventType.Unload,
                 LoadSceneMode = LoadSceneMode.Single,
@@ -403,8 +403,8 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator SceneEventMessageLoadComplete()
         {
-            Client.SceneManager.SkipSceneHandling = true;
-            var eventData = new SceneEventData(Client)
+            m_Client.SceneManager.SkipSceneHandling = true;
+            var eventData = new SceneEventData(m_Client)
             {
                 SceneEventType = SceneEventType.LoadComplete,
                 LoadSceneMode = LoadSceneMode.Single,
@@ -423,8 +423,8 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator SceneEventMessageUnloadComplete()
         {
-            Client.SceneManager.SkipSceneHandling = true;
-            var eventData = new SceneEventData(Client)
+            m_Client.SceneManager.SkipSceneHandling = true;
+            var eventData = new SceneEventData(m_Client)
             {
                 SceneEventType = SceneEventType.UnloadComplete,
                 LoadSceneMode = LoadSceneMode.Single,
@@ -443,8 +443,8 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator SceneEventMessageLoadCompleted()
         {
-            Client.SceneManager.SkipSceneHandling = true;
-            var eventData = new SceneEventData(Client)
+            m_Client.SceneManager.SkipSceneHandling = true;
+            var eventData = new SceneEventData(m_Client)
             {
                 SceneEventType = SceneEventType.LoadEventCompleted,
                 LoadSceneMode = LoadSceneMode.Single,
@@ -465,8 +465,8 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator SceneEventMessageUnloadLoadCompleted()
         {
-            Client.SceneManager.SkipSceneHandling = true;
-            var eventData = new SceneEventData(Client)
+            m_Client.SceneManager.SkipSceneHandling = true;
+            var eventData = new SceneEventData(m_Client)
             {
                 SceneEventType = SceneEventType.UnloadEventCompleted,
                 LoadSceneMode = LoadSceneMode.Single,
@@ -487,8 +487,8 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator SceneEventMessageSynchronize()
         {
-            Client.SceneManager.SkipSceneHandling = true;
-            var eventData = new SceneEventData(Client)
+            m_Client.SceneManager.SkipSceneHandling = true;
+            var eventData = new SceneEventData(m_Client)
             {
                 SceneEventType = SceneEventType.Synchronize,
                 LoadSceneMode = LoadSceneMode.Single,
@@ -512,8 +512,8 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator SceneEventMessageReSynchronize()
         {
-            Client.SceneManager.SkipSceneHandling = true;
-            var eventData = new SceneEventData(Client)
+            m_Client.SceneManager.SkipSceneHandling = true;
+            var eventData = new SceneEventData(m_Client)
             {
                 SceneEventType = SceneEventType.ReSynchronize,
                 LoadSceneMode = LoadSceneMode.Single,
@@ -532,8 +532,8 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator SceneEventMessageSynchronizeComplete()
         {
-            Client.SceneManager.SkipSceneHandling = true;
-            var eventData = new SceneEventData(Client)
+            m_Client.SceneManager.SkipSceneHandling = true;
+            var eventData = new SceneEventData(m_Client)
             {
                 SceneEventType = SceneEventType.ReSynchronize,
                 LoadSceneMode = LoadSceneMode.Single,
@@ -552,8 +552,8 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator SceneEventMessageActiveSceneChanged()
         {
-            Client.SceneManager.SkipSceneHandling = true;
-            var eventData = new SceneEventData(Client)
+            m_Client.SceneManager.SkipSceneHandling = true;
+            var eventData = new SceneEventData(m_Client)
             {
                 SceneEventType = SceneEventType.ActiveSceneChanged,
                 ActiveSceneHash = XXHash.Hash32("ActiveScene")
@@ -569,15 +569,15 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest, Ignore("Serializing twice causes data to disappear in the SceneManager for this event")]
         public IEnumerator SceneEventMessageObjectSceneChanged()
         {
-            Client.SceneManager.SkipSceneHandling = true;
+            m_Client.SceneManager.SkipSceneHandling = true;
             var prefabNetworkObject = m_SpawnObject.GetComponent<NetworkObject>();
-            Client.SceneManager.ObjectsMigratedIntoNewScene = new Dictionary<int, Dictionary<ulong, List<NetworkObject>>>
+            m_Client.SceneManager.ObjectsMigratedIntoNewScene = new Dictionary<int, Dictionary<ulong, List<NetworkObject>>>
             {
                 { 0, new Dictionary<ulong, List<NetworkObject>>()}
             };
 
-            Client.SceneManager.ObjectsMigratedIntoNewScene[0].Add(Client.LocalClientId, new List<NetworkObject>() { prefabNetworkObject });
-            var eventData = new SceneEventData(Client)
+            m_Client.SceneManager.ObjectsMigratedIntoNewScene[0].Add(m_Client.LocalClientId, new List<NetworkObject>() { prefabNetworkObject });
+            var eventData = new SceneEventData(m_Client)
             {
                 SceneEventType = SceneEventType.ObjectSceneChanged,
             };
@@ -592,12 +592,12 @@ namespace Unity.Netcode.RuntimeTests
 
         private IEnumerator SendMessage<T>(ref T message) where T : INetworkMessage
         {
-            Client.MessageManager.SetVersion(k_ClientId, XXHash.Hash32(typeof(T).FullName), message.Version);
+            m_Client.MessageManager.SetVersion(k_ClientId, XXHash.Hash32(typeof(T).FullName), message.Version);
 
             var clientIds = new NativeArray<ulong>(1, Allocator.Temp);
             clientIds[0] = k_ClientId;
-            Client.MessageManager.SendMessage(ref message, NetworkDelivery.ReliableSequenced, clientIds);
-            Client.MessageManager.ProcessSendQueues();
+            m_Client.MessageManager.SendMessage(ref message, NetworkDelivery.ReliableSequenced, clientIds);
+            m_Client.MessageManager.ProcessSendQueues();
             return m_ClientCodecHook.WaitForMessageReceived(message);
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/DistributedAuthorityCodecTests.cs
@@ -68,6 +68,14 @@ namespace Unity.Netcode.RuntimeTests
             }
         }
 
+        /// <summary>
+        /// Don't auto start the session owner for codec tests
+        /// </summary>
+        internal override bool ShouldAutoStartSessionOwner()
+        {
+            return false;
+        }
+
         protected override void OnOneTimeSetup()
         {
             // Prevents the tests from running if no CMB Service is detected

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/RpcProxyMessageTesting.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/RpcProxyMessageTesting.cs
@@ -21,7 +21,7 @@ namespace Unity.Netcode.RuntimeTests
     {
         protected override int NumberOfClients => 2;
 
-        private List<RpcProxyTest> m_ProxyTestInstances = new List<RpcProxyTest>();
+        private List<RpcProxyText> m_ProxyTestInstances = new List<RpcProxyText>();
 
         private StringBuilder m_ValidationLogger = new StringBuilder();
 
@@ -42,7 +42,7 @@ namespace Unity.Netcode.RuntimeTests
 
         protected override void OnCreatePlayerPrefab()
         {
-            m_PlayerPrefab.AddComponent<RpcProxyTest>();
+            m_PlayerPrefab.AddComponent<RpcProxyText>();
             base.OnCreatePlayerPrefab();
         }
 
@@ -72,7 +72,7 @@ namespace Unity.Netcode.RuntimeTests
                     {
                         m_ValidationLogger.AppendLine($"Client-{networkManager.LocalClientId} does not have a cloned instance for Player-{proxy.OwnerClientId}!");
                     }
-                    var clonedPlayer = networkManager.SpawnManager.SpawnedObjects[proxy.NetworkObjectId].GetComponent<RpcProxyTest>();
+                    var clonedPlayer = networkManager.SpawnManager.SpawnedObjects[proxy.NetworkObjectId].GetComponent<RpcProxyText>();
                     // For each cloned player, each client should receive 1 RPC call per cloned player instance.
                     // Example (With 3 clients including session owner):
                     // Client-1 (SO): Sends to NotAuthority
@@ -98,7 +98,7 @@ namespace Unity.Netcode.RuntimeTests
         {
             foreach (var client in m_NetworkManagers)
             {
-                m_ProxyTestInstances.Add(client.LocalClient.PlayerObject.GetComponent<RpcProxyTest>());
+                m_ProxyTestInstances.Add(client.LocalClient.PlayerObject.GetComponent<RpcProxyText>());
             }
 
             foreach (var clientProxyTest in m_ProxyTestInstances)
@@ -110,7 +110,7 @@ namespace Unity.Netcode.RuntimeTests
             AssertOnTimeout(m_ValidationLogger.ToString());
         }
 
-        public class RpcProxyTest : NetworkBehaviour
+        public class RpcProxyText : NetworkBehaviour
         {
             public List<ulong> ReceivedRpc = new List<ulong>();
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/RpcProxyMessageTesting.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/RpcProxyMessageTesting.cs
@@ -25,13 +25,6 @@ namespace Unity.Netcode.RuntimeTests
 
         private StringBuilder m_ValidationLogger = new StringBuilder();
 
-        protected override void OnPreInitializeConfiguration()
-        {
-            System.Environment.SetEnvironmentVariable("USE_CMB_SERVICE", "true");
-            System.Environment.SetEnvironmentVariable("CMB_SERVICE_PORT", null);
-            base.OnPreInitializeConfiguration();
-        }
-
         public RpcProxyMessageTesting(HostOrServer hostOrServer) : base(hostOrServer) { }
 
         protected override IEnumerator OnSetup()

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/RpcProxyMessageTesting.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/RpcProxyMessageTesting.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using NUnit.Framework;
 using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine.TestTools;
 
 namespace Unity.Netcode.RuntimeTests
 {
@@ -20,9 +21,16 @@ namespace Unity.Netcode.RuntimeTests
     {
         protected override int NumberOfClients => 2;
 
-        private List<RpcProxyText> m_ProxyTestInstances = new List<RpcProxyText>();
+        private List<RpcProxyTest> m_ProxyTestInstances = new List<RpcProxyTest>();
 
         private StringBuilder m_ValidationLogger = new StringBuilder();
+
+        protected override void OnPreInitializeConfiguration()
+        {
+            System.Environment.SetEnvironmentVariable("USE_CMB_SERVICE", "true");
+            System.Environment.SetEnvironmentVariable("CMB_SERVICE_PORT", null);
+            base.OnPreInitializeConfiguration();
+        }
 
         public RpcProxyMessageTesting(HostOrServer hostOrServer) : base(hostOrServer) { }
 
@@ -34,7 +42,7 @@ namespace Unity.Netcode.RuntimeTests
 
         protected override void OnCreatePlayerPrefab()
         {
-            m_PlayerPrefab.AddComponent<RpcProxyText>();
+            m_PlayerPrefab.AddComponent<RpcProxyTest>();
             base.OnCreatePlayerPrefab();
         }
 
@@ -44,28 +52,53 @@ namespace Unity.Netcode.RuntimeTests
             m_ValidationLogger.Clear();
             foreach (var proxy in m_ProxyTestInstances)
             {
-                if (proxy.ReceivedRpc.Count < NumberOfClients)
+
+                // Since we are sending to everyone but the authority, the local instance of each client's player should have zero
+                // entries.
+                if (proxy.ReceivedRpc.Count != 0)
                 {
-                    m_ValidationLogger.AppendLine($"Not all clients received RPC from Client-{proxy.OwnerClientId}!");
+                    m_ValidationLogger.AppendLine($"Client-{proxy.OwnerClientId} sent itself an Rpc!");
                 }
-                foreach (var clientId in proxy.ReceivedRpc)
+                foreach (var networkManager in m_NetworkManagers)
                 {
-                    if (clientId == proxy.OwnerClientId)
+                    // Skip the local player instance
+                    if (networkManager.LocalClientId == proxy.OwnerClientId)
                     {
-                        m_ValidationLogger.AppendLine($"Client-{proxy.OwnerClientId} sent itself an Rpc!");
+                        continue;
+                    }
+
+                    // Get the cloned player instance of the player based on the player's NetworkObjectId
+                    if (!networkManager.SpawnManager.SpawnedObjects.ContainsKey(proxy.NetworkObjectId))
+                    {
+                        m_ValidationLogger.AppendLine($"Client-{networkManager.LocalClientId} does not have a cloned instance for Player-{proxy.OwnerClientId}!");
+                    }
+                    var clonedPlayer = networkManager.SpawnManager.SpawnedObjects[proxy.NetworkObjectId].GetComponent<RpcProxyTest>();
+                    // For each cloned player, each client should receive 1 RPC call per cloned player instance.
+                    // Example (With 3 clients including session owner):
+                    // Client-1 (SO): Sends to NotAuthority
+                    // Client-2: Should receive 1 RPC on its clone of Player-1
+                    // Client-3: Should receive 1 RPC on its clone of Player-1
+                    // Client-2: Sends to NotAuthority
+                    // Client-1: Should receive 1 RPC on its clone of Player-2
+                    // Client-3: Should receive 1 RPC on its clone of Player-2
+                    // Client-3: Sends to NotAuthority
+                    // Client-1: Should receive 1 RPC on its clone of Player-3
+                    // Client-2: Should receive 1 RPC on its clone of Player-3
+                    if (clonedPlayer.ReceivedRpc.Count != 1)
+                    {
+                        m_ValidationLogger.AppendLine($"[{clonedPlayer.name}] Received ({clonedPlayer.ReceivedRpc.Count}) RPCs when we were expected only 1!");
                     }
                 }
             }
             return m_ValidationLogger.Length == 0;
         }
 
-
+        [UnityTest]
         public IEnumerator ProxyDoesNotInvokeOnSender()
         {
-            m_ProxyTestInstances.Add(m_ServerNetworkManager.LocalClient.PlayerObject.GetComponent<RpcProxyText>());
-            foreach (var client in m_ClientNetworkManagers)
+            foreach (var client in m_NetworkManagers)
             {
-                m_ProxyTestInstances.Add(client.LocalClient.PlayerObject.GetComponent<RpcProxyText>());
+                m_ProxyTestInstances.Add(client.LocalClient.PlayerObject.GetComponent<RpcProxyTest>());
             }
 
             foreach (var clientProxyTest in m_ProxyTestInstances)
@@ -77,7 +110,7 @@ namespace Unity.Netcode.RuntimeTests
             AssertOnTimeout(m_ValidationLogger.ToString());
         }
 
-        public class RpcProxyText : NetworkBehaviour
+        public class RpcProxyTest : NetworkBehaviour
         {
             public List<ulong> ReceivedRpc = new List<ulong>();
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NestedNetworkManagerTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NestedNetworkManagerTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using Unity.Netcode.TestHelpers.Runtime;
 using Unity.Netcode.Transports.UTP;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -8,6 +9,13 @@ namespace Unity.Netcode.RuntimeTests
 {
     internal class NestedNetworkManagerTests
     {
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // TODO: [CmbServiceTests] if this test is deemed needed to test against the CMB server then update this test.
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
+
         [Test]
         public void CheckNestedNetworkManager()
         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourUpdaterTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourUpdaterTests.cs
@@ -171,11 +171,6 @@ namespace Unity.Netcode.RuntimeTests
             m_ClientCount = UseCMBService() ? numberOfClients + 1 : numberOfClients;
         }
 
-        protected override void OnOneTimeTearDown()
-        {
-            base.OnOneTimeTearDown();
-        }
-
         protected override IEnumerator OnSetup()
         {
             m_SpawnedObjects.Clear();

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourUpdaterTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourUpdaterTests.cs
@@ -168,12 +168,7 @@ namespace Unity.Netcode.RuntimeTests
                 SecondType = second
             };
             // Adjust the client count if connecting to the service.
-            m_ClientCount = UseCMBServiceEnviromentVariableSet() ? numberOfClients + 1 : numberOfClients;
-        }
-
-        protected override bool UseCMBService()
-        {
-            return true;
+            m_ClientCount = UseCMBService() ? numberOfClients + 1 : numberOfClients;
         }
 
         protected override void OnOneTimeTearDown()

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourUpdaterTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourUpdaterTests.cs
@@ -168,7 +168,7 @@ namespace Unity.Netcode.RuntimeTests
                 SecondType = second
             };
             // Adjust the client count if connecting to the service.
-            m_ClientCount = UseCMBService() ? numberOfClients + 1 : numberOfClients;
+            m_ClientCount = numberOfClients;
         }
 
         protected override IEnumerator OnSetup()

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourUpdaterTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourUpdaterTests.cs
@@ -1,11 +1,11 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using NUnit.Framework;
 using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
 using UnityEngine.TestTools;
-using Object = UnityEngine.Object;
 
 namespace Unity.Netcode.RuntimeTests
 {
@@ -85,15 +85,6 @@ namespace Unity.Netcode.RuntimeTests
             m_SeconValue = new NetworkVariable<int>(default, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
         }
 
-        public override void OnNetworkSpawn()
-        {
-            // Non-Authority will register each NetworkObject when it is spawned
-            if ((NetworkManager.DistributedAuthorityMode && !IsOwner) || (!NetworkManager.DistributedAuthorityMode && !IsServer))
-            {
-                NetworkBehaviourUpdaterTests.ClientSideNotifyObjectSpawned(gameObject);
-            }
-        }
-
         /// <summary>
         /// Server side only, sets the NetworkVariables being used to the ValueToSetNetVarTo
         /// that is pre-configured when the Network Prefab is created.
@@ -160,12 +151,14 @@ namespace Unity.Netcode.RuntimeTests
     internal class NetworkBehaviourUpdaterTests : NetcodeIntegrationTest
     {
         // Go ahead and create maximum number of clients (not all tests will use them)
-        protected override int NumberOfClients => m_NumberOfClients;
+        protected override int NumberOfClients => m_ClientCount;
         public const int NetVarValueToSet = 1;
-        private static List<GameObject> s_ClientSpawnedNetworkObjects = new List<GameObject>();
+        private List<ulong> m_SpawnedObjects = new List<ulong>();
         private GameObject m_PrefabToSpawn;
         private NetVarCombinationTypes m_NetVarCombinationTypes;
-        private int m_NumberOfClients = 0;
+        private int m_ClientCount = 0;
+
+        private StringBuilder m_ErrorLog = new StringBuilder();
 
         public NetworkBehaviourUpdaterTests(HostOrServer hostOrServer, int numberOfClients, NetVarContainer.NetVarsToCheck first, NetVarContainer.NetVarsToCheck second) : base(hostOrServer)
         {
@@ -174,25 +167,24 @@ namespace Unity.Netcode.RuntimeTests
                 FirstType = first,
                 SecondType = second
             };
-            m_NumberOfClients = numberOfClients;
+            // Adjust the client count if connecting to the service.
+            m_ClientCount = UseCMBServiceEnviromentVariableSet() ? numberOfClients + 1 : numberOfClients;
+        }
+
+        protected override bool UseCMBService()
+        {
+            return true;
+        }
+
+        protected override void OnOneTimeTearDown()
+        {
+            base.OnOneTimeTearDown();
         }
 
         protected override IEnumerator OnSetup()
         {
-            s_ClientSpawnedNetworkObjects.Clear();
+            m_SpawnedObjects.Clear();
             return base.OnSetup();
-        }
-
-        /// <summary>
-        /// Clients will call this when NetworkObjects are spawned on their end
-        /// </summary>
-        /// <param name="objectSpaned">the GameObject of the NetworkObject spawned</param>
-        public static void ClientSideNotifyObjectSpawned(GameObject objectSpaned)
-        {
-            if (!s_ClientSpawnedNetworkObjects.Contains(objectSpaned))
-            {
-                s_ClientSpawnedNetworkObjects.Add(objectSpaned);
-            }
         }
 
         protected override void OnServerAndClientsCreated()
@@ -222,6 +214,31 @@ namespace Unity.Netcode.RuntimeTests
         }
 
         /// <summary>
+        /// Determines if all clients have spawned clone instances.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="m_ErrorLog"/> will contain log entries of the
+        /// <see cref="NetworkManager"/> instances and NetworkObjects
+        /// that did not get spawned.
+        /// </remarks>
+        /// <returns>true(success) or false (failure)</returns>
+        private bool AllClientsSpawnedObjects()
+        {
+            m_ErrorLog.Clear();
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                foreach (var networkObjectId in m_SpawnedObjects)
+                {
+                    if (!networkManager.SpawnManager.SpawnedObjects.ContainsKey(networkObjectId))
+                    {
+                        m_ErrorLog.AppendLine($"[{networkManager.name}] Has not spawned {nameof(NetworkObject)}-{networkObjectId}.");
+                    }
+                }
+            }
+            return m_ErrorLog.Length == 0;
+        }
+
+        /// <summary>
         /// The updated BehaviourUpdaterAllTests was re-designed to replicate the same functionality being tested in the
         /// original version of this test with additional time out handling and a re-organization in the order of operations.
         /// Things like making sure all clients have spawned the NetworkObjects in question prior to testing for the
@@ -243,22 +260,19 @@ namespace Unity.Netcode.RuntimeTests
             // the appropriate number of NetworkObjects with the NetVarContainer behaviour
             var numberOfObjectsToSpawn = numToSpawn * NumberOfClients;
 
-            var authority = m_NetworkTopologyType == NetworkTopologyTypes.DistributedAuthority ? m_ClientNetworkManagers[0] : m_ServerNetworkManager;
+            var authority = GetAuthorityNetworkManager();
 
             // spawn the objects
             for (int i = 0; i < numToSpawn; i++)
             {
-                var spawnedObject = Object.Instantiate(m_PrefabToSpawn);
+                var spawnedObject = SpawnObject(m_PrefabToSpawn, authority);
                 spawnedPrefabs.Add(spawnedObject);
-                var networkSpawnedObject = spawnedObject.GetComponent<NetworkObject>();
-                networkSpawnedObject.NetworkManagerOwner = authority;
-                networkSpawnedObject.Spawn();
+                m_SpawnedObjects.Add(spawnedObject.GetComponent<NetworkObject>().NetworkObjectId);
             }
 
             // Waits for all clients to spawn the NetworkObjects
-            yield return WaitForConditionOrTimeOut(() => numberOfObjectsToSpawn == s_ClientSpawnedNetworkObjects.Count);
-            Assert.IsFalse(s_GlobalTimeoutHelper.TimedOut, $"Timed out waiting for clients to report spawning objects! " +
-                $"Total reported client-side spawned objects {s_ClientSpawnedNetworkObjects.Count}");
+            yield return WaitForConditionOrTimeOut(AllClientsSpawnedObjects);
+            AssertOnTimeout($"Timed out waiting for clients to report spawning objects!\n {m_ErrorLog}");
 
 
             // Once all clients have spawned the NetworkObjects, set the network variables for
@@ -287,12 +301,19 @@ namespace Unity.Netcode.RuntimeTests
 
             // Get a list of all NetVarContainer components on the client-side spawned NetworkObjects
             var clientSideNetVarContainers = new List<NetVarContainer>();
-            foreach (var clientSpawnedObjects in s_ClientSpawnedNetworkObjects)
+            foreach (var networkManager in m_NetworkManagers)
             {
-                var netVarContainers = clientSpawnedObjects.GetComponents<NetVarContainer>();
-                foreach (var netvarContiner in netVarContainers)
+                if (networkManager == authority)
                 {
-                    clientSideNetVarContainers.Add(netvarContiner);
+                    continue;
+                }
+                foreach (var networkObjectId in m_SpawnedObjects)
+                {
+                    var netVarContainers = networkManager.SpawnManager.SpawnedObjects[networkObjectId].GetComponents<NetVarContainer>();
+                    foreach (var netvarContiner in netVarContainers)
+                    {
+                        clientSideNetVarContainers.Add(netvarContiner);
+                    }
                 }
             }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerCustomMessageManagerTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerCustomMessageManagerTests.cs
@@ -1,10 +1,18 @@
 using NUnit.Framework;
+using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
 
 namespace Unity.Netcode.RuntimeTests
 {
     internal class NetworkManagerCustomMessageManagerTests
     {
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // This test does not need to run against the Rust server.
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
+
         [Test]
         public void CustomMessageManagerAssigned()
         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerEventsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerEventsTests.cs
@@ -17,6 +17,13 @@ namespace Unity.Netcode.RuntimeTests
         private bool m_Instantiated;
         private bool m_Destroyed;
 
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // TODO: [CmbServiceTests] if this test is deemed needed to test against the CMB server then update this test.
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
+
         /// <summary>
         /// Validates the <see cref="NetworkManager.OnInstantiated"/> and <see cref="NetworkManager.OnDestroying"/> event notifications
         /// </summary>

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerSceneManagerTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerSceneManagerTests.cs
@@ -1,10 +1,18 @@
 using NUnit.Framework;
+using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
 
 namespace Unity.Netcode.RuntimeTests
 {
     internal class NetworkManagerSceneManagerTests
     {
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // This test does not need to run against the Rust server.
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
+
         [Test]
         public void SceneManagerAssigned()
         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerTransportTests.cs
@@ -11,6 +11,13 @@ namespace Unity.Netcode.RuntimeTests
 {
     internal class NetworkManagerTransportTests
     {
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // This test does not need to run against the Rust server.
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
+
         [Test]
         public void ClientDoesNotStartWhenTransportFails()
         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOwnershipTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOwnershipTests.cs
@@ -92,8 +92,8 @@ namespace Unity.Netcode.RuntimeTests
             base.OnServerAndClientsCreated();
         }
 
-        [Test]
-        public void TestPlayerIsOwned()
+        [UnityTest]
+        public IEnumerator TestPlayerIsOwned()
         {
             var clientOwnedObjects = m_ClientNetworkManagers[0].SpawnManager.GetClientOwnedObjects(m_ClientNetworkManagers[0].LocalClientId);
 
@@ -102,6 +102,7 @@ namespace Unity.Netcode.RuntimeTests
 
             clientPlayerObject = m_ClientNetworkManagers[0].LocalClient.OwnedObjects.Where((c) => c.IsLocalPlayer).FirstOrDefault();
             Assert.NotNull(clientPlayerObject, $"Client Id {m_ClientNetworkManagers[0].LocalClientId} does not have its local player marked as an owned object using local client!");
+            yield return null;
         }
 
         private bool AllObjectsSpawnedOnClients()

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOwnershipTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectOwnershipTests.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using NUnit.Framework;
 using Unity.Netcode.Components;
 using Unity.Netcode.TestHelpers.Runtime;
@@ -443,15 +444,18 @@ namespace Unity.Netcode.RuntimeTests
             return true;
         }
 
+        private StringBuilder m_ErrorLog = new StringBuilder();
+
         private bool ServerHasCorrectClientOwnedObjectCount()
         {
+            m_ErrorLog.Clear();
             var authority = GetAuthorityNetworkManager();
-            // Only check when we are the host
-            if (authority.IsHost)
+            // Only check when we are the host or session owner
+            if (authority.IsHost || (!authority.IsServer && authority.LocalClient.IsSessionOwner))
             {
                 if (authority.LocalClient.OwnedObjects.Length < k_NumberOfSpawnedObjects)
                 {
-                    return false;
+                    m_ErrorLog.AppendLine($"[{authority.name}] Has only {authority.LocalClient.OwnedObjects.Length} spawned objects and expected is {k_NumberOfSpawnedObjects}");
                 }
             }
 
@@ -459,10 +463,10 @@ namespace Unity.Netcode.RuntimeTests
             {
                 if (connectedClient.Value.OwnedObjects.Length < k_NumberOfSpawnedObjects)
                 {
-                    return false;
+                    m_ErrorLog.AppendLine($"[Client-{connectedClient.Key}] Has only {connectedClient.Value.OwnedObjects.Length} spawned objects and expected is {k_NumberOfSpawnedObjects}");
                 }
             }
-            return true;
+            return m_ErrorLog.Length == 0;
         }
 
         [UnityTest]
@@ -470,7 +474,7 @@ namespace Unity.Netcode.RuntimeTests
         {
             foreach (var manager in m_NetworkManagers)
             {
-                for (int i = 0; i < 5; i++)
+                for (int i = 0; i < k_NumberOfSpawnedObjects; i++)
                 {
                     SpawnObject(m_OwnershipPrefab, manager);
                 }
@@ -480,7 +484,7 @@ namespace Unity.Netcode.RuntimeTests
             AssertOnTimeout($"Not all clients spawned {k_NumberOfSpawnedObjects} {nameof(NetworkObject)}s!");
 
             yield return WaitForConditionOrTimeOut(ServerHasCorrectClientOwnedObjectCount);
-            AssertOnTimeout($"Server does not have the correct count for all clients spawned {k_NumberOfSpawnedObjects} {nameof(NetworkObject)}s!");
+            AssertOnTimeout($"Server does not have the correct count for all clients spawned {k_NumberOfSpawnedObjects} {nameof(NetworkObject)}s!\n {m_ErrorLog}");
         }
 
         /// <summary>
@@ -496,7 +500,7 @@ namespace Unity.Netcode.RuntimeTests
 
             if (m_DistributedAuthority)
             {
-                var authorityId = Random.Range(1, NumberOfClients) - 1;
+                var authorityId = Random.Range(1, TotalClients) - 1;
                 authorityManager = m_ClientNetworkManagers[authorityId];
                 m_OwnershipObject = SpawnObject(m_OwnershipPrefab, authorityManager);
                 m_OwnershipNetworkObject = m_OwnershipObject.GetComponent<NetworkObject>();

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectSpawnManyObjectsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectSpawnManyObjectsTests.cs
@@ -68,6 +68,8 @@ namespace Unity.Netcode.RuntimeTests
 
             AssertOnTimeout($"Timed out waiting for the client to spawn {k_SpawnedObjects} objects! Time to spawn: {timeSpawned} | Time to timeout: {timeStarted - Time.realtimeSinceStartup}", timeoutHelper);
 
+            // Provide one full tick for all messages to finish being processed.
+            // DANGO-TODO: Determine if this is only when testing against Rust server (i.e. messages still pending and clients shutting down before they are dequeued)
             yield return s_DefaultWaitForTick;
         }
     }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectSpawnManyObjectsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectSpawnManyObjectsTests.cs
@@ -67,6 +67,8 @@ namespace Unity.Netcode.RuntimeTests
             yield return WaitForConditionOrTimeOut(() => SpawnObjecTrackingComponent.SpawnedObjects == k_SpawnedObjects, timeoutHelper);
 
             AssertOnTimeout($"Timed out waiting for the client to spawn {k_SpawnedObjects} objects! Time to spawn: {timeSpawned} | Time to timeout: {timeStarted - Time.realtimeSinceStartup}", timeoutHelper);
+
+            yield return s_DefaultWaitForTick;
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformStateTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformStateTests.cs
@@ -1,6 +1,7 @@
 #if !MULTIPLAYER_TOOLS
 using NUnit.Framework;
 using Unity.Netcode.Components;
+using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
 
 
@@ -76,6 +77,13 @@ namespace Unity.Netcode.RuntimeTests
         private TransformSpace m_TransformSpace;
         private Precision m_Precision;
         private Rotation m_Rotation;
+
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // This test does not need to run against the Rust server.
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
 
         public NetworkTransformStateTests(TransformSpace transformSpace, Precision precision, Rotation rotation)
         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkUpdateLoopTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkUpdateLoopTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Linq;
 using NUnit.Framework;
+using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
 using UnityEngine.LowLevel;
 using UnityEngine.PlayerLoop;
@@ -11,6 +12,14 @@ namespace Unity.Netcode.RuntimeTests
 {
     internal class NetworkUpdateLoopTests
     {
+
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // This test does not need to run against the Rust server.
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
+
         [Test]
         public void RegisterCustomLoopInTheMiddle()
         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVarBufferCopyTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVarBufferCopyTest.cs
@@ -101,9 +101,16 @@ namespace Unity.Netcode.RuntimeTests
                 base.OnNetworkSpawn();
             }
         }
-        protected override int NumberOfClients => 1;
+        protected override int NumberOfClients => m_ClientCount;
 
-        public NetworkVarBufferCopyTest(HostOrServer hostOrServer) : base(hostOrServer) { }
+        private const int k_ClientCount = 1;
+        private int m_ClientCount = k_ClientCount;
+
+        public NetworkVarBufferCopyTest(HostOrServer hostOrServer) : base(hostOrServer)
+        {
+            // Adjust the client count if connecting to the CMB service.
+            m_ClientCount = UseCMBService() ? k_ClientCount + 1 : k_ClientCount;
+        }
 
         private static List<DummyNetBehaviour> s_ClientDummyNetBehavioursSpawned = new List<DummyNetBehaviour>();
         public static void ClientDummyNetBehaviourSpawned(DummyNetBehaviour dummyNetBehaviour)
@@ -126,7 +133,7 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator TestEntireBufferIsCopiedOnNetworkVariableDelta()
         {
-            // This is the *SERVER VERSION* of the *CLIENT PLAYER*
+            // This is the *SERVER/SESSION OWNER VERSION* of the *CLIENT PLAYER*
             var authority = GetAuthorityNetworkManager();
             var nonAuthority = GetNonAuthorityNetworkManager();
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVarBufferCopyTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVarBufferCopyTest.cs
@@ -101,15 +101,10 @@ namespace Unity.Netcode.RuntimeTests
                 base.OnNetworkSpawn();
             }
         }
-        protected override int NumberOfClients => m_ClientCount;
-
-        private const int k_ClientCount = 1;
-        private int m_ClientCount = k_ClientCount;
+        protected override int NumberOfClients => 1;
 
         public NetworkVarBufferCopyTest(HostOrServer hostOrServer) : base(hostOrServer)
         {
-            // Adjust the client count if connecting to the CMB service.
-            m_ClientCount = UseCMBService() ? k_ClientCount + 1 : k_ClientCount;
         }
 
         private static List<DummyNetBehaviour> s_ClientDummyNetBehavioursSpawned = new List<DummyNetBehaviour>();

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVisibilityTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVisibilityTests.cs
@@ -49,35 +49,21 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator HiddenObjectsTest()
         {
-            var expectedCount = NumberOfClients + (m_UseHost ? 1 : 0);
-#if UNITY_2023_1_OR_NEWER
-            yield return WaitForConditionOrTimeOut(() => Object.FindObjectsByType<NetworkVisibilityComponent>(FindObjectsSortMode.None).Where((c) => c.IsSpawned).Count() == expectedCount);
-#else
-            yield return WaitForConditionOrTimeOut(() => Object.FindObjectsOfType<NetworkVisibilityComponent>().Where((c) => c.IsSpawned).Count() == expectedCount);
-#endif
-
-            Assert.IsFalse(s_GlobalTimeoutHelper.TimedOut, "Timed out waiting for the visible object count to equal 2!");
+            yield return WaitForConditionOrTimeOut(() => Object.FindObjectsByType<NetworkVisibilityComponent>(FindObjectsSortMode.None).Where((c) => c.IsSpawned).Count() == TotalClients);
+            AssertOnTimeout($"Timed out waiting for the visible object count to equal {TotalClients}!Actual count {Object.FindObjectsByType<NetworkVisibilityComponent>(FindObjectsSortMode.None).Count(c => c.IsSpawned)}");
         }
 
         [UnityTest]
         public IEnumerator HideShowAndDeleteTest()
         {
-            var expectedCount = NumberOfClients + (m_UseHost ? 1 : 0);
-#if UNITY_2023_1_OR_NEWER
-            yield return WaitForConditionOrTimeOut(() => Object.FindObjectsByType<NetworkVisibilityComponent>(FindObjectsSortMode.None).Count(c => c.IsSpawned) == expectedCount);
-#else
-            yield return WaitForConditionOrTimeOut(() => Object.FindObjectsOfType<NetworkVisibilityComponent>().Where((c) => c.IsSpawned).Count() == expectedCount);
-#endif
-            AssertOnTimeout($"Timed out waiting for the visible object count to equal 2! Actual count {Object.FindObjectsByType<NetworkVisibilityComponent>(FindObjectsSortMode.None).Count(c => c.IsSpawned)}");
+            yield return WaitForConditionOrTimeOut(() => Object.FindObjectsByType<NetworkVisibilityComponent>(FindObjectsSortMode.None).Count(c => c.IsSpawned) == TotalClients);
+
+            AssertOnTimeout($"Timed out waiting for the visible object count to equal {TotalClients}! Actual count {Object.FindObjectsByType<NetworkVisibilityComponent>(FindObjectsSortMode.None).Count(c => c.IsSpawned)}");
 
             var sessionOwnerNetworkObject = m_SpawnedObject.GetComponent<NetworkObject>();
             var nonAuthority = GetNonAuthorityNetworkManager();
             sessionOwnerNetworkObject.NetworkHide(nonAuthority.LocalClientId);
-#if UNITY_2023_1_OR_NEWER
-            yield return WaitForConditionOrTimeOut(() => Object.FindObjectsByType<NetworkVisibilityComponent>(FindObjectsSortMode.None).Where((c) => c.IsSpawned).Count() == expectedCount - 1);
-#else
-            yield return WaitForConditionOrTimeOut(() => Object.FindObjectsOfType<NetworkVisibilityComponent>().Where((c) => c.IsSpawned).Count() == expectedCount - 1);
-#endif
+            yield return WaitForConditionOrTimeOut(() => Object.FindObjectsByType<NetworkVisibilityComponent>(FindObjectsSortMode.None).Where((c) => c.IsSpawned).Count() == TotalClients - 1);
             AssertOnTimeout($"Timed out waiting for {m_SpawnedObject.name} to be hidden from client!");
             var networkObjectId = sessionOwnerNetworkObject.NetworkObjectId;
             sessionOwnerNetworkObject.NetworkShow(nonAuthority.LocalClientId);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbodyTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbodyTest.cs
@@ -339,10 +339,8 @@ namespace Unity.Netcode.RuntimeTests
     [TestFixture(HostOrServer.DAHost, ContactEventTypes.WithInfo)]
     internal class RigidbodyContactEventManagerTests : IntegrationTestWithApproximation
     {
-        protected override int NumberOfClients => m_ClientCount;
+        protected override int NumberOfClients => 1;
 
-        private const int k_ClientCount = 1;
-        private int m_ClientCount = k_ClientCount;
         private GameObject m_RigidbodyContactEventManager;
 
         public enum ContactEventTypes
@@ -356,8 +354,6 @@ namespace Unity.Netcode.RuntimeTests
 
         public RigidbodyContactEventManagerTests(HostOrServer hostOrServer, ContactEventTypes contactEventType) : base(hostOrServer)
         {
-            // Adjust the client count if connecting to the CMB service.
-            m_ClientCount = UseCMBService() ? k_ClientCount + 1 : k_ClientCount;
             m_ContactEventType = contactEventType;
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbodyTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Physics/NetworkRigidbodyTest.cs
@@ -339,9 +339,10 @@ namespace Unity.Netcode.RuntimeTests
     [TestFixture(HostOrServer.DAHost, ContactEventTypes.WithInfo)]
     internal class RigidbodyContactEventManagerTests : IntegrationTestWithApproximation
     {
-        protected override int NumberOfClients => 1;
+        protected override int NumberOfClients => m_ClientCount;
 
-
+        private const int k_ClientCount = 1;
+        private int m_ClientCount = k_ClientCount;
         private GameObject m_RigidbodyContactEventManager;
 
         public enum ContactEventTypes
@@ -355,6 +356,8 @@ namespace Unity.Netcode.RuntimeTests
 
         public RigidbodyContactEventManagerTests(HostOrServer hostOrServer, ContactEventTypes contactEventType) : base(hostOrServer)
         {
+            // Adjust the client count if connecting to the CMB service.
+            m_ClientCount = UseCMBService() ? k_ClientCount + 1 : k_ClientCount;
             m_ContactEventType = contactEventType;
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/NetworkPrefabHandlerTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/NetworkPrefabHandlerTests.cs
@@ -16,6 +16,12 @@ namespace Unity.Netcode.RuntimeTests
     /// </summary>
     internal class NetworkPrefabHandlerTests
     {
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // TODO: [CmbServiceTests] if this test is deemed needed to test against the CMB server then update this test.
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
 
         private const string k_TestPrefabObjectName = "NetworkPrefabTestObject";
         private uint m_ObjectId = 1;
@@ -27,6 +33,8 @@ namespace Unity.Netcode.RuntimeTests
             m_ObjectId++;
             return validPrefab.gameObject;
         }
+
+
 
         /// <summary>
         /// Tests the NetwokConfig NetworkPrefabsList initialization during NetworkManager's Init method to make sure that

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/NetworkPrefabOverrideTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/NetworkPrefabOverrideTests.cs
@@ -133,10 +133,11 @@ namespace Unity.Netcode.RuntimeTests
         /// </summary>
         protected override void OnServerAndClientsCreated()
         {
+            var authorityNetworkManager = GetAuthorityNetworkManager();
             // Create a NetworkPrefab with an override
-            var basePrefab = NetcodeIntegrationTestHelpers.CreateNetworkObject($"{k_PrefabRootName}-base", m_ServerNetworkManager, true);
+            var basePrefab = NetcodeIntegrationTestHelpers.CreateNetworkObject($"{k_PrefabRootName}-base", authorityNetworkManager, true);
             basePrefab.AddComponent<SpawnDespawnDestroyNotifications>();
-            var targetPrefab = NetcodeIntegrationTestHelpers.CreateNetworkObject($"{k_PrefabRootName}-over", m_ServerNetworkManager, true);
+            var targetPrefab = NetcodeIntegrationTestHelpers.CreateNetworkObject($"{k_PrefabRootName}-over", authorityNetworkManager, true);
             targetPrefab.AddComponent<SpawnDespawnDestroyNotifications>();
             m_PrefabOverride = new NetworkPrefab()
             {
@@ -147,17 +148,21 @@ namespace Unity.Netcode.RuntimeTests
             };
 
             // Add the prefab override handler for instance specific player prefabs to the server side
-            var playerPrefabOverrideHandler = m_ServerNetworkManager.gameObject.AddComponent<TestPrefabOverrideHandler>();
+            var playerPrefabOverrideHandler = authorityNetworkManager.gameObject.AddComponent<TestPrefabOverrideHandler>();
             playerPrefabOverrideHandler.ServerSideInstance = m_PlayerPrefab;
             playerPrefabOverrideHandler.ClientSideInstance = m_ClientSidePlayerPrefab.Prefab;
 
             // Add the NetworkPrefab with override
-            m_ServerNetworkManager.NetworkConfig.Prefabs.Add(m_PrefabOverride);
+            authorityNetworkManager.NetworkConfig.Prefabs.Add(m_PrefabOverride);
             // Add the client player prefab that will be used on clients (and the host)
-            m_ServerNetworkManager.NetworkConfig.Prefabs.Add(m_ClientSidePlayerPrefab);
+            authorityNetworkManager.NetworkConfig.Prefabs.Add(m_ClientSidePlayerPrefab);
 
             foreach (var networkManager in m_ClientNetworkManagers)
             {
+                if (authorityNetworkManager == networkManager)
+                {
+                    continue;
+                }
                 // Add the prefab override handler for instance specific player prefabs to the client side
                 playerPrefabOverrideHandler = networkManager.gameObject.AddComponent<TestPrefabOverrideHandler>();
                 playerPrefabOverrideHandler.ServerSideInstance = m_PlayerPrefab;
@@ -208,7 +213,7 @@ namespace Unity.Netcode.RuntimeTests
 
         private GameObject GetPlayerNetworkPrefabObject(NetworkManager networkManager)
         {
-            return networkManager.IsClient ? m_ClientSidePlayerPrefab.Prefab : m_PlayerPrefab;
+            return networkManager != GetAuthorityNetworkManager() ? m_ClientSidePlayerPrefab.Prefab : m_PlayerPrefab;
         }
 
         [UnityTest]
@@ -217,11 +222,13 @@ namespace Unity.Netcode.RuntimeTests
             var prefabNetworkObject = (NetworkObject)null;
             var spawnedGlobalObjectId = (uint)0;
 
+            var authorityNetworkManager = GetAuthorityNetworkManager();
+
             if (!m_UseHost)
             {
                 // If running as just a server, validate that all player prefab clone instances are the server side version
-                prefabNetworkObject = GetPlayerNetworkPrefabObject(m_ServerNetworkManager).GetComponent<NetworkObject>();
-                foreach (var playerEntry in m_PlayerNetworkObjects[m_ServerNetworkManager.LocalClientId])
+                prefabNetworkObject = GetPlayerNetworkPrefabObject(authorityNetworkManager).GetComponent<NetworkObject>();
+                foreach (var playerEntry in m_PlayerNetworkObjects[authorityNetworkManager.LocalClientId])
                 {
                     spawnedGlobalObjectId = playerEntry.Value.GlobalObjectIdHash;
                     Assert.IsTrue(prefabNetworkObject.GlobalObjectIdHash == spawnedGlobalObjectId, $"Server-Side {playerEntry.Value.name} was spawned as prefab ({spawnedGlobalObjectId}) but we expected ({prefabNetworkObject.GlobalObjectIdHash})!");
@@ -254,7 +261,7 @@ namespace Unity.Netcode.RuntimeTests
 
             // Validates prefab overrides via NetworkPrefab configuration.
             var spawnedInstance = (NetworkObject)null;
-            var networkManagerOwner = m_ServerNetworkManager;
+            var networkManagerOwner = authorityNetworkManager;
 
             if (m_DistributedAuthority)
             {
@@ -291,15 +298,17 @@ namespace Unity.Netcode.RuntimeTests
             yield return WaitForConditionOrTimeOut(ObjectSpawnedOnAllNetworkMangers);
             AssertOnTimeout($"The spawned prefab override validation failed!\n {builder}");
 
+            var nonAuthorityInstance = GetNonAuthorityNetworkManager();
+
             // Verify that the despawn and destroy order of operations is correct for client owned NetworkObjects and the nunmber of times each is invoked is correct
-            spawnedInstance = NetworkObject.InstantiateAndSpawn(m_PrefabOverride.SourcePrefabToOverride, networkManagerOwner, m_ClientNetworkManagers[0].LocalClientId);
+            spawnedInstance = NetworkObject.InstantiateAndSpawn(m_PrefabOverride.SourcePrefabToOverride, networkManagerOwner, nonAuthorityInstance.LocalClientId);
 
 
             yield return WaitForConditionOrTimeOut(ObjectSpawnedOnAllNetworkMangers);
             AssertOnTimeout($"The spawned prefab override validation failed!\n {builder}");
 
-            var clientId = m_ClientNetworkManagers[0].LocalClientId;
-            m_ClientNetworkManagers[0].Shutdown();
+            var clientId = nonAuthorityInstance.LocalClientId;
+            nonAuthorityInstance.Shutdown();
 
             // Wait until all of the client's owned objects are destroyed
             // If no asserts occur, then the despawn & destroy order of operations and invocation count is correct

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Profiling/NetworkVariableNameTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Profiling/NetworkVariableNameTests.cs
@@ -8,6 +8,13 @@ namespace Unity.Netcode.RuntimeTests
     {
         private NetworkVariableNameComponent m_NetworkVariableNameComponent;
 
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // TODO: [CmbServiceTests] if this test is deemed needed to test against the CMB server then update this test.
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
+
         [SetUp]
         public void SetUp()
         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/RpcQueueTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/RpcQueueTests.cs
@@ -15,6 +15,13 @@ namespace Unity.Netcode.RuntimeTests
     /// </summary>
     internal class RpcQueueTests
     {
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // TODO: [CmbServiceTests] if this test is deemed needed to test against the CMB server then update this test.
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
+
         [SetUp]
         public void Setup()
         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/NetworkBehaviourReferenceTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/NetworkBehaviourReferenceTests.cs
@@ -15,6 +15,13 @@ namespace Unity.Netcode.RuntimeTests
     /// </summary>
     internal class NetworkBehaviourReferenceTests : IDisposable
     {
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // TODO: [CmbServiceTests] if this test is deemed needed to test against the CMB server then update this test.
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
+
         private class TestNetworkBehaviour : NetworkBehaviour
         {
             public static bool ReceivedRPC;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/NetworkObjectReferenceTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/NetworkObjectReferenceTests.cs
@@ -17,6 +17,13 @@ namespace Unity.Netcode.RuntimeTests
     /// </summary>
     internal class NetworkObjectReferenceTests : IDisposable
     {
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // TODO: [CmbServiceTests] if this test is deemed needed to test against the CMB server then update this test.
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
+
         private class TestNetworkBehaviour : NetworkBehaviour
         {
             public static bool ReceivedRPC;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/StartStopTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/StartStopTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
 
 namespace Unity.Netcode.RuntimeTests
@@ -6,6 +7,13 @@ namespace Unity.Netcode.RuntimeTests
     internal class StartStopTests
     {
         private NetworkManager m_NetworkManager;
+
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // This test does not need to run against the Rust server.
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
 
         [SetUp]
         public void Setup()

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Timing/NetworkTimeSystemTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Timing/NetworkTimeSystemTests.cs
@@ -17,6 +17,13 @@ namespace Unity.Netcode.RuntimeTests
 
         private float m_OriginalTimeScale = 1.0f;
 
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // TODO: [CmbServiceTests] if this test is deemed needed to test against the CMB server then update this test.
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
+
         [SetUp]
         public void Setup()
         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeInitializationTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeInitializationTest.cs
@@ -15,6 +15,13 @@ namespace Unity.Netcode.RuntimeTests
         private int m_ConnectedTick;
         private NetworkManager m_Client;
 
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // TODO: [CmbServiceTests] if this test is deemed needed to test against the CMB server then update this test.
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
+
         [UnityTest]
         public IEnumerator TestClientTimeInitializationOnConnect([Values(0, 1f)] float serverStartDelay, [Values(0, 1f)] float clientStartDelay, [Values(true, false)] bool isHost)
         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportConnectionTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportConnectionTests.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using Unity.Netcode.TestHelpers.Runtime;
 using Unity.Netcode.Transports.UTP;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -18,6 +19,13 @@ namespace Unity.Netcode.RuntimeTests
         private UnityTransport[] m_Clients = new UnityTransport[k_NumClients];
         private List<TransportEvent> m_ServerEvents;
         private List<TransportEvent>[] m_ClientsEvents = new List<TransportEvent>[k_NumClients];
+
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // TODO: [CmbServiceTests] if this test is deemed needed to test against the CMB server then update this test.
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
 
         [UnityTearDown]
         public IEnumerator Cleanup()

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using NUnit.Framework;
+using Unity.Netcode.TestHelpers.Runtime;
 using Unity.Netcode.Transports.UTP;
 using Unity.Networking.Transport;
 using UnityEngine;
@@ -33,6 +34,13 @@ namespace Unity.Netcode.RuntimeTests
 
         private UnityTransport m_Server, m_Client1, m_Client2;
         private List<TransportEvent> m_ServerEvents, m_Client1Events, m_Client2Events;
+
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // TODO: [CmbServiceTests] if this test is deemed needed to test against the CMB server then update this test.
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
 
         [UnityTearDown]
         public IEnumerator Cleanup()

--- a/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
@@ -1542,16 +1542,6 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
     }
 
-    [TestFixture(HostOrServer.Host)]
-    [TestFixture(HostOrServer.Server)]
-    internal class UniversalRpcTestDefaultSendToSpecifiedInParamsSendingToServerAndOwner : UniversalRpcTestsBase
-    {
-        public UniversalRpcTestDefaultSendToSpecifiedInParamsSendingToServerAndOwner(HostOrServer hostOrServer) : base(hostOrServer)
-        {
-
-        }
-    }
-
     [TestFixture(HostOrServer.DAHost)]
     [TestFixture(HostOrServer.Host)]
     [TestFixture(HostOrServer.Server)]

--- a/pvpExceptions.json
+++ b/pvpExceptions.json
@@ -173,7 +173,6 @@
           "Unity.Netcode.TestHelpers.Runtime.NetcodeIntegrationTestHelpers: uint GetNextGlobalIdHashValue(): undocumented",
           "Unity.Netcode.TestHelpers.Runtime.NetcodeIntegrationTestHelpers: IsNetcodeIntegrationTestRunning: undocumented",
           "Unity.Netcode.TestHelpers.Runtime.NetcodeIntegrationTestHelpers: void RegisterNetcodeIntegrationTest(bool): undocumented",
-          "Unity.Netcode.TestHelpers.Runtime.NetcodeIntegrationTestHelpers: GameObject CreateNetworkObjectPrefab(string, NetworkManager, params NetworkManager[]): undocumented",
           "Unity.Netcode.TestHelpers.Runtime.NetcodeIntegrationTestHelpers: void MarkAsSceneObjectRoot(GameObject, NetworkManager, NetworkManager[]): undocumented",
           "Unity.Netcode.TestHelpers.Runtime.NetcodeIntegrationTestHelpers: IEnumerator WaitForClientConnected(NetworkManager, ResultWrapper<bool>, float): missing <returns>",
           "Unity.Netcode.TestHelpers.Runtime.NetcodeIntegrationTestHelpers: IEnumerator WaitForClientsConnected(NetworkManager[], ResultWrapper<bool>, float): missing <returns>",

--- a/testproject/Assets/Tests/Runtime/AddressablesTests.cs
+++ b/testproject/Assets/Tests/Runtime/AddressablesTests.cs
@@ -39,6 +39,12 @@ namespace TestProject.RuntimeTests
             ShutdownAndCleanUp();
         }
 
+        // TODO: [CmbServiceTests] Adapt to run with the service
+        protected override bool UseCMBService()
+        {
+            return false;
+        }
+
         private IEnumerator LoadAsset(AssetReferenceGameObject asset, NetcodeIntegrationTestHelpers.ResultWrapper<GameObject> prefab)
         {
             var handle = asset.LoadAssetAsync();

--- a/testproject/Assets/Tests/Runtime/DontDestroyOnLoadTests.cs
+++ b/testproject/Assets/Tests/Runtime/DontDestroyOnLoadTests.cs
@@ -9,11 +9,15 @@ using UnityEngine.TestTools;
 
 namespace TestProject.RuntimeTests
 {
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.DAHost)]
     public class DontDestroyOnLoadTests : NetcodeIntegrationTest
     {
         private const int k_ClientsToConnect = 4;
         protected override int NumberOfClients => 0;
         private GameObject m_DontDestroyOnLoadObject;
+
+        public DontDestroyOnLoadTests(HostOrServer hostOrServer) : base(hostOrServer) { }
 
         protected override void OnServerAndClientsCreated()
         {
@@ -52,7 +56,7 @@ namespace TestProject.RuntimeTests
         [UnityTest]
         public IEnumerator ValidateNetworkObjectSynchronization()
         {
-            var objectInstance = SpawnObject(m_DontDestroyOnLoadObject, m_ServerNetworkManager);
+            var objectInstance = SpawnObject(m_DontDestroyOnLoadObject, GetAuthorityNetworkManager());
             m_SpawnedNetworkObjectId = objectInstance.GetComponent<NetworkObject>().NetworkObjectId;
             // Wait a tick for the object to be automatically migrated into the DDOL
             yield return s_DefaultWaitForTick;

--- a/testproject/Assets/Tests/Runtime/MessageOrdering.cs
+++ b/testproject/Assets/Tests/Runtime/MessageOrdering.cs
@@ -16,6 +16,12 @@ namespace TestProject.RuntimeTests
         private NetworkManager m_ServerNetworkManager;
         private NetworkManager[] m_ClientNetworkManagers;
 
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // TODO: [CmbServiceTests] if this test is deemed needed to test against the CMB server then update this test.
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
 
         [UnitySetUp]
         public IEnumerator SetUp()

--- a/testproject/Assets/Tests/Runtime/MultiClientConnectionApproval.cs
+++ b/testproject/Assets/Tests/Runtime/MultiClientConnectionApproval.cs
@@ -22,6 +22,13 @@ namespace TestProject.RuntimeTests
         private bool m_DelayedApproval;
         private List<NetworkManager.ConnectionApprovalResponse> m_ResponseToSet = new List<NetworkManager.ConnectionApprovalResponse>();
 
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // TODO: [CmbServiceTests] if this test is deemed needed to test against the CMB server then update this test.
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
+
         /// <summary>
         /// Tests connection approval and connection approval failure
         /// </summary>

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/ClientSynchronizationModeTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/ClientSynchronizationModeTests.cs
@@ -56,6 +56,12 @@ namespace TestProject.RuntimeTests
             m_ServerPreloadState = serverPreloadStates;
         }
 
+        // TODO: [CmbServiceTests] Adapt to run with the service
+        protected override bool UseCMBService()
+        {
+            return false;
+        }
+
         protected override IEnumerator OnSetup()
         {
             m_TempClientPreLoadedScenes.Clear();

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/InScenePlacedNetworkObjectTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/InScenePlacedNetworkObjectTests.cs
@@ -581,6 +581,13 @@ namespace TestProject.RuntimeTests
 
         private Scene m_Scene;
 
+
+        // TODO: [CmbServiceTests] Adapt to run with the service
+        protected override bool UseCMBService()
+        {
+            return false;
+        }
+
         protected override IEnumerator OnSetup()
         {
             SceneManager.sceneLoaded += SceneManager_sceneLoaded;

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectTestComponent.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkObjectTestComponent.cs
@@ -56,7 +56,7 @@ namespace TestProject.RuntimeTests
                 }
             }
 
-            if (IsServer)
+            if (IsServer || IsSessionOwner)
             {
                 ServerNetworkObjectInstance = NetworkObject;
                 if (DisableOnSpawn && !ObjectWasDisabledUponSpawn)

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerDDOLTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerDDOLTests.cs
@@ -19,6 +19,13 @@ namespace TestProject.RuntimeTests
 
         protected float m_ConditionMetFrequency = 0.1f;
 
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // This does not need to be tested against a CMB Server
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
+
         [UnitySetUp]
         protected IEnumerator SetUp()
         {

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/SceneEventDataTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/SceneEventDataTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using NUnit.Framework;
 using Unity.Netcode;
+using Unity.Netcode.TestHelpers.Runtime;
 using Unity.Netcode.Transports.UTP;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -15,6 +17,13 @@ namespace TestProject.RuntimeTests
     /// </summary>
     public class SceneEventDataTests
     {
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // This test does not need to run against a CMB server
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
+
         /// <summary>
         /// This verifies that change from Allocator.TmpJob to Allocator.Persistent
         /// will not cause memory leak warning notifications if the scene event takes

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/SpawnNetworkObjectsDuringSceneEventsTest.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/SpawnNetworkObjectsDuringSceneEventsTest.cs
@@ -32,6 +32,12 @@ namespace TestProject.RuntimeTests
             }
         }
 
+        // TODO: [CmbServiceTests] Adapt to run with the service
+        protected override bool UseCMBService()
+        {
+            return false;
+        }
+
         protected override void OnServerAndClientsCreated()
         {
             SpawnObjectTrackingComponent.SpawnedObjects = 0;

--- a/testproject/Assets/Tests/Runtime/NetworkTransform/NestedNetworkTransformTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkTransform/NestedNetworkTransformTests.cs
@@ -129,6 +129,12 @@ namespace TestProject.RuntimeTests
 
         }
 
+        // TODO: [CmbServiceTests] Adapt to run with the service
+        protected override bool UseCMBService()
+        {
+            return false;
+        }
+
         protected override void OnOneTimeSetup()
         {
             m_OriginalVarianceThreshold = base.GetDeltaVarianceThreshold();

--- a/testproject/Assets/Tests/Runtime/NetworkVariableInitializationOnNetworkSpawnTest.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkVariableInitializationOnNetworkSpawnTest.cs
@@ -12,6 +12,13 @@ namespace TestProject.RuntimeTests
     {
         private GameObject m_Prefab;
 
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // TODO: [CmbServiceTests] if this test is deemed needed to test against the CMB server then update this test.
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
+
         [UnitySetUp]
         public IEnumerator SetUp()
         {

--- a/testproject/Assets/Tests/Runtime/NoMemoryLeakOnNetworkManagerShutdownTest.cs
+++ b/testproject/Assets/Tests/Runtime/NoMemoryLeakOnNetworkManagerShutdownTest.cs
@@ -12,6 +12,13 @@ namespace TestProject.RuntimeTests
     {
         private GameObject m_Prefab;
 
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // TODO: [CmbServiceTests] if this test is deemed needed to test against the CMB server then update this test.
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
+
         [SetUp]
         public void Setup()
         {

--- a/testproject/Assets/Tests/Runtime/ObjectParenting/NetworkObjectParentingTests.cs
+++ b/testproject/Assets/Tests/Runtime/ObjectParenting/NetworkObjectParentingTests.cs
@@ -38,6 +38,13 @@ namespace TestProject.RuntimeTests
             m_NetworkTopologyType = networkTopologyType;
         }
 
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            // TODO: [CmbServiceTests] if this test is deemed needed to test against the CMB server then update this test.
+            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+        }
+
         private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
         {
             if (scene.name == nameof(NetworkObjectParentingTests))

--- a/testproject/Assets/Tests/Runtime/OnNetworkSpawnExceptionTests.cs
+++ b/testproject/Assets/Tests/Runtime/OnNetworkSpawnExceptionTests.cs
@@ -94,6 +94,13 @@ namespace TestProject.RuntimeTests
         private GameObject m_DespawnWithAndWithoutExceptionPrefab;
 
         private const int k_NumObjects = 10;
+
+        // TODO: [CmbServiceTests] Adapt to run with the service
+        protected override bool UseCMBService()
+        {
+            return false;
+        }
+
         [UnityTest]
         public IEnumerator WhenOnNetworkSpawnThrowsException_FutureOnNetworkSpawnsAreNotPrevented()
         {

--- a/testproject/Assets/Tests/Runtime/PrefabExtendedTests.cs
+++ b/testproject/Assets/Tests/Runtime/PrefabExtendedTests.cs
@@ -36,6 +36,12 @@ namespace TestProject.RuntimeTests
 
         private StringBuilder m_ErrorLog = new StringBuilder();
 
+        // TODO: [CmbServiceTests] Adapt to run with the service
+        protected override bool UseCMBService()
+        {
+            return false;
+        }
+
         public PrefabExtendedTests(SceneManagementTypes sceneManagementType)
         {
             m_SceneManagementEnabled = sceneManagementType == SceneManagementTypes.SceneManagementEnabled;

--- a/testproject/Assets/Tests/Runtime/RpcObserverTests.cs
+++ b/testproject/Assets/Tests/Runtime/RpcObserverTests.cs
@@ -14,9 +14,8 @@ namespace TestProject.RuntimeTests
     /// Integration test to validate ClientRpcs will only
     /// send to observers of the NetworkObject
     /// </summary>
-#if NGO_DAMODE
+
     [TestFixture(HostOrServer.DAHost)]
-#endif
     [TestFixture(HostOrServer.Host)]
     [TestFixture(HostOrServer.Server)]
     public class RpcObserverTests : NetcodeIntegrationTest
@@ -30,6 +29,12 @@ namespace TestProject.RuntimeTests
 
         private NativeArray<ulong> m_NonObserverArrayError;
         private bool m_ArrayAllocated;
+
+        // TODO: [CmbServiceTests] Adapt to run with the service
+        protected override bool UseCMBService()
+        {
+            return false;
+        }
 
         public RpcObserverTests(HostOrServer hostOrServer) : base(hostOrServer) { }
 

--- a/testproject/Assets/Tests/Runtime/RpcTestsAutomated.cs
+++ b/testproject/Assets/Tests/Runtime/RpcTestsAutomated.cs
@@ -17,6 +17,12 @@ namespace TestProject.RuntimeTests
 
         protected override int NumberOfClients => 4;
 
+        // TODO: [CmbServiceTests] Adapt to run with the service
+        protected override bool UseCMBService()
+        {
+            return false;
+        }
+
         protected override NetworkManagerInstatiationMode OnSetIntegrationTestMode()
         {
             return NetworkManagerInstatiationMode.DoNotCreate;

--- a/testproject/Assets/Tests/Runtime/RpcUserSerializableTypesTest.cs
+++ b/testproject/Assets/Tests/Runtime/RpcUserSerializableTypesTest.cs
@@ -48,10 +48,9 @@ namespace TestProject.RuntimeTests
         }
     }
 
-#if NGO_DAMODE
+
     [TestFixture(NetworkTopologyTypes.DistributedAuthority)]
     [TestFixture(NetworkTopologyTypes.ClientServer)]
-#endif 
     public class RpcUserSerializableTypesTest : NetcodeIntegrationTest
     {
         private UserSerializableClass m_UserSerializableClass;
@@ -83,9 +82,13 @@ namespace TestProject.RuntimeTests
 
         protected override int NumberOfClients => 1;
 
-#if NGO_DAMODE
+        // TODO: [CmbServiceTests] Adapt to run with the service
+        protected override bool UseCMBService()
+        {
+            return false;
+        }
+
         public RpcUserSerializableTypesTest(NetworkTopologyTypes networkTopologyType) : base(networkTopologyType) { }
-#endif
 
         protected override NetworkManagerInstatiationMode OnSetIntegrationTestMode()
         {
@@ -114,7 +117,7 @@ namespace TestProject.RuntimeTests
             // [Client-Side] We only need to get the client side Player's NetworkObject so we can grab that instance of the TestSerializationComponent
             // Use the client's instance of the 
             var targetContext = m_ClientNetworkManagers[0];
-#if NGO_DAMODE
+
             // When in distributed authority mode:
             // Owner Instances
             // - Can send ClientRpcs
@@ -127,7 +130,7 @@ namespace TestProject.RuntimeTests
                 // Use the server instance of the client's player
                 targetContext = m_ServerNetworkManager;
             }
-#endif
+
             var clientContextPlayerResult = new NetcodeIntegrationTestHelpers.ResultWrapper<NetworkObject>();
             yield return NetcodeIntegrationTestHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId), targetContext, clientContextPlayerResult);
 
@@ -339,7 +342,6 @@ namespace TestProject.RuntimeTests
                                  serverIntListCalled && serverStrListCalled;
             };
 
-#if NGO_DAMODE
             // When in distributed authority mode:
             // Owner Instances
             // - Can send ClientRpcs
@@ -356,7 +358,6 @@ namespace TestProject.RuntimeTests
                 serverSideNetworkBehaviourClass.SendStringListOwnerRpc(strList);
             }
             else
-#endif
             {
                 clientSideNetworkBehaviourClass.SendMyObjectServerRpc(obj);
                 clientSideNetworkBehaviourClass.SendMySharedObjectReferencedByIdServerRpc(obj2);
@@ -533,7 +534,6 @@ namespace TestProject.RuntimeTests
                                  serverIntListCalled && serverStrListCalled;
             };
 
-#if NGO_DAMODE
             // When in distributed authority mode:
             // Owner Instances
             // - Can send ClientRpcs
@@ -550,7 +550,6 @@ namespace TestProject.RuntimeTests
                 serverSideNetworkBehaviourClass.SendStringListOwnerRpc(strList);
             }
             else
-#endif
             {
                 clientSideNetworkBehaviourClass.SendMyObjectServerRpc(objs);
                 clientSideNetworkBehaviourClass.SendMySharedObjectReferencedByIdServerRpc(objs2);
@@ -703,7 +702,6 @@ namespace TestProject.RuntimeTests
             yield return NetcodeIntegrationTestHelpers.GetNetworkObjectByRepresentation((x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId), m_ClientNetworkManagers[0], clientClientPlayerResult);
             var clientSideNetworkBehaviourClass = clientClientPlayerResult.Result.gameObject.GetComponent<TestCustomTypesArrayComponent>();
 
-#if NGO_DAMODE
             // When in distributed authority mode:
             // Owner Instances
             // - Can send ClientRpcs
@@ -719,7 +717,6 @@ namespace TestProject.RuntimeTests
                 serverSideNetworkBehaviourClass.OnSerializableStructsUpdatedClientRpc = OnClientReceivedUserSerializableStructsUpdated;
             }
             else
-#endif
             {
                 serverSideNetworkBehaviourClass.OnSerializableClassesUpdatedServerRpc = OnServerReceivedUserSerializableClassesUpdated;
                 serverSideNetworkBehaviourClass.OnSerializableStructsUpdatedServerRpc = OnServerReceivedUserSerializableStructsUpdated;
@@ -749,7 +746,6 @@ namespace TestProject.RuntimeTests
                     };
                     m_UserSerializableStructArray.Add(userSerializableStruct);
                 }
-#if NGO_DAMODE
                 // When in distributed authority mode:
                 // Owner Instances
                 // - Can send ClientRpcs
@@ -763,7 +759,6 @@ namespace TestProject.RuntimeTests
                     serverSideNetworkBehaviourClass.ClientStartStructTest(m_UserSerializableStructArray.ToArray());
                 }
                 else
-#endif
                 {
                     clientSideNetworkBehaviourClass.ClientStartTest(m_UserSerializableClassArray.ToArray());
                     clientSideNetworkBehaviourClass.ClientStartStructTest(m_UserSerializableStructArray.ToArray());
@@ -771,7 +766,6 @@ namespace TestProject.RuntimeTests
             }
             else
             {
-#if NGO_DAMODE
                 // When in distributed authority mode:
                 // Owner Instances
                 // - Can send ClientRpcs
@@ -785,7 +779,6 @@ namespace TestProject.RuntimeTests
                     serverSideNetworkBehaviourClass.ClientStartStructTest(null);
                 }
                 else
-#endif
                 {
                     clientSideNetworkBehaviourClass.ClientStartTest(null);
                     clientSideNetworkBehaviourClass.ClientStartStructTest(null);
@@ -958,13 +951,11 @@ namespace TestProject.RuntimeTests
         /// <param name="userSerializableClass"></param>
         public void ClientStartTest(UserSerializableClass userSerializableClass)
         {
-#if NGO_DAMODE
             if (NetworkManager.DistributedAuthorityMode)
             {
                 SendOwnerSerializedDataClassRpc(userSerializableClass);
             }
             else
-#endif
             {
                 SendServerSerializedDataClassServerRpc(userSerializableClass);
             }
@@ -1024,13 +1015,11 @@ namespace TestProject.RuntimeTests
         #region ClientStartTest(TemplatedType<int> t1val, TemplatedType<int>.NestedTemplatedType<int> t2val, TemplatedType<int>.Enum enumVal)
         public void ClientStartTest(TemplatedType<int> t1val, TemplatedType<int>.NestedTemplatedType<int> t2val, TemplatedType<int>.Enum enumVal)
         {
-#if NGO_DAMODE
             if (NetworkManager.DistributedAuthorityMode)
             {
                 SendTemplateStructOwnerRpc(t1val, t2val, enumVal);
             }
             else
-#endif
             {
                 SendTemplateStructServerRpc(t1val, t2val, enumVal);
             }
@@ -1076,13 +1065,11 @@ namespace TestProject.RuntimeTests
         #region ClientStartTest(NetworkSerializableTemplatedType<int> t1val, NetworkSerializableTemplatedType<int>.NestedTemplatedType<int> t2val)
         public void ClientStartTest(NetworkSerializableTemplatedType<int> t1val, NetworkSerializableTemplatedType<int>.NestedTemplatedType<int> t2val)
         {
-#if NGO_DAMODE
             if (NetworkManager.DistributedAuthorityMode)
             {
                 SendNetworkSerializableTemplateStructOwnerRpc(t1val, t2val);
             }
             else
-#endif
             {
                 SendNetworkSerializableTemplateStructServerRpc(t1val, t2val);
             }
@@ -1128,13 +1115,11 @@ namespace TestProject.RuntimeTests
         #region ClientStartTest(TemplatedType<int>[] t1val, TemplatedType<int>.NestedTemplatedType<int>[] t2val, TemplatedType<int>.Enum[] enumVal)
         public void ClientStartTest(TemplatedType<int>[] t1val, TemplatedType<int>.NestedTemplatedType<int>[] t2val, TemplatedType<int>.Enum[] enumVal)
         {
-#if NGO_DAMODE
             if (NetworkManager.DistributedAuthorityMode)
             {
                 SendTemplateStructOwnerRpc(t1val, t2val, enumVal);
             }
             else
-#endif
             {
                 SendTemplateStructServerRpc(t1val, t2val, enumVal);
             }
@@ -1181,13 +1166,11 @@ namespace TestProject.RuntimeTests
         #region ClientStartTest(NetworkSerializableTemplatedType<int>[] t1val, NetworkSerializableTemplatedType<int>.NestedTemplatedType<int>[] t2val)
         public void ClientStartTest(NetworkSerializableTemplatedType<int>[] t1val, NetworkSerializableTemplatedType<int>.NestedTemplatedType<int>[] t2val)
         {
-#if NGO_DAMODE
             if (NetworkManager.DistributedAuthorityMode)
             {
                 SendNetworkSerializableTemplateStructOwnerRpc(t1val, t2val);
             }
             else
-#endif
             {
                 SendNetworkSerializableTemplateStructServerRpc(t1val, t2val);
             }
@@ -1237,13 +1220,11 @@ namespace TestProject.RuntimeTests
         /// <param name="userSerializableStruct"></param>
         public void ClientStartTest(UserSerializableStruct userSerializableStruct)
         {
-#if NGO_DAMODE
             if (NetworkManager.DistributedAuthorityMode)
             {
                 SendServerSerializedDataStructOwnerRpc(userSerializableStruct);
             }
             else
-#endif
             {
                 SendServerSerializedDataStructServerRpc(userSerializableStruct);
             }
@@ -1286,10 +1267,6 @@ namespace TestProject.RuntimeTests
             OnSerializableStructUpdated?.Invoke(userSerializableStruct);
         }
         #endregion
-
-
-
-
 
 
         #region SendMyObject
@@ -1469,13 +1446,11 @@ namespace TestProject.RuntimeTests
         /// <param name="userSerializableClass"></param>
         public void ClientStartTest(UserSerializableClass[] userSerializableClasses)
         {
-#if NGO_DAMODE
             if (NetworkManager.DistributedAuthorityMode)
             {
                 SendServerSerializedDataClassArryOwnerRpc(userSerializableClasses);
             }
             else
-#endif
             {
                 SendServerSerializedDataClassArryServerRpc(userSerializableClasses);
             }
@@ -1536,13 +1511,11 @@ namespace TestProject.RuntimeTests
         /// <param name="userSerializableStructs"></param>
         public void ClientStartStructTest(UserSerializableStruct[] userSerializableStructs)
         {
-#if NGO_DAMODE
             if (NetworkManager.DistributedAuthorityMode)
             {
                 SendServerSerializedDataStructArrayOwnerRpc(userSerializableStructs);
             }
             else
-#endif
             {
                 SendServerSerializedDataStructArrayServerRpc(userSerializableStructs);
             }

--- a/testproject/Assets/Tests/Runtime/SceneObjectsNotDestroyedOnShutdownTest.cs
+++ b/testproject/Assets/Tests/Runtime/SceneObjectsNotDestroyedOnShutdownTest.cs
@@ -19,6 +19,12 @@ namespace TestProject.RuntimeTests
         private Scene m_TestScene;
         private WaitForSeconds m_DefaultWaitForTick = new WaitForSeconds(1.0f / 30);
 
+        // TODO: [CmbServiceTests] Adapt to run with the service
+        protected override bool UseCMBService()
+        {
+            return false;
+        }
+
         [UnityTest]
         public IEnumerator SceneObjectsNotDestroyedOnShutdown()
         {
@@ -27,30 +33,19 @@ namespace TestProject.RuntimeTests
 
             yield return WaitForConditionOrTimeOut(() => m_TestScene.IsValid() && m_TestScene.isLoaded);
             AssertOnTimeout($"Timed out waiting for scene {k_TestScene} to load!");
-#if UNITY_2023_1_OR_NEWER
             var loadedInSceneObject = Object.FindObjectsByType<NetworkObject>(FindObjectsSortMode.InstanceID).Where((c) => c.name.Contains(k_SceneObjectName)).FirstOrDefault();
-#else
-            var loadedInSceneObject = Object.FindObjectsOfType<NetworkObject>().Where((c) => c.name.Contains(k_SceneObjectName)).FirstOrDefault();
-#endif
             Assert.IsNotNull(loadedInSceneObject, $"Failed to find {k_SceneObjectName} before starting client!");
 
             AssertOnTimeout($"Timed out waiting to find {k_SceneObjectName} after scene load and before starting client!\"");
 
             yield return CreateAndStartNewClient();
 
-#if UNITY_2023_1_OR_NEWER
             var loadedInSceneObjects = Object.FindObjectsByType<NetworkObject>(FindObjectsSortMode.InstanceID).Where((c) => c.name.Contains(k_SceneObjectName));
-#else
-            var loadedInSceneObjects = Object.FindObjectsOfType<NetworkObject>().Where((c) => c.name.Contains(k_SceneObjectName));
-#endif
             Assert.IsTrue(loadedInSceneObjects.Count() > 1, $"Only found one instance of {k_SceneObjectName} after client connected!");
             m_ClientNetworkManagers[0].Shutdown();
             yield return m_DefaultWaitForTick;
-#if UNITY_2023_1_OR_NEWER
             loadedInSceneObjects = Object.FindObjectsByType<NetworkObject>(FindObjectsSortMode.InstanceID).Where((c) => c.name.Contains(k_SceneObjectName));
-#else
-            loadedInSceneObjects = Object.FindObjectsOfType<NetworkObject>().Where((c) => c.name.Contains(k_SceneObjectName));
-#endif
+
             Assert.IsTrue(loadedInSceneObjects.Count() > 1, $"Only found one instance of {k_SceneObjectName} after client shutdown!");
         }
 
@@ -63,11 +58,7 @@ namespace TestProject.RuntimeTests
             yield return WaitForConditionOrTimeOut(() => m_TestScene.IsValid() && m_TestScene.isLoaded);
             AssertOnTimeout($"Timed out waiting for scene {k_TestScene} to load!");
 
-#if UNITY_2023_1_OR_NEWER
             var loadedInSceneObject = Object.FindObjectsByType<NetworkObject>(FindObjectsSortMode.InstanceID).Where((c) => c.name.Contains(k_SceneObjectName)).FirstOrDefault();
-#else
-            var loadedInSceneObject = Object.FindObjectsOfType<NetworkObject>().Where((c) => c.name.Contains(k_SceneObjectName)).FirstOrDefault();
-#endif
             Assert.IsNotNull(loadedInSceneObject, $"Failed to find {k_SceneObjectName} before starting client!");
             yield return CreateAndStartNewClient();
 
@@ -77,11 +68,7 @@ namespace TestProject.RuntimeTests
             yield return WaitForConditionOrTimeOut(() => PlayerHasChildren(clientId));
             AssertOnTimeout($"Client-{clientId} player never parented {k_SceneObjectName}!");
 
-#if UNITY_2023_1_OR_NEWER
             var loadedInSceneObjects = Object.FindObjectsByType<NetworkObject>(FindObjectsSortMode.InstanceID).Where((c) => c.name.Contains(k_SceneObjectName));
-#else
-            var loadedInSceneObjects = Object.FindObjectsOfType<NetworkObject>().Where((c) => c.name.Contains(k_SceneObjectName));
-#endif
             Assert.IsTrue(loadedInSceneObjects.Count() > 1, $"Only found one instance of {k_SceneObjectName} after client connected!");
             m_ClientNetworkManagers[0].Shutdown();
             yield return m_DefaultWaitForTick;
@@ -89,11 +76,8 @@ namespace TestProject.RuntimeTests
             // Sanity check to make sure the client's player no longer has any children
             yield return WaitForConditionOrTimeOut(() => PlayerNoLongerExistsWithChildren(clientId));
             AssertOnTimeout($"Client-{clientId} player still exits with children after client shutdown!");
-#if UNITY_2023_1_OR_NEWER
+
             loadedInSceneObjects = Object.FindObjectsByType<NetworkObject>(FindObjectsSortMode.InstanceID).Where((c) => c.name.Contains(k_SceneObjectName));
-#else
-            loadedInSceneObjects = Object.FindObjectsOfType<NetworkObject>().Where((c) => c.name.Contains(k_SceneObjectName));
-#endif
             // Make sure any in-scene placed NetworkObject instantiated has no parent
             foreach (var insceneObject in loadedInSceneObjects)
             {


### PR DESCRIPTION
## This PR Includes

### Initial setup changes
- Minor improvements to the initial CMB server detection and adjustments to the initial configuration order of operations.
- Session owner now starts and connects ahead of the other clients.

### Ignoring tests
This PR includes updates that will ignore any test that:
- Uses a client-server network topology
  - _No point in re-running these as they will have already run multiple times on multiple platforms before testing against the CMB server._
- Has overridden UseCmbService and is returning false.
  - _The test has yet to be converted and so no point in even attempting to run it._
  - _This also includes the `TODO: [CmbServiceTests]` to help track all tests that need to be converted or reviewed to determine if they need to be converted._
- Is not derived from NetcodeIntegrationTest.
  - _Many of these (not all) don't need to run again, but they all have the `TODO: [CmbServiceTests]` to help track all tests that need to be converted or not._
- Does not need to be tested against the CMB Server (i.e. a test for some kind of functionality without actually starting a session and the like).

_(This helps to reduce the time to complete the CMB Server integration tests)_

### Marking/Tracking "for review" tests
Assuring that every test that needs to be reviewed includes the `TODO: [CmbServiceTests]` using of the two ways:

For classes that derive from `NetcodeIntegrationTest` the existing pattern used in #3423 was applied:
```
        // TODO: [CmbServiceTests] Adapt to run with the service
        protected override bool UseCMBService()
        {
            return false;
        }
```

For classes that **do not** derive from `NetcodeIntegrationTest`, an added internal helper method was used:
```
        [OneTimeSetUp]
        public void OneTimeSetup()
        {
            // TODO: [CmbServiceTests] if this test is deemed needed to test against the CMB server then update this test.
            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
        }
```

_(This PR includes some tests that includes one of the two script segments but was was reviewed and determined it didn't need to be run against a CMB server)_

## Fixes
Some issues were exposed in regards to the `NetworkClient` not being set to approved on all clients relative to each local `NetworkManager` instance when using the distributed authority network topology and connecting to a CMB server.

## Changelog

NA - All internal testing and/or specific to testing.

## Testing and Documentation

- Includes integration test adjustments.
- Includes `NetcodeIntegrationTest` related adjustments.
- Includes `NetcodeIntegrationTestHelpers` related adjustments.
- No documentation changes or additions were necessary.

## Backport

Does not require a backport since these changes are specific to updates in #3423 and over-all distributed authority integration testing.