### PR TITLE
ci: Disabled ps5 configuration (NGOv2.X)

### DIFF
--- a/.yamato/console-standalone-test.yml
+++ b/.yamato/console-standalone-test.yml
@@ -55,7 +55,7 @@ console_standalone_build_{{ project.name }}_{{ platform.name }}_{{ editor }}:
   variables:
 # PS4 related
     SCE_ORBIS_SDK_DIR: 'C:\Users\bokken\SCE\ps4_sdk_12_00'
-# PS5 related
+# PS5 related --> THIS WAS DISABLED IN PROJECT.METAFILE. SEE MTT-12118
     SCE_PROSPERO_SDK_DIR: 'C:\Program Files (x86)\SCE\Prospero SDKs\9.000'
     SHADER_COMPILER_PATH: '${SCE_PROSPERO_SDK_DIR}\target\bins'
     SCE_ROOT_DIR: 'C:\Program Files (x86)\SCE'
@@ -94,7 +94,7 @@ console_standalone_test_{{ project.name }}_{{ platform.name }}_{{ editor }}:
   variables:
 # PS4 related
     SCE_ORBIS_SDK_DIR: 'C:\Users\bokken\SCE\ps4_sdk_12_00'
-# PS5 related
+# PS5 related --> THIS WAS DISABLED IN PROJECT.METAFILE. SEE MTT-12118
     SCE_PROSPERO_SDK_DIR: 'C:\Program Files (x86)\SCE\Prospero SDKs\9.000'
     SHADER_COMPILER_PATH: '${SCE_PROSPERO_SDK_DIR}\target\bins'
     SCE_ROOT_DIR: 'C:\Program Files (x86)\SCE'

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -99,11 +99,11 @@ test_platforms:
           image: package-ci/win10-ps4:v4
           flavor: b1.large
           standalone: PS4
-        - name: ps5
-          type: Unity::VM
-          image: package-ci/win10-ps5:v4
-          flavor: b1.large
-          standalone: PS5
+        # - name: ps5 --> SEE MTT-12118
+        #  type: Unity::VM
+        #  image: package-ci/win10-ps5:v4
+        #  flavor: b1.large
+        #  standalone: PS5
         - name: switch
           type: Unity::VM
           image: package-ci/win10-switch:v4
@@ -125,11 +125,11 @@ test_platforms:
           image: package-ci/win10-ps4:v4
           flavor: b1.large
           standalone: PS4
-        - name: ps5
-          type:  Unity::console::ps5
-          image: package-ci/win10-ps5:v4
-          flavor: b1.large
-          standalone: PS5
+        #- name: ps5 --> SEE MTT-12118
+        #  type:  Unity::console::ps5
+        #  image: package-ci/win10-ps5:v4
+        #  flavor: b1.large
+        #  standalone: PS5
         - name: switch
           type: Unity::console::switch
           image: package-ci/win10-switch:v4


### PR DESCRIPTION
This PR disables CI for ps5 due to known constant failures. Bug was reported in MTT-12118.
The issue probably steams from the fact that SDK was deprecated or image used was modified since this failure started happening without our input with error of

> One or more non-test related errors or failures occurred. Details: Message: Build failed; Unity Player for PS5 SDK Version 9.00 (0x09000000) was not found at C:/build/output/Unity-Technologies/com.unity.netcode.gameobjects/.Editor/Data/PlaybackEngines/PS5Player. Check if SDK 9.00 is supported by this release. NOTE: Current SDK folder is set to C:/Program Files (x86)/SCE/Prospero SDKs/9.000, File: C:/build/output/unity/unity/PlatformDependent/PS5/Editor/Managed/PS5SDKTools.cs, Line: 1447 Message: Exception: Build Failed: There was a problem with the PS5 build environment , File: C:/build/output/unity/unity/PlatformDependent/PS5/Editor/Managed/PS5BeeBuildPostProcessor.cs, Line: 407 Message: Error building Player: Exception: Build Failed: There was a problem with the PS5 build environment

Note that the lack of ps5 tests should not greatly affect our CI coverage since we are running tests against all other consoles (PS4 included)

## Backport
Backport PR --> https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3438