### PR TITLE
fix: ubuntu-22.04:v4.72.0 dotnet issues

### DIFF
--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -22,7 +22,7 @@
 small_agent_platform: 
     - name: ubuntu
       type: Unity::VM
-      image: package-ci/ubuntu-22.04:v4
+      image: package-ci/ubuntu-22.04:v4.71.0
       flavor: b1.small
 
 
@@ -37,7 +37,7 @@ test_platforms:
     default:
         - name: ubuntu
           type: Unity::VM
-          image: package-ci/ubuntu-22.04:v4
+          image: package-ci/ubuntu-22.04:v4.71.0
           flavor: b1.large
           standalone: StandaloneLinux64
     desktop:  


### PR DESCRIPTION
Locking us into ubuntu-22.04:v4.71.0 until ubuntu-22.04:v4.72.0 issue is resolved.

## Changelog

NA

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.


<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Backport

This is a backport of #3448