### PR TITLE
fix: owner authoritative parenting backport

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -417,6 +417,24 @@ namespace Unity.Netcode
         /// </summary>
         public bool AutoObjectParentSync = true;
 
+        /// <summary>
+        /// Determines if the owner will apply transform values sent by the parenting message.
+        /// </summary>
+        /// <remarks>
+        /// When enabled, the resultant parenting transform changes sent by the authority will be applied on all instances. <br />
+        /// When disabled, the resultant parenting transform changes sent by the authority will not be applied on the owner's instance. <br />
+        /// When disabled, all non-owner instances will still be synchronized by the authority's transform values when parented.
+        /// </remarks>
+        [Tooltip("When disabled (default enabled), the owner will not apply a server or host's transform properties when parenting changes. Primarily useful for client-server network topology configurations.")]
+        public bool SyncOwnerTransformWhenParented = true;
+
+        /// <summary>
+        /// Client-Server specific, when enabled an owner of a NetworkObject can parent locally as opposed to requiring the owner to notify the server it would like to be parented.
+        /// This behavior is always true when using a distributed authority network topology and does not require it to be set.
+        /// </summary>
+        [Tooltip("When enabled (default disabled), owner's can parent a NetworkObject locally without having to send an RPC to the server or host. Only pertinent when using client-server network topology configurations.")]
+        public bool AllowOwnerToParent;
+
         internal readonly HashSet<ulong> Observers = new HashSet<ulong>();
 
 #if MULTIPLAYER_TOOLS
@@ -1086,8 +1104,9 @@ namespace Unity.Netcode
             {
                 return false;
             }
-
-            if (!NetworkManager.IsServer && !NetworkManager.ShutdownInProgress)
+            // If we don't have authority and we are not shutting down, then don't allow any parenting.
+            // If we are shutting down and don't have authority then allow it.
+            if (!(NetworkManager.IsServer || (AllowOwnerToParent && IsOwner)) && !NetworkManager.ShutdownInProgress)
             {
                 return false;
             }
@@ -1101,6 +1120,8 @@ namespace Unity.Netcode
             {
                 return false;
             }
+
+
 
             m_CachedWorldPositionStays = worldPositionStays;
 
@@ -1135,7 +1156,9 @@ namespace Unity.Netcode
                 return;
             }
 
-            if (!NetworkManager.IsServer)
+            var hasAuthority = NetworkManager.IsServer || (AllowOwnerToParent && IsOwner);
+
+            if (!hasAuthority)
             {
                 // Log exception if we are a client and not shutting down.
                 if (!NetworkManager.ShutdownInProgress)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformBase.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformBase.cs
@@ -347,7 +347,6 @@ namespace Unity.Netcode.RuntimeTests
             base.OnNewClientCreated(networkManager);
         }
 
-
         /// <summary>
         /// Returns true when the server-host and all clients have
         /// instantiated the child object to be used in <see cref="NetworkTransformParentingLocalSpaceOffsetTests"/>
@@ -378,6 +377,18 @@ namespace Unity.Netcode.RuntimeTests
             return true;
         }
 
+        protected bool AllFirstLevelChildObjectInstancesHaveChild()
+        {
+            foreach (var instance in ChildObjectComponent.ClientInstances.Values)
+            {
+                if (instance.transform.parent == null)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         protected bool AllChildObjectInstancesHaveChild()
         {
             foreach (var instance in ChildObjectComponent.ClientInstances.Values)
@@ -392,6 +403,33 @@ namespace Unity.Netcode.RuntimeTests
                 foreach (var instance in ChildObjectComponent.ClientSubChildInstances.Values)
                 {
                     if (instance.transform.parent == null)
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        protected bool AllFirstLevelChildObjectInstancesHaveNoParent()
+        {
+            foreach (var instance in ChildObjectComponent.ClientInstances.Values)
+            {
+                if (instance.transform.parent != null)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        protected bool AllSubChildObjectInstancesHaveNoParent()
+        {
+            if (ChildObjectComponent.HasSubChild)
+            {
+                foreach (var instance in ChildObjectComponent.ClientSubChildInstances.Values)
+                {
+                    if (instance.transform.parent != null)
                     {
                         return false;
                     }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformBase.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformBase.cs
@@ -377,6 +377,10 @@ namespace Unity.Netcode.RuntimeTests
             return true;
         }
 
+        /// <summary>
+        /// Conditional check that all child object instances also have a child
+        /// </summary>
+        /// <returns>true if they do and false if they do not</returns>
         protected bool AllFirstLevelChildObjectInstancesHaveChild()
         {
             foreach (var instance in ChildObjectComponent.ClientInstances.Values)
@@ -389,6 +393,10 @@ namespace Unity.Netcode.RuntimeTests
             return true;
         }
 
+        /// <summary>
+        /// Conditional check that all child instances have a child.
+        /// </summary>
+        /// <returns>true if they do and false if they do not</returns>
         protected bool AllChildObjectInstancesHaveChild()
         {
             foreach (var instance in ChildObjectComponent.ClientInstances.Values)
@@ -411,6 +419,10 @@ namespace Unity.Netcode.RuntimeTests
             return true;
         }
 
+        /// <summary>
+        /// Conditional check that all first level child objects have no parent.
+        /// </summary>
+        /// <returns>true if they do and false if they do not</returns>
         protected bool AllFirstLevelChildObjectInstancesHaveNoParent()
         {
             foreach (var instance in ChildObjectComponent.ClientInstances.Values)
@@ -423,6 +435,10 @@ namespace Unity.Netcode.RuntimeTests
             return true;
         }
 
+        /// <summary>
+        /// Conditional check that all sub-child objects have no parent.
+        /// </summary>
+        /// <returns>true if they do and false if they do not</returns>
         protected bool AllSubChildObjectInstancesHaveNoParent()
         {
             if (ChildObjectComponent.HasSubChild)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using NUnit.Framework;
+using Unity.Netcode.Components;
 using UnityEngine;
 
 namespace Unity.Netcode.RuntimeTests
@@ -86,6 +87,214 @@ namespace Unity.Netcode.RuntimeTests
             {
                 Assert.True(success, m_InfoMessage.ToString());
             }
+        }
+
+        private void UpdateTransformLocal(NetworkTransform networkTransformTestComponent)
+        {
+            networkTransformTestComponent.transform.localPosition += GetRandomVector3(0.5f, 2.0f);
+            var rotation = networkTransformTestComponent.transform.localRotation;
+            var eulerRotation = rotation.eulerAngles;
+            eulerRotation += GetRandomVector3(0.5f, 5.0f);
+            rotation.eulerAngles = eulerRotation;
+            networkTransformTestComponent.transform.localRotation = rotation;
+        }
+
+        private void UpdateTransformWorld(NetworkTransform networkTransformTestComponent)
+        {
+            networkTransformTestComponent.transform.position += GetRandomVector3(0.5f, 2.0f);
+            var rotation = networkTransformTestComponent.transform.rotation;
+            var eulerRotation = rotation.eulerAngles;
+            eulerRotation += GetRandomVector3(0.5f, 5.0f);
+            rotation.eulerAngles = eulerRotation;
+            networkTransformTestComponent.transform.rotation = rotation;
+        }
+
+        /// <summary>
+        /// This test is based on the v2.x SwitchTransformSpaceWhenParented test but only validates the ability for an owner to
+        /// apply parenting locally in order to help synchronizing when parenting.
+        /// </summary>
+        [Test]
+        public void OwnerParentingTest([Values(0.5f, 1.0f, 5.0f)] float scale)
+        {
+            m_UseParentingThreshold = true;
+            // Get the NetworkManager that will have authority in order to spawn with the correct authority
+            var isServerAuthority = m_Authority == Authority.ServerAuthority;
+            var authorityNetworkManager = m_ServerNetworkManager;
+            if (!isServerAuthority)
+            {
+                authorityNetworkManager = m_ClientNetworkManagers[0];
+            }
+
+            var childAuthorityNetworkManager = m_ClientNetworkManagers[0];
+            if (!isServerAuthority)
+            {
+                childAuthorityNetworkManager = m_ServerNetworkManager;
+            }
+
+            // Spawn a parent and children
+            ChildObjectComponent.HasSubChild = true;
+            // Modify our prefabs for this specific test
+            m_ChildObject.AllowOwnerToParent = true;
+            m_SubChildObject.AllowOwnerToParent = true;
+
+
+            var authoritySideParent = SpawnObject(m_ParentObject.gameObject, authorityNetworkManager).GetComponent<NetworkObject>();
+            var authoritySideChild = SpawnObject(m_ChildObject.gameObject, childAuthorityNetworkManager).GetComponent<NetworkObject>();
+            var authoritySideSubChild = SpawnObject(m_SubChildObject.gameObject, childAuthorityNetworkManager).GetComponent<NetworkObject>();
+
+            // Assure all of the child object instances are spawned before proceeding to parenting
+            var success = WaitForConditionOrTimeOutWithTimeTravel(AllChildObjectInstancesAreSpawned);
+            Assert.True(success, "Timed out waiting for all child instances to be spawned!");
+
+            // Get the owner instance if in client-server mode with owner authority
+            if (m_Authority == Authority.OwnerAuthority)
+            {
+                authoritySideParent = s_GlobalNetworkObjects[authoritySideParent.OwnerClientId][authoritySideParent.NetworkObjectId];
+                authoritySideChild = s_GlobalNetworkObjects[authoritySideChild.OwnerClientId][authoritySideChild.NetworkObjectId];
+                authoritySideSubChild = s_GlobalNetworkObjects[authoritySideSubChild.OwnerClientId][authoritySideSubChild.NetworkObjectId];
+            }
+
+            // Get the authority parent and child instances
+            m_AuthorityParentObject = NetworkTransformTestComponent.AuthorityInstance.NetworkObject;
+            m_AuthorityChildObject = ChildObjectComponent.AuthorityInstance.NetworkObject;
+            m_AuthoritySubChildObject = ChildObjectComponent.AuthoritySubInstance.NetworkObject;
+
+            // The child NetworkTransform will use world space when world position stays and
+            // local space when world position does not stay when parenting.
+            ChildObjectComponent.AuthorityInstance.UseHalfFloatPrecision = m_Precision == Precision.Half;
+            ChildObjectComponent.AuthorityInstance.UseQuaternionSynchronization = m_Rotation == Rotation.Quaternion;
+            ChildObjectComponent.AuthorityInstance.UseQuaternionCompression = m_RotationCompression == RotationCompression.QuaternionCompress;
+
+            ChildObjectComponent.AuthoritySubInstance.UseHalfFloatPrecision = m_Precision == Precision.Half;
+            ChildObjectComponent.AuthoritySubInstance.UseQuaternionSynchronization = m_Rotation == Rotation.Quaternion;
+            ChildObjectComponent.AuthoritySubInstance.UseQuaternionCompression = m_RotationCompression == RotationCompression.QuaternionCompress;
+
+            // Set whether we are interpolating or not
+            m_AuthorityParentNetworkTransform = m_AuthorityParentObject.GetComponent<NetworkTransformTestComponent>();
+            m_AuthorityParentNetworkTransform.Interpolate = true;
+            m_AuthorityChildNetworkTransform = m_AuthorityChildObject.GetComponent<ChildObjectComponent>();
+            m_AuthorityChildNetworkTransform.Interpolate = true;
+            m_AuthoritySubChildNetworkTransform = m_AuthoritySubChildObject.GetComponent<ChildObjectComponent>();
+            m_AuthoritySubChildNetworkTransform.Interpolate = true;
+
+            // Apply a scale to the parent object to make sure the scale on the child is properly updated on
+            // non-authority instances.
+            var halfScale = scale * 0.5f;
+            m_AuthorityParentObject.transform.localScale = GetRandomVector3(scale - halfScale, scale + halfScale);
+            m_AuthorityChildObject.transform.localScale = GetRandomVector3(scale - halfScale, scale + halfScale);
+            m_AuthoritySubChildObject.transform.localScale = GetRandomVector3(scale - halfScale, scale + halfScale);
+
+            // Allow one tick for authority to update these changes
+            TimeTravelAdvanceTick();
+            success = WaitForConditionOrTimeOutWithTimeTravel(PositionRotationScaleMatches);
+
+            Assert.True(success, "All transform values did not match prior to parenting!");
+
+            success = WaitForConditionOrTimeOutWithTimeTravel(PositionRotationScaleMatches);
+
+            Assert.True(success, "All transform values did not match prior to parenting!");
+
+            // Move things around while parenting and removing the parent
+            // Not the absolute "perfect" test, but it validates the clients all synchronize
+            // parenting and transform values.
+            for (int i = 0; i < 30; i++)
+            {
+                // Provide two network ticks for interpolation to finalize
+                TimeTravelAdvanceTick();
+                TimeTravelAdvanceTick();
+
+                // This validates each child instance has preserved their local space values
+                AllChildrenLocalTransformValuesMatch(false, ChildrenTransformCheckType.Connected_Clients);
+
+                // This validates each sub-child instance has preserved their local space values
+                AllChildrenLocalTransformValuesMatch(true, ChildrenTransformCheckType.Connected_Clients);
+                // Parent while in motion
+                if (i == 5)
+                {
+                    // Parent the child under the parent with the current world position stays setting
+                    Assert.True(authoritySideChild.TrySetParent(authoritySideParent.transform), $"[Child][Client-{authoritySideChild.NetworkManagerOwner.LocalClientId}] Failed to set child's parent!");
+
+                    // This waits for all child instances to be parented
+                    success = WaitForConditionOrTimeOutWithTimeTravel(AllFirstLevelChildObjectInstancesHaveChild, 300);
+                    Assert.True(success, "Timed out waiting for all instances to have parented a child!");
+                }
+
+                if (i == 10)
+                {
+                    // Parent the sub-child under the child with the current world position stays setting
+                    Assert.True(authoritySideSubChild.TrySetParent(authoritySideChild.transform), $"[Sub-Child][Client-{authoritySideSubChild.NetworkManagerOwner.LocalClientId}] Failed to set sub-child's parent!");
+
+                    // This waits for all child instances to be parented
+                    success = WaitForConditionOrTimeOutWithTimeTravel(AllChildObjectInstancesHaveChild, 300);
+                    Assert.True(success, "Timed out waiting for all instances to have parented a child!");
+                }
+
+                if (i == 15)
+                {
+                    // Verify that a late joining client will synchronize to the parented NetworkObjects properly
+                    CreateAndStartNewClientWithTimeTravel();
+
+                    // Assure all of the child object instances are spawned (basically for the newly connected client)
+                    success = WaitForConditionOrTimeOutWithTimeTravel(AllChildObjectInstancesAreSpawned, 300);
+                    Assert.True(success, "Timed out waiting for all child instances to be spawned!");
+
+                    // This waits for all child instances to be parented
+                    success = WaitForConditionOrTimeOutWithTimeTravel(AllChildObjectInstancesHaveChild, 300);
+                    Assert.True(success, "Timed out waiting for all instances to have parented a child!");
+
+                    // This validates each child instance has preserved their local space values
+                    AllChildrenLocalTransformValuesMatch(false, ChildrenTransformCheckType.Late_Join_Client);
+
+                    // This validates each sub-child instance has preserved their local space values
+                    AllChildrenLocalTransformValuesMatch(true, ChildrenTransformCheckType.Late_Join_Client);
+                }
+
+                if (i == 20)
+                {
+                    // Remove the parent
+                    Assert.True(authoritySideSubChild.TryRemoveParent(), $"[Sub-Child][Client-{authoritySideSubChild.NetworkManagerOwner.LocalClientId}] Failed to set sub-child's parent!");
+
+                    // This waits for all child instances to have the parent removed
+                    success = WaitForConditionOrTimeOutWithTimeTravel(AllSubChildObjectInstancesHaveNoParent, 300);
+                    Assert.True(success, "Timed out waiting for all instances remove the parent!");
+                }
+
+                if (i == 25)
+                {
+                    // Parent the child under the parent with the current world position stays setting
+                    Assert.True(authoritySideChild.TryRemoveParent(), $"[Child][Client-{authoritySideChild.NetworkManagerOwner.LocalClientId}] Failed to remove parent!");
+
+                    // This waits for all child instances to be parented
+                    success = WaitForConditionOrTimeOutWithTimeTravel(AllFirstLevelChildObjectInstancesHaveNoParent, 300);
+                    Assert.True(success, "Timed out waiting for all instances remove the parent!");
+                }
+                UpdateTransformWorld(m_AuthorityParentNetworkTransform);
+                if (m_AuthorityChildNetworkTransform.InLocalSpace)
+                {
+                    UpdateTransformLocal(m_AuthorityChildNetworkTransform);
+                }
+                else
+                {
+                    UpdateTransformWorld(m_AuthorityChildNetworkTransform);
+                }
+
+                if (m_AuthoritySubChildNetworkTransform.InLocalSpace)
+                {
+                    UpdateTransformLocal(m_AuthoritySubChildNetworkTransform);
+                }
+                else
+                {
+                    UpdateTransformWorld(m_AuthoritySubChildNetworkTransform);
+                }
+            }
+
+            success = WaitForConditionOrTimeOutWithTimeTravel(PositionRotationScaleMatches, 300);
+
+            Assert.True(success, "All transform values did not match prior to parenting!");
+
+            // Revert the modifications made for this specific test
+            m_ChildObject.AllowOwnerToParent = false;
+            m_SubChildObject.AllowOwnerToParent = false;
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -113,6 +113,7 @@ namespace Unity.Netcode.RuntimeTests
         /// This test is based on the v2.x SwitchTransformSpaceWhenParented test but only validates the ability for an owner to
         /// apply parenting locally in order to help synchronizing when parenting.
         /// </summary>
+        /// <param name="scale">various scale values to be applied</param>
         [Test]
         public void OwnerParentingTest([Values(0.5f, 1.0f, 5.0f)] float scale)
         {


### PR DESCRIPTION
This PR backports the the `NetworkObject.SyncOwnerTransformWhenParented` and `NetworkObject.AllowOwnerToParent` functionality.

[MTTB-1284](https://jira.unity3d.com/browse/MTTB-1284)

fix: #2842

## Changelog

- Added: `NetworkObject.SyncOwnerTransformWhenParented` which will not synchronize transform values sent by the server when parented (primarily for owner authoritative motion models).
- Added: `NetworkObject.AllowOwnerToParent` which allows a client owner to parent locally and have the changes synchronize with the server and other clients (primarily for owner authoritative motion models).


## Testing and Documentation

- Includes backported integration test modified to the constraints of v1.x.
- Includes additions to public API documentation.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Backport

No back port needed as this is a targeted backport of certain v2.x features that could be useful to projects still using v1.x.