### PR TITLE
fix: MTTB-1273 Inconsistent SceneName in SceneEvent

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -14,6 +14,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed inconsistencies in the `OnSceneEvent` callback. (#3458)
 - Fixed issues with the `NetworkBehaviour` and `NetworkVariable` length safety checks. (#3405)
 - Fixed memory leaks when domain reload is disabled. (#3427)
 - Fixed an exception being thrown when unregistering a custom message handler from within the registered callback. (#3417)

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
 using Unity.Collections;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -61,6 +63,20 @@ namespace Unity.Netcode
         /// </list>
         /// </summary>
         public string SceneName;
+
+        /// <summary>
+        /// This will be set to the path to the scene that the event pertains to.<br />
+        /// This is set for the following <see cref="Netcode.SceneEventType"/>s:
+        /// <list type="bullet">
+        /// <item><term><see cref="SceneEventType.Load"/></term></item>
+        /// <item><term><see cref="SceneEventType.Unload"/></term></item>
+        /// <item><term><see cref="SceneEventType.LoadComplete"/></term></item>
+        /// <item><term><see cref="SceneEventType.UnloadComplete"/></term></item>
+        /// <item><term><see cref="SceneEventType.LoadEventCompleted"/></term></item>
+        /// <item><term><see cref="SceneEventType.UnloadEventCompleted"/></term></item>
+        /// </list>
+        /// </summary>
+        public string ScenePath;
 
         /// <summary>
         /// When a scene is loaded, the Scene structure is returned.<br />
@@ -1056,43 +1072,18 @@ namespace Unity.Netcode
             var sceneEvent = SceneEventDataStore[sceneEventId];
             sceneEvent.SenderClientId = NetworkManager.LocalClientId;
 
-            if (NetworkManager.DistributedAuthorityMode && !NetworkManager.DAHost)
+            // Send to each individual client to assure only the in-scene placed NetworkObjects being observed by the client
+            // is serialized
+            foreach (var clientId in targetClientIds)
             {
-                if (NetworkManager.DistributedAuthorityMode && HasSceneAuthority())
+                sceneEvent.TargetClientId = clientId;
+                var message = new SceneEventMessage
                 {
-                    sceneEvent.TargetClientId = NetworkManager.ServerClientId;
-                    var message = new SceneEventMessage
-                    {
-                        EventData = sceneEvent,
-                    };
-                    var size = NetworkManager.ConnectionManager.SendMessage(ref message, k_DeliveryType, NetworkManager.ServerClientId);
-                    NetworkManager.NetworkMetrics.TrackSceneEventSent(NetworkManager.ServerClientId, (uint)sceneEvent.SceneEventType, SceneNameFromHash(sceneEvent.SceneHash), size);
-                }
-                foreach (var clientId in targetClientIds)
-                {
-                    sceneEvent.TargetClientId = clientId;
-                    var message = new SceneEventMessage
-                    {
-                        EventData = sceneEvent,
-                    };
-                    var size = NetworkManager.ConnectionManager.SendMessage(ref message, k_DeliveryType, NetworkManager.ServerClientId);
-                    NetworkManager.NetworkMetrics.TrackSceneEventSent(clientId, (uint)sceneEvent.SceneEventType, SceneNameFromHash(sceneEvent.SceneHash), size);
-                }
-            }
-            else
-            {
-                // Send to each individual client to assure only the in-scene placed NetworkObjects being observed by the client
-                // is serialized
-                foreach (var clientId in targetClientIds)
-                {
-                    sceneEvent.TargetClientId = clientId;
-                    var message = new SceneEventMessage
-                    {
-                        EventData = sceneEvent,
-                    };
-                    var size = NetworkManager.ConnectionManager.SendMessage(ref message, k_DeliveryType, clientId);
-                    NetworkManager.NetworkMetrics.TrackSceneEventSent(clientId, (uint)sceneEvent.SceneEventType, SceneNameFromHash(sceneEvent.SceneHash), size);
-                }
+                    EventData = sceneEvent,
+                };
+                var sendTarget = NetworkManager.CMBServiceConnection ? NetworkManager.ServerClientId : clientId;
+                var size = NetworkManager.ConnectionManager.SendMessage(ref message, k_DeliveryType, sendTarget);
+                NetworkManager.NetworkMetrics.TrackSceneEventSent(clientId, (uint)sceneEvent.SceneEventType, SceneNameFromHash(sceneEvent.SceneHash), size);
             }
         }
 
@@ -1233,24 +1224,7 @@ namespace Unity.Netcode
             }
 
             // Send a local notification to the session owner that all clients are done loading or unloading
-            OnSceneEvent?.Invoke(new SceneEvent()
-            {
-                SceneEventType = sceneEventProgress.SceneEventType,
-                SceneName = SceneNameFromHash(sceneEventProgress.SceneHash),
-                ClientId = NetworkManager.CurrentSessionOwner,
-                LoadSceneMode = sceneEventProgress.LoadSceneMode,
-                ClientsThatCompleted = clientsThatCompleted,
-                ClientsThatTimedOut = clientsThatTimedOut,
-            });
-
-            if (sceneEventData.SceneEventType == SceneEventType.LoadEventCompleted)
-            {
-                OnLoadEventCompleted?.Invoke(SceneNameFromHash(sceneEventProgress.SceneHash), sceneEventProgress.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
-            }
-            else
-            {
-                OnUnloadEventCompleted?.Invoke(SceneNameFromHash(sceneEventProgress.SceneHash), sceneEventProgress.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
-            }
+            InvokeSceneEvents(NetworkManager.CurrentSessionOwner, sceneEventData);
 
             EndSceneEvent(sceneEventData.SceneEventId);
             return true;
@@ -1267,7 +1241,6 @@ namespace Unity.Netcode
         {
             var sceneName = scene.name;
             var sceneHandle = scene.handle;
-
 
             if (!scene.isLoaded)
             {
@@ -1294,6 +1267,8 @@ namespace Unity.Netcode
                     sceneHandle = ClientSceneHandleToServerSceneHandle[sceneHandle];
                 }
             }
+
+            sceneEventProgress.LoadSceneMode = LoadSceneMode.Additive;
 
             // Any NetworkObjects marked to not be destroyed with a scene and reside within the scene about to be unloaded
             // should be migrated temporarily into the DDOL, once the scene is unloaded they will be migrated into the
@@ -1322,16 +1297,7 @@ namespace Unity.Netcode
             var sceneUnload = SceneManagerHandler.UnloadSceneAsync(scene, sceneEventProgress);
 
             // Notify local server that a scene is going to be unloaded
-            OnSceneEvent?.Invoke(new SceneEvent()
-            {
-                AsyncOperation = sceneUnload,
-                SceneEventType = sceneEventData.SceneEventType,
-                LoadSceneMode = sceneEventData.LoadSceneMode,
-                SceneName = sceneName,
-                ClientId = NetworkManager.LocalClientId  // Session owner can only invoke this
-            });
-
-            OnUnload?.Invoke(NetworkManager.LocalClientId, sceneName, sceneUnload);
+            InvokeSceneEvents(NetworkManager.LocalClientId, sceneEventData, sceneUnload);
 
             //Return the status
             return sceneEventProgress.Status;
@@ -1393,16 +1359,12 @@ namespace Unity.Netcode
             }
 
             // Notify the local client that a scene is going to be unloaded
-            OnSceneEvent?.Invoke(new SceneEvent()
-            {
-                AsyncOperation = sceneUnload,
-                SceneEventType = sceneEventData.SceneEventType,
-                LoadSceneMode = LoadSceneMode.Additive,     // The only scenes unloaded are scenes that were additively loaded
-                SceneName = sceneName,
-                ClientId = NetworkManager.LocalClientId   // Server sent this message to the client, but client is executing it
-            });
 
-            OnUnload?.Invoke(NetworkManager.LocalClientId, sceneName, sceneUnload);
+            // The only scenes unloaded are scenes that were additively loaded
+            sceneEventData.LoadSceneMode = LoadSceneMode.Additive;
+
+            // Server sent this message to the client, but client is executing it
+            InvokeSceneEvents(NetworkManager.LocalClientId, sceneEventData, sceneUnload);
         }
 
         /// <summary>
@@ -1447,15 +1409,7 @@ namespace Unity.Netcode
             sceneEventData.SceneEventType = SceneEventType.UnloadComplete;
 
             //Notify the client or server that a scene was unloaded
-            OnSceneEvent?.Invoke(new SceneEvent()
-            {
-                SceneEventType = sceneEventData.SceneEventType,
-                LoadSceneMode = sceneEventData.LoadSceneMode,
-                SceneName = SceneNameFromHash(sceneEventData.SceneHash),
-                ClientId = NetworkManager.LocalClientId,
-            });
-
-            OnUnloadComplete?.Invoke(NetworkManager.LocalClientId, SceneNameFromHash(sceneEventData.SceneHash));
+            InvokeSceneEvents(NetworkManager.LocalClientId, sceneEventData);
 
             if (!HasSceneAuthority())
             {
@@ -1547,6 +1501,8 @@ namespace Unity.Netcode
             sceneEventData.SceneHash = SceneHashFromNameOrPath(sceneName);
             sceneEventData.LoadSceneMode = loadSceneMode;
             var sceneEventId = sceneEventData.SceneEventId;
+            // LoadScene can be called with either a sceneName or a scenePath. Ensure that sceneName is correct at this point
+            sceneName = SceneNameFromHash(sceneEventData.SceneHash);
             // This both checks to make sure the scene is valid and if not resets the active scene event
             m_IsSceneEventActive = ValidateSceneBeforeLoading(sceneEventData.SceneHash, loadSceneMode);
             if (!m_IsSceneEventActive)
@@ -1583,15 +1539,7 @@ namespace Unity.Netcode
             var sceneLoad = SceneManagerHandler.LoadSceneAsync(sceneName, loadSceneMode, sceneEventProgress);
 
             // Notify the local server that a scene loading event has begun
-            OnSceneEvent?.Invoke(new SceneEvent()
-            {
-                AsyncOperation = sceneLoad,
-                SceneEventType = sceneEventData.SceneEventType,
-                LoadSceneMode = sceneEventData.LoadSceneMode,
-                SceneName = sceneName,
-                ClientId = NetworkManager.LocalClientId
-            });
-            OnLoad?.Invoke(NetworkManager.LocalClientId, sceneName, sceneEventData.LoadSceneMode, sceneLoad);
+            InvokeSceneEvents(NetworkManager.LocalClientId, sceneEventData, sceneLoad);
 
             //Return our scene progress instance
             return sceneEventProgress.Status;
@@ -1673,6 +1621,7 @@ namespace Unity.Netcode
                             AsyncOperation = m_AsyncOperation,
                             SceneEventType = SceneEventType.UnloadComplete,
                             SceneName = m_Scene.name,
+                            ScenePath = m_Scene.path,
                             LoadSceneMode = m_LoadSceneMode,
                             ClientId = m_ClientId
                         });
@@ -1697,6 +1646,7 @@ namespace Unity.Netcode
                     AsyncOperation = m_AsyncOperation,
                     SceneEventType = SceneEventType.Unload,
                     SceneName = m_Scene.name,
+                    ScenePath = m_Scene.path,
                     LoadSceneMode = m_LoadSceneMode,
                     ClientId = clientId
                 });
@@ -1758,16 +1708,7 @@ namespace Unity.Netcode
             }
             var sceneLoad = SceneManagerHandler.LoadSceneAsync(sceneName, sceneEventData.LoadSceneMode, sceneEventProgress);
 
-            OnSceneEvent?.Invoke(new SceneEvent()
-            {
-                AsyncOperation = sceneLoad,
-                SceneEventType = sceneEventData.SceneEventType,
-                LoadSceneMode = sceneEventData.LoadSceneMode,
-                SceneName = sceneName,
-                ClientId = NetworkManager.LocalClientId
-            });
-
-            OnLoad?.Invoke(NetworkManager.LocalClientId, sceneName, sceneEventData.LoadSceneMode, sceneLoad);
+            InvokeSceneEvents(NetworkManager.LocalClientId, sceneEventData, sceneLoad);
         }
 
         /// <summary>
@@ -1905,17 +1846,8 @@ namespace Unity.Netcode
             m_IsSceneEventActive = false;
 
             sceneEventData.SceneEventType = SceneEventType.LoadComplete;
-            //First, notify local server that the scene was loaded
-            OnSceneEvent?.Invoke(new SceneEvent()
-            {
-                SceneEventType = sceneEventData.SceneEventType,
-                LoadSceneMode = sceneEventData.LoadSceneMode,
-                SceneName = SceneNameFromHash(sceneEventData.SceneHash),
-                ClientId = NetworkManager.LocalClientId,
-                Scene = scene,
-            });
-
-            OnLoadComplete?.Invoke(NetworkManager.LocalClientId, SceneNameFromHash(sceneEventData.SceneHash), sceneEventData.LoadSceneMode);
+            // First, notify local server that the scene was loaded
+            InvokeSceneEvents(NetworkManager.LocalClientId, sceneEventData, scene: scene);
 
             //Second, only if we are a host do we want register having loaded for the associated SceneEventProgress
             if (SceneEventProgressTracking.ContainsKey(sceneEventData.SceneEventProgressId) && NetworkManager.IsClient)
@@ -1965,16 +1897,7 @@ namespace Unity.Netcode
             }
 
             // Notify local client that the scene was loaded
-            OnSceneEvent?.Invoke(new SceneEvent()
-            {
-                SceneEventType = SceneEventType.LoadComplete,
-                LoadSceneMode = sceneEventData.LoadSceneMode,
-                SceneName = SceneNameFromHash(sceneEventData.SceneHash),
-                ClientId = NetworkManager.LocalClientId,
-                Scene = scene,
-            });
-
-            OnLoadComplete?.Invoke(NetworkManager.LocalClientId, SceneNameFromHash(sceneEventData.SceneHash), sceneEventData.LoadSceneMode);
+            InvokeSceneEvents(NetworkManager.LocalClientId, sceneEventData, scene: scene);
 
             EndSceneEvent(sceneEventId);
         }
@@ -2204,6 +2127,7 @@ namespace Unity.Netcode
                     SceneEventType = SceneEventType.Load,
                     LoadSceneMode = loadSceneMode,
                     SceneName = sceneName,
+                    ScenePath = ScenePathFromHash(sceneHash),
                     ClientId = NetworkManager.LocalClientId,
                 });
 
@@ -2278,16 +2202,7 @@ namespace Unity.Netcode
             EndSceneEvent(responseSceneEventData.SceneEventId);
 
             // Send notification to local client that the scene has finished loading
-            OnSceneEvent?.Invoke(new SceneEvent()
-            {
-                SceneEventType = SceneEventType.LoadComplete,
-                LoadSceneMode = loadSceneMode,
-                SceneName = sceneName,
-                Scene = nextScene,
-                ClientId = NetworkManager.LocalClientId,
-            });
-
-            OnLoadComplete?.Invoke(NetworkManager.LocalClientId, sceneName, loadSceneMode);
+            InvokeSceneEvents(NetworkManager.LocalClientId, responseSceneEventData, scene: nextScene);
 
             // Check to see if we still have scenes to load and synchronize with
             HandleClientSceneEvent(sceneEventId);
@@ -2512,27 +2427,10 @@ namespace Unity.Netcode
                 case SceneEventType.UnloadEventCompleted:
                     {
                         // Notify the local client that all clients have finished loading or unloading
-                        OnSceneEvent?.Invoke(new SceneEvent()
-                        {
-                            SceneEventType = sceneEventData.SceneEventType,
-                            LoadSceneMode = sceneEventData.LoadSceneMode,
-                            SceneName = SceneNameFromHash(sceneEventData.SceneHash),
-                            ClientId = NetworkManager.ServerClientId,
-                            ClientsThatCompleted = sceneEventData.ClientsCompleted,
-                            ClientsThatTimedOut = sceneEventData.ClientsTimedOut,
-                        });
-
-                        if (sceneEventData.SceneEventType == SceneEventType.LoadEventCompleted)
-                        {
-                            OnLoadEventCompleted?.Invoke(SceneNameFromHash(sceneEventData.SceneHash), sceneEventData.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
-                        }
-                        else
-                        {
-                            OnUnloadEventCompleted?.Invoke(SceneNameFromHash(sceneEventData.SceneHash), sceneEventData.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
-                        }
+                        var clientId = NetworkManager.CMBServiceConnection ? NetworkManager.CurrentSessionOwner : NetworkManager.ServerClientId;
+                        InvokeSceneEvents(clientId, sceneEventData);
 
                         EndSceneEvent(sceneEventId);
-
                         break;
                     }
                 default:
@@ -2553,42 +2451,15 @@ namespace Unity.Netcode
             switch (sceneEventData.SceneEventType)
             {
                 case SceneEventType.LoadComplete:
-                    {
-                        // Notify the local server that the client has finished loading a scene
-                        OnSceneEvent?.Invoke(new SceneEvent()
-                        {
-                            SceneEventType = sceneEventData.SceneEventType,
-                            LoadSceneMode = sceneEventData.LoadSceneMode,
-                            SceneName = SceneNameFromHash(sceneEventData.SceneHash),
-                            ClientId = clientId
-                        });
-
-                        OnLoadComplete?.Invoke(clientId, SceneNameFromHash(sceneEventData.SceneHash), sceneEventData.LoadSceneMode);
-
-                        if (SceneEventProgressTracking.ContainsKey(sceneEventData.SceneEventProgressId))
-                        {
-                            SceneEventProgressTracking[sceneEventData.SceneEventProgressId].ClientFinishedSceneEvent(clientId);
-                        }
-                        EndSceneEvent(sceneEventId);
-                        break;
-                    }
                 case SceneEventType.UnloadComplete:
                     {
+                        // Notify the local server that the client has finished unloading a scene
+                        InvokeSceneEvents(clientId, sceneEventData);
+
                         if (SceneEventProgressTracking.ContainsKey(sceneEventData.SceneEventProgressId))
                         {
                             SceneEventProgressTracking[sceneEventData.SceneEventProgressId].ClientFinishedSceneEvent(clientId);
                         }
-                        // Notify the local server that the client has finished unloading a scene
-                        OnSceneEvent?.Invoke(new SceneEvent()
-                        {
-                            SceneEventType = sceneEventData.SceneEventType,
-                            LoadSceneMode = sceneEventData.LoadSceneMode,
-                            SceneName = SceneNameFromHash(sceneEventData.SceneHash),
-                            ClientId = clientId
-                        });
-
-                        OnUnloadComplete?.Invoke(clientId, SceneNameFromHash(sceneEventData.SceneHash));
-
                         EndSceneEvent(sceneEventId);
                         break;
                     }
@@ -3322,6 +3193,46 @@ namespace Unity.Netcode
             }
 
             return mapping;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void InvokeSceneEvents(ulong clientId, SceneEventData eventData, AsyncOperation asyncOperation = null, Scene scene = default)
+        {
+            var sceneName = SceneNameFromHash(eventData.SceneHash);
+            OnSceneEvent?.Invoke(new SceneEvent()
+            {
+                AsyncOperation = asyncOperation,
+                SceneEventType = eventData.SceneEventType,
+                SceneName = sceneName,
+                ScenePath = ScenePathFromHash(eventData.SceneHash),
+                ClientId = clientId,
+                LoadSceneMode = eventData.LoadSceneMode,
+                ClientsThatCompleted = eventData.ClientsCompleted,
+                ClientsThatTimedOut = eventData.ClientsTimedOut,
+                Scene = scene,
+            });
+
+            switch (eventData.SceneEventType)
+            {
+                case SceneEventType.Load:
+                    OnLoad?.Invoke(clientId, sceneName, eventData.LoadSceneMode, asyncOperation);
+                    break;
+                case SceneEventType.Unload:
+                    OnUnload?.Invoke(clientId, sceneName, asyncOperation);
+                    break;
+                case SceneEventType.LoadComplete:
+                    OnLoadComplete?.Invoke(NetworkManager.LocalClientId, sceneName, eventData.LoadSceneMode);
+                    break;
+                case SceneEventType.UnloadComplete:
+                    OnUnloadComplete?.Invoke(clientId, sceneName);
+                    break;
+                case SceneEventType.LoadEventCompleted:
+                    OnLoadEventCompleted?.Invoke(SceneNameFromHash(eventData.SceneHash), eventData.LoadSceneMode, eventData.ClientsCompleted, eventData.ClientsTimedOut);
+                    break;
+                case SceneEventType.UnloadEventCompleted:
+                    OnUnloadEventCompleted?.Invoke(SceneNameFromHash(eventData.SceneHash), eventData.LoadSceneMode, eventData.ClientsCompleted, eventData.ClientsTimedOut);
+                    break;
+            }
         }
 
     }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -3220,7 +3220,7 @@ namespace Unity.Netcode
                     OnUnload?.Invoke(clientId, sceneName, asyncOperation);
                     break;
                 case SceneEventType.LoadComplete:
-                    OnLoadComplete?.Invoke(NetworkManager.LocalClientId, sceneName, eventData.LoadSceneMode);
+                    OnLoadComplete?.Invoke(clientId, sceneName, eventData.LoadSceneMode);
                     break;
                 case SceneEventType.UnloadComplete:
                     OnUnloadComplete?.Invoke(clientId, sceneName);

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
 using Unity.Collections;
 using UnityEngine;
 using UnityEngine.SceneManagement;

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
@@ -124,7 +124,7 @@ namespace Unity.Netcode
             {
                 // If we are the host, then add the host-client to the list
                 // of clients that completed if the AsyncOperation is done.
-                if (m_NetworkManager.IsHost && m_AsyncOperation.isDone)
+                if ((m_NetworkManager.IsHost || m_NetworkManager.LocalClient.IsSessionOwner) && m_AsyncOperation.isDone)
                 {
                     clients.Add(m_NetworkManager.LocalClientId);
                 }

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -1671,35 +1671,19 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
         /// <summary>
         /// Waits until the specified condition returns true or a timeout occurs, then asserts if the timeout was reached.
-        /// </summary>
-        /// <param name="checkForCondition">A delegate that returns true when the desired condition is met.</param>
-        /// <param name="timeoutErrorMessage">The error message to include in the assertion if the timeout is reached.</param>
-        /// <param name="timeOutHelper">An optional <see cref="TimeoutHelper"/> to control the timeout period. If null, the default timeout is used.</param>
-        /// <returns>An <see cref="IEnumerator"/> for use in Unity coroutines.</returns>
-        protected IEnumerator WaitForConditionOrAssert(Func<bool> checkForCondition, string timeoutErrorMessage, TimeoutHelper timeOutHelper = null)
-        {
-            yield return WaitForConditionOrTimeOut(checkForCondition, timeOutHelper);
-            AssertOnTimeout(timeoutErrorMessage, timeOutHelper);
-        }
-
-        /// <summary>
-        /// Waits until the specified condition returns true or a timeout occurs, then asserts if the timeout was reached.
         /// This overload allows the condition to provide additional error details via a <see cref="StringBuilder"/>.
         /// </summary>
         /// <param name="checkForCondition">A delegate that takes a <see cref="StringBuilder"/> for error details and returns true when the desired condition is met.</param>
-        /// <param name="timeoutErrorMessage">The error message to include in the assertion if the timeout is reached. The information on the StringBuilder will be appended on a new line</param>
         /// <param name="timeOutHelper">An optional <see cref="TimeoutHelper"/> to control the timeout period. If null, the default timeout is used.</param>
         /// <returns>An <see cref="IEnumerator"/> for use in Unity coroutines.</returns>
-        protected IEnumerator WaitForConditionOrAssert(Func<StringBuilder, bool> checkForCondition, string timeoutErrorMessage, TimeoutHelper timeOutHelper = null)
+        protected IEnumerator WaitForConditionOrTimeOut(Func<StringBuilder, bool> checkForCondition, TimeoutHelper timeOutHelper = null)
         {
-            var errorBuilder = new StringBuilder();
             yield return WaitForConditionOrTimeOut(() =>
             {
                 // Clear errorBuilder before each check to ensure the errorBuilder only contains information from the lastest run
-                errorBuilder.Clear();
-                return checkForCondition(errorBuilder);
+                m_InternalErrorLog.Clear();
+                return checkForCondition(m_InternalErrorLog);
             }, timeOutHelper);
-            AssertOnTimeout($"{timeoutErrorMessage}\n{errorBuilder}", timeOutHelper);
         }
 
         /// <summary>
@@ -2057,7 +2041,14 @@ namespace Unity.Netcode.TestHelpers.Runtime
         protected void AssertOnTimeout(string timeOutErrorMessage, TimeoutHelper assignedTimeoutHelper = null)
         {
             var timeoutHelper = assignedTimeoutHelper ?? s_GlobalTimeoutHelper;
-            Assert.False(timeoutHelper.TimedOut, timeOutErrorMessage);
+
+            if (m_InternalErrorLog.Length > 0)
+            {
+                Assert.False(timeoutHelper.TimedOut, $"{timeOutErrorMessage}\n{m_InternalErrorLog}");
+                m_InternalErrorLog.Clear();
+            }
+
+            Assert.False(timeoutHelper.TimedOut, $"{timeOutErrorMessage}");
         }
 
 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -1194,7 +1194,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
                     // Wait for all clients to connect
                     WaitForClientsConnectedOrTimeOutWithTimeTravel();
 
-                    AssertOnTimeout($"{nameof(StartServerAndClients)} timed out waiting for all clients to be connected!");
+                    AssertOnTimeout($"{nameof(StartServerAndClients)} timed out waiting for all clients to be connected!\n {m_InternalErrorLog}");
 
                     if (m_UseHost || authorityManager.IsHost)
                     {

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -2046,6 +2046,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             {
                 Assert.False(timeoutHelper.TimedOut, $"{timeOutErrorMessage}\n{m_InternalErrorLog}");
                 m_InternalErrorLog.Clear();
+                return;
             }
 
             Assert.False(timeoutHelper.TimedOut, $"{timeOutErrorMessage}");

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -1663,12 +1663,27 @@ namespace Unity.Netcode.TestHelpers.Runtime
             return success;
         }
 
+        /// <summary>
+        /// Waits until the specified condition returns true or a timeout occurs, then asserts if the timeout was reached.
+        /// </summary>
+        /// <param name="checkForCondition">A delegate that returns true when the desired condition is met.</param>
+        /// <param name="timeoutErrorMessage">The error message to include in the assertion if the timeout is reached.</param>
+        /// <param name="timeOutHelper">An optional <see cref="TimeoutHelper"/> to control the timeout period. If null, the default timeout is used.</param>
+        /// <returns>An <see cref="IEnumerator"/> for use in Unity coroutines.</returns>
         public IEnumerator WaitForConditionOrAssert(Func<bool> checkForCondition, string timeoutErrorMessage, TimeoutHelper timeOutHelper = null)
         {
             yield return WaitForConditionOrTimeOut(checkForCondition, timeOutHelper);
             AssertOnTimeout(timeoutErrorMessage, timeOutHelper);
         }
 
+        /// <summary>
+        /// Waits until the specified condition returns true or a timeout occurs, then asserts if the timeout was reached.
+        /// This overload allows the condition to provide additional error details via a <see cref="StringBuilder"/>.
+        /// </summary>
+        /// <param name="checkForCondition">A delegate that takes a <see cref="StringBuilder"/> for error details and returns true when the desired condition is met.</param>
+        /// <param name="timeoutErrorMessage">The error message to include in the assertion if the timeout is reached. The information on the StringBuilder will be appended on a new line</param>
+        /// <param name="timeOutHelper">An optional <see cref="TimeoutHelper"/> to control the timeout period. If null, the default timeout is used.</param>
+        /// <returns>An <see cref="IEnumerator"/> for use in Unity coroutines.</returns>
         public IEnumerator WaitForConditionOrAssert(Func<StringBuilder, bool> checkForCondition, string timeoutErrorMessage, TimeoutHelper timeOutHelper = null)
         {
             var errorBuilder = new StringBuilder();

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -1693,7 +1693,12 @@ namespace Unity.Netcode.TestHelpers.Runtime
         protected IEnumerator WaitForConditionOrAssert(Func<StringBuilder, bool> checkForCondition, string timeoutErrorMessage, TimeoutHelper timeOutHelper = null)
         {
             var errorBuilder = new StringBuilder();
-            yield return WaitForConditionOrTimeOut(() => checkForCondition(errorBuilder), timeOutHelper);
+            yield return WaitForConditionOrTimeOut(() =>
+            {
+                // Clear errorBuilder before each check to ensure the errorBuilder only contains information from the lastest run
+                errorBuilder.Clear();
+                return checkForCondition(errorBuilder);
+            }, timeOutHelper);
             AssertOnTimeout($"{timeoutErrorMessage}\n{errorBuilder}", timeOutHelper);
         }
 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -1635,12 +1635,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 throw new ArgumentNullException($"checkForCondition cannot be null!");
             }
 
-            // If none is provided we use the default global time out helper
-            if (timeOutHelper == null)
-            {
-                timeOutHelper = s_GlobalTimeoutHelper;
-            }
-
             conditionalPredicate.Started();
             yield return WaitForConditionOrTimeOut(conditionalPredicate.HasConditionBeenReached, timeOutHelper);
             conditionalPredicate.Finished(timeOutHelper.TimedOut);
@@ -1667,6 +1661,19 @@ namespace Unity.Netcode.TestHelpers.Runtime
             var success = WaitForConditionOrTimeOutWithTimeTravel(conditionalPredicate.HasConditionBeenReached, maxTries);
             conditionalPredicate.Finished(!success);
             return success;
+        }
+
+        public IEnumerator WaitForConditionOrAssert(Func<bool> checkForCondition, string timeoutErrorMessage, TimeoutHelper timeOutHelper = null)
+        {
+            yield return WaitForConditionOrTimeOut(checkForCondition, timeOutHelper);
+            AssertOnTimeout(timeoutErrorMessage, timeOutHelper);
+        }
+
+        public IEnumerator WaitForConditionOrAssert(Func<StringBuilder, bool> checkForCondition, string timeoutErrorMessage, TimeoutHelper timeOutHelper = null)
+        {
+            var errorBuilder = new StringBuilder();
+            yield return WaitForConditionOrTimeOut(() => checkForCondition(errorBuilder), timeOutHelper);
+            AssertOnTimeout($"{timeoutErrorMessage}\n{errorBuilder.ToString()}", timeOutHelper);
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTest.cs
@@ -1635,6 +1635,12 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 throw new ArgumentNullException($"checkForCondition cannot be null!");
             }
 
+            // If none is provided we use the default global time out helper
+            if (timeOutHelper == null)
+            {
+                timeOutHelper = s_GlobalTimeoutHelper;
+            }
+
             conditionalPredicate.Started();
             yield return WaitForConditionOrTimeOut(conditionalPredicate.HasConditionBeenReached, timeOutHelper);
             conditionalPredicate.Finished(timeOutHelper.TimedOut);
@@ -1670,7 +1676,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// <param name="timeoutErrorMessage">The error message to include in the assertion if the timeout is reached.</param>
         /// <param name="timeOutHelper">An optional <see cref="TimeoutHelper"/> to control the timeout period. If null, the default timeout is used.</param>
         /// <returns>An <see cref="IEnumerator"/> for use in Unity coroutines.</returns>
-        public IEnumerator WaitForConditionOrAssert(Func<bool> checkForCondition, string timeoutErrorMessage, TimeoutHelper timeOutHelper = null)
+        protected IEnumerator WaitForConditionOrAssert(Func<bool> checkForCondition, string timeoutErrorMessage, TimeoutHelper timeOutHelper = null)
         {
             yield return WaitForConditionOrTimeOut(checkForCondition, timeOutHelper);
             AssertOnTimeout(timeoutErrorMessage, timeOutHelper);
@@ -1684,11 +1690,11 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// <param name="timeoutErrorMessage">The error message to include in the assertion if the timeout is reached. The information on the StringBuilder will be appended on a new line</param>
         /// <param name="timeOutHelper">An optional <see cref="TimeoutHelper"/> to control the timeout period. If null, the default timeout is used.</param>
         /// <returns>An <see cref="IEnumerator"/> for use in Unity coroutines.</returns>
-        public IEnumerator WaitForConditionOrAssert(Func<StringBuilder, bool> checkForCondition, string timeoutErrorMessage, TimeoutHelper timeOutHelper = null)
+        protected IEnumerator WaitForConditionOrAssert(Func<StringBuilder, bool> checkForCondition, string timeoutErrorMessage, TimeoutHelper timeOutHelper = null)
         {
             var errorBuilder = new StringBuilder();
             yield return WaitForConditionOrTimeOut(() => checkForCondition(errorBuilder), timeOutHelper);
-            AssertOnTimeout($"{timeoutErrorMessage}\n{errorBuilder.ToString()}", timeOutHelper);
+            AssertOnTimeout($"{timeoutErrorMessage}\n{errorBuilder}", timeOutHelper);
         }
 
         /// <summary>

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/OnSceneEventCallbackTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/OnSceneEventCallbackTests.cs
@@ -106,7 +106,8 @@ namespace TestProject.RuntimeTests
                 // Load the scene initially
                 authority.SceneManager.LoadScene(k_SceneToLoad, LoadSceneMode.Additive);
 
-                yield return WaitForConditionOrAssert(ValidateSceneIsLoaded, $"[Setup] Timed out waiting for client to load the scene {k_SceneToLoad}!");
+                yield return WaitForConditionOrTimeOut(ValidateSceneIsLoaded);
+                AssertOnTimeout($"[Setup] Timed out waiting for client to load the scene {k_SceneToLoad}!");
 
                 // Wait for any pending messages to be processed
                 yield return null;
@@ -179,14 +180,16 @@ namespace TestProject.RuntimeTests
             {
                 Assert.That(authority.SceneManager.LoadScene(loadCall, LoadSceneMode.Additive) == SceneEventProgressStatus.Started);
 
-                yield return WaitForConditionOrAssert(ValidateSceneIsLoaded, $"[Test] Timed out waiting for client to load the scene {k_SceneToLoad}!");
+                yield return WaitForConditionOrTimeOut(ValidateSceneIsLoaded);
+                AssertOnTimeout($"[Test] Timed out waiting for client to load the scene {k_SceneToLoad}!");
             }
             else
             {
                 Assert.That(loadedScene.name, Is.EqualTo(k_SceneToLoad), "scene was not loaded!");
                 Assert.That(authority.SceneManager.UnloadScene(loadedScene) == SceneEventProgressStatus.Started);
 
-                yield return WaitForConditionOrAssert(ValidateSceneIsUnloaded, $"[Test] Timed out waiting for client to unload the scene {k_SceneToLoad}!");
+                yield return WaitForConditionOrTimeOut(ValidateSceneIsUnloaded);
+                AssertOnTimeout($"[Test] Timed out waiting for client to unload the scene {k_SceneToLoad}!");
             }
 
             // Wait for all messages to process
@@ -219,7 +222,7 @@ namespace TestProject.RuntimeTests
                 }
             }
 
-            return true;
+            return false;
         }
 
         private bool ValidateSceneIsUnloaded()

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/OnSceneEventCallbackTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/OnSceneEventCallbackTests.cs
@@ -1,0 +1,264 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Unity.Netcode;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+
+namespace TestProject.RuntimeTests
+{
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    [TestFixture(HostOrServer.DAHost)]
+    public class OnSceneEventCallbackTests : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 1;
+
+        private const string k_SceneToLoad = "EmptyScene";
+        private const string k_PathToLoad = "Assets/Scenes/EmptyScene.unity";
+
+        public OnSceneEventCallbackTests(HostOrServer hostOrServer) : base(hostOrServer)
+        {
+
+        }
+
+        private struct ExpectedEvent
+        {
+            public SceneEvent SceneEvent;
+            public string SceneName;
+            public string ScenePath;
+        }
+
+        private readonly Queue<ExpectedEvent> m_ExpectedEventQueue = new();
+
+        private static int s_NumEventsProcessed;
+        private void OnSceneEvent(SceneEvent sceneEvent)
+        {
+            VerboseDebug($"OnSceneEvent! Type: {sceneEvent.SceneEventType}.");
+            if (m_ExpectedEventQueue.Count > 0)
+            {
+                var expectedEvent = m_ExpectedEventQueue.Dequeue();
+
+                ValidateEventsAreEqual(expectedEvent.SceneEvent, sceneEvent);
+
+                // Only LoadComplete events have an attached scene
+                if (sceneEvent.SceneEventType == SceneEventType.LoadComplete)
+                {
+                    ValidateReceivedScene(expectedEvent, sceneEvent.Scene);
+                }
+            }
+            else
+            {
+                Assert.Fail($"Received unexpected event at index {s_NumEventsProcessed}: {sceneEvent.SceneEventType}");
+            }
+            s_NumEventsProcessed++;
+        }
+
+        public enum ClientType
+        {
+            Authority,
+            NonAuthority,
+        }
+
+        public enum Action
+        {
+            Load,
+            Unload,
+        }
+
+        [UnityTest]
+        public IEnumerator LoadAndUnloadCallbacks([Values] ClientType clientType, [Values] Action action)
+        {
+            yield return RunSceneEventCallbackTest(clientType, action, k_SceneToLoad);
+        }
+
+        [UnityTest]
+        public IEnumerator LoadSceneFromPath([Values] ClientType clientType)
+        {
+            yield return RunSceneEventCallbackTest(clientType, Action.Load, k_PathToLoad);
+        }
+
+        private IEnumerator RunSceneEventCallbackTest(ClientType clientType, Action action, string loadCall)
+        {
+            if (m_UseCmbService)
+            {
+                yield return s_DefaultWaitForTick;
+            }
+
+            var authority = GetAuthorityNetworkManager();
+            var nonAuthority = GetNonAuthorityNetworkManager();
+            var managerToTest = clientType == ClientType.Authority ? authority : nonAuthority;
+
+
+            var expectedCompletedClients = new List<ulong>{nonAuthority.LocalClientId};
+            // the authority ID is not inside ClientsThatCompleted when running as a server
+            if (m_UseHost)
+            {
+                expectedCompletedClients.Insert(0, authority.LocalClientId);
+            }
+
+            Scene loadedScene = default;
+            if (action == Action.Unload)
+            {
+                // Load the scene initially
+                authority.SceneManager.LoadScene(k_SceneToLoad, LoadSceneMode.Additive);
+
+                yield return WaitForConditionOrTimeOut(ValidateSceneIsLoaded);
+                AssertOnTimeout($"Timed out waiting for client to load the scene {k_SceneToLoad}!");
+
+                // Wait for any pending messages to be processed
+                yield return null;
+
+                // Get a reference to the scene to test
+                loadedScene = SceneManager.GetSceneByName(k_SceneToLoad);
+            }
+
+            s_NumEventsProcessed = 0;
+            m_ExpectedEventQueue.Clear();
+            m_ExpectedEventQueue.Enqueue(new ExpectedEvent()
+            {
+                SceneEvent = new SceneEvent()
+                {
+                    SceneEventType = action == Action.Load ? SceneEventType.Load : SceneEventType.Unload,
+                    LoadSceneMode = LoadSceneMode.Additive,
+                    SceneName = k_SceneToLoad,
+                    ScenePath = k_PathToLoad,
+                    ClientId = managerToTest.LocalClientId,
+                },
+            });
+            m_ExpectedEventQueue.Enqueue(new ExpectedEvent()
+            {
+                SceneEvent = new SceneEvent()
+                {
+                    SceneEventType = action == Action.Load ? SceneEventType.LoadComplete : SceneEventType.UnloadComplete,
+                    LoadSceneMode = LoadSceneMode.Additive,
+                    SceneName = k_SceneToLoad,
+                    ScenePath = k_PathToLoad,
+                    ClientId = managerToTest.LocalClientId,
+                },
+                SceneName = action == Action.Load ? k_SceneToLoad : null,
+                ScenePath = action == Action.Load ? k_PathToLoad : null
+            });
+
+            if (clientType == ClientType.Authority)
+            {
+                m_ExpectedEventQueue.Enqueue(new ExpectedEvent()
+                {
+                    SceneEvent = new SceneEvent()
+                    {
+                        SceneEventType = action == Action.Load ? SceneEventType.LoadComplete : SceneEventType.UnloadComplete,
+                        LoadSceneMode = LoadSceneMode.Additive,
+                        SceneName = k_SceneToLoad,
+                        ScenePath = k_PathToLoad,
+                        ClientId = nonAuthority.LocalClientId,
+                    }
+                });
+            }
+
+            m_ExpectedEventQueue.Enqueue(new ExpectedEvent()
+            {
+                SceneEvent = new SceneEvent()
+                {
+                    SceneEventType = action == Action.Load ? SceneEventType.LoadEventCompleted : SceneEventType.UnloadEventCompleted,
+                    LoadSceneMode = LoadSceneMode.Additive,
+                    SceneName = k_SceneToLoad,
+                    ScenePath = k_PathToLoad,
+                    ClientId = authority.LocalClientId,
+                    ClientsThatCompleted = expectedCompletedClients,
+                    ClientsThatTimedOut = new List<ulong>()
+                }
+            });
+
+            //////////////////////////////////////////
+            // Testing event notifications
+            managerToTest.SceneManager.OnSceneEvent += OnSceneEvent;
+
+            if (action == Action.Load)
+            {
+                Assert.That(authority.SceneManager.LoadScene(loadCall, LoadSceneMode.Additive) == SceneEventProgressStatus.Started);
+
+                yield return WaitForConditionOrTimeOut(ValidateSceneIsLoaded);
+                AssertOnTimeout($"Timed out waiting for client to load the scene {k_SceneToLoad}!");
+            }
+            else
+            {
+                Assert.That(loadedScene.name, Is.EqualTo(k_SceneToLoad), "scene was not loaded!");
+                Assert.That(authority.SceneManager.UnloadScene(loadedScene) == SceneEventProgressStatus.Started);
+
+                yield return WaitForConditionOrTimeOut(ValidateSceneIsUnloaded);
+                AssertOnTimeout($"Timed out waiting for client to unload the scene {k_SceneToLoad}!");
+            }
+
+            // Wait for all messages to process
+            yield return null;
+
+            if (m_ExpectedEventQueue.Count > 0)
+            {
+                Assert.Fail($"Failed to invoke all expected OnSceneEvent callbacks. {m_ExpectedEventQueue.Count} callbacks missing. First missing event is {m_ExpectedEventQueue.Dequeue().SceneEvent.SceneEventType}");
+            }
+
+            managerToTest.SceneManager.OnSceneEvent -= OnSceneEvent;
+        }
+
+        private bool ValidateSceneIsLoaded()
+        {
+            foreach (var manager in m_NetworkManagers)
+            {
+                // default will have isLoaded as false so we can get the scene or default and test on isLoaded
+                var loadedScene = manager.SceneManager.ScenesLoaded.Values.FirstOrDefault(scene => scene.name == k_SceneToLoad);
+                if (!loadedScene.isLoaded)
+                {
+                    return false;
+                }
+
+                if (manager.SceneManager.SceneEventProgressTracking.Count > 0)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private bool ValidateSceneIsUnloaded()
+        {
+            foreach (var manager in m_NetworkManagers)
+            {
+                if (manager.SceneManager.ScenesLoaded.Values.Any(scene => scene.name == k_SceneToLoad))
+                {
+                    return false;
+                }
+
+                if (manager.SceneManager.SceneEventProgressTracking.Count > 0)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private static void ValidateEventsAreEqual(SceneEvent expectedEvent, SceneEvent sceneEvent)
+        {
+            AssertField(expectedEvent.SceneEventType, sceneEvent.SceneEventType, nameof(sceneEvent.SceneEventType), sceneEvent.SceneEventType);
+            AssertField(expectedEvent.LoadSceneMode, sceneEvent.LoadSceneMode, nameof(sceneEvent.LoadSceneMode), sceneEvent.SceneEventType);
+            AssertField(expectedEvent.SceneName, sceneEvent.SceneName, nameof(sceneEvent.SceneName), sceneEvent.SceneEventType);
+            AssertField(expectedEvent.ClientId, sceneEvent.ClientId, nameof(sceneEvent.ClientId), sceneEvent.SceneEventType);
+            AssertField(expectedEvent.ClientsThatCompleted, sceneEvent.ClientsThatCompleted, nameof(sceneEvent.SceneEventType), sceneEvent.SceneEventType);
+            AssertField(expectedEvent.ClientsThatTimedOut, sceneEvent.ClientsThatTimedOut, nameof(sceneEvent.ClientsThatTimedOut), sceneEvent.SceneEventType);
+        }
+
+        // The LoadCompleted event includes the scene being loaded
+        private static void ValidateReceivedScene(ExpectedEvent expectedEvent, Scene scene)
+        {
+            AssertField(expectedEvent.SceneName, scene.name, "Scene.name", SceneEventType.LoadComplete);
+            AssertField(expectedEvent.ScenePath, scene.path, "Scene.path", SceneEventType.LoadComplete);
+        }
+
+        private static void AssertField<T>(T expected, T actual, string fieldName, SceneEventType type)
+        {
+            Assert.AreEqual(expected, actual, $"Failed on event {s_NumEventsProcessed} - {type}: Expected {fieldName} to be {expected}. Found {actual}");
+        }
+    }
+}

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/OnSceneEventCallbackTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/OnSceneEventCallbackTests.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using NUnit.Framework;
 using Unity.Netcode;
 using Unity.Netcode.TestHelpers.Runtime;
@@ -105,8 +106,7 @@ namespace TestProject.RuntimeTests
                 // Load the scene initially
                 authority.SceneManager.LoadScene(k_SceneToLoad, LoadSceneMode.Additive);
 
-                yield return WaitForConditionOrTimeOut(ValidateSceneIsLoaded);
-                AssertOnTimeout($"Timed out waiting for client to load the scene {k_SceneToLoad}!");
+                yield return WaitForConditionOrAssert(ValidateSceneIsLoaded, $"[Setup] Timed out waiting for client to load the scene {k_SceneToLoad}!");
 
                 // Wait for any pending messages to be processed
                 yield return null;
@@ -179,16 +179,14 @@ namespace TestProject.RuntimeTests
             {
                 Assert.That(authority.SceneManager.LoadScene(loadCall, LoadSceneMode.Additive) == SceneEventProgressStatus.Started);
 
-                yield return WaitForConditionOrTimeOut(ValidateSceneIsLoaded);
-                AssertOnTimeout($"Timed out waiting for client to load the scene {k_SceneToLoad}!");
+                yield return WaitForConditionOrAssert(ValidateSceneIsLoaded, $"[Test] Timed out waiting for client to load the scene {k_SceneToLoad}!");
             }
             else
             {
                 Assert.That(loadedScene.name, Is.EqualTo(k_SceneToLoad), "scene was not loaded!");
                 Assert.That(authority.SceneManager.UnloadScene(loadedScene) == SceneEventProgressStatus.Started);
 
-                yield return WaitForConditionOrTimeOut(ValidateSceneIsUnloaded);
-                AssertOnTimeout($"Timed out waiting for client to unload the scene {k_SceneToLoad}!");
+                yield return WaitForConditionOrAssert(ValidateSceneIsUnloaded, $"[Test] Timed out waiting for client to unload the scene {k_SceneToLoad}!");
             }
 
             // Wait for all messages to process
@@ -202,7 +200,7 @@ namespace TestProject.RuntimeTests
             managerToTest.SceneManager.OnSceneEvent -= OnSceneEvent;
         }
 
-        private bool ValidateSceneIsLoaded()
+        private bool ValidateSceneIsLoaded(StringBuilder errorBuilder)
         {
             foreach (var manager in m_NetworkManagers)
             {
@@ -210,11 +208,13 @@ namespace TestProject.RuntimeTests
                 var loadedScene = manager.SceneManager.ScenesLoaded.Values.FirstOrDefault(scene => scene.name == k_SceneToLoad);
                 if (!loadedScene.isLoaded)
                 {
+                    errorBuilder.AppendLine($"[ValidateIsLoaded] Scene {loadedScene.name} exists but is not loaded!");
                     return false;
                 }
 
                 if (manager.SceneManager.SceneEventProgressTracking.Count > 0)
                 {
+                    errorBuilder.AppendLine($"[ValidateIsLoaded] NetworkManager {manager.name} still has progress tracking events.");
                     return false;
                 }
             }

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/OnSceneEventCallbackTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/OnSceneEventCallbackTests.cs
@@ -92,7 +92,7 @@ namespace TestProject.RuntimeTests
             var managerToTest = clientType == ClientType.Authority ? authority : nonAuthority;
 
 
-            var expectedCompletedClients = new List<ulong>{nonAuthority.LocalClientId};
+            var expectedCompletedClients = new List<ulong> { nonAuthority.LocalClientId };
             // the authority ID is not inside ClientsThatCompleted when running as a server
             if (m_UseHost)
             {

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/OnSceneEventCallbackTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/OnSceneEventCallbackTests.cs
@@ -222,7 +222,7 @@ namespace TestProject.RuntimeTests
                 }
             }
 
-            return false;
+            return true;
         }
 
         private bool ValidateSceneIsUnloaded()

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/OnSceneEventCallbackTests.cs.meta
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/OnSceneEventCallbackTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 85ef6a4707d04010a84eeea61fdeb9a8
+timeCreated: 1747776388


### PR DESCRIPTION
<!-- Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->
[MTTB-1278](https://jira.unity3d.com/browse/MTTB-1273)
fixes: #3418 

## Changelog

- Added: A `ScenePath` field on the `SceneEvent` returned by the `OnSceneEvent` callback.
- Fixed: Various bugs around the `OnSceneEvent` callback.

## Testing and Documentation

- Includes unit tests.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Backport

<!-- If this is a backport:
 - Add the following to the PR title: "\[Backport\] ..." .
 - Link to the original PR.
If this needs a backport - state this here
If a backport is not needed please provide the reason why.
If the "Backports" section is not present it will lead to a CI test failure. 
-->

Backported by #3487 