### PR TITLE
Fix NetworkVariables sometimes dropping changes

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -1002,8 +1002,8 @@ namespace Unity.Netcode
                         if (networkVariable.CanSend())
                         {
                             shouldSend = true;
+                            break;
                         }
-                        break;
                     }
                 }
 


### PR DESCRIPTION
## Changelog

- Fixed: NetworkVariables no longer sometimes drop changes to them without sending an update message

## Issue description

Consider a NetworkBehavior that contains two NetworkVariables: a float, then an int. Both are changed, but the change to the float is tiny, within the tolerances for `NetworkVariable.ExceedsDirtinessThreshold`. This means that while both NetworkVariables have `.IsDirty()` be true, `.CanSend()` is false for the first float NetworkVariable.

When looping through NetworkVariableFields in the code around the PR, the NetworkVariable<float> is processed first. It is dirty, and the target client can read it, so the first if statement is entered. However, CanSend is false (because it's within the dirtiness threshold), so `shouldSend` is not set to true. Then, `break;` is encountered, stopping looping through the behaviour's NetworkVariables. `shouldSend` is false, so the updates to the second NetworkVariable<int> are not sent.

Later on, at the bottom of `NetworkBehaviour.PostNetworkVariableWrite`, the dirty flag is cleared for all NetworkVariables, via `MarkVariablesDirty(false)`. This means that the `NetworkVariable<int>` is not checked to be sent again - so if it only changed the once, on other clients, the variable is never updated to the new value. (Changing it again can "unstick" it, because you might get lucky in this for loop the next time and not have a variable that is dirty but canSend=false before the changed NetworkVariable - but in my case, the variable hardly ever changes).

---

This was broken in this PR, where the `if (networkVariable.CanSend())` if statement was added, but the `break;` was not moved inside it: https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/2820