### PR TITLE
fix: dont destroy with owner not being honored when client exits

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -14,6 +14,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where the `NetworkObject.DontDestroyWithOwner` was not being honored. (#3477)
 - Fixed issue where invoking `NetworkObject.NetworkShow` and `NetworkObject.ChangeOwnership` consecutively within the same call stack location could result in an unnecessary change in ownership error message generated on the target client side. (#3468)
 - Fixed issue where `NetworkVariable`s on a `NetworkBehaviour` could fail to synchronize changes if one has `NetworkVariableUpdateTraits` set and is dirty but is not ready to send. (#3466)
 - Fixed inconsistencies in the `OnSceneEvent` callback. (#3458)

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -1177,7 +1177,7 @@ namespace Unity.Netcode
                     {
                         // If destroying with owner, then always despawn and destroy (or defer destroying to prefab handler)
                         // Handle an object with no observers other than the current disconnecting client as destroying with owner
-                        if (!ownedObject.DontDestroyWithOwner || ownedObject.Observers.Count == 0 || (ownedObject.Observers.Count == 1 && ownedObject.Observers.Contains(clientId)))
+                        if (!ownedObject.DontDestroyWithOwner && (ownedObject.Observers.Count == 0 || (ownedObject.Observers.Count == 1 && ownedObject.Observers.Contains(clientId))))
                         {
                             if (NetworkManager.PrefabHandler.ContainsHandler(ownedObject.GlobalObjectIdHash))
                             {
@@ -1243,7 +1243,7 @@ namespace Unity.Netcode
                                     }
 
                                     // Skip destroy with owner objects as they will be processed by the outer loop
-                                    if (!childObject.DontDestroyWithOwner || childObject.Observers.Count == 0 || (childObject.Observers.Count == 1 && childObject.Observers.Contains(clientId)))
+                                    if (!childObject.DontDestroyWithOwner && (childObject.Observers.Count == 0 || (childObject.Observers.Count == 1 && childObject.Observers.Contains(clientId))))
                                     {
                                         continue;
                                     }

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1449,7 +1449,7 @@ namespace Unity.Netcode
                     {
                         // If it is an in-scene placed NetworkObject then just despawn and let it be destroyed when the scene
                         // is unloaded. Otherwise, despawn and destroy it.
-                        var shouldDestroy = !(networkObjects[i].DontDestroyWithOwner || networkObjects[i].IsSceneObject == null || (networkObjects[i].IsSceneObject != null && networkObjects[i].IsSceneObject.Value));
+                        var shouldDestroy = !(networkObjects[i].IsSceneObject == null || (networkObjects[i].IsSceneObject != null && networkObjects[i].IsSceneObject.Value));
 
                         // If we are going to destroy this NetworkObject, check for any in-scene placed children that need to be removed
                         if (shouldDestroy)

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1449,7 +1449,7 @@ namespace Unity.Netcode
                     {
                         // If it is an in-scene placed NetworkObject then just despawn and let it be destroyed when the scene
                         // is unloaded. Otherwise, despawn and destroy it.
-                        var shouldDestroy = !(networkObjects[i].IsSceneObject == null || (networkObjects[i].IsSceneObject != null && networkObjects[i].IsSceneObject.Value));
+                        var shouldDestroy = !(networkObjects[i].DontDestroyWithOwner || networkObjects[i].IsSceneObject == null || (networkObjects[i].IsSceneObject != null && networkObjects[i].IsSceneObject.Value));
 
                         // If we are going to destroy this NetworkObject, check for any in-scene placed children that need to be removed
                         if (shouldDestroy)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectDontDestroyWithOwnerTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectDontDestroyWithOwnerTests.cs
@@ -23,6 +23,7 @@ namespace Unity.Netcode.RuntimeTests
         }
 
         protected GameObject m_PrefabToSpawn;
+        protected GameObject m_PrefabNoObserversSpawn;
 
         public NetworkObjectDontDestroyWithOwnerTests(HostOrServer hostOrServer) : base(hostOrServer) { }
 
@@ -30,6 +31,11 @@ namespace Unity.Netcode.RuntimeTests
         {
             m_PrefabToSpawn = CreateNetworkObjectPrefab("ClientOwnedObject");
             m_PrefabToSpawn.GetComponent<NetworkObject>().DontDestroyWithOwner = true;
+
+            m_PrefabNoObserversSpawn = CreateNetworkObjectPrefab("NoObserversObject");
+            var prefabNoObserversNetworkObject = m_PrefabNoObserversSpawn.GetComponent<NetworkObject>();
+            prefabNoObserversNetworkObject.SpawnWithObservers = false;
+            prefabNoObserversNetworkObject.DontDestroyWithOwner = true;
         }
 
         [UnityTest]
@@ -73,6 +79,31 @@ namespace Unity.Netcode.RuntimeTests
                 // ensure ownership was transferred back
                 Assert.That(networkObject.OwnerClientId == m_ServerNetworkManager.LocalClientId);
             }
+        }
+
+        [UnityTest]
+        public IEnumerator NetworkShowThenClientDisconnects()
+        {
+            var authorityManager = GetAuthorityNetworkManager();
+            var networkObject = SpawnObject(m_PrefabNoObserversSpawn, authorityManager).GetComponent<NetworkObject>();
+            var longWait = new WaitForSeconds(0.25f);
+            yield return longWait;
+            var nonAuthorityManager = GetNonAuthorityNetworkManager();
+            Assert.False(nonAuthorityManager.SpawnManager.SpawnedObjects.ContainsKey(networkObject.NetworkObjectId), $"[Client-{nonAuthorityManager.LocalClientId}] " +
+                $"Already has an instance of {networkObject.name} when it should not!");
+            networkObject.NetworkShow(nonAuthorityManager.LocalClientId);
+            networkObject.ChangeOwnership(nonAuthorityManager.LocalClientId);
+
+            yield return WaitForConditionOrTimeOut(() => nonAuthorityManager.SpawnManager.SpawnedObjects.ContainsKey(networkObject.NetworkObjectId)
+            && nonAuthorityManager.SpawnManager.SpawnedObjects[networkObject.NetworkObjectId].OwnerClientId == nonAuthorityManager.LocalClientId);
+            AssertOnTimeout($"[Client-{nonAuthorityManager.LocalClientId}] Failed to spawn {networkObject.name} when it was shown!");
+
+            yield return s_DefaultWaitForTick;
+
+            nonAuthorityManager.Shutdown();
+
+            yield return longWait;
+            Assert.True(networkObject.IsSpawned, $"The spawned test prefab was despawned on the authority side when it shouldn't have been!");
         }
     }
 }


### PR DESCRIPTION
Based on issue #3472, this PR resolves the issue where the `NetworkObject.DontDestroyWithOwner` was not being honored.

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->

## Changelog

- Fixed: Issue where the `NetworkObject.DontDestroyWithOwner` was not being honored.

## Testing and Documentation

- Includes integration test `NetworkObjectDontDestroyWithOwnerTests.NetworkShowThenClientDisconnects`.
- No documentation changes or additions were necessary.


<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Backport
The v1.x branch does no have this issue, but went ahead and backported the test in #3478. 

<!-- If this is a backport:
 - Add the following to the PR title: "\[Backport\] ..." .
 - Link to the original PR.
If this needs a backport - state this here
If a backport is not needed please provide the reason why.
If the "Backports" section is not present it will lead to a CI test failure. 
-->