### PR TITLE
chore: Added API exception to 2.4.1 release (PVP related)

### DIFF
--- a/ValidationExceptions.json
+++ b/ValidationExceptions.json
@@ -1,0 +1,10 @@
+{
+  "ErrorExceptions": [
+    {
+      "ValidationTest": "API Validation",
+      "ExceptionMessage": "Assembly \"Unity.Netcode.Editor.PackageChecker\" no longer exists or is no longer included in build. This change requires a new major version.",
+      "PackageVersion": "2.4.1"
+    }
+  ],
+  "WarningExceptions": []
+}


### PR DESCRIPTION
This PR adds an exception towards an exception "_Assembly "Unity.Netcode.Editor.PackageChecker" no longer exists or is no longer included in build. This change requires a new major version_"

Feel to merge and release if we are ok with this modification (that it won't affect users projects). This was the only error marked by API validation

## Backport
Not needed since it's a specific release related. **Note that this change also doesn't need to be ported to develop-2.0.0 since it affects only this release**