### PR TITLE
fix: Reset NetworkClient upon shutdown [Backport]

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -15,6 +15,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where `NetworkClient` could persist some settings if re-using the same `NetworkManager` instance. (#3494)
+- Fixed issue where a pooled `NetworkObject` was not resetting the internal latest parent property when despawned. (#3494)
 - Fixed issue where `NetworkVariable`s on a `NetworkBehaviour` could fail to synchronize changes if one has `NetworkVariableUpdateTraits` set and is dirty but is not ready to send. (#3465)
 - Fixed issue where when a client changes ownership via RPC the `NetworkBehaviour.OnOwnershipChanged` can result in identical previous and current owner identifiers. (#3434)
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1265,8 +1265,8 @@ namespace Unity.Netcode
             // In the event shutdown is invoked within OnClientStopped or OnServerStopped, set it to false again
             m_ShuttingDown = false;
 
-            // Reset the client's roles
-            ConnectionManager.LocalClient.SetRole(false, false);
+            // Completely reset the NetworkClient
+            ConnectionManager.LocalClient = new NetworkClient();
 
             // This cleans up the internal prefabs list
             NetworkConfig?.Prefabs?.Shutdown();

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -913,6 +913,14 @@ namespace Unity.Netcode
             NetworkManager.SpawnManager.DespawnObject(this, destroy);
         }
 
+        internal void ResetOnDespawn()
+        {
+            // Always clear out the observers list when despawned
+            Observers.Clear();
+            IsSpawned = false;
+            m_LatestParent = null;
+        }
+
         /// <summary>
         /// Removes all ownership of an object from any client. Can only be called from server
         /// </summary>

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1170,15 +1170,13 @@ namespace Unity.Netcode
                 }
             }
 
-            networkObject.IsSpawned = false;
-
             if (SpawnedObjects.Remove(networkObject.NetworkObjectId))
             {
                 SpawnedObjectsList.Remove(networkObject);
             }
 
-            // Always clear out the observers list when despawned
-            networkObject.Observers.Clear();
+            // Reset the NetworkObject when despawned.
+            networkObject.ResetOnDespawn();
 
             var gobj = networkObject.gameObject;
             if (destroyGameObject && gobj != null)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DisconnectTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DisconnectTests.cs
@@ -150,8 +150,8 @@ namespace Unity.Netcode.RuntimeTests
 
             if (clientDisconnectType == ClientDisconnectType.ServerDisconnectsClient)
             {
-                m_ClientNetworkManagers[0].OnClientDisconnectCallback += OnClientDisconnectCallback;
-                m_ClientNetworkManagers[0].OnConnectionEvent += OnConnectionEvent;
+                clientManager.OnClientDisconnectCallback += OnClientDisconnectCallback;
+                clientManager.OnConnectionEvent += OnConnectionEvent;
                 m_ServerNetworkManager.OnConnectionEvent += OnConnectionEvent;
                 m_ServerNetworkManager.DisconnectClient(m_ClientId);
             }
@@ -159,9 +159,18 @@ namespace Unity.Netcode.RuntimeTests
             {
                 m_ServerNetworkManager.OnClientDisconnectCallback += OnClientDisconnectCallback;
                 m_ServerNetworkManager.OnConnectionEvent += OnConnectionEvent;
-                m_ClientNetworkManagers[0].OnConnectionEvent += OnConnectionEvent;
+                clientManager.OnConnectionEvent += OnConnectionEvent;
 
-                yield return StopOneClient(m_ClientNetworkManagers[0]);
+                yield return StopOneClient(clientManager);
+
+                if (clientManager.ConnectionManager != null)
+                {
+                    Assert.False(clientManager.ConnectionManager.LocalClient.IsClient, $"{clientManager.name} still has IsClient setting!");
+                    Assert.False(clientManager.ConnectionManager.LocalClient.IsConnected, $"{clientManager.name} still has IsConnected setting!");
+                    Assert.False(clientManager.ConnectionManager.LocalClient.ClientId != 0, $"{clientManager.name} still has ClientId ({clientManager.ConnectionManager.LocalClient.ClientId}) setting!");
+                    Assert.False(clientManager.ConnectionManager.LocalClient.IsApproved, $"{clientManager.name} still has IsApproved setting!");
+                    Assert.IsNull(clientManager.ConnectionManager.LocalClient.PlayerObject, $"{clientManager.name} still has Player assigned!");
+                }
             }
 
             yield return WaitForConditionOrTimeOut(() => m_ClientDisconnected);
@@ -216,6 +225,15 @@ namespace Unity.Netcode.RuntimeTests
 
                 Assert.IsTrue(m_DisconnectedEvent.ContainsKey(m_ServerNetworkManager), $"Could not find the server {nameof(NetworkManager)} disconnect event entry!");
                 Assert.IsTrue(m_DisconnectedEvent[m_ServerNetworkManager].ClientId == NetworkManager.ServerClientId, $"Expected ClientID {m_ClientId} but found ClientID {m_DisconnectedEvent[m_ServerNetworkManager].ClientId} for the server {nameof(NetworkManager)} disconnect event entry!");
+                yield return s_DefaultWaitForTick;
+                if (m_ServerNetworkManager.ConnectionManager != null)
+                {
+                    Assert.False(m_ServerNetworkManager.ConnectionManager.LocalClient.IsClient, $"{m_ServerNetworkManager.name} still has IsClient setting!");
+                    Assert.False(m_ServerNetworkManager.ConnectionManager.LocalClient.IsConnected, $"{m_ServerNetworkManager.name} still has IsConnected setting!");
+                    Assert.False(m_ServerNetworkManager.ConnectionManager.LocalClient.ClientId != 0, $"{m_ServerNetworkManager.name} still has ClientId ({clientManager.ConnectionManager.LocalClient.ClientId}) setting!");
+                    Assert.False(m_ServerNetworkManager.ConnectionManager.LocalClient.IsApproved, $"{m_ServerNetworkManager.name} still has IsApproved setting!");
+                    Assert.IsNull(m_ServerNetworkManager.ConnectionManager.LocalClient.PlayerObject, $"{m_ServerNetworkManager.name} still has Player assigned!");
+                }
             }
         }
     }


### PR DESCRIPTION
This PR addresses some NetworkManager instance clean up when shutdown including the ConnectionManager's NetworkClient.
This PR also includes a clean up for NetworkObject upon despawning in the event one is using an object pool.

[MTT-12384](https://jira.unity3d.com/browse/MTT-12384)

## Changelog

- Fixed: Issue where `NetworkClient` could persist some settings if re-using the same `NetworkManager` instance.
- Fixed: Issue where a pooled `NetworkObject` was not resetting the internal latest parent property when despawned.

## Testing and Documentation

- Includes integration test updates.
- No documentation changes or additions were necessary.


<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Backport
This is a back port of #3491.
<!-- If this is a backport:
 - Add the following to the PR title: "\[Backport\] ..." .
 - Link to the original PR.
If this needs a backport - state this here
If a backport is not needed please provide the reason why.
If the "Backports" section is not present it will lead to a CI test failure. 
-->