### PR TITLE
fix: DestroyWithScene causes errors on non-authority side

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -23,6 +23,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Fixed
 
 - Fixed `NullReferenceException` on `NetworkList` when used without a NetworkManager in scene. (#3503)
+- Fixed distributed authority related issue where enabling the `NetworkObject.DestroyWithScene` would cause errors when a destroying non-authority instances due to loading (single mode) or unloading scene events. (#3500)
 - Fixed issue where `NetworkClient` could persist some settings if re-using the same `NetworkManager` instance. (#3491)
 - Fixed issue where a pooled `NetworkObject` was not resetting the internal latest parent property when despawned. (#3491)
 - Fixed issue where the initial client synchronization pre-serialization process was not excluding spawned `NetworkObject` instances that already had pending visibility for the client being synchronized. (#3488)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -14,6 +14,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed distributed authority related issue where enabling the `NetworkObject.DestroyWithScene` would cause errors when a destroying non-authority instances due to loading (single mode) or unloading scene events. (#3500)
 
 ### Changed
 
@@ -23,7 +24,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Fixed
 
 - Fixed `NullReferenceException` on `NetworkList` when used without a NetworkManager in scene. (#3503)
-- Fixed distributed authority related issue where enabling the `NetworkObject.DestroyWithScene` would cause errors when a destroying non-authority instances due to loading (single mode) or unloading scene events. (#3500)
 - Fixed issue where `NetworkClient` could persist some settings if re-using the same `NetworkManager` instance. (#3491)
 - Fixed issue where a pooled `NetworkObject` was not resetting the internal latest parent property when despawned. (#3491)
 - Fixed issue where the initial client synchronization pre-serialization process was not excluding spawned `NetworkObject` instances that already had pending visibility for the client being synchronized. (#3488)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1723,6 +1723,14 @@ namespace Unity.Netcode
             // Authority is the server (client-server) and the owner or DAHost (distributed authority) when destroying a NetworkObject
             var isAuthority = HasAuthority || NetworkManager.DAHost;
 
+            // If we are not the authority, check to see if this is one of the edge case scenarios where a NetworkObject could be getting
+            // destroyed due to unloading a scene or loading a scene in single mode.
+            if (!isAuthority && IsSpawned && NetworkManager.DistributedAuthorityMode && NetworkManager.NetworkConfig.EnableSceneManagement
+                && NetworkManager.SceneManager.ShouldObjectBeDestroyedWhenUnloaded(this))
+            {
+                isAuthority = true;
+            }
+
             if (NetworkManager.IsListening && !isAuthority && IsSpawned &&
                 (IsSceneObject == null || (IsSceneObject.Value != true)))
             {
@@ -1733,6 +1741,7 @@ namespace Unity.Netcode
                 // if this happens. Instead, we should just generate a network log error and exit early (as long as we are not shutting down).
                 if (!NetworkManager.ShutdownInProgress)
                 {
+
                     // Since we still have a session connection, log locally and on the server to inform user of this issue.
                     if (NetworkManager.LogLevel <= LogLevel.Error)
                     {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1721,8 +1721,8 @@ namespace Unity.Netcode
                 return;
             }
 
-            // An authoritzed destroy is when it is happening on the authority instance or it is being destroyed due to
-            // a scene event that will automatically destroy any NetworkObject instances that should be destroyed with the scene.
+            // An authorized destroy is when done by the authority instance or done due to a a scene event and the NetworkObject
+            // was marked as destroy pending scene event (which means the destroy with scene property was set).
             var isAuthorityDestroy = HasAuthority || NetworkManager.DAHost || DestroyPendingSceneEvent;
 
             if (NetworkManager.IsListening && !isAuthorityDestroy && IsSpawned &&

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1200,6 +1200,7 @@ namespace Unity.Netcode
         /// Gets whether or not the object should be automatically removed when the scene is unloaded.
         /// </summary>
         public bool DestroyWithScene { get; set; }
+        internal bool DestroyPendingSceneEvent;
 
         /// <summary>
         /// When set to true and the active scene is changed, this will automatically migrate the <see cref="NetworkObject"/>
@@ -1720,18 +1721,11 @@ namespace Unity.Netcode
                 return;
             }
 
-            // Authority is the server (client-server) and the owner or DAHost (distributed authority) when destroying a NetworkObject
-            var isAuthority = HasAuthority || NetworkManager.DAHost;
+            // An authoritzed destroy is when it is happening on the authority instance or it is being destroyed due to
+            // a scene event that will automatically destroy any NetworkObject instances that should be destroyed with the scene.
+            var isAuthorityDestroy = HasAuthority || NetworkManager.DAHost || DestroyPendingSceneEvent;
 
-            // If we are not the authority, check to see if this is one of the edge case scenarios where a NetworkObject could be getting
-            // destroyed due to unloading a scene or loading a scene in single mode.
-            if (!isAuthority && IsSpawned && NetworkManager.DistributedAuthorityMode && NetworkManager.NetworkConfig.EnableSceneManagement
-                && NetworkManager.SceneManager.ShouldObjectBeDestroyedWhenUnloaded(this))
-            {
-                isAuthority = true;
-            }
-
-            if (NetworkManager.IsListening && !isAuthority && IsSpawned &&
+            if (NetworkManager.IsListening && !isAuthorityDestroy && IsSpawned &&
                 (IsSceneObject == null || (IsSceneObject.Value != true)))
             {
                 // If we destroyed a GameObject with a NetworkObject component on the non-authority side, handle cleaning up the SceneMigrationSynchronization.
@@ -1741,7 +1735,6 @@ namespace Unity.Netcode
                 // if this happens. Instead, we should just generate a network log error and exit early (as long as we are not shutting down).
                 if (!NetworkManager.ShutdownInProgress)
                 {
-
                     // Since we still have a session connection, log locally and on the server to inform user of this issue.
                     if (NetworkManager.LogLevel <= LogLevel.Error)
                     {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1721,7 +1721,7 @@ namespace Unity.Netcode
                 return;
             }
 
-            // An authorized destroy is when done by the authority instance or done due to a a scene event and the NetworkObject
+            // An authorized destroy is when done by the authority instance or done due to a scene event and the NetworkObject
             // was marked as destroy pending scene event (which means the destroy with scene property was set).
             var isAuthorityDestroy = HasAuthority || NetworkManager.DAHost || DestroyPendingSceneEvent;
 

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1093,7 +1093,7 @@ namespace Unity.Netcode
                 {
                     EventData = sceneEvent,
                 };
-                var sendTarget = distributedAuthority && !NetworkManager.DAHost  ? NetworkManager.ServerClientId : clientId;
+                var sendTarget = distributedAuthority && !NetworkManager.DAHost ? NetworkManager.ServerClientId : clientId;
                 var size = NetworkManager.ConnectionManager.SendMessage(ref message, k_DeliveryType, sendTarget);
                 NetworkManager.NetworkMetrics.TrackSceneEventSent(clientId, (uint)sceneEvent.SceneEventType, SceneNameFromHash(sceneEvent.SceneHash), size);
             }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1,3 +1,4 @@
+using Codice.CM.Common.Tree.Partial;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -2818,6 +2819,44 @@ namespace Unity.Netcode
                 if (!sceneEventEntry.Value.HasTimedOut() && sceneEventEntry.Value.SceneEventType != SceneEventType.Synchronize && sceneEventEntry.Value.Status == SceneEventProgressStatus.Started)
                 {
                     return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Used to determine if it is valid for a distributed authority client to destroy a spawned object
+        /// based on any current scene event in progress and/or the GameObject's scene status.
+        /// <see cref="NetworkObject.OnDestroy"/>
+        /// </summary>
+        /// <param name="networkObject">the NetworkObject to check</param>
+        internal bool ShouldObjectBeDestroyedWhenUnloaded(NetworkObject networkObject)
+        {
+            if (!IsSceneEventInProgress())
+            {
+                return false;
+            }
+            if (!networkObject.gameObject.scene.isLoaded)
+            {
+                return networkObject.DestroyWithScene;
+            }
+            var objectScene = networkObject.gameObject.scene;
+            var objectSceneHash = SceneHashFromNameOrPath(objectScene.name);
+            foreach (var sceneEventEntry in SceneEventProgressTracking)
+            {
+                if (sceneEventEntry.Value.HasTimedOut())
+                {
+                    continue;
+                }
+                if (sceneEventEntry.Value.SceneEventType == SceneEventType.Unload && sceneEventEntry.Value.Status == SceneEventProgressStatus.Started
+                    && sceneEventEntry.Value.SceneHash == objectSceneHash)
+                {
+                    return networkObject.DestroyWithScene;
+                }
+                if (sceneEventEntry.Value.SceneEventType == SceneEventType.Load && sceneEventEntry.Value.LoadSceneMode == LoadSceneMode.Single &&
+                    sceneEventEntry.Value.SceneHash != objectSceneHash)
+                {
+                    return networkObject.DestroyWithScene;
                 }
             }
             return false;

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1062,7 +1062,8 @@ namespace Unity.Netcode
         /// <param name="targetClientIds">array of client identifiers to receive the scene event message</param>
         private void SendSceneEventData(uint sceneEventId, ulong[] targetClientIds)
         {
-            if (targetClientIds.Length == 0 && !NetworkManager.DistributedAuthorityMode)
+            var distributedAuthority = NetworkManager.DistributedAuthorityMode;
+            if (targetClientIds.Length == 0 && !distributedAuthority)
             {
                 // This would be the Host/Server with no clients connected
                 // Silently return as there is nothing to be done
@@ -1072,7 +1073,7 @@ namespace Unity.Netcode
             sceneEvent.SenderClientId = NetworkManager.LocalClientId;
 
             // Send related message to the CMB service
-            if (NetworkManager.DistributedAuthorityMode && NetworkManager.CMBServiceConnection && HasSceneAuthority())
+            if (distributedAuthority && NetworkManager.CMBServiceConnection && HasSceneAuthority())
             {
                 sceneEvent.TargetClientId = NetworkManager.ServerClientId;
                 var message = new SceneEventMessage
@@ -1092,7 +1093,7 @@ namespace Unity.Netcode
                 {
                     EventData = sceneEvent,
                 };
-                var sendTarget = NetworkManager.CMBServiceConnection ? NetworkManager.ServerClientId : clientId;
+                var sendTarget = distributedAuthority && !NetworkManager.DAHost  ? NetworkManager.ServerClientId : clientId;
                 var size = NetworkManager.ConnectionManager.SendMessage(ref message, k_DeliveryType, sendTarget);
                 NetworkManager.NetworkMetrics.TrackSceneEventSent(clientId, (uint)sceneEvent.SceneEventType, SceneNameFromHash(sceneEvent.SceneHash), size);
             }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -2679,11 +2679,18 @@ namespace Unity.Netcode
             // Create a local copy of the spawned objects list since the spawn manager will adjust the list as objects
             // are despawned.
             var localSpawnedObjectsHashSet = new HashSet<NetworkObject>(NetworkManager.SpawnManager.SpawnedObjectsList);
+            var distributedAuthority = NetworkManager.DistributedAuthorityMode;
             foreach (var networkObject in localSpawnedObjectsHashSet)
             {
                 if (networkObject == null || (networkObject != null && networkObject.gameObject.scene == DontDestroyOnLoadScene))
                 {
                     continue;
+                }
+
+                // Check to determine if we need to allow destroying a non-authority instance
+                if (distributedAuthority && networkObject.DestroyWithScene && !networkObject.HasAuthority)
+                {
+                    networkObject.DestroyPendingSceneEvent = true;
                 }
 
                 // Only NetworkObjects marked to not be destroyed with the scene
@@ -2818,44 +2825,6 @@ namespace Unity.Netcode
                 if (!sceneEventEntry.Value.HasTimedOut() && sceneEventEntry.Value.SceneEventType != SceneEventType.Synchronize && sceneEventEntry.Value.Status == SceneEventProgressStatus.Started)
                 {
                     return true;
-                }
-            }
-            return false;
-        }
-
-        /// <summary>
-        /// Used to determine if it is valid for a distributed authority client to destroy a spawned object
-        /// based on any current scene event in progress and/or the GameObject's scene status.
-        /// <see cref="NetworkObject.OnDestroy"/>
-        /// </summary>
-        /// <param name="networkObject">the NetworkObject to check</param>
-        internal bool ShouldObjectBeDestroyedWhenUnloaded(NetworkObject networkObject)
-        {
-            if (!IsSceneEventInProgress())
-            {
-                return false;
-            }
-            if (!networkObject.gameObject.scene.isLoaded)
-            {
-                return networkObject.DestroyWithScene;
-            }
-            var objectScene = networkObject.gameObject.scene;
-            var objectSceneHash = SceneHashFromNameOrPath(objectScene.name);
-            foreach (var sceneEventEntry in SceneEventProgressTracking)
-            {
-                if (sceneEventEntry.Value.HasTimedOut())
-                {
-                    continue;
-                }
-                if (sceneEventEntry.Value.SceneEventType == SceneEventType.Unload && sceneEventEntry.Value.Status == SceneEventProgressStatus.Started
-                    && sceneEventEntry.Value.SceneHash == objectSceneHash)
-                {
-                    return networkObject.DestroyWithScene;
-                }
-                if (sceneEventEntry.Value.SceneEventType == SceneEventType.Load && sceneEventEntry.Value.LoadSceneMode == LoadSceneMode.Single &&
-                    sceneEventEntry.Value.SceneHash != objectSceneHash)
-                {
-                    return networkObject.DestroyWithScene;
                 }
             }
             return false;

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1,4 +1,3 @@
-using Codice.CM.Common.Tree.Partial;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectDestroyTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectDestroyTests.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using NUnit.Framework;
 using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectDestroyTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/NetworkObjectDestroyTests.cs
@@ -1,4 +1,6 @@
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
@@ -21,56 +23,91 @@ namespace Unity.Netcode.RuntimeTests
     {
         protected override int NumberOfClients => 2;
 
-        // TODO: [CmbServiceTests] Adapt to run with the service
-        protected override bool UseCMBService()
+        public class DestroyTestComponent : NetworkBehaviour
         {
-            return false;
+            public static List<string> ObjectsDestroyed = new List<string>();
+
+            public override void OnDestroy()
+            {
+                ObjectsDestroyed.Add(gameObject.name);
+                base.OnDestroy();
+            }
         }
 
         public NetworkObjectDestroyTests(NetworkTopologyTypes networkTopologyType) : base(networkTopologyType) { }
 
+        protected override IEnumerator OnSetup()
+        {
+            // Re-apply the default for each test
+            LogAssert.ignoreFailingMessages = false;
+            DestroyTestComponent.ObjectsDestroyed.Clear();
+            return base.OnSetup();
+        }
+
         protected override void OnCreatePlayerPrefab()
         {
+            m_PlayerPrefab.AddComponent<DestroyTestComponent>();
             var playerNetworkObject = m_PlayerPrefab.GetComponent<NetworkObject>();
             playerNetworkObject.SceneMigrationSynchronization = true;
             base.OnCreatePlayerPrefab();
         }
 
+        private NetworkManager GetAuthorityOfNetworkObject(ulong networkObjectId)
+        {
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                if (!networkManager.SpawnManager.SpawnedObjects.ContainsKey(networkObjectId))
+                {
+                    continue;
+                }
+
+                if (networkManager.SpawnManager.SpawnedObjects[networkObjectId].HasAuthority)
+                {
+                    return networkManager;
+                }
+            }
+            return null;
+        }
+
+        private bool NetworkObjectDoesNotExist(ulong networkObjectId)
+        {
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                if (networkManager.SpawnManager.SpawnedObjects.ContainsKey(networkObjectId))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         /// <summary>
-        /// Tests that a server can destroy a NetworkObject and that it gets despawned correctly.
+        /// Tests that the authority NetworkManager instance of a NetworkObject is allowed to destroy it.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>IEnumerator</returns>
         [UnityTest]
         public IEnumerator TestNetworkObjectAuthorityDestroy()
         {
-            // This is the *SERVER VERSION* of the *CLIENT PLAYER*
-            var serverClientPlayerResult = new NetcodeIntegrationTestHelpers.ResultWrapper<NetworkObject>();
-            yield return NetcodeIntegrationTestHelpers.GetNetworkObjectByRepresentation(x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId, m_ServerNetworkManager, serverClientPlayerResult);
 
-            // This is the *CLIENT VERSION* of the *CLIENT PLAYER*
-            var clientClientPlayerResult = new NetcodeIntegrationTestHelpers.ResultWrapper<NetworkObject>();
-            yield return NetcodeIntegrationTestHelpers.GetNetworkObjectByRepresentation(x => x.IsPlayerObject && x.OwnerClientId == m_ClientNetworkManagers[0].LocalClientId, m_ClientNetworkManagers[0], clientClientPlayerResult);
+            var ownerNetworkManager = m_ClientNetworkManagers[1];
+            var clientId = ownerNetworkManager.LocalClientId;
+            var localClientPlayer = ownerNetworkManager.LocalClient.PlayerObject;
+            var localNetworkObjectId = localClientPlayer.NetworkObjectId;
 
-            Assert.IsNotNull(serverClientPlayerResult.Result.gameObject);
-            Assert.IsNotNull(clientClientPlayerResult.Result.gameObject);
+            var authorityNetworkManager = GetAuthorityOfNetworkObject(localClientPlayer.NetworkObjectId);
+            Assert.True(authorityNetworkManager != null, $"Could not find the authority of {localClientPlayer}!");
 
-            var targetNetworkManager = m_ClientNetworkManagers[0];
-            if (m_DistributedAuthority)
-            {
-                targetNetworkManager = m_ClientNetworkManagers[1];
-                // destroy the authoritative player (distributed authority)
-                Object.Destroy(clientClientPlayerResult.Result.gameObject);
-            }
-            else
-            {
-                // destroy the authoritative player (client-server)
-                Object.Destroy(serverClientPlayerResult.Result.gameObject);
-            }
+            var authorityPlayerClone = authorityNetworkManager.ConnectedClients[clientId].PlayerObject;
 
-            yield return NetcodeIntegrationTestHelpers.WaitForMessageOfTypeHandled<DestroyObjectMessage>(targetNetworkManager);
+            // Have the authority NetworkManager destroy the player instance
+            Object.Destroy(authorityPlayerClone.gameObject);
 
-            Assert.IsTrue(serverClientPlayerResult.Result == null); // Assert.IsNull doesn't work here
-            Assert.IsTrue(clientClientPlayerResult.Result == null);
+            var messageListener = m_DistributedAuthority ? m_ClientNetworkManagers[0] : m_ClientNetworkManagers[1];
+
+            yield return NetcodeIntegrationTestHelpers.WaitForMessageOfTypeHandled<DestroyObjectMessage>(messageListener);
+
+            yield return WaitForConditionOrTimeOut(() => NetworkObjectDoesNotExist(localNetworkObjectId));
+            AssertOnTimeout($"Not all network managers despawned and destroyed player instance NetworkObjectId: {localNetworkObjectId}");
 
             // validate that any unspawned networkobject can be destroyed
             var go = new GameObject();
@@ -97,48 +134,31 @@ namespace Unity.Netcode.RuntimeTests
         public IEnumerator TestNetworkObjectClientDestroy([Values] ClientDestroyObject clientDestroyObject)
         {
             var isShuttingDown = clientDestroyObject == ClientDestroyObject.ShuttingDown;
-            var clientPlayer = m_ClientNetworkManagers[0].LocalClient.PlayerObject;
-            var clientId = clientPlayer.OwnerClientId;
 
-            //destroying a NetworkObject while shutting down is allowed
+            var localNetworkManager = m_ClientNetworkManagers[1];
+            var clientId = localNetworkManager.LocalClientId;
+            var localClientPlayer = localNetworkManager.LocalClient.PlayerObject;
+
+            var nonAuthorityClient = m_ClientNetworkManagers[0];
+            var clientPlayerClone = nonAuthorityClient.ConnectedClients[clientId].PlayerObject;
+
             if (isShuttingDown)
             {
-                if (m_DistributedAuthority)
-                {
-                    // Shutdown the 2nd client
-                    m_ClientNetworkManagers[1].Shutdown();
-                }
-                else
-                {
-                    // Shutdown the
-                    m_ClientNetworkManagers[0].Shutdown();
-                }
+                // The non-authority client is allowed to destroy any spawned object it does not
+                // have authority over when it shuts down.
+                nonAuthorityClient.Shutdown();
             }
             else
             {
+                // The non-authority client is =NOT= allowed to destroy any spawned object it does not
+                // have authority over during runtime.
                 LogAssert.ignoreFailingMessages = true;
-                NetworkLog.NetworkManagerOverride = m_ClientNetworkManagers[0];
+                NetworkLog.NetworkManagerOverride = nonAuthorityClient;
+                Object.Destroy(clientPlayerClone.gameObject);
             }
 
-            m_ClientPlayerName = clientPlayer.gameObject.name;
-            m_ClientNetworkObjectId = clientPlayer.NetworkObjectId;
-            if (m_DistributedAuthority)
-            {
-                m_ClientPlayerName = m_PlayerNetworkObjects[m_ClientNetworkManagers[1].LocalClientId][m_ClientNetworkManagers[0].LocalClientId].gameObject.name;
-                m_ClientNetworkObjectId = m_PlayerNetworkObjects[m_ClientNetworkManagers[1].LocalClientId][m_ClientNetworkManagers[0].LocalClientId].NetworkObjectId;
-
-                if (!isShuttingDown)
-                {
-                    NetworkLog.NetworkManagerOverride = m_ClientNetworkManagers[1];
-                }
-                // the 2nd client attempts to destroy the 1st client's player object (if shutting down then "ok" if not then not "ok")
-                Object.DestroyImmediate(m_PlayerNetworkObjects[m_ClientNetworkManagers[1].LocalClientId][m_ClientNetworkManagers[0].LocalClientId].gameObject);
-            }
-            else
-            {
-                // the 1st client attempts to destroy its own player object (if shutting down then "ok" if not then not "ok")
-                Object.DestroyImmediate(m_ClientNetworkManagers[0].LocalClient.PlayerObject.gameObject);
-            }
+            m_ClientPlayerName = clientPlayerClone.gameObject.name;
+            m_ClientNetworkObjectId = clientPlayerClone.NetworkObjectId;
 
             // destroying a NetworkObject while a session is active is not allowed
             if (!isShuttingDown)
@@ -146,13 +166,15 @@ namespace Unity.Netcode.RuntimeTests
                 yield return WaitForConditionOrTimeOut(HaveLogsBeenReceived);
                 AssertOnTimeout($"Not all expected logs were received when destroying a {nameof(NetworkObject)} on the client side during an active session!");
             }
-            if (m_DistributedAuthority)
-            {
-                Assert.IsFalse(m_ClientNetworkManagers[1].SpawnManager.NetworkObjectsToSynchronizeSceneChanges.ContainsKey(m_ClientNetworkObjectId), $"Player object {m_ClientNetworkObjectId} still exists within {nameof(NetworkSpawnManager.NetworkObjectsToSynchronizeSceneChanges)}!");
-            }
             else
             {
-                Assert.IsFalse(m_ClientNetworkManagers[0].SpawnManager.NetworkObjectsToSynchronizeSceneChanges.ContainsKey(m_ClientNetworkObjectId), $"Player object {m_ClientNetworkObjectId} still exists within {nameof(NetworkSpawnManager.NetworkObjectsToSynchronizeSceneChanges)}!");
+                bool NonAuthorityClientDestroyed()
+                {
+                    return DestroyTestComponent.ObjectsDestroyed.Contains(m_ClientPlayerName);
+                }
+
+                yield return WaitForConditionOrTimeOut(NonAuthorityClientDestroyed);
+                AssertOnTimeout($"Timed out waiting for player object {m_ClientNetworkObjectId} to no longer exist within {nameof(NetworkSpawnManager.NetworkObjectsToSynchronizeSceneChanges)}!");
             }
         }
 
@@ -183,8 +205,14 @@ namespace Unity.Netcode.RuntimeTests
         protected override IEnumerator OnTearDown()
         {
             NetworkLog.NetworkManagerOverride = null;
-            LogAssert.ignoreFailingMessages = false;
             return base.OnTearDown();
+        }
+
+        protected override void OnOneTimeTearDown()
+        {
+            // Re-apply the default as the last exiting action
+            LogAssert.ignoreFailingMessages = false;
+            base.OnOneTimeTearDown();
         }
     }
 }

--- a/testproject/Assets/Tests/Runtime/NetworkObjectDestroyWithSceneTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkObjectDestroyWithSceneTests.cs
@@ -3,7 +3,6 @@ using System.Text;
 using NUnit.Framework;
 using Unity.Netcode;
 using Unity.Netcode.TestHelpers.Runtime;
-using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 

--- a/testproject/Assets/Tests/Runtime/NetworkObjectDestroyWithSceneTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkObjectDestroyWithSceneTests.cs
@@ -1,0 +1,197 @@
+using System.Collections;
+using System.Text;
+using NUnit.Framework;
+using Unity.Netcode;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+
+namespace TestProject.RuntimeTests
+{
+    [TestFixture(HostOrServer.DAHost)]
+    [TestFixture(HostOrServer.Host)]
+    internal class NetworkObjectDestroyWithSceneTests : NetcodeIntegrationTest
+    {
+        private const string k_SceneToLoad = "EmptyScene";
+        protected override int NumberOfClients => 2;
+
+        private bool m_SceneHasLoaded;
+        private Scene m_SceneLoaded;
+        private Scene m_NotSessionOwnerScene;
+        private NetworkManager m_SessionOwner;
+        private NetworkManager m_NotSessionOwner;
+        private NetworkObject m_SpawnedInstance;
+        private StringBuilder m_ErrorLog = new StringBuilder();
+        private NetworkObject m_TestPrefab;
+
+        public NetworkObjectDestroyWithSceneTests(HostOrServer hostOrServer) : base(hostOrServer) { }
+
+        protected override void OnServerAndClientsCreated()
+        {
+            m_TestPrefab = CreateNetworkObjectPrefab("TestObject").GetComponent<NetworkObject>();
+            m_TestPrefab.DestroyWithScene = true;
+            m_TestPrefab.SceneMigrationSynchronization = true;
+            base.OnServerAndClientsCreated();
+        }
+
+        /// <summary>
+        /// Conditional that determines if all <see cref="NetworkManager"/> instances have
+        /// spawned or despawned the instance.
+        /// </summary>
+        private bool ObjectSpawnedOnAllNetworkManagers(bool isSpawned)
+        {
+            m_ErrorLog.Clear();
+            var networkObjectId = m_SpawnedInstance.NetworkObjectId;
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                var containsKey = networkManager.SpawnManager.SpawnedObjects.ContainsKey(networkObjectId);
+                if ((isSpawned && !containsKey) || (!isSpawned && containsKey))
+                {
+                    m_ErrorLog.AppendLine($"[{networkManager.name}] NetworkObjectId-{networkObjectId} should be spawned ({isSpawned}) but its key status is ({containsKey})!");
+                    continue;
+                }
+            }
+            return m_ErrorLog.Length == 0;
+        }
+
+        /// <summary>
+        /// Condition that determines if all instances of the spawned object were migrated
+        /// to the loaded scene.
+        /// </summary>
+        private bool AllInstancesMovedToScene()
+        {
+            var networkObjectId = m_SpawnedInstance.NetworkObjectId;
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                if (!networkManager.SpawnManager.SpawnedObjects.ContainsKey(networkObjectId))
+                {
+                    return false;
+                }
+                if (networkManager.SpawnManager.SpawnedObjects[networkObjectId].gameObject.scene.name != m_SceneLoaded.name)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        [UnityTest]
+        public IEnumerator DestroyWithScene()
+        {
+            // Get the session owner
+            m_SessionOwner = GetAuthorityNetworkManager();
+            // Get a non-session owner client
+            m_NotSessionOwner = GetNonAuthorityNetworkManager();
+
+            // Register for scene events on the session owner side.
+            m_SessionOwner.SceneManager.OnSceneEvent += OnSessionOwnerSceneEvent;
+
+            // Register for scene events on the non-session owner side.
+            // (this is the scene we want to migrate the spawned object into when running a distributed authority session)
+            m_NotSessionOwner.SceneManager.OnSceneEvent += OnNonSessionOwnerSceneEvent;
+
+            // Have the session owner load the scene
+            Assert.True(m_SessionOwner.SceneManager.LoadScene(k_SceneToLoad, LoadSceneMode.Additive) == SceneEventProgressStatus.Started, $"[{m_SessionOwner.name}] Failed to begin loading scene {k_SceneToLoad}!");
+            yield return WaitForConditionOrTimeOut(() => m_SceneHasLoaded && m_NotSessionOwnerScene != null
+            && m_NotSessionOwnerScene.IsValid() && m_NotSessionOwnerScene.isLoaded);
+            AssertOnTimeout($"Scene loading event for {k_SceneToLoad} failed to complete!");
+
+            // Depending on network topology, spawn the object with the appropriate owner.
+            var owner = m_DistributedAuthority ? m_NotSessionOwner : m_SessionOwner;
+            m_SpawnedInstance = SpawnObject(m_TestPrefab.gameObject, m_NotSessionOwner, true).GetComponent<NetworkObject>();
+
+            var instanceName = m_SpawnedInstance.name;
+            yield return WaitForConditionOrTimeOut(() => ObjectSpawnedOnAllNetworkManagers(true));
+            AssertOnTimeout($"Not all clients spawned an instance of {instanceName}!");
+
+            var sceneToMigrateTo = m_DistributedAuthority ? m_NotSessionOwnerScene : m_SceneLoaded;
+            // Migrate the newly spawned object into the recently loaded scene so we can unload the scene
+            // and make sure the spawned object is destroyed when that happens.
+            SceneManager.MoveGameObjectToScene(m_SpawnedInstance.gameObject, sceneToMigrateTo);
+
+            yield return WaitForConditionOrTimeOut(AllInstancesMovedToScene);
+            AssertOnTimeout($"Not all instances of {instanceName} moved to scene {k_SceneToLoad}!");
+
+            // Have the session owner unload the scene containing the spawned object
+            VerboseDebug($"Unloading scene {k_SceneToLoad}");
+            Assert.True(m_SessionOwner.SceneManager.UnloadScene(m_SceneLoaded) == SceneEventProgressStatus.Started, $"[{m_SessionOwner.name}] Failed to begin unloading scene {k_SceneToLoad}!");
+            yield return WaitForConditionOrTimeOut(() => !m_SceneHasLoaded);
+            AssertOnTimeout($"Scene unloading event for {k_SceneToLoad} failed to complete!");
+
+            // Assure the spawned object was destroyed when the scene was unloaded
+            yield return WaitForConditionOrTimeOut(() => ObjectSpawnedOnAllNetworkManagers(false));
+            AssertOnTimeout($"Not all despawned an instance of {instanceName}!\n {m_ErrorLog}");
+        }
+
+        /// <summary>
+        /// Handles scene events for the session owner
+        /// </summary>
+        private void OnSessionOwnerSceneEvent(SceneEvent sceneEvent)
+        {
+            if (sceneEvent.ClientId != m_SessionOwner.LocalClientId)
+            {
+                return;
+            }
+
+            switch (sceneEvent.SceneEventType)
+            {
+                case SceneEventType.LoadComplete:
+                    {
+                        VerboseDebug($"Scene loaded: {sceneEvent.Scene.name}");
+                        m_SceneLoaded = sceneEvent.Scene;
+                        break;
+                    }
+                case SceneEventType.LoadEventCompleted:
+                    {
+                        m_SceneHasLoaded = true;
+                        break;
+                    }
+                case SceneEventType.UnloadEventCompleted:
+                    {
+                        m_SessionOwner.SceneManager.OnSceneEvent -= OnSessionOwnerSceneEvent;
+                        m_SceneHasLoaded = false;
+                        break;
+                    }
+            }
+        }
+
+        /// <summary>
+        /// Handles scene events for the non-session owner
+        /// </summary>
+        private void OnNonSessionOwnerSceneEvent(SceneEvent sceneEvent)
+        {
+            if (sceneEvent.ClientId != m_NotSessionOwner.LocalClientId)
+            {
+                return;
+            }
+
+            switch (sceneEvent.SceneEventType)
+            {
+                case SceneEventType.LoadComplete:
+                    {
+                        VerboseDebug($"Scene loaded: {sceneEvent.Scene.name}");
+                        m_NotSessionOwnerScene = sceneEvent.Scene;
+                        m_NotSessionOwner.SceneManager.OnSceneEvent -= OnNonSessionOwnerSceneEvent;
+                        break;
+                    }
+            }
+        }
+
+
+        protected override IEnumerator OnTearDown()
+        {
+            // In case of an error, assure the scene is unloaded
+            if (m_SceneLoaded.IsValid() && m_SceneLoaded.isLoaded)
+            {
+                SceneManager.UnloadSceneAsync(m_SceneLoaded);
+            }
+
+            if (m_NotSessionOwnerScene.IsValid() && m_NotSessionOwnerScene.isLoaded)
+            {
+                SceneManager.UnloadSceneAsync(m_NotSessionOwnerScene);
+            }
+            return base.OnTearDown();
+        }
+    }
+}

--- a/testproject/Assets/Tests/Runtime/NetworkObjectDestroyWithSceneTests.cs.meta
+++ b/testproject/Assets/Tests/Runtime/NetworkObjectDestroyWithSceneTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 845ca300447eee44bb076430583c80a2


### PR DESCRIPTION
### Description

This PR fixes the issue where enabling the `NetworkObject.DestroyWithScene` would cause errors on non-authority instances when loading a new scene (in single mode) or unloading the scene that the `NetworkObject` instance currently resides and using the distributed authority network topology.

Fix: #3144

[MTTB-1384](https://jira.unity3d.com/browse/MTTB-1384)

## Changelog

- Fixed: Distributed authority related issue where enabling the `NetworkObject.DestroyWithScene` would cause errors when a destroying non-authority instances due to loading (single mode) or unloading scene events.

## Testing and Documentation

- Includes new integration test: `NetworkObjectDestroyWithSceneTests`.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Backport

This is a v2.x distributed authority only issue.

<!-- If this is a backport:
 - Add the following to the PR title: "\[Backport\] ..." .
 - Link to the original PR.
If this needs a backport - state this here
If a backport is not needed please provide the reason why.
If the "Backports" section is not present it will lead to a CI test failure. 
-->