### PR TITLE
fix: [Up-port] Avoid throwing exception when using NetworkList without a NetworkManager

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -13,6 +13,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed `NullReferenceException` on `NetworkList` when used without a NetworkManager in scene. (#3503)
 - Fixed issue where `NetworkClient` could persist some settings if re-using the same `NetworkManager` instance. (#3491)
 - Fixed issue where a pooled `NetworkObject` was not resetting the internal latest parent property when despawned. (#3491)
 - Fixed issue where the initial client synchronization pre-serialization process was not excluding spawned `NetworkObject` instances that already had pending visibility for the client being synchronized. (#3488)

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkVariableDeltaMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkVariableDeltaMessage.cs
@@ -144,9 +144,9 @@ namespace Unity.Netcode
                 var startingSize = writer.Length;
                 var networkVariable = NetworkBehaviour.NetworkVariableFields[i];
                 var shouldWrite = networkVariable.IsDirty() &&
-                    networkVariable.CanClientRead(TargetClientId) &&
-                    (networkManager.IsServer || networkVariable.CanWrite() &&
-                    networkVariable.CanSend();
+                    networkVariable.CanClientRead(TargetClientId)
+                    && networkManager.IsServer ||
+                    (networkVariable.CanWrite && networkVariable.CanSend());
 
                 // Prevent the server from writing to the client that owns a given NetworkVariable
                 // Allowing the write would send an old value to the client and cause jitter

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkVariableDeltaMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkVariableDeltaMessage.cs
@@ -145,7 +145,7 @@ namespace Unity.Netcode
                 var networkVariable = NetworkBehaviour.NetworkVariableFields[i];
                 var shouldWrite = networkVariable.IsDirty() &&
                     networkVariable.CanClientRead(TargetClientId) &&
-                    (networkManager.IsServer || networkVariable.CanClientWrite(networkManager.LocalClientId)) &&
+                    (networkManager.IsServer || networkVariable.CanWrite() &&
                     networkVariable.CanSend();
 
                 // Prevent the server from writing to the client that owns a given NetworkVariable

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/AnticipatedNetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/AnticipatedNetworkVariable.cs
@@ -217,7 +217,7 @@ namespace Unity.Netcode
             m_LastAnticipationCounter = m_NetworkBehaviour.NetworkManager.AnticipationSystem.AnticipationCounter;
             m_AnticipatedValue = value;
             NetworkVariableSerialization<T>.Duplicate(m_AnticipatedValue, ref m_PreviousAnticipatedValue);
-            if (CanClientWrite(m_NetworkBehaviour.NetworkManager.LocalClientId))
+            if (CanWrite())
             {
                 AuthoritativeValue = value;
             }

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/AnticipatedNetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/AnticipatedNetworkVariable.cs
@@ -217,7 +217,7 @@ namespace Unity.Netcode
             m_LastAnticipationCounter = m_NetworkBehaviour.NetworkManager.AnticipationSystem.AnticipationCounter;
             m_AnticipatedValue = value;
             NetworkVariableSerialization<T>.Duplicate(m_AnticipatedValue, ref m_PreviousAnticipatedValue);
-            if (CanWrite())
+            if (CanWrite)
             {
                 AuthoritativeValue = value;
             }

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -428,7 +428,7 @@ namespace Unity.Netcode
         public void Add(T item)
         {
             // check write permissions
-            if (!CanClientWrite(m_NetworkManager.LocalClientId))
+            if (LocalClientCannotWrite())
             {
                 LogWritePermissionError();
                 return;
@@ -455,7 +455,7 @@ namespace Unity.Netcode
         public void Clear()
         {
             // check write permissions
-            if (!CanClientWrite(m_NetworkManager.LocalClientId))
+            if (LocalClientCannotWrite())
             {
                 LogWritePermissionError();
                 return;
@@ -493,7 +493,7 @@ namespace Unity.Netcode
         public bool Remove(T item)
         {
             // check write permissions
-            if (!CanClientWrite(m_NetworkManager.LocalClientId))
+            if (LocalClientCannotWrite())
             {
                 LogWritePermissionError();
                 return false;
@@ -542,7 +542,7 @@ namespace Unity.Netcode
         public void Insert(int index, T item)
         {
             // check write permissions
-            if (!CanClientWrite(m_NetworkManager.LocalClientId))
+            if (LocalClientCannotWrite())
             {
                 LogWritePermissionError();
                 return;
@@ -578,7 +578,7 @@ namespace Unity.Netcode
         public void RemoveAt(int index)
         {
             // check write permissions
-            if (!CanClientWrite(m_NetworkManager.LocalClientId))
+            if (LocalClientCannotWrite())
             {
                 throw new InvalidOperationException("Client is not allowed to write to this NetworkList");
             }
@@ -610,7 +610,7 @@ namespace Unity.Netcode
             set
             {
                 // check write permissions
-                if (!CanClientWrite(m_NetworkManager.LocalClientId))
+                if (LocalClientCannotWrite())
                 {
                     LogWritePermissionError();
                     return;

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -428,7 +428,7 @@ namespace Unity.Netcode
         public void Add(T item)
         {
             // check write permissions
-            if (CannotWrite())
+            if (CannotWrite)
             {
                 LogWritePermissionError();
                 return;
@@ -455,7 +455,7 @@ namespace Unity.Netcode
         public void Clear()
         {
             // check write permissions
-            if (CannotWrite())
+            if (CannotWrite)
             {
                 LogWritePermissionError();
                 return;
@@ -493,7 +493,7 @@ namespace Unity.Netcode
         public bool Remove(T item)
         {
             // check write permissions
-            if (CannotWrite())
+            if (CannotWrite)
             {
                 LogWritePermissionError();
                 return false;
@@ -542,7 +542,7 @@ namespace Unity.Netcode
         public void Insert(int index, T item)
         {
             // check write permissions
-            if (CannotWrite())
+            if (CannotWrite)
             {
                 LogWritePermissionError();
                 return;
@@ -578,7 +578,7 @@ namespace Unity.Netcode
         public void RemoveAt(int index)
         {
             // check write permissions
-            if (CannotWrite())
+            if (CannotWrite)
             {
                 throw new InvalidOperationException("Client is not allowed to write to this NetworkList");
             }
@@ -610,7 +610,7 @@ namespace Unity.Netcode
             set
             {
                 // check write permissions
-                if (CannotWrite())
+                if (CannotWrite)
                 {
                     LogWritePermissionError();
                     return;

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -428,7 +428,7 @@ namespace Unity.Netcode
         public void Add(T item)
         {
             // check write permissions
-            if (LocalClientCannotWrite())
+            if (CannotWrite())
             {
                 LogWritePermissionError();
                 return;
@@ -455,7 +455,7 @@ namespace Unity.Netcode
         public void Clear()
         {
             // check write permissions
-            if (LocalClientCannotWrite())
+            if (CannotWrite())
             {
                 LogWritePermissionError();
                 return;
@@ -493,7 +493,7 @@ namespace Unity.Netcode
         public bool Remove(T item)
         {
             // check write permissions
-            if (LocalClientCannotWrite())
+            if (CannotWrite())
             {
                 LogWritePermissionError();
                 return false;
@@ -542,7 +542,7 @@ namespace Unity.Netcode
         public void Insert(int index, T item)
         {
             // check write permissions
-            if (LocalClientCannotWrite())
+            if (CannotWrite())
             {
                 LogWritePermissionError();
                 return;
@@ -578,7 +578,7 @@ namespace Unity.Netcode
         public void RemoveAt(int index)
         {
             // check write permissions
-            if (LocalClientCannotWrite())
+            if (CannotWrite())
             {
                 throw new InvalidOperationException("Client is not allowed to write to this NetworkList");
             }
@@ -610,7 +610,7 @@ namespace Unity.Netcode
             set
             {
                 // check write permissions
-                if (LocalClientCannotWrite())
+                if (CannotWrite())
                 {
                     LogWritePermissionError();
                     return;

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -128,7 +128,7 @@ namespace Unity.Netcode
             get => m_InternalValue;
             set
             {
-                if (m_NetworkManager && !CanClientWrite(m_NetworkManager.LocalClientId))
+                if (LocalClientCannotWrite())
                 {
                     LogWritePermissionError();
                     return;
@@ -162,7 +162,7 @@ namespace Unity.Netcode
             var isDirty = base.IsDirty();
 
             // A client without permissions invoking this method should only check to assure the current value is equal to the last known current value
-            if (m_NetworkManager && !CanClientWrite(m_NetworkManager.LocalClientId))
+            if (LocalClientCannotWrite())
             {
                 // If modifications are detected, then revert back to the last known current value
                 if (!NetworkVariableSerialization<T>.AreEqual(ref m_InternalValue, ref m_InternalOriginalValue))
@@ -245,7 +245,7 @@ namespace Unity.Netcode
         {
             // If the client does not have write permissions but the internal value is determined to be locally modified and we are applying updates, then we should revert
             // to the original collection value prior to applying updates (primarily for collections).
-            if (!NetworkUpdaterCheck && m_NetworkManager && !CanClientWrite(m_NetworkManager.LocalClientId) && !NetworkVariableSerialization<T>.AreEqual(ref m_InternalValue, ref m_InternalOriginalValue))
+            if (!NetworkUpdaterCheck && LocalClientCannotWrite() && !NetworkVariableSerialization<T>.AreEqual(ref m_InternalValue, ref m_InternalOriginalValue))
             {
                 NetworkVariableSerialization<T>.Duplicate(m_InternalOriginalValue, ref m_InternalValue);
                 return true;
@@ -307,7 +307,7 @@ namespace Unity.Netcode
         {
             // If the client does not have write permissions but the internal value is determined to be locally modified and we are applying updates, then we should revert
             // to the original collection value prior to applying updates (primarily for collections).
-            if (m_NetworkManager && !CanClientWrite(m_NetworkManager.LocalClientId) && !NetworkVariableSerialization<T>.AreEqual(ref m_InternalOriginalValue, ref m_InternalValue))
+            if (LocalClientCannotWrite() && !NetworkVariableSerialization<T>.AreEqual(ref m_InternalOriginalValue, ref m_InternalValue))
             {
                 NetworkVariableSerialization<T>.Duplicate(m_InternalOriginalValue, ref m_InternalValue);
             }
@@ -349,7 +349,7 @@ namespace Unity.Netcode
         {
             // If the client does not have write permissions but the internal value is determined to be locally modified and we are applying updates, then we should revert
             // to the original collection value prior to applying updates (primarily for collections).
-            if (m_NetworkManager && !CanClientWrite(m_NetworkManager.LocalClientId) && !NetworkVariableSerialization<T>.AreEqual(ref m_InternalOriginalValue, ref m_InternalValue))
+            if (LocalClientCannotWrite() && !NetworkVariableSerialization<T>.AreEqual(ref m_InternalOriginalValue, ref m_InternalValue))
             {
                 NetworkVariableSerialization<T>.Duplicate(m_InternalOriginalValue, ref m_InternalValue);
             }

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -128,7 +128,7 @@ namespace Unity.Netcode
             get => m_InternalValue;
             set
             {
-                if (CannotWrite())
+                if (CannotWrite)
                 {
                     LogWritePermissionError();
                     return;
@@ -162,7 +162,7 @@ namespace Unity.Netcode
             var isDirty = base.IsDirty();
 
             // A client without permissions invoking this method should only check to assure the current value is equal to the last known current value
-            if (CannotWrite())
+            if (CannotWrite)
             {
                 // If modifications are detected, then revert back to the last known current value
                 if (!NetworkVariableSerialization<T>.AreEqual(ref m_InternalValue, ref m_InternalOriginalValue))
@@ -245,7 +245,7 @@ namespace Unity.Netcode
         {
             // If the client does not have write permissions but the internal value is determined to be locally modified and we are applying updates, then we should revert
             // to the original collection value prior to applying updates (primarily for collections).
-            if (!NetworkUpdaterCheck && CannotWrite() && !NetworkVariableSerialization<T>.AreEqual(ref m_InternalValue, ref m_InternalOriginalValue))
+            if (!NetworkUpdaterCheck && CannotWrite && !NetworkVariableSerialization<T>.AreEqual(ref m_InternalValue, ref m_InternalOriginalValue))
             {
                 NetworkVariableSerialization<T>.Duplicate(m_InternalOriginalValue, ref m_InternalValue);
                 return true;
@@ -307,7 +307,7 @@ namespace Unity.Netcode
         {
             // If the client does not have write permissions but the internal value is determined to be locally modified and we are applying updates, then we should revert
             // to the original collection value prior to applying updates (primarily for collections).
-            if (CannotWrite() && !NetworkVariableSerialization<T>.AreEqual(ref m_InternalOriginalValue, ref m_InternalValue))
+            if (CannotWrite && !NetworkVariableSerialization<T>.AreEqual(ref m_InternalOriginalValue, ref m_InternalValue))
             {
                 NetworkVariableSerialization<T>.Duplicate(m_InternalOriginalValue, ref m_InternalValue);
             }
@@ -349,7 +349,7 @@ namespace Unity.Netcode
         {
             // If the client does not have write permissions but the internal value is determined to be locally modified and we are applying updates, then we should revert
             // to the original collection value prior to applying updates (primarily for collections).
-            if (CannotWrite() && !NetworkVariableSerialization<T>.AreEqual(ref m_InternalOriginalValue, ref m_InternalValue))
+            if (CannotWrite && !NetworkVariableSerialization<T>.AreEqual(ref m_InternalOriginalValue, ref m_InternalValue))
             {
                 NetworkVariableSerialization<T>.Duplicate(m_InternalOriginalValue, ref m_InternalValue);
             }

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -128,7 +128,7 @@ namespace Unity.Netcode
             get => m_InternalValue;
             set
             {
-                if (LocalClientCannotWrite())
+                if (CannotWrite())
                 {
                     LogWritePermissionError();
                     return;
@@ -162,7 +162,7 @@ namespace Unity.Netcode
             var isDirty = base.IsDirty();
 
             // A client without permissions invoking this method should only check to assure the current value is equal to the last known current value
-            if (LocalClientCannotWrite())
+            if (CannotWrite())
             {
                 // If modifications are detected, then revert back to the last known current value
                 if (!NetworkVariableSerialization<T>.AreEqual(ref m_InternalValue, ref m_InternalOriginalValue))
@@ -245,7 +245,7 @@ namespace Unity.Netcode
         {
             // If the client does not have write permissions but the internal value is determined to be locally modified and we are applying updates, then we should revert
             // to the original collection value prior to applying updates (primarily for collections).
-            if (!NetworkUpdaterCheck && LocalClientCannotWrite() && !NetworkVariableSerialization<T>.AreEqual(ref m_InternalValue, ref m_InternalOriginalValue))
+            if (!NetworkUpdaterCheck && CannotWrite() && !NetworkVariableSerialization<T>.AreEqual(ref m_InternalValue, ref m_InternalOriginalValue))
             {
                 NetworkVariableSerialization<T>.Duplicate(m_InternalOriginalValue, ref m_InternalValue);
                 return true;
@@ -307,7 +307,7 @@ namespace Unity.Netcode
         {
             // If the client does not have write permissions but the internal value is determined to be locally modified and we are applying updates, then we should revert
             // to the original collection value prior to applying updates (primarily for collections).
-            if (LocalClientCannotWrite() && !NetworkVariableSerialization<T>.AreEqual(ref m_InternalOriginalValue, ref m_InternalValue))
+            if (CannotWrite() && !NetworkVariableSerialization<T>.AreEqual(ref m_InternalOriginalValue, ref m_InternalValue))
             {
                 NetworkVariableSerialization<T>.Duplicate(m_InternalOriginalValue, ref m_InternalValue);
             }
@@ -349,7 +349,7 @@ namespace Unity.Netcode
         {
             // If the client does not have write permissions but the internal value is determined to be locally modified and we are applying updates, then we should revert
             // to the original collection value prior to applying updates (primarily for collections).
-            if (LocalClientCannotWrite() && !NetworkVariableSerialization<T>.AreEqual(ref m_InternalOriginalValue, ref m_InternalValue))
+            if (CannotWrite() && !NetworkVariableSerialization<T>.AreEqual(ref m_InternalOriginalValue, ref m_InternalValue))
             {
                 NetworkVariableSerialization<T>.Duplicate(m_InternalOriginalValue, ref m_InternalValue);
             }

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using UnityEngine;
 
 namespace Unity.Netcode
@@ -379,6 +380,16 @@ namespace Unity.Netcode
                 case NetworkVariableWritePermission.Owner:
                     return clientId == m_NetworkBehaviour.NetworkObject.OwnerClientId;
             }
+        }
+
+        /// <summary>
+        /// Catches if the current <see cref="NetworkManager.LocalClientId"/> is not valid to write to this variable.
+        /// </summary>
+        /// <returns>false if the current <see cref="NetworkManager.LocalClientId"/> can write to this variable, true otherwise</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal bool LocalClientCannotWrite()
+        {
+            return m_NetworkManager && !CanClientWrite(m_NetworkManager.LocalClientId);
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
@@ -383,14 +383,14 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// Catches if the current <see cref="NetworkManager.LocalClientId"/> is not valid to write to this variable.
+        /// Returns true if the current <see cref="NetworkManager.LocalClientId"/> can write to this variable; otherwise false.
         /// </summary>
-        /// <returns>false if the current <see cref="NetworkManager.LocalClientId"/> can write to this variable, true otherwise</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal bool LocalClientCannotWrite()
-        {
-            return m_NetworkManager && !CanClientWrite(m_NetworkManager.LocalClientId);
-        }
+        internal bool CanWrite => m_NetworkManager && CanClientWrite(m_NetworkManager.LocalClientId);
+
+        /// <summary>
+        /// Returns false if the current <see cref="NetworkManager.LocalClientId"/> can write to this variable; otherwise true.
+        /// </summary>
+        internal bool CannotWrite => m_NetworkManager && !CanClientWrite(m_NetworkManager.LocalClientId);
 
         /// <summary>
         /// Returns the ClientId of the owning client

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.CompilerServices;
 using UnityEngine;
 
 namespace Unity.Netcode


### PR DESCRIPTION
<!-- Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. Delete bullet points below that don't apply, and update the changelog section as appropriate. -->

<!-- Add short version of the JIRA ticket to the PR title (e.g. "feat: new shiny feature [MTT-123]") -->
Up-port of #3502  
Fixes #2539 


## Changelog

- Added: `LocalClientCannotWrite` function to co-locate the shared functionality
- Fixed: Ensure that the `NetworkManager` exists before attempting to access the `LocalClientId`

## Testing and Documentation

- No tests have been added.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Backport

<!-- If this is a backport:
 - Add the following to the PR title: "\[Backport\] ..." .
 - Link to the original PR.
If this needs a backport - state this here
If a backport is not needed please provide the reason why.
If the "Backports" section is not present it will lead to a CI test failure. 
-->

Backported in #3502 