### PR TITLE
chore: Add tech writer to codeowners 2.x

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,3 +9,4 @@ AssemblyInfo.cs @NoelStephensUnity @EmandM @Unity-Technologies/netcode-qa
 .gitignore @NoelStephensUnity @EmandM @Unity-Technologies/netcode-qa
 .github/ @NoelStephensUnity @EmandM @Unity-Technologies/netcode-qa
 .yamato/ @NoelStephensUnity @EmandM @Unity-Technologies/netcode-qa
+com.unity.netcode.gameobjects/Documentation*/ @jabbacakes


### PR DESCRIPTION
Updating codeowners file for 2.x so I can stalk the documentation folder.

## Backport
https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3524