### PR TITLE
chore: [UpPort] Reduce the number of jobs running on PR triggers

### DIFF
--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -45,18 +45,23 @@
 # Since standards job is a part of initial checks it's not present as direct dependency here!!!!!!!!!!!!!!!!!!!!
 pull_request_trigger:
   name: Pull Request Trigger (develop, develop-2.0.0, & release branches)
+  # Run the following tests on a selection of different desktop platforms
   dependencies:
-    # Run package EditMode and Playmode package tests on trunk
-    - .yamato/_run-all.yml#run_all_package_tests_trunk
-    # Run package EditMode and Playmode package tests on minimum supported editor (6000.0 in case of NGOv2.X)
-    - .yamato/_run-all.yml#run_all_package_tests_6000
-    # Run project EditMode and Playmode project tests on trunk
-    - .yamato/_run-all.yml#run_all_project_tests_trunk
-    # Run project EditMode and Playmode project tests on minimum supported editor (6000.0 in case of NGOv2.X)
-    - .yamato/_run-all.yml#run_all_project_tests_6000
-    # Run standalone test. Run windows standalone tests as this is our most common platform, and run ubuntu rust tests.
+    # Run package EditMode and Playmode package tests on trunk and an older supported editor (6000.0)
+    - .yamato/package-tests.yml#package_test_-_ngo_trunk_mac
+    - .yamato/package-tests.yml#package_test_-_ngo_6000.0_win
+
+    # Run testproject EditMode and Playmode project tests on trunk and an older supported editor (6000.0)
+    - .yamato/project-tests.yml#test_testproject_win_trunk
+    - .yamato/project-tests.yml#test_testproject_mac_6000.0
+
+    # Run tools integration tests EditMode and Playmode tests on trunk and an older supported editor (6000.0)
+    - .yamato/project-tests.yml#test_testproject-tools-integration_ubuntu_6000.0
+    - .yamato/project-tests.yml#test_testproject-tools-integration_win_trunk
+
+    # Run standalone test. We run it only on Ubuntu since it's the fastest machine, and it was noted that for example distribution on macOS is taking 40m since we switched to Apple Silicon
     # Coverage on other standalone machines is present in Nightly job so it's enough to not run all of them for PRs
-    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_win_il2cpp_6000.0
+    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_ubuntu_il2cpp_2022.3
     - .yamato/cmb-service-standalone-tests.yml#cmb_service_standalone_test_testproject_ubuntu_il2cpp_6000.0
   triggers:
     cancel_old_ci: true

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -61,7 +61,7 @@ pull_request_trigger:
 
     # Run standalone test. We run it only on Ubuntu since it's the fastest machine, and it was noted that for example distribution on macOS is taking 40m since we switched to Apple Silicon
     # Coverage on other standalone machines is present in Nightly job so it's enough to not run all of them for PRs
-    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_win_il2cpp_6000.0.0
+    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_win_il2cpp_6000.0
     - .yamato/cmb-service-standalone-tests.yml#cmb_service_standalone_test_testproject_ubuntu_il2cpp_trunk
   triggers:
     cancel_old_ci: true

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -61,7 +61,7 @@ pull_request_trigger:
 
     # Run standalone test. We run it only on Ubuntu since it's the fastest machine, and it was noted that for example distribution on macOS is taking 40m since we switched to Apple Silicon
     # Coverage on other standalone machines is present in Nightly job so it's enough to not run all of them for PRs
-    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_ubuntu_il2cpp_6000.0
+    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_win_il2cpp_6000.0.0
     - .yamato/cmb-service-standalone-tests.yml#cmb_service_standalone_test_testproject_ubuntu_il2cpp_trunk
   triggers:
     cancel_old_ci: true

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -55,10 +55,6 @@ pull_request_trigger:
     - .yamato/project-tests.yml#test_testproject_win_trunk
     - .yamato/project-tests.yml#test_testproject_mac_6000.0
 
-    # Run tools integration tests EditMode and Playmode tests on trunk and an older supported editor (6000.0)
-    - .yamato/project-tests.yml#test_testproject-tools-integration_ubuntu_6000.0
-    - .yamato/project-tests.yml#test_testproject-tools-integration_win_trunk
-
     # Run standalone test. We run it only on Ubuntu since it's the fastest machine, and it was noted that for example distribution on macOS is taking 40m since we switched to Apple Silicon
     # Coverage on other standalone machines is present in Nightly job so it's enough to not run all of them for PRs
     - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_win_il2cpp_6000.0

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -61,8 +61,8 @@ pull_request_trigger:
 
     # Run standalone test. We run it only on Ubuntu since it's the fastest machine, and it was noted that for example distribution on macOS is taking 40m since we switched to Apple Silicon
     # Coverage on other standalone machines is present in Nightly job so it's enough to not run all of them for PRs
-    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_ubuntu_il2cpp_2022.3
-    - .yamato/cmb-service-standalone-tests.yml#cmb_service_standalone_test_testproject_ubuntu_il2cpp_6000.0
+    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_ubuntu_il2cpp_6000.0
+    - .yamato/cmb-service-standalone-tests.yml#cmb_service_standalone_test_testproject_ubuntu_il2cpp_trunk
   triggers:
     cancel_old_ci: true
     pull_requests:

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -157,6 +157,7 @@ validation_editors:
     all:
         - 6000.0
         - 6000.1 
+        - 6000.2
         - trunk
         
         

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -185,3 +185,6 @@ projects:
         - name: minimalproject
           path: minimalproject
           has_tests: false
+        - name: testproject-tools-integration
+          path: testproject-tools-integration
+          has_tests: true

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -19,7 +19,7 @@
 # The small agent was created to handle jobs that don't involve running Unity and are in general super light when it comes to resource usage (for example pack job).
 # It uses ubuntu since Linux VMs are faster and cheaper to provision than Mac or Windows Virtual Machines (VMs).
 # The b1.small flavour is nearly always sufficient for jobs that don’t involve running Unity Editor.
-small_agent_platform: 
+small_agent_platform:
     - name: ubuntu
       type: Unity::VM
       image: package-ci/ubuntu-22.04:v4
@@ -40,7 +40,7 @@ test_platforms:
           image: package-ci/ubuntu-22.04:v4
           flavor: b1.large
           standalone: StandaloneLinux64
-    desktop:  
+    desktop:
         - name: ubuntu
           type: Unity::VM
           image: package-ci/ubuntu-22.04:v4
@@ -146,7 +146,7 @@ test_platforms:
           image: package-ci/win10-xbox:v4
           flavor: b1.large
           standalone: GameCoreScarlett
-    
+
 # EDITOR CONFIGURATIONS-------------------------------------------------------------------------------
 # Editors to be used for testing. NGOv2.X official support started from 6000.0 editor
 # TODO: When a new editor will be released it should be added to this list
@@ -156,14 +156,14 @@ validation_editors:
         - trunk
     all:
         - 6000.0
-        - 6000.1 
+        - 6000.1
         - 6000.2
         - trunk
-        
-        
+
+
 # Scripting backends used by Standalone RunTimeTests---------------------------------------------------
 
-scripting_backends: 
+scripting_backends:
   - mono
   - il2cpp
 
@@ -185,6 +185,3 @@ projects:
         - name: minimalproject
           path: minimalproject
           has_tests: false
-        - name: testproject-tools-integration
-          path: testproject-tools-integration
-          has_tests: true


### PR DESCRIPTION
Reduce the number of jobs that are running on each PR from 43 jobs to 26.

## Changelog

- Changed: Updated the automated test configuration.

## Testing and Documentation


## Backport

<!-- If this is a backport:
 - Add the following to the PR title: "\[Backport\] ..." .
 - Link to the original PR.
If this needs a backport - state this here
If a backport is not needed please provide the reason why.
If the "Backports" section is not present it will lead to a CI test failure. 
-->

This is an up-port of #3543 