### PR TITLE
fix: PlayerSpawnObjectVisibilityTests test instability

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/PlayerSpawnObjectVisibilityTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkObject/PlayerSpawnObjectVisibilityTests.cs
@@ -13,7 +13,6 @@ namespace Unity.Netcode.RuntimeTests
     internal class PlayerSpawnObjectVisibilityTests : NetcodeIntegrationTest
     {
         protected override int NumberOfClients => 0;
-
         public enum PlayerSpawnStages
         {
             OnNetworkSpawn,
@@ -64,6 +63,25 @@ namespace Unity.Netcode.RuntimeTests
         }
 
         /// <summary>
+        /// Bypassing this on v1.x as the deferred show message could be processed on the next
+        /// frame from when the client registers having connected.
+        /// </summary>
+        protected override bool ShouldWaitForNewClientToConnect(NetworkManager networkManager)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// Validate that the player object is spawned on the client side.
+        /// </summary>
+        /// <returns></returns>
+        private bool ClientSpawnedPlayer()
+        {
+            var playerObject = m_ClientNetworkManagers[0].LocalClient.PlayerObject;
+            return playerObject != null && playerObject.IsSpawned && playerObject.IsOwner;
+        }
+
+        /// <summary>
         /// Tests the scenario where under a client-server network topology if a player prefab
         /// is spawned by the server with no observers but the player prefab itself has server
         /// side script that will network show the spawned object to the owning client.
@@ -81,7 +99,17 @@ namespace Unity.Netcode.RuntimeTests
 
             yield return CreateAndStartNewClient();
 
-            yield return new WaitForSeconds(0.25f);
+            // Wait for the new client to connect
+            yield return WaitForClientsConnectedOrTimeOut();
+            AssertOnTimeout($"Timed out waiting for client to connect!");
+            OnNewClientStartedAndConnected(m_ClientNetworkManagers[0]);
+
+            // Wait for the new client to have spawned the player
+            yield return WaitForConditionOrTimeOut(ClientSpawnedPlayer);
+            AssertOnTimeout($"Timed out waiting for client to spawn its player object!");
+
+            // Provide some time to assure there are no additional attempts to spawn the same instance
+            yield return new WaitForSeconds(0.5f);
 
             NetcodeLogAssert.LogWasNotReceived(LogType.Warning, new Regex("but it is already in the spawned list!"));
             var client = m_ClientNetworkManagers[0];


### PR DESCRIPTION
Adjusting the PlayerSpawnObjectVisibilityTests so that it provides some additional time for the deferred NetworkShow message to be processed.

[MTT-12644](https://jira.unity3d.com/browse/MTT-12644)

## Changelog

NA

## Testing and Documentation

- Includes integration test adjustments.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Backport

#3548 is the up-port for this instability fix.

<!-- If this is a backport:
 - Add the following to the PR title: "\[Backport\] ..." .
 - Link to the original PR.
If this needs a backport - state this here
If a backport is not needed please provide the reason why.
If the "Backports" section is not present it will lead to a CI test failure. 
-->