### PR TITLE
fix: PlayerSpawnObjectVisibilityTests test instability [Up-Port]

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Editor/Build/BuildTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Build/BuildTests.cs
@@ -12,6 +12,8 @@ namespace Unity.Netcode.EditorTests
     {
         public const string DefaultBuildScenePath = "Tests/Editor/Build/BuildTestScene.unity";
 
+        // Increased the Build test timeout from 3 to 10 minutes.
+        [Timeout(900000)]
         [Test]
         public void BasicBuildTest()
         {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/InterpolationStopAndStartMotionTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/InterpolationStopAndStartMotionTest.cs
@@ -270,7 +270,8 @@ namespace Unity.Netcode.RuntimeTests
                             // Add it to the table of state updates
                             var stateEntry = new StateEntry()
                             {
-                                TimeAdded = Time.realtimeSinceStartup,
+                                // Use the server time to get the valid "relative" time since the session started.
+                                TimeAdded = NetworkManager.ServerTime.TimeAsFloat,
                                 State = m_PosInterpolator.InterpolateState,
                             };
 


### PR DESCRIPTION
This PR addresses some v2.x test instabilities that includes:

- An up-port of #3547.
- A fix for the `InterpolationStopAndStartMotionTest` instabilities.
- A fix for the `BuildTests.BasicBuildTest` instabilities.

[MTT-12645](https://jira.unity3d.com/browse/MTT-12645)

## Changelog

NA

## Testing and Documentation

- Includes integration test modifications.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Backport

This is an up-port of #3547.

<!-- If this is a backport:
 - Add the following to the PR title: "\[Backport\] ..." .
 - Link to the original PR.
If this needs a backport - state this here
If a backport is not needed please provide the reason why.
If the "Backports" section is not present it will lead to a CI test failure. 
-->