### PR TITLE
fix: Extended UniversalRpcTests run times

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageCorruptionTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageCorruptionTests.cs
@@ -95,7 +95,8 @@ namespace Unity.Netcode.EditorTests
                             for (int i = 0; i < 4; i++)
                             {
                                 var currentByte = batchData.GetUnsafePtr()[i];
-                                batchData.WriteByteSafe((byte)(currentByte == 0 ? 1 : 0));
+                                currentByte = (byte)((currentByte + 1) % 255);
+                                batchData.WriteByteSafe(currentByte);
                                 MessageQueue.Add(batchData.ToArray());
                             }
                             break;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
@@ -43,6 +43,7 @@ namespace Unity.Netcode.RuntimeTests
 
                 // Need to destroy the GameObject (all assigned components will get destroyed too)
                 UnityEngine.Object.DestroyImmediate(m_Server.gameObject);
+                m_Server = null;
             }
 
             if (m_Client1)
@@ -51,6 +52,7 @@ namespace Unity.Netcode.RuntimeTests
 
                 // Need to destroy the GameObject (all assigned components will get destroyed too)
                 UnityEngine.Object.DestroyImmediate(m_Client1.gameObject);
+                m_Client1 = null;
             }
 
             if (m_Client2)
@@ -59,6 +61,7 @@ namespace Unity.Netcode.RuntimeTests
 
                 // Need to destroy the GameObject (all assigned components will get destroyed too)
                 UnityEngine.Object.DestroyImmediate(m_Client2.gameObject);
+                m_Client2 = null;
             }
 
             m_ServerEvents?.Clear();
@@ -315,7 +318,7 @@ namespace Unity.Netcode.RuntimeTests
             m_Server.StartServer();
             m_Client1.StartClient();
 
-            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_Client1Events);
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_Client1Events, 5.0f);
 
             m_Server.Shutdown();
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
@@ -475,6 +475,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
         protected override bool m_TearDownIsACoroutine => false;
 
         protected GameObject m_ServerObject;
+        protected NetworkObject m_ServerNetworkObject;
 
         protected override void OnCreatePlayerPrefab()
         {
@@ -483,16 +484,9 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
         protected override void OnServerAndClientsCreated()
         {
-            m_ServerObject = new GameObject { name = "Server Object" };
-            var networkObject = m_ServerObject.AddComponent<NetworkObject>();
+            m_ServerObject = CreateNetworkObjectPrefab("Server Object");
+            m_ServerNetworkObject = m_ServerObject.GetComponent<NetworkObject>();
             m_ServerObject.AddComponent<UniversalRpcNetworkBehaviour>();
-            networkObject.NetworkManagerOwner = m_ServerNetworkManager;
-            NetcodeIntegrationTestHelpers.MakeNetworkObjectTestPrefab(networkObject);
-            m_ServerNetworkManager.AddNetworkPrefab(m_ServerObject);
-            foreach (var client in m_ClientNetworkManagers)
-            {
-                client.AddNetworkPrefab(m_ServerObject);
-            }
         }
 
         protected override void OnInlineTearDown()
@@ -538,6 +532,28 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
             return m_PlayerNetworkObjects[onClient][ownerClientId].GetComponent<UniversalRpcNetworkBehaviour>();
         }
+
+        protected UniversalRpcNetworkBehaviour GetPlayerObjectNext(ulong ownerClientId, ulong senderClientId)
+        {
+            var networkObjectId = 0UL;
+
+            var senderNetworkManager = senderClientId == NetworkManager.ServerClientId ? m_ServerNetworkManager :
+                m_ClientNetworkManagers.Where((c) => c.LocalClientId == senderClientId).First();
+            var ownerNetworkManager = ownerClientId == NetworkManager.ServerClientId ? m_ServerNetworkManager :
+                m_ClientNetworkManagers.Where((c) => c.LocalClientId == ownerClientId).First();
+
+            if (ownerClientId == NetworkManager.ServerClientId && !m_ServerNetworkManager.IsHost)
+            {
+                networkObjectId = m_ServerNetworkObject.NetworkObjectId;
+            }
+            else
+            {
+                networkObjectId = ownerNetworkManager.LocalClient.PlayerObject.NetworkObjectId;
+            }
+
+            return senderNetworkManager.SpawnManager.SpawnedObjects[networkObjectId].GetComponent<UniversalRpcNetworkBehaviour>();
+        }
+
 
         protected void VerifyLocalReceived(ulong objectOwner, ulong sender, string name, bool verifyReceivedFrom, int expectedReceived = 1)
         {
@@ -921,6 +937,489 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
     [Timeout(1200000)] // Tracked in MTT-11359
     [TestFixture(HostOrServer.Host)]
     [TestFixture(HostOrServer.Server)]
+    internal class UniversalRpcGroupedTests : UniversalRpcTestsBase
+    {
+        public enum TestTypes
+        {
+            DisallowedOverride,
+            SenderClientId,
+            SendingNoOverride,
+            SendingNoOverrideWithParams,
+            SendingNoOverrideWithParamsAndRpcParams,
+            SendingWithGroupNotOverride,
+            SendingWithGroupOverride,
+            SendingWithTargetOverride,
+            TestRequireOwnership,
+        }
+
+        private enum TestTables
+        {
+            ActionTableA,
+            ActionTableB,
+            ActionTableC
+        }
+
+        private Dictionary<TestTypes, Action<SendTo, ulong, ulong>> m_TestTypeToActionTableA = new Dictionary<TestTypes, Action<SendTo, ulong, ulong>>();
+        private Dictionary<TestTypes, Action<SendTo, SendTo, ulong, ulong>> m_TestTypeToActionTableB = new Dictionary<TestTypes, Action<SendTo, SendTo, ulong, ulong>>();
+        private Dictionary<TestTypes, Action<SendTo, ulong[], ulong, ulong, AllocationType>> m_TestTypeToActionTableC = new Dictionary<TestTypes, Action<SendTo, ulong[], ulong, ulong, AllocationType>>();
+
+
+        private Dictionary<TestTypes, TestTables> m_TestTypesToTableTypes = new Dictionary<TestTypes, TestTables>();
+        private Dictionary<TestTables, Action<TestTypes>> m_TableTypesToTestStartAction = new Dictionary<TestTables, Action<TestTypes>>();
+        private Dictionary<TestTypes, ulong[][]> m_TypeToRecipientGroupsTable = new Dictionary<TestTypes, ulong[][]>();
+
+        public UniversalRpcGroupedTests(HostOrServer hostOrServer) : base(hostOrServer)
+        {
+            InitTestTypeToActionTable();
+        }
+
+        private void AddTestTypeA(TestTypes testType, Action<SendTo, ulong, ulong> action)
+        {
+            m_TestTypesToTableTypes.Add(testType, TestTables.ActionTableA);
+            m_TestTypeToActionTableA.Add(testType, action);
+        }
+
+        private void AddTestTypeB(TestTypes testType, Action<SendTo, SendTo, ulong, ulong> action)
+        {
+            m_TestTypesToTableTypes.Add(testType, TestTables.ActionTableB);
+            m_TestTypeToActionTableB.Add(testType, action);
+        }
+
+        private void AddTestTypeC(TestTypes testType, Action<SendTo, ulong[], ulong, ulong, AllocationType> action)
+        {
+            m_TestTypesToTableTypes.Add(testType, TestTables.ActionTableC);
+            m_TestTypeToActionTableC.Add(testType, action);
+        }
+
+        private void InitTestTypeToActionTable()
+        {
+            // Create a look up table to know what kind of test table action will be invoked
+            m_TableTypesToTestStartAction.Add(TestTables.ActionTableA, RunTestTypeA);
+            m_TableTypesToTestStartAction.Add(TestTables.ActionTableB, RunTestTypeB);
+            m_TableTypesToTestStartAction.Add(TestTables.ActionTableC, RunTestTypeC);
+
+            // Type A action registrations
+            AddTestTypeA(TestTypes.DisallowedOverride, DisallowedOverride);
+            AddTestTypeA(TestTypes.SenderClientId, SenderClientId);
+            AddTestTypeA(TestTypes.SendingNoOverride, SendingNoOverride);
+            AddTestTypeA(TestTypes.SendingNoOverrideWithParams, SendingNoOverrideWithParams);
+            AddTestTypeA(TestTypes.SendingNoOverrideWithParamsAndRpcParams, SendingNoOverrideWithParamsAndRpcParams);
+            AddTestTypeA(TestTypes.TestRequireOwnership, TestRequireOwnership);
+
+            // Type B action registrations
+            AddTestTypeB(TestTypes.SendingWithTargetOverride, SendingWithTargetOverride);
+
+            // Type C action registrations
+            AddTestTypeC(TestTypes.SendingWithGroupOverride, SendingWithGroupOverride);
+            m_TypeToRecipientGroupsTable.Add(TestTypes.SendingWithGroupOverride, RecipientGroupsA);
+            AddTestTypeC(TestTypes.SendingWithGroupNotOverride, SendingWithGroupNotOverride);
+            m_TypeToRecipientGroupsTable.Add(TestTypes.SendingWithGroupNotOverride, RecipientGroupsB);
+        }
+
+        private Action<SendTo, ulong, ulong> GetTestTypeActionA(TestTypes testType)
+        {
+            if (m_TestTypeToActionTableA.ContainsKey(testType))
+            {
+                return m_TestTypeToActionTableA[testType];
+            }
+            return MockSendA;
+        }
+
+        private Action<SendTo, SendTo, ulong, ulong> GetTestTypeActionB(TestTypes testType)
+        {
+            if (m_TestTypeToActionTableB.ContainsKey(testType))
+            {
+                return m_TestTypeToActionTableB[testType];
+            }
+            return MockSendB;
+        }
+
+        private Action<SendTo, ulong[], ulong, ulong, AllocationType> GetTestTypeActionC(TestTypes testType)
+        {
+            if (m_TestTypeToActionTableC.ContainsKey(testType))
+            {
+                return m_TestTypeToActionTableC[testType];
+            }
+            return MockSendC;
+        }
+
+        [UnityTest]
+        public IEnumerator RunGroupTestTypes([Values] TestTypes testType)
+        {
+            var testTypeToRun = m_TestTypesToTableTypes[testType];
+            m_TableTypesToTestStartAction[testTypeToRun].Invoke(testType);
+            // Provide a small break to test runner in-between each test type
+            // since they are running all iterations of the legacy test type's
+            // values.
+            yield return s_DefaultWaitForTick;
+        }
+
+        #region TYPE-A Tests
+
+        private void RunTestTypeA(TestTypes testType)
+        {
+            var sendToValues = new List<SendTo>() { SendTo.Everyone, SendTo.Me, SendTo.Owner, SendTo.Server, SendTo.NotMe, SendTo.NotOwner, SendTo.NotServer, SendTo.ClientsAndHost };
+            var numberOfClientsULong = (ulong)NumberOfClients;
+            var actionToInvoke = GetTestTypeActionA(testType);
+            try
+            {
+                foreach (var sendTo in sendToValues)
+                {
+                    for (ulong objectOwner = 0; objectOwner <= numberOfClientsULong; objectOwner++)
+                    {
+                        for (ulong sender = 0; sender <= numberOfClientsULong; sender++)
+                        {
+                            actionToInvoke.Invoke(sendTo, objectOwner, sender);
+                            Clear();
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail($"Threw Exception:{ex.Message}!\n{ex.StackTrace}");
+            }
+        }
+
+        /// <summary>
+        /// Invoked if a <see cref="TestTypes"/> does not have an action yet for this <see cref="TestTables.ActionTableA"/> action.
+        /// </summary>
+        private void MockSendA(SendTo sendTo, ulong objectOwner, ulong sender)
+        {
+        }
+        private void SenderClientId(SendTo sendTo, ulong objectOwner, ulong sender)
+        {
+            var sendMethodName = $"DefaultTo{sendTo}WithRpcParamsRpc";
+            var verifyMethodName = $"VerifySentTo{sendTo}WithReceivedFrom";
+
+            var senderObject = GetPlayerObject(objectOwner, sender);
+            var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
+            sendMethod.Invoke(senderObject, new object[] { new RpcParams() });
+
+            var verifyMethod = GetType().GetMethod(verifyMethodName);
+            verifyMethod.Invoke(this, new object[] { objectOwner, sender, sendMethodName });
+        }
+
+        private void DisallowedOverride(SendTo sendTo, ulong objectOwner, ulong sender)
+        {
+            var senderObject = GetPlayerObject(objectOwner, sender);
+            var methodName = $"DefaultTo{sendTo}WithRpcParamsRpc";
+            var method = senderObject.GetType().GetMethod(methodName);
+            Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => method.Invoke(senderObject, new object[] { (RpcParams)senderObject.RpcTarget.Everyone })));
+            Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => method.Invoke(senderObject, new object[] { (RpcParams)senderObject.RpcTarget.Owner })));
+            Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => method.Invoke(senderObject, new object[] { (RpcParams)senderObject.RpcTarget.NotOwner })));
+            Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => method.Invoke(senderObject, new object[] { (RpcParams)senderObject.RpcTarget.Server })));
+            Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => method.Invoke(senderObject, new object[] { (RpcParams)senderObject.RpcTarget.NotServer })));
+            Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => method.Invoke(senderObject, new object[] { (RpcParams)senderObject.RpcTarget.ClientsAndHost })));
+            Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => method.Invoke(senderObject, new object[] { (RpcParams)senderObject.RpcTarget.Me })));
+            Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => method.Invoke(senderObject, new object[] { (RpcParams)senderObject.RpcTarget.NotMe })));
+            Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => method.Invoke(senderObject, new object[] { (RpcParams)senderObject.RpcTarget.Single(0, RpcTargetUse.Temp) })));
+            Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => method.Invoke(senderObject, new object[] { (RpcParams)senderObject.RpcTarget.Not(0, RpcTargetUse.Temp) })));
+            Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => method.Invoke(senderObject, new object[] { (RpcParams)senderObject.RpcTarget.Group(new[] { 0ul, 1ul, 2ul }, RpcTargetUse.Temp) })));
+            Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => method.Invoke(senderObject, new object[] { (RpcParams)senderObject.RpcTarget.Not(new[] { 0ul, 1ul, 2ul }, RpcTargetUse.Temp) })));
+        }
+
+        private void SendingNoOverride(SendTo sendTo, ulong objectOwner, ulong sender)
+        {
+            var sendMethodName = $"DefaultTo{sendTo}Rpc";
+            var verifyMethodName = $"VerifySentTo{sendTo}";
+
+            var senderObject = GetPlayerObjectNext(objectOwner, sender);
+            var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
+            sendMethod.Invoke(senderObject, new object[] { });
+
+            var verifyMethod = GetType().GetMethod(verifyMethodName);
+            verifyMethod.Invoke(this, new object[] { objectOwner, sender, sendMethodName });
+        }
+
+        private void SendingNoOverrideWithParams(SendTo sendTo, ulong objectOwner, ulong sender)
+        {
+            var rand = new Random();
+            var i = rand.Next();
+            var f = (float)rand.NextDouble();
+            var b = rand.Next() % 2 == 1;
+            var s = "";
+            var numChars = rand.Next() % 5 + 5;
+            const string chars = "abcdefghijklmnopqrstuvwxycABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-=_+[]{}\\|;':\",./<>?";
+            for (var j = 0; j < numChars; ++j)
+            {
+                s += chars[rand.Next(chars.Length)];
+            }
+
+            var sendMethodName = $"DefaultTo{sendTo}WithParamsRpc";
+            var verifyMethodName = $"VerifySentTo{sendTo}WithParams";
+
+            var senderObject = GetPlayerObject(objectOwner, sender);
+            var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
+            sendMethod.Invoke(senderObject, new object[] { i, b, f, s });
+
+            var verifyMethod = GetType().GetMethod(verifyMethodName);
+            verifyMethod.Invoke(this, new object[] { objectOwner, sender, sendMethodName, i, b, f, s });
+        }
+
+        private void SendingNoOverrideWithParamsAndRpcParams(SendTo sendTo, ulong objectOwner, ulong sender)
+        {
+            var rand = new Random();
+            var i = rand.Next();
+            var f = (float)rand.NextDouble();
+            var b = rand.Next() % 2 == 1;
+            var s = "";
+            var numChars = rand.Next() % 5 + 5;
+            const string chars = "abcdefghijklmnopqrstuvwxycABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-=_+[]{}\\|;':\",./<>?";
+            for (var j = 0; j < numChars; ++j)
+            {
+                s += chars[rand.Next(chars.Length)];
+            }
+
+            var sendMethodName = $"DefaultTo{sendTo}WithParamsAndRpcParamsRpc";
+            var verifyMethodName = $"VerifySentTo{sendTo}WithParams";
+
+            var senderObject = GetPlayerObject(objectOwner, sender);
+            var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
+            sendMethod.Invoke(senderObject, new object[] { i, b, f, s, new RpcParams() });
+
+            var verifyMethod = GetType().GetMethod(verifyMethodName);
+            verifyMethod.Invoke(this, new object[] { objectOwner, sender, sendMethodName, i, b, f, s });
+        }
+
+        private void TestRequireOwnership(SendTo sendTo, ulong objectOwner, ulong sender)
+        {
+            var sendMethodName = $"DefaultTo{sendTo}RequireOwnershipRpc";
+
+            var senderObject = GetPlayerObject(objectOwner, sender);
+            var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
+            if (sender != objectOwner)
+            {
+                Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => sendMethod.Invoke(senderObject, new object[] { })));
+            }
+            else
+            {
+                var verifyMethodName = $"VerifySentTo{sendTo}";
+                sendMethod.Invoke(senderObject, new object[] { });
+
+                var verifyMethod = GetType().GetMethod(verifyMethodName);
+                verifyMethod.Invoke(this, new object[] { objectOwner, sender, sendMethodName });
+            }
+        }
+        #endregion
+
+        #region TYPE-B Tests
+        private void RunTestTypeB(TestTypes testType)
+        {
+            var sendToValues = new List<SendTo>() { SendTo.Everyone, SendTo.Me, SendTo.Owner, SendTo.Server, SendTo.NotMe, SendTo.NotOwner, SendTo.NotServer, SendTo.ClientsAndHost };
+            var numberOfClientsULong = (ulong)NumberOfClients;
+            var actionToInvoke = GetTestTypeActionB(testType);
+            try
+            {
+                foreach (var defaultSendTo in sendToValues)
+                {
+                    foreach (var overrideSendTo in sendToValues)
+                    {
+                        for (ulong objectOwner = 0; objectOwner <= numberOfClientsULong; objectOwner++)
+                        {
+                            for (ulong sender = 0; sender <= numberOfClientsULong; sender++)
+                            {
+                                actionToInvoke.Invoke(defaultSendTo, overrideSendTo, objectOwner, sender);
+                                Clear();
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail($"Threw Exception:{ex.Message}!\n{ex.StackTrace}");
+            }
+        }
+
+        /// <summary>
+        /// Invoked if a <see cref="TestTypes"/> does not have an action yet for this <see cref="TestTables.ActionTableB"/> action.
+        /// </summary>
+        private void MockSendB(SendTo defaultSendTo, SendTo overrideSendTo, ulong objectOwner, ulong sender)
+        {
+        }
+        private void SendingWithTargetOverride(SendTo defaultSendTo, SendTo overrideSendTo, ulong objectOwner, ulong sender)
+        {
+            var sendMethodName = $"DefaultTo{defaultSendTo}AllowOverrideRpc";
+            var targetField = typeof(RpcTarget).GetField(overrideSendTo.ToString());
+            var verifyMethodName = $"VerifySentTo{overrideSendTo}";
+
+            var senderObject = GetPlayerObject(objectOwner, sender);
+            var target = (BaseRpcTarget)targetField.GetValue(senderObject.RpcTarget);
+            var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
+            sendMethod.Invoke(senderObject, new object[] { (RpcParams)target });
+
+            var verifyMethod = GetType().GetMethod(verifyMethodName);
+            verifyMethod.Invoke(this, new object[] { objectOwner, sender, sendMethodName });
+        }
+        #endregion
+
+        #region TYPE-C Tests
+        public static ulong[][] RecipientGroupsA = new[]{
+            new[] { 0ul },
+            new[] { 1ul },
+            new[] { 0ul, 1ul },
+            new[] { 0ul, 1ul, 2ul }
+        };
+
+        public static ulong[][] RecipientGroupsB = new[]
+{
+            new ulong[] {},
+            new[] { 0ul },
+            new[] { 1ul },
+            new[] { 0ul, 1ul },
+        };
+
+        public enum AllocationType
+        {
+            Array,
+            NativeArray,
+            NativeList,
+            List
+        }
+
+        private void RunTestTypeC(TestTypes testType)
+        {
+            var sendToValues = new List<SendTo>() { SendTo.Everyone, SendTo.Me, SendTo.Owner, SendTo.Server, SendTo.NotMe, SendTo.NotOwner, SendTo.NotServer, SendTo.ClientsAndHost };
+            var allocationTypes = new List<AllocationType>() { AllocationType.Array, AllocationType.NativeArray, AllocationType.NativeList, AllocationType.List };
+            var numberOfClientsULong = (ulong)NumberOfClients;
+            var actionToInvoke = GetTestTypeActionC(testType);
+            var recipientGroups = m_TypeToRecipientGroupsTable[testType];
+            try
+            {
+                foreach (var defaultSendTo in sendToValues)
+                {
+                    foreach (var sendGroup in recipientGroups)
+                    {
+
+                        for (ulong objectOwner = 0; objectOwner <= numberOfClientsULong; objectOwner++)
+                        {
+                            for (ulong sender = 0; sender <= numberOfClientsULong; sender++)
+                            {
+                                foreach (var allocationType in allocationTypes)
+                                {
+                                    actionToInvoke.Invoke(defaultSendTo, sendGroup, objectOwner, sender, allocationType);
+                                    Clear();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail($"Threw Exception:{ex.Message}!\n{ex.StackTrace}");
+            }
+        }
+
+        private void MockSendC(SendTo defaultSendTo, ulong[] recipient, ulong objectOwner, ulong sender, AllocationType allocationType)
+        {
+        }
+
+        private void SendingWithGroupOverride(SendTo defaultSendTo, ulong[] recipient, ulong objectOwner, ulong sender, AllocationType allocationType)
+        {
+            var sendMethodName = $"DefaultTo{defaultSendTo}AllowOverrideRpc";
+
+            var senderObject = GetPlayerObject(objectOwner, sender);
+            BaseRpcTarget target = null;
+            switch (allocationType)
+            {
+                case AllocationType.Array:
+                    target = senderObject.RpcTarget.Group(recipient, RpcTargetUse.Temp);
+                    break;
+                case AllocationType.List:
+                    target = senderObject.RpcTarget.Group(recipient.ToList(), RpcTargetUse.Temp);
+                    break;
+                case AllocationType.NativeArray:
+                    var arr = new NativeArray<ulong>(recipient, Allocator.Temp);
+                    target = senderObject.RpcTarget.Group(arr, RpcTargetUse.Temp);
+                    arr.Dispose();
+                    break;
+                case AllocationType.NativeList:
+                    // For some reason on 2020.3, calling list.AsArray() and passing that to the next function
+                    // causes Allocator.Temp allocations to become invalid somehow. This is not an issue on later
+                    // versions of Unity.
+                    var list = new NativeList<ulong>(recipient.Length, Allocator.TempJob);
+                    foreach (var id in recipient)
+                    {
+                        list.Add(id);
+                    }
+                    target = senderObject.RpcTarget.Group(list, RpcTargetUse.Temp);
+                    list.Dispose();
+                    break;
+            }
+            var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
+            sendMethod.Invoke(senderObject, new object[] { (RpcParams)target });
+
+            VerifyRemoteReceived(objectOwner, sender, sendMethodName, s_ClientIds.Where(c => recipient.Contains(c)).ToArray(), false);
+            VerifyNotReceived(objectOwner, s_ClientIds.Where(c => !recipient.Contains(c)).ToArray());
+
+            // Pass some time to make sure that no other client ever receives this
+            TimeTravel(1f, 30);
+            VerifyNotReceived(objectOwner, s_ClientIds.Where(c => !recipient.Contains(c)).ToArray());
+        }
+
+        private void SendingWithGroupNotOverride(SendTo defaultSendTo, ulong[] recipient, ulong objectOwner, ulong sender, AllocationType allocationType)
+        {
+            var sendMethodName = $"DefaultTo{defaultSendTo}AllowOverrideRpc";
+
+            var senderObject = GetPlayerObject(objectOwner, sender);
+            BaseRpcTarget target = null;
+            switch (allocationType)
+            {
+                case AllocationType.Array:
+                    target = senderObject.RpcTarget.Not(recipient, RpcTargetUse.Temp);
+                    break;
+                case AllocationType.List:
+                    target = senderObject.RpcTarget.Not(recipient.ToList(), RpcTargetUse.Temp);
+                    break;
+                case AllocationType.NativeArray:
+                    var arr = new NativeArray<ulong>(recipient, Allocator.Temp);
+                    target = senderObject.RpcTarget.Not(arr, RpcTargetUse.Temp);
+                    arr.Dispose();
+                    break;
+                case AllocationType.NativeList:
+                    // For some reason on 2020.3, calling list.AsArray() and passing that to the next function
+                    // causes Allocator.Temp allocations to become invalid somehow. This is not an issue on later
+                    // versions of Unity.
+                    var list = new NativeList<ulong>(recipient.Length, Allocator.TempJob);
+                    foreach (var id in recipient)
+                    {
+                        list.Add(id);
+                    }
+                    target = senderObject.RpcTarget.Not(list, RpcTargetUse.Temp);
+                    list.Dispose();
+                    break;
+            }
+            var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
+            sendMethod.Invoke(senderObject, new object[] { (RpcParams)target });
+
+            VerifyRemoteReceived(objectOwner, sender, sendMethodName, s_ClientIds.Where(c => !recipient.Contains(c)).ToArray(), false);
+            VerifyNotReceived(objectOwner, s_ClientIds.Where(c => recipient.Contains(c)).ToArray());
+
+            // Pass some time to make sure that no other client ever receives this
+            TimeTravel(1f, 30);
+            VerifyNotReceived(objectOwner, s_ClientIds.Where(c => recipient.Contains(c)).ToArray());
+        }
+        #endregion
+
+    }
+
+#if USE_LEGACY_UNIVERSALRPC_TESTS
+    [Timeout(1200000)] // Tracked in MTT-11359
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    internal class UniversalRpcTestDefaultSendToSpecifiedInParamsSendingToServerAndOwner : UniversalRpcTestsBase
+    {
+        public UniversalRpcTestDefaultSendToSpecifiedInParamsSendingToServerAndOwner(HostOrServer hostOrServer) : base(hostOrServer)
+        {
+
+        }
+    }
+
+    [Timeout(1200000)] // Tracked in MTT-11359
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
     internal class UniversalRpcTestSendingNoOverride : UniversalRpcTestsBase
     {
         public UniversalRpcTestSendingNoOverride(HostOrServer hostOrServer) : base(hostOrServer)
@@ -929,24 +1428,44 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
         }
 
         [Test]
-        public void TestSendingNoOverride(
-            // Excludes SendTo.SpecifiedInParams
-            [Values(SendTo.Everyone, SendTo.Me, SendTo.Owner, SendTo.Server, SendTo.NotMe, SendTo.NotOwner, SendTo.NotServer, SendTo.ClientsAndHost)] SendTo sendTo,
-            [Values(0u, 1u, 2u)] ulong objectOwner,
-            [Values(0u, 1u, 2u)] ulong sender
-        )
+        public void TestSendingNoOverride()
+        {
+            var sendToValues = new List<SendTo>() { SendTo.Everyone, SendTo.Me, SendTo.Owner, SendTo.Server, SendTo.NotMe, SendTo.NotOwner, SendTo.NotServer, SendTo.ClientsAndHost };
+            var numberOfClientsULong = (ulong)NumberOfClients;
+            var progressLog = new StringBuilder();
+            try
+            {
+                foreach (var sendTo in sendToValues)
+                {
+                    for (ulong objectOwner = 0; objectOwner <= numberOfClientsULong; objectOwner++)
+                    {
+                        for (ulong sender = 0; sender <= numberOfClientsULong; sender++)
+                        {
+                            progressLog.AppendLine($"[SendTo: {sendTo}][Owner: {objectOwner}][Sender:{sender}]");
+                            InternalTestSendingNoOverride(sendTo, objectOwner, sender);
+                            Clear();
+                        }
+                    }
+                }
+            }
+            catch(Exception ex)
+            {
+                Assert.Fail($"Threw Exception:{ex.Message}!\n{progressLog.ToString()}");
+            }
+        }
+
+        private void InternalTestSendingNoOverride(SendTo sendTo, ulong objectOwner, ulong sender)
         {
             var sendMethodName = $"DefaultTo{sendTo}Rpc";
             var verifyMethodName = $"VerifySentTo{sendTo}";
 
-            var senderObject = GetPlayerObject(objectOwner, sender);
+            var senderObject = GetPlayerObjectNext(objectOwner, sender);
             var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
             sendMethod.Invoke(senderObject, new object[] { });
 
             var verifyMethod = GetType().GetMethod(verifyMethodName);
-            verifyMethod.Invoke(this, new object[] { objectOwner, sender, sendMethodName });
+            verifyMethod?.Invoke(this, new object[] { objectOwner, sender, sendMethodName });
         }
-
     }
 
     [Timeout(1200000)] // Tracked in MTT-11359
@@ -1173,6 +1692,9 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
     }
 
+#endif
+
+    #region ALREADY-OPTIMIZED-GROUP-A
     [Timeout(1200000)] // Tracked in MTT-11359
     [TestFixture(HostOrServer.Host)]
     [TestFixture(HostOrServer.Server)]
@@ -1268,7 +1790,9 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
         }
 
     }
+    #endregion
 
+#if USE_LEGACY_UNIVERSALRPC_TESTS
     [Timeout(1200000)] // Tracked in MTT-11359
     [TestFixture(HostOrServer.Host)]
     [TestFixture(HostOrServer.Server)]
@@ -1346,7 +1870,6 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             VerifyNotReceived(objectOwner, s_ClientIds.Where(c => !recipient.Contains(c)).ToArray());
         }
     }
-
 
     [Timeout(1200000)] // Tracked in MTT-11359
     [TestFixture(HostOrServer.Host)]
@@ -1426,18 +1949,9 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             VerifyNotReceived(objectOwner, s_ClientIds.Where(c => recipient.Contains(c)).ToArray());
         }
     }
+#endif
 
-    [Timeout(1200000)] // Tracked in MTT-11359
-    [TestFixture(HostOrServer.Host)]
-    [TestFixture(HostOrServer.Server)]
-    internal class UniversalRpcTestDefaultSendToSpecifiedInParamsSendingToServerAndOwner : UniversalRpcTestsBase
-    {
-        public UniversalRpcTestDefaultSendToSpecifiedInParamsSendingToServerAndOwner(HostOrServer hostOrServer) : base(hostOrServer)
-        {
-
-        }
-    }
-
+    #region ALREADY-OPTIMIZED-OR-LOW-IMPACT-GROUP-B
     [Timeout(1200000)] // Tracked in MTT-11359
     [TestFixture(HostOrServer.Host)]
     [TestFixture(HostOrServer.Server)]
@@ -1623,7 +2137,6 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
                 OnInlineTearDown();
             }
         }
-
     }
 
     [Timeout(1200000)] // Tracked in MTT-11359
@@ -1935,5 +2448,6 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
         }
 
     }
+    #endregion
 }
 #endif

--- a/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
@@ -475,7 +475,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
         protected override bool m_TearDownIsACoroutine => false;
 
         protected GameObject m_ServerObject;
-        protected NetworkObject m_ServerNetworkObject;
+        internal NetworkObject ServerNetworkObject;
 
         protected override void OnCreatePlayerPrefab()
         {
@@ -485,7 +485,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
         protected override void OnServerAndClientsCreated()
         {
             m_ServerObject = CreateNetworkObjectPrefab("Server Object");
-            m_ServerNetworkObject = m_ServerObject.GetComponent<NetworkObject>();
+            ServerNetworkObject = m_ServerObject.GetComponent<NetworkObject>();
             m_ServerObject.AddComponent<UniversalRpcNetworkBehaviour>();
         }
 
@@ -533,7 +533,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             return m_PlayerNetworkObjects[onClient][ownerClientId].GetComponent<UniversalRpcNetworkBehaviour>();
         }
 
-        protected UniversalRpcNetworkBehaviour GetPlayerObjectNext(ulong ownerClientId, ulong senderClientId)
+        internal UniversalRpcNetworkBehaviour InternalGetPlayerObject(ulong ownerClientId, ulong senderClientId)
         {
             var networkObjectId = 0UL;
 
@@ -544,7 +544,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
             if (ownerClientId == NetworkManager.ServerClientId && !m_ServerNetworkManager.IsHost)
             {
-                networkObjectId = m_ServerNetworkObject.NetworkObjectId;
+                networkObjectId = ServerNetworkObject.NetworkObjectId;
             }
             else
             {
@@ -554,10 +554,10 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             return senderNetworkManager.SpawnManager.SpawnedObjects[networkObjectId].GetComponent<UniversalRpcNetworkBehaviour>();
         }
 
-
+        #region VERIFY METHODS
         protected void VerifyLocalReceived(ulong objectOwner, ulong sender, string name, bool verifyReceivedFrom, int expectedReceived = 1)
         {
-            var obj = GetPlayerObject(objectOwner, sender);
+            var obj = InternalGetPlayerObject(objectOwner, sender);
             Assert.AreEqual(name, obj.Received);
             Assert.That(obj.ReceivedCount, Is.EqualTo(expectedReceived));
             Assert.IsNull(obj.ReceivedParams);
@@ -569,7 +569,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
         protected void VerifyLocalReceivedWithParams(ulong objectOwner, ulong sender, string name, int i, bool b, float f, string s)
         {
-            var obj = GetPlayerObject(objectOwner, sender);
+            var obj = InternalGetPlayerObject(objectOwner, sender);
             Assert.AreEqual(name, obj.Received);
             Assert.That(obj.ReceivedCount, Is.EqualTo(1));
             Assert.IsNotNull(obj.ReceivedParams);
@@ -583,7 +583,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
         {
             foreach (var client in receivedBy)
             {
-                UniversalRpcNetworkBehaviour playerObject = GetPlayerObject(objectOwner, client);
+                UniversalRpcNetworkBehaviour playerObject = InternalGetPlayerObject(objectOwner, client);
                 Assert.AreEqual(string.Empty, playerObject.Received);
                 Assert.That(playerObject.ReceivedCount, Is.EqualTo(0));
                 Assert.IsNull(playerObject.ReceivedParams);
@@ -656,7 +656,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
             foreach (var client in receivedBy)
             {
-                UniversalRpcNetworkBehaviour playerObject = GetPlayerObject(objectOwner, client);
+                UniversalRpcNetworkBehaviour playerObject = InternalGetPlayerObject(objectOwner, client);
                 Assert.AreEqual(message, playerObject.Received);
                 Assert.That(playerObject.ReceivedCount, Is.EqualTo(expectedReceived));
                 Assert.IsNull(playerObject.ReceivedParams);
@@ -730,7 +730,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
             foreach (var client in receivedBy)
             {
-                UniversalRpcNetworkBehaviour playerObject = GetPlayerObject(objectOwner, client);
+                UniversalRpcNetworkBehaviour playerObject = InternalGetPlayerObject(objectOwner, client);
                 Assert.AreEqual(message, playerObject.Received);
                 Assert.That(playerObject.ReceivedCount, Is.EqualTo(1));
 
@@ -920,6 +920,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
         {
             VerifySentToNotIdWithParams(objectOwner, sender, sender, methodName, i, b, f, s);
         }
+        #endregion
 
         public void RethrowTargetInvocationException(Action action)
         {
@@ -1092,7 +1093,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             var sendMethodName = $"DefaultTo{sendTo}WithRpcParamsRpc";
             var verifyMethodName = $"VerifySentTo{sendTo}WithReceivedFrom";
 
-            var senderObject = GetPlayerObject(objectOwner, sender);
+            var senderObject = InternalGetPlayerObject(objectOwner, sender);
             var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
             sendMethod.Invoke(senderObject, new object[] { new RpcParams() });
 
@@ -1102,7 +1103,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
         private void DisallowedOverride(SendTo sendTo, ulong objectOwner, ulong sender)
         {
-            var senderObject = GetPlayerObject(objectOwner, sender);
+            var senderObject = InternalGetPlayerObject(objectOwner, sender);
             var methodName = $"DefaultTo{sendTo}WithRpcParamsRpc";
             var method = senderObject.GetType().GetMethod(methodName);
             Assert.Throws<RpcException>(() => RethrowTargetInvocationException(() => method.Invoke(senderObject, new object[] { (RpcParams)senderObject.RpcTarget.Everyone })));
@@ -1124,7 +1125,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             var sendMethodName = $"DefaultTo{sendTo}Rpc";
             var verifyMethodName = $"VerifySentTo{sendTo}";
 
-            var senderObject = GetPlayerObjectNext(objectOwner, sender);
+            var senderObject = InternalGetPlayerObject(objectOwner, sender);
             var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
             sendMethod.Invoke(senderObject, new object[] { });
 
@@ -1149,7 +1150,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             var sendMethodName = $"DefaultTo{sendTo}WithParamsRpc";
             var verifyMethodName = $"VerifySentTo{sendTo}WithParams";
 
-            var senderObject = GetPlayerObject(objectOwner, sender);
+            var senderObject = InternalGetPlayerObject(objectOwner, sender);
             var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
             sendMethod.Invoke(senderObject, new object[] { i, b, f, s });
 
@@ -1174,7 +1175,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             var sendMethodName = $"DefaultTo{sendTo}WithParamsAndRpcParamsRpc";
             var verifyMethodName = $"VerifySentTo{sendTo}WithParams";
 
-            var senderObject = GetPlayerObject(objectOwner, sender);
+            var senderObject = InternalGetPlayerObject(objectOwner, sender);
             var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
             sendMethod.Invoke(senderObject, new object[] { i, b, f, s, new RpcParams() });
 
@@ -1186,7 +1187,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
         {
             var sendMethodName = $"DefaultTo{sendTo}RequireOwnershipRpc";
 
-            var senderObject = GetPlayerObject(objectOwner, sender);
+            var senderObject = InternalGetPlayerObject(objectOwner, sender);
             var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
             if (sender != objectOwner)
             {
@@ -1244,7 +1245,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             var targetField = typeof(RpcTarget).GetField(overrideSendTo.ToString());
             var verifyMethodName = $"VerifySentTo{overrideSendTo}";
 
-            var senderObject = GetPlayerObject(objectOwner, sender);
+            var senderObject = InternalGetPlayerObject(objectOwner, sender);
             var target = (BaseRpcTarget)targetField.GetValue(senderObject.RpcTarget);
             var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
             sendMethod.Invoke(senderObject, new object[] { (RpcParams)target });
@@ -1320,7 +1321,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
         {
             var sendMethodName = $"DefaultTo{defaultSendTo}AllowOverrideRpc";
 
-            var senderObject = GetPlayerObject(objectOwner, sender);
+            var senderObject = InternalGetPlayerObject(objectOwner, sender);
             BaseRpcTarget target = null;
             switch (allocationType)
             {
@@ -1363,7 +1364,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
         {
             var sendMethodName = $"DefaultTo{defaultSendTo}AllowOverrideRpc";
 
-            var senderObject = GetPlayerObject(objectOwner, sender);
+            var senderObject = InternalGetPlayerObject(objectOwner, sender);
             BaseRpcTarget target = null;
             switch (allocationType)
             {
@@ -1723,7 +1724,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
                             OnInlineSetup();
                             var sendMethodName = $"DefaultTo{defaultSendTo}AllowOverrideRpc";
 
-                            var senderObject = GetPlayerObject(objectOwner, sender);
+                            var senderObject = InternalGetPlayerObject(objectOwner, sender);
                             var target = senderObject.RpcTarget.Single(recipient, RpcTargetUse.Temp);
                             var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
                             sendMethod.Invoke(senderObject, new object[] { (RpcParams)target });
@@ -1771,7 +1772,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
                             OnInlineSetup();
                             var sendMethodName = $"DefaultTo{defaultSendTo}AllowOverrideRpc";
 
-                            var senderObject = GetPlayerObject(objectOwner, sender);
+                            var senderObject = InternalGetPlayerObject(objectOwner, sender);
                             var target = senderObject.RpcTarget.Not(recipient, RpcTargetUse.Temp);
                             var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
                             sendMethod.Invoke(senderObject, new object[] { (RpcParams)target });
@@ -2050,7 +2051,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
                 var sendMethodName = $"DefaultTo{defaultSendTo}DeferLocalRpc";
                 var verifyMethodName = $"VerifySentTo{defaultSendTo}";
-                var senderObject = GetPlayerObject(objectOwner, sender);
+                var senderObject = InternalGetPlayerObject(objectOwner, sender);
                 var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
                 sendMethod.Invoke(senderObject, new object[] { new RpcParams() });
 
@@ -2088,7 +2089,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
                 var sendMethodName = $"DefaultTo{defaultSendTo}WithRpcParamsRpc";
                 var verifyMethodName = $"VerifySentTo{defaultSendTo}";
-                var senderObject = GetPlayerObject(objectOwner, sender);
+                var senderObject = InternalGetPlayerObject(objectOwner, sender);
                 var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
                 sendMethod.Invoke(senderObject, new object[] { (RpcParams)LocalDeferMode.Defer });
 
@@ -2126,7 +2127,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
                 var sendMethodName = $"DefaultTo{defaultSendTo}DeferLocalRpc";
                 var verifyMethodName = $"VerifySentTo{defaultSendTo}";
-                var senderObject = GetPlayerObject(objectOwner, sender);
+                var senderObject = InternalGetPlayerObject(objectOwner, sender);
                 var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
                 sendMethod.Invoke(senderObject, new object[] { (RpcParams)LocalDeferMode.SendImmediate });
 
@@ -2152,7 +2153,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
         [Test]
         public void TestMutualRecursion()
         {
-            var serverObj = GetPlayerObject(NetworkManager.ServerClientId, NetworkManager.ServerClientId);
+            var serverObj = InternalGetPlayerObject(NetworkManager.ServerClientId, NetworkManager.ServerClientId);
 
             serverObj.MutualRecursionClientRpc();
 
@@ -2203,7 +2204,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
         [Test]
         public void TestSelfRecursion()
         {
-            var serverObj = GetPlayerObject(NetworkManager.ServerClientId, NetworkManager.ServerClientId);
+            var serverObj = InternalGetPlayerObject(NetworkManager.ServerClientId, NetworkManager.ServerClientId);
 
             serverObj.SelfRecursiveRpc();
 
@@ -2322,11 +2323,11 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
             if (m_ObjType == ObjType.Server)
             {
-                m_Obj = GetPlayerObject(NetworkManager.ServerClientId, NetworkManager.ServerClientId);
+                m_Obj = InternalGetPlayerObject(NetworkManager.ServerClientId, NetworkManager.ServerClientId);
             }
             else
             {
-                m_Obj = GetPlayerObject(1, 1);
+                m_Obj = InternalGetPlayerObject(1, 1);
             }
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
@@ -935,7 +935,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
         }
     }
 
-    [Timeout(1200000)] // Tracked in MTT-11359
+    [Timeout(2400000)] // Extended time out
     [TestFixture(HostOrServer.Host)]
     [TestFixture(HostOrServer.Server)]
     internal class UniversalRpcGroupedTests : UniversalRpcTestsBase
@@ -1044,6 +1044,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             return MockSendC;
         }
 
+        [Timeout(900000)]
         [UnityTest]
         public IEnumerator RunGroupTestTypes([Values] TestTypes testType)
         {
@@ -1066,6 +1067,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             {
                 foreach (var sendTo in sendToValues)
                 {
+                    UnityEngine.Debug.Log($"[{testType}][{sendTo}]");
                     for (ulong objectOwner = 0; objectOwner <= numberOfClientsULong; objectOwner++)
                     {
                         for (ulong sender = 0; sender <= numberOfClientsULong; sender++)
@@ -1214,6 +1216,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             {
                 foreach (var defaultSendTo in sendToValues)
                 {
+                    UnityEngine.Debug.Log($"[{testType}][{defaultSendTo}]");
                     foreach (var overrideSendTo in sendToValues)
                     {
                         for (ulong objectOwner = 0; objectOwner <= numberOfClientsULong; objectOwner++)
@@ -1290,6 +1293,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             {
                 foreach (var defaultSendTo in sendToValues)
                 {
+                    UnityEngine.Debug.Log($"[{testType}][{defaultSendTo}]");
                     foreach (var sendGroup in recipientGroups)
                     {
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
@@ -1724,41 +1724,37 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
         }
 
         [UnityTest]
-        public IEnumerator TestSendingWithSingleOverride()
+        public IEnumerator TestSendingWithSingleOverride([Values(SendTo.Everyone, SendTo.Me, SendTo.Owner, SendTo.Server, SendTo.NotMe, SendTo.NotOwner, SendTo.NotServer, SendTo.ClientsAndHost)] SendTo defaultSendTo)
         {
-            foreach (var defaultSendTo in Enum.GetValues(typeof(SendTo)))
+            for (ulong recipient = 0u; recipient <= 2u; ++recipient)
             {
-                for (ulong recipient = 0u; recipient <= 2u; ++recipient)
+                for (ulong objectOwner = 0u; objectOwner <= 2u; ++objectOwner)
                 {
-                    for (ulong objectOwner = 0u; objectOwner <= 2u; ++objectOwner)
+                    for (ulong sender = 0u; sender <= 2u; ++sender)
                     {
-                        for (ulong sender = 0u; sender <= 2u; ++sender)
+                        if (++YieldCheck % YieldCycleCount == 0)
                         {
-                            if (++YieldCheck % YieldCycleCount == 0)
-                            {
-                                yield return null;
-                            }
-                            OnInlineSetup();
-                            var sendMethodName = $"DefaultTo{defaultSendTo}AllowOverrideRpc";
-
-                            var senderObject = InternalGetPlayerObject(objectOwner, sender);
-                            var target = senderObject.RpcTarget.Single(recipient, RpcTargetUse.Temp);
-                            var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
-                            sendMethod.Invoke(senderObject, new object[] { (RpcParams)target });
-
-                            VerifyRemoteReceived(objectOwner, sender, sendMethodName, new[] { recipient }, false);
-                            VerifyNotReceived(objectOwner, s_ClientIds.Where(c => recipient != c).ToArray());
-
-                            // Pass some time to make sure that no other client ever receives this
-                            TimeTravel(1f, 30);
-                            VerifyNotReceived(objectOwner, s_ClientIds.Where(c => recipient != c).ToArray());
-                            OnInlineTearDown();
+                            yield return null;
                         }
+                        OnInlineSetup();
+                        var sendMethodName = $"DefaultTo{defaultSendTo}AllowOverrideRpc";
+
+                        var senderObject = InternalGetPlayerObject(objectOwner, sender);
+                        var target = senderObject.RpcTarget.Single(recipient, RpcTargetUse.Temp);
+                        var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
+                        sendMethod.Invoke(senderObject, new object[] { (RpcParams)target });
+
+                        VerifyRemoteReceived(objectOwner, sender, sendMethodName, new[] { recipient }, false);
+                        VerifyNotReceived(objectOwner, s_ClientIds.Where(c => recipient != c).ToArray());
+
+                        // Pass some time to make sure that no other client ever receives this
+                        TimeTravel(1f, 30);
+                        VerifyNotReceived(objectOwner, s_ClientIds.Where(c => recipient != c).ToArray());
+                        OnInlineTearDown();
                     }
                 }
             }
         }
-
     }
 
     [Timeout(1200000)] // Tracked in MTT-11359
@@ -1772,36 +1768,33 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
         }
 
         [UnityTest]
-        public IEnumerator TestSendingWithSingleNotOverride()
+        public IEnumerator TestSendingWithSingleNotOverride([Values(SendTo.Everyone, SendTo.Me, SendTo.Owner, SendTo.Server, SendTo.NotMe, SendTo.NotOwner, SendTo.NotServer, SendTo.ClientsAndHost)] SendTo defaultSendTo)
         {
-            foreach (var defaultSendTo in Enum.GetValues(typeof(SendTo)))
+            for (ulong recipient = 0u; recipient <= 2u; ++recipient)
             {
-                for (ulong recipient = 0u; recipient <= 2u; ++recipient)
+                for (ulong objectOwner = 0u; objectOwner <= 2u; ++objectOwner)
                 {
-                    for (ulong objectOwner = 0u; objectOwner <= 2u; ++objectOwner)
+                    for (ulong sender = 0u; sender <= 2u; ++sender)
                     {
-                        for (ulong sender = 0u; sender <= 2u; ++sender)
+                        if (++YieldCheck % YieldCycleCount == 0)
                         {
-                            if (++YieldCheck % YieldCycleCount == 0)
-                            {
-                                yield return null;
-                            }
-                            OnInlineSetup();
-                            var sendMethodName = $"DefaultTo{defaultSendTo}AllowOverrideRpc";
-
-                            var senderObject = InternalGetPlayerObject(objectOwner, sender);
-                            var target = senderObject.RpcTarget.Not(recipient, RpcTargetUse.Temp);
-                            var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
-                            sendMethod.Invoke(senderObject, new object[] { (RpcParams)target });
-
-                            VerifyRemoteReceived(objectOwner, sender, sendMethodName, s_ClientIds.Where(c => recipient != c).ToArray(), false);
-                            VerifyNotReceived(objectOwner, new[] { recipient });
-
-                            // Pass some time to make sure that no other client ever receives this
-                            TimeTravel(1f, 30);
-                            VerifyNotReceived(objectOwner, new[] { recipient });
-                            OnInlineTearDown();
+                            yield return null;
                         }
+                        OnInlineSetup();
+                        var sendMethodName = $"DefaultTo{defaultSendTo}AllowOverrideRpc";
+
+                        var senderObject = InternalGetPlayerObject(objectOwner, sender);
+                        var target = senderObject.RpcTarget.Not(recipient, RpcTargetUse.Temp);
+                        var sendMethod = senderObject.GetType().GetMethod(sendMethodName);
+                        sendMethod.Invoke(senderObject, new object[] { (RpcParams)target });
+
+                        VerifyRemoteReceived(objectOwner, sender, sendMethodName, s_ClientIds.Where(c => recipient != c).ToArray(), false);
+                        VerifyNotReceived(objectOwner, new[] { recipient });
+
+                        // Pass some time to make sure that no other client ever receives this
+                        TimeTravel(1f, 30);
+                        VerifyNotReceived(objectOwner, new[] { recipient });
+                        OnInlineTearDown();
                     }
                 }
             }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
@@ -947,8 +947,6 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             SendingNoOverride,
             SendingNoOverrideWithParams,
             SendingNoOverrideWithParamsAndRpcParams,
-            SendingWithGroupNotOverride,
-            SendingWithGroupOverride,
             SendingWithTargetOverride,
             TestRequireOwnership,
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/UniversalRpcTests.cs
@@ -953,6 +953,12 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             TestRequireOwnership,
         }
 
+        public enum TestTypesC
+        {
+            SendingWithGroupNotOverride,
+            SendingWithGroupOverride,
+        }
+
         private enum TestTables
         {
             ActionTableA,
@@ -962,12 +968,14 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
 
         private Dictionary<TestTypes, Action<SendTo, ulong, ulong>> m_TestTypeToActionTableA = new Dictionary<TestTypes, Action<SendTo, ulong, ulong>>();
         private Dictionary<TestTypes, Action<SendTo, SendTo, ulong, ulong>> m_TestTypeToActionTableB = new Dictionary<TestTypes, Action<SendTo, SendTo, ulong, ulong>>();
-        private Dictionary<TestTypes, Action<SendTo, ulong[], ulong, ulong, AllocationType>> m_TestTypeToActionTableC = new Dictionary<TestTypes, Action<SendTo, ulong[], ulong, ulong, AllocationType>>();
+        private Dictionary<TestTypesC, Action<SendTo, ulong[], ulong, ulong, AllocationType>> m_TestTypeToActionTableC = new Dictionary<TestTypesC, Action<SendTo, ulong[], ulong, ulong, AllocationType>>();
 
-
+        private delegate IEnumerator TestTypeHandler(TestTypes testType);
         private Dictionary<TestTypes, TestTables> m_TestTypesToTableTypes = new Dictionary<TestTypes, TestTables>();
         private Dictionary<TestTables, Action<TestTypes>> m_TableTypesToTestStartAction = new Dictionary<TestTables, Action<TestTypes>>();
-        private Dictionary<TestTypes, ulong[][]> m_TypeToRecipientGroupsTable = new Dictionary<TestTypes, ulong[][]>();
+
+
+        private Dictionary<TestTypesC, ulong[][]> m_TypeToRecipientGroupsTable = new Dictionary<TestTypesC, ulong[][]>();
 
         public UniversalRpcGroupedTests(HostOrServer hostOrServer) : base(hostOrServer)
         {
@@ -986,9 +994,8 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             m_TestTypeToActionTableB.Add(testType, action);
         }
 
-        private void AddTestTypeC(TestTypes testType, Action<SendTo, ulong[], ulong, ulong, AllocationType> action)
+        private void AddTestTypeC(TestTypesC testType, Action<SendTo, ulong[], ulong, ulong, AllocationType> action)
         {
-            m_TestTypesToTableTypes.Add(testType, TestTables.ActionTableC);
             m_TestTypeToActionTableC.Add(testType, action);
         }
 
@@ -997,7 +1004,6 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             // Create a look up table to know what kind of test table action will be invoked
             m_TableTypesToTestStartAction.Add(TestTables.ActionTableA, RunTestTypeA);
             m_TableTypesToTestStartAction.Add(TestTables.ActionTableB, RunTestTypeB);
-            m_TableTypesToTestStartAction.Add(TestTables.ActionTableC, RunTestTypeC);
 
             // Type A action registrations
             AddTestTypeA(TestTypes.DisallowedOverride, DisallowedOverride);
@@ -1011,10 +1017,10 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             AddTestTypeB(TestTypes.SendingWithTargetOverride, SendingWithTargetOverride);
 
             // Type C action registrations
-            AddTestTypeC(TestTypes.SendingWithGroupOverride, SendingWithGroupOverride);
-            m_TypeToRecipientGroupsTable.Add(TestTypes.SendingWithGroupOverride, RecipientGroupsA);
-            AddTestTypeC(TestTypes.SendingWithGroupNotOverride, SendingWithGroupNotOverride);
-            m_TypeToRecipientGroupsTable.Add(TestTypes.SendingWithGroupNotOverride, RecipientGroupsB);
+            AddTestTypeC(TestTypesC.SendingWithGroupOverride, SendingWithGroupOverride);
+            m_TypeToRecipientGroupsTable.Add(TestTypesC.SendingWithGroupOverride, RecipientGroupsA);
+            AddTestTypeC(TestTypesC.SendingWithGroupNotOverride, SendingWithGroupNotOverride);
+            m_TypeToRecipientGroupsTable.Add(TestTypesC.SendingWithGroupNotOverride, RecipientGroupsB);
         }
 
         private Action<SendTo, ulong, ulong> GetTestTypeActionA(TestTypes testType)
@@ -1035,7 +1041,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             return MockSendB;
         }
 
-        private Action<SendTo, ulong[], ulong, ulong, AllocationType> GetTestTypeActionC(TestTypes testType)
+        private Action<SendTo, ulong[], ulong, ulong, AllocationType> GetTestTypeActionC(TestTypesC testType)
         {
             if (m_TestTypeToActionTableC.ContainsKey(testType))
             {
@@ -1044,12 +1050,23 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             return MockSendC;
         }
 
-        [Timeout(900000)]
         [UnityTest]
         public IEnumerator RunGroupTestTypes([Values] TestTypes testType)
         {
             var testTypeToRun = m_TestTypesToTableTypes[testType];
             m_TableTypesToTestStartAction[testTypeToRun].Invoke(testType);
+            // Provide a small break to test runner in-between each test type
+            // since they are running all iterations of the legacy test type's
+            // values.
+            yield return s_DefaultWaitForTick;
+        }
+
+        [Timeout(900000)]
+        [UnityTest]
+        public IEnumerator RunGroupWithGroupOverridesTestTypes([Values] TestTypesC testType, [Values(SendTo.Everyone, SendTo.Me, SendTo.Owner, SendTo.Server, SendTo.NotMe, SendTo.NotOwner, SendTo.NotServer, SendTo.ClientsAndHost)] SendTo sendTo)
+        {
+            RunTestTypeC(testType, sendTo);
+
             // Provide a small break to test runner in-between each test type
             // since they are running all iterations of the legacy test type's
             // values.
@@ -1074,6 +1091,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
                         {
                             actionToInvoke.Invoke(sendTo, objectOwner, sender);
                             Clear();
+                            MockTransport.ClearQueues();
                         }
                     }
                 }
@@ -1225,6 +1243,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
                             {
                                 actionToInvoke.Invoke(defaultSendTo, overrideSendTo, objectOwner, sender);
                                 Clear();
+                                MockTransport.ClearQueues();
                             }
                         }
                     }
@@ -1282,38 +1301,34 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             List
         }
 
-        private void RunTestTypeC(TestTypes testType)
+        private void RunTestTypeC(TestTypesC testType, SendTo defaultSendTo)
         {
-            var sendToValues = new List<SendTo>() { SendTo.Everyone, SendTo.Me, SendTo.Owner, SendTo.Server, SendTo.NotMe, SendTo.NotOwner, SendTo.NotServer, SendTo.ClientsAndHost };
             var allocationTypes = new List<AllocationType>() { AllocationType.Array, AllocationType.NativeArray, AllocationType.NativeList, AllocationType.List };
             var numberOfClientsULong = (ulong)NumberOfClients;
             var actionToInvoke = GetTestTypeActionC(testType);
             var recipientGroups = m_TypeToRecipientGroupsTable[testType];
-            try
+            foreach (var sendGroup in recipientGroups)
             {
-                foreach (var defaultSendTo in sendToValues)
+                try
                 {
-                    UnityEngine.Debug.Log($"[{testType}][{defaultSendTo}]");
-                    foreach (var sendGroup in recipientGroups)
+                    for (ulong objectOwner = 0; objectOwner <= numberOfClientsULong; objectOwner++)
                     {
-
-                        for (ulong objectOwner = 0; objectOwner <= numberOfClientsULong; objectOwner++)
+                        for (ulong sender = 0; sender <= numberOfClientsULong; sender++)
                         {
-                            for (ulong sender = 0; sender <= numberOfClientsULong; sender++)
+                            foreach (var allocationType in allocationTypes)
                             {
-                                foreach (var allocationType in allocationTypes)
-                                {
-                                    actionToInvoke.Invoke(defaultSendTo, sendGroup, objectOwner, sender, allocationType);
-                                    Clear();
-                                }
+                                actionToInvoke.Invoke(defaultSendTo, sendGroup, objectOwner, sender, allocationType);
+                                TimeTravel(s_DefaultWaitForTick.waitTime, 4);
+                                Clear();
+                                MockTransport.ClearQueues();
                             }
                         }
                     }
                 }
-            }
-            catch (Exception ex)
-            {
-                Assert.Fail($"Threw Exception:{ex.Message}!\n{ex.StackTrace}");
+                catch (Exception ex)
+                {
+                    Assert.Fail($"Threw Exception:{ex.Message}!\n{ex.StackTrace}");
+                }
             }
         }
 

--- a/testproject/ProjectSettings/ProjectSettings.asset
+++ b/testproject/ProjectSettings/ProjectSettings.asset
@@ -51,7 +51,7 @@ PlayerSettings:
   m_MTRendering: 1
   mipStripping: 0
   numberOfMipsStripped: 0
-  m_StackTraceTypes: 010000000100000001000000010000000100000001000000
+  m_StackTraceTypes: 010000000100000001000000000000000100000001000000
   iosShowActivityIndicatorOnLoading: -1
   androidShowActivityIndicatorOnLoading: -1
   iosUseCustomAppBackgroundBehavior: 0


### PR DESCRIPTION
This PR condenses the total number of tests from roughly ~10k down to ~3.5k by grouping like test types and migrating all `[Values]` decorated parameters to local properties. 

**This helps to reduce:**
- The time spent setting up and tearing down a test for each unique parameter value combination.
- The time spent starting and stopping NetworkManagers.
- The total number of tests is more than cut in half.
  - _There is a known limitation with 2021 & 2022 TestRunner where reaching/exceed the 8-10k total tests count range can start to impact performance._

## Changelog

NA

## Testing and Documentation

- Includes some `UniversalRpcTests` refactoring.
- Includes new `UniversalRpcGroupedTests`.
- Includes commenting out all legacy tests that were migrated into `UniversalRpcGroupedTests`.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Backport
This most likely could be up-ported to v2.x, but for the time being this should be reviewed merged for the v1.14.0 release.

<!-- If this is a backport:
 - Add the following to the PR title: "\[Backport\] ..." .
 - Link to the original PR.
If this needs a backport - state this here
If a backport is not needed please provide the reason why.
If the "Backports" section is not present it will lead to a CI test failure. 
-->