### PR TITLE
fix: Replaced HashSet.UnionWith() with loop in NetworkBehaviourUpdate() to avoid heap alloc

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
@@ -34,7 +34,10 @@ namespace Unity.Netcode
 #endif
             try
             {
-                m_DirtyNetworkObjects.UnionWith(m_PendingDirtyNetworkObjects);
+                foreach (var o in m_PendingDirtyNetworkObjects)
+                {
+                    m_DirtyNetworkObjects.Add(o);
+                }
                 m_PendingDirtyNetworkObjects.Clear();
 
                 // NetworkObject references can become null, when hidden or despawned. Once NUll, there is no point


### PR DESCRIPTION
Discovered while profiling a server that had frequent pending dirty network objects to process

## Changelog

Fixed: Removed heap alloc in NetworkBehaviourUpdate

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

## Backport