### PR TITLE
feat: add `AsNativeArray()` read‑only accessor to `NetworkList<T>

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -632,6 +632,18 @@ namespace Unity.Netcode
             }
         }
 
+        /// <summary>
+        /// Returns the contents of the NetworkList as a read-only NativeArray.
+        /// </summary>
+        /// <remarks>
+        /// This method returns the list contents as a NativeArray.ReadOnly. Be careful with the lifetime of the NativeArray.
+        /// </remarks>
+        /// <returns>A read-only NativeArray of the list contents.</returns>
+        public NativeArray<T>.ReadOnly AsNativeArray()
+        {
+            return m_List.AsReadOnly();
+        }
+
         private void HandleAddListEvent(NetworkListEvent<T> listEvent)
         {
             m_DirtyEvents.Add(listEvent);

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -633,12 +633,20 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// Returns the contents of the NetworkList as a read-only NativeArray.
+        /// Gets a **zero‑allocation**, read‑only
+        /// <see cref="Unity.Collections.NativeArray{T}.ReadOnly"/> view over the current
+        /// elements of this <see cref="NetworkList{T}"/>.
         /// </summary>
         /// <remarks>
-        /// This method returns the list contents as a NativeArray.ReadOnly. Be careful with the lifetime of the NativeArray.
+        /// The returned array stays valid **only until** the list is mutated (add, remove,
+        /// clear, resize) or the container is <see cref="Dispose()"/>d.  Continuing to use
+        /// it afterwards results in undefined behaviour; callers are responsible for
+        /// ensuring a safe lifetime.
         /// </remarks>
-        /// <returns>A read-only NativeArray of the list contents.</returns>
+        /// <returns>
+        /// A read‑only <see cref="Unity.Collections.NativeArray{T}.ReadOnly"/> that shares
+        /// the same backing memory as this list.
+        /// </returns>
         public NativeArray<T>.ReadOnly AsNativeArray()
         {
             return m_List.AsReadOnly();


### PR DESCRIPTION
This PR exposes the contents of a `NetworkList<T>` as a **read‑only `NativeArray<T>`**.  
It addresses the recurring need to interoperate efficiently with Burst‑compiled or `IJob`‑based code without paying the cost of element‑wise copies or allocations.  
The accessor simply forwards `m_List.AsReadOnly()`, preserving zero‑allocation semantics while respecting `NativeArray`’s lifetime constraints (call‑site must guarantee the list is not mutated or disposed).  
No behavioural changes are introduced—only a pure additive surface‑area expansion.  

## Changelog

### com.unity.netcode.gameobjects

* **Added**: `NetworkList<T>.AsNativeArray()` → returns the list contents as a `NativeArray<T>.ReadOnly`.

## Testing and Documentation

* No tests have been added. *(The method is a thin wrapper around an existing, fully‑tested Unity collection API.)*
* Includes documentation for a previously‑undocumented public API entry point (XML doc‑comment added inline).
