### PR TITLE
fix: connection approval cannot exceed mtu size

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -17,6 +17,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where NetworkConfig.ConnectionData could cause the ConnectionRequestMessage to exceed the transport's MTU size and would result in a buffer overflow error. (#3564)
 - Fixed regression issue in v2.x where `NetworkObject.GetNetworkBehaviourAtOrderIndex` was converted from public to internal. (#3541)
 - Fixed ensuring OnValueChanged callback is still triggered on the authority when a collection changes and then reverts to the previous value in the same frame. (#3539)
 - Fixed synchronizing the destroyGameObject parameter to clients for InScenePlaced network objects. (#3514)

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -635,7 +635,7 @@ namespace Unity.Netcode
                 }
             }
 
-            SendMessage(ref message, NetworkDelivery.ReliableSequenced, NetworkManager.ServerClientId);
+            SendMessage(ref message, NetworkDelivery.ReliableFragmentedSequenced, NetworkManager.ServerClientId);
             message.MessageVersions.Dispose();
         }
 


### PR DESCRIPTION
This PR resolves the issue where a `NetworkConfig.ConnectionData` that caused the `ConnectionRequestMessage` to exceed the transport's MTU size would result in a buffer overflow error by updating  `ConnectionRequestMessage` to use the `ReliableFragmentedSequenced` pipeline as opposed to the `ReliableSequenced` pipeline.

[MTTB-1467](https://jira.unity3d.com/browse/MTTB-1467)

## Changelog

- Fixed: issue where NetworkConfig.ConnectionData could cause the ConnectionRequestMessage to exceed the transport's MTU size and would result in a buffer overflow error.

## Testing and Documentation

- Includes modifications to `ConnectionApprovalTests` integration tests to use a > MTU size `NetworkConfig.ConnectionData`.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Backport

This needs to be back ported to the v1.x branch.

<!-- If this is a backport:
 - Add the following to the PR title: "\[Backport\] ..." .
 - Link to the original PR.
If this needs a backport - state this here
If a backport is not needed please provide the reason why.
If the "Backports" section is not present it will lead to a CI test failure. 
-->