### PR TITLE
fix: extended integrationtest run times [up-port #3560]

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageCorruptionTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Messaging/MessageCorruptionTests.cs
@@ -90,10 +90,13 @@ namespace Unity.Netcode.EditorTests
                             break;
                         }
                     case TypeOfCorruption.CorruptBytes:
-                        batchData.Seek(batchData.Length - 2);
-                        var currentByte = batchData.GetUnsafePtr()[0];
-                        batchData.WriteByteSafe((byte)(currentByte == 0 ? 1 : 0));
-                        MessageQueue.Add(batchData.ToArray());
+                        for (int i = 0; i < 4; i++)
+                        {
+                            var currentByte = batchData.GetUnsafePtr()[i];
+                            currentByte = (byte)((currentByte + 1) % 255);
+                            batchData.WriteByteSafe(currentByte);
+                            MessageQueue.Add(batchData.ToArray());
+                        }
                         break;
                     case TypeOfCorruption.Truncated:
                         batchData.Truncate(batchData.Length - 1);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportTests.cs
@@ -51,6 +51,7 @@ namespace Unity.Netcode.RuntimeTests
 
                 // Need to destroy the GameObject (all assigned components will get destroyed too)
                 UnityEngine.Object.DestroyImmediate(m_Server.gameObject);
+                m_Server = null;
             }
 
             if (m_Client1)
@@ -59,6 +60,7 @@ namespace Unity.Netcode.RuntimeTests
 
                 // Need to destroy the GameObject (all assigned components will get destroyed too)
                 UnityEngine.Object.DestroyImmediate(m_Client1.gameObject);
+                m_Client1 = null;
             }
 
             if (m_Client2)
@@ -67,6 +69,7 @@ namespace Unity.Netcode.RuntimeTests
 
                 // Need to destroy the GameObject (all assigned components will get destroyed too)
                 UnityEngine.Object.DestroyImmediate(m_Client2.gameObject);
+                m_Client2 = null;
             }
             m_ServerEvents?.Clear();
             m_Client1Events?.Clear();
@@ -317,7 +320,7 @@ namespace Unity.Netcode.RuntimeTests
             m_Server.StartServer();
             m_Client1.StartClient();
 
-            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_Client1Events);
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_Client1Events, 5.0f);
 
             var serverClientId = m_Client1.ServerClientId;
 


### PR DESCRIPTION
Up-porting some of the fixes and optimizations applied to v1.14.0 branch.

The total test count prior to optimizations:
<img width="641" height="642" alt="image" src="https://github.com/user-attachments/assets/d45a0b22-a9ae-4674-b176-ec25646503ae" />

The total test count after optimizations:
<img width="638" height="635" alt="image" src="https://github.com/user-attachments/assets/632897f6-9381-42b3-b5d0-b83e9e06cda9" />


## Changelog

NA

## Testing and Documentation

- Includes integration test fixes and refactoring.
- No documentation changes or additions were necessary.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater] was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Backport
This is the up-port of #3560.

<!-- If this is a backport:
 - Add the following to the PR title: "\[Backport\] ..." .
 - Link to the original PR.
If this needs a backport - state this here
If a backport is not needed please provide the reason why.
If the "Backports" section is not present it will lead to a CI test failure. 
-->