### PR TITLE
feat: add `AsNativeArray()` read‑only accessor to `NetworkList<T>`

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,6 +10,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
+- Added `AsNativeArray()` read‑only accessor to `NetworkList<T>` (#3567)
 - Added serializer for `Pose` (#3546)
 - Added methods `GetDefaultNetworkSettings` and `GetDefaultPipelineConfigurations` to `UnityTransport`. These can be used to retrieve the default settings and pipeline stages that are used by `UnityTransport`. This is useful when providing a custom driver constructor through `UnityTransport.s_DriverConstructor`, since it allows reusing or tuning the existing configuration instead of trying to recreate it. This means a transport with a custom driver can now easily benefit from most of the features of `UnityTransport`, like integration with the Network Simulator and Network Profiler from the multiplayer tools package. (#3501)
 - Added mappings between `ClientId` and `TransportId`. (#3516)

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -632,19 +632,17 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// Gets a **zero‑allocation**, read‑only
-        /// <see cref="Unity.Collections.NativeArray{T}.ReadOnly"/> view over the current
+        /// Gets a **zero‑allocation**, <see cref="NativeArray{T}.ReadOnly"/> view over the current
         /// elements of this <see cref="NetworkList{T}"/>.
         /// </summary>
         /// <remarks>
         /// The returned array stays valid **only until** the list is mutated (add, remove,
-        /// clear, resize) or the container is <see cref="Dispose()"/>d.  Continuing to use
-        /// it afterwards results in undefined behaviour; callers are responsible for
-        /// ensuring a safe lifetime.
+        /// clear, resize) or <see cref="Dispose()"/> is called on the container.  Continuing to use
+        /// the array after it is invalid will result in undefined behaviour;
+        /// callers are responsible for ensuring a safe lifetime.
         /// </remarks>
         /// <returns>
-        /// A read‑only <see cref="Unity.Collections.NativeArray{T}.ReadOnly"/> that shares
-        /// the same backing memory as this list.
+        /// A <see cref="NativeArray{T}.ReadOnly"/> reference that shares the same backing memory as this list.
         /// </returns>
         public NativeArray<T>.ReadOnly AsNativeArray()
         {

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -631,6 +631,18 @@ namespace Unity.Netcode
             }
         }
 
+        /// <summary>
+        /// Returns the contents of the NetworkList as a read-only NativeArray.
+        /// </summary>
+        /// <remarks>
+        /// This method returns the list contents as a NativeArray.ReadOnly. Be careful with the lifetime of the NativeArray.
+        /// </remarks>
+        /// <returns>A read-only NativeArray of the list contents.</returns>
+        public NativeArray<T>.ReadOnly AsNativeArray()
+        {
+            return m_List.AsReadOnly();
+        }
+
         private void HandleAddListEvent(NetworkListEvent<T> listEvent)
         {
             m_DirtyEvents.Add(listEvent);

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -632,12 +632,20 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// Returns the contents of the NetworkList as a read-only NativeArray.
+        /// Gets a **zero‑allocation**, read‑only
+        /// <see cref="Unity.Collections.NativeArray{T}.ReadOnly"/> view over the current
+        /// elements of this <see cref="NetworkList{T}"/>.
         /// </summary>
         /// <remarks>
-        /// This method returns the list contents as a NativeArray.ReadOnly. Be careful with the lifetime of the NativeArray.
+        /// The returned array stays valid **only until** the list is mutated (add, remove,
+        /// clear, resize) or the container is <see cref="Dispose()"/>d.  Continuing to use
+        /// it afterwards results in undefined behaviour; callers are responsible for
+        /// ensuring a safe lifetime.
         /// </remarks>
-        /// <returns>A read-only NativeArray of the list contents.</returns>
+        /// <returns>
+        /// A read‑only <see cref="Unity.Collections.NativeArray{T}.ReadOnly"/> that shares
+        /// the same backing memory as this list.
+        /// </returns>
         public NativeArray<T>.ReadOnly AsNativeArray()
         {
             return m_List.AsReadOnly();


### PR DESCRIPTION
Continues: #3562 from @harayuu9

This PR exposes the contents of a `NetworkList<T>` as a **read‑only `NativeArray<T>`**.  
It addresses the recurring need to interoperate efficiently with Burst‑compiled or `IJob`‑based code without paying the cost of element‑wise copies or allocations.  
The accessor simply forwards `m_List.AsReadOnly()`, preserving zero‑allocation semantics while respecting `NativeArray`’s lifetime constraints (call‑site must guarantee the list is not mutated or disposed).  
No behavioural changes are introduced—only a pure additive surface‑area expansion. 

## Changelog

- Added: `NetworkList<T>.AsNativeArray()` to return the list contents as a `NativeArray<T>.ReadOnly`.

## Testing and Documentation

- No tests have been added.
- Includes documentation for the newly added public API function.

## Backport

This adds new API surface area and so no backport is required.