### PR TITLE
fix: [UpPort] Replaced HashSet.UnionWith() with loop to avoid heap alloc

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -17,6 +17,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Removed allocation to the heap in NetworkBehaviourUpdate. (#3573)
 - Fixed issue where NetworkConfig.ConnectionData could cause the ConnectionRequestMessage to exceed the transport's MTU size and would result in a buffer overflow error. (#3564)
 - Fixed regression issue in v2.x where `NetworkObject.GetNetworkBehaviourAtOrderIndex` was converted from public to internal. (#3541)
 - Fixed ensuring OnValueChanged callback is still triggered on the authority when a collection changes and then reverts to the previous value in the same frame. (#3539)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
@@ -34,7 +34,10 @@ namespace Unity.Netcode
 #endif
             try
             {
-                m_DirtyNetworkObjects.UnionWith(m_PendingDirtyNetworkObjects);
+                foreach (var o in m_PendingDirtyNetworkObjects)
+                {
+                    m_DirtyNetworkObjects.Add(o);
+                }
                 m_PendingDirtyNetworkObjects.Clear();
 
                 // NetworkObject references can become null, when hidden or despawned. Once NUll, there is no point

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
@@ -34,9 +34,9 @@ namespace Unity.Netcode
 #endif
             try
             {
-                foreach (var o in m_PendingDirtyNetworkObjects)
+                foreach (var dirtyNetworkObject in m_PendingDirtyNetworkObjects)
                 {
-                    m_DirtyNetworkObjects.Add(o);
+                    m_DirtyNetworkObjects.Add(dirtyNetworkObject);
                 }
                 m_PendingDirtyNetworkObjects.Clear();
 


### PR DESCRIPTION
Discovered while profiling a server that had frequent pending dirty network objects to process

## Changelog

Fixed: Removed heap alloc in NetworkBehaviourUpdate

## Testing and Documentation

- No tests have been added.
- No documentation changes or additions were necessary.

## Backport
This is an up-port of #3568 