### PR TITLE
perf: Optimize NetworkList indexer setter performance

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -19,6 +19,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+- Optimized `NetworkList<T>` indexer setter to skip operations when the new value equals the existing value, improving performance by avoiding unnecessary list events and network synchronization. (#????)
+
 
 ## [2.5.0] - 2025-08-01
 

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -617,6 +617,13 @@ namespace Unity.Netcode
                 }
 
                 var previousValue = m_List[index];
+
+                // Compare the Value being applied to the current value
+                if (NetworkVariableSerialization<T>.AreEqual(ref previousValue, ref value))
+                {
+                    return;
+                }
+
                 m_List[index] = value;
 
                 var listEvent = new NetworkListEvent<T>()


### PR DESCRIPTION
This PR adds an equality check to the `NetworkList<T>` indexer setter, aligning its behavior with `NetworkVariable<T>.Value`. Since `NetworkList<T>` already constrains `T` to `IEquatable<T>`, this change is both safe and broadly applicable. It avoids redundant assignments when the new value is equal to the current value, which improves runtime efficiency and avoids unnecessary event dispatch and network synchronization.

## Changelog

### com.unity.netcode.gameobjects

- Changed: Optimized `NetworkList<T>` indexer setter to skip operations when the new value equals the existing value, improving performance by avoiding unnecessary list events and network synchronization.

## Testing and Documentation

- No documentation changes or additions were necessary.

## Backport

Not applicable.