### PR TITLE
chore: Fixing whitespace errors

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkRigidBodyBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkRigidBodyBase.cs
@@ -416,7 +416,7 @@ namespace Unity.Netcode.Components
             }
 #endif
 #if COM_UNITY_MODULES_PHYSICS && !COM_UNITY_MODULES_PHYSICS2D
-           return m_InternalRigidbody.angularVelocity;
+            return m_InternalRigidbody.angularVelocity;
 #endif
 #if !COM_UNITY_MODULES_PHYSICS && COM_UNITY_MODULES_PHYSICS2D
             return Vector3.forward * m_InternalRigidbody2D.angularVelocity;


### PR DESCRIPTION
## Purpose of this PR
This PR aims to fix failures of **Standards Check - NGO minimalproject [ubuntu, trunk]** noticed on `#ngo-test-failures` since it will block PRs from merging.

This issue was introduced in https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3422 and wasn't detected since on PRs we require **Standards Check - NGO testproject [ubuntu, trunk]** to pass and apparently it's not using the Physics package so this part of the code was not covered by standards check. Physics module is included in minimalproject in which on weekly trigger this issue was flagged 

### Jira ticket
Too small task, not applicable

## Documentation
No documentation changes or additions were necessary.

## Testing & QA
Test was run and passed

## Backport
The issue is related to `develop-2.0.0` only