### PR TITLE
fix: [Backport] Correct error message about send queue being full

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -61,7 +61,7 @@ namespace Unity.Netcode.Transports.UTP
         private static readonly FixedString128Bytes k_NetworkVersionMismatch = "Connection ID is invalid. Likely caused by sending on stale connection {0}.";
         private static readonly FixedString128Bytes k_NetworkStateMismatch = "Connection state is invalid. Likely caused by sending on connection {0} which is stale or still connecting.";
         private static readonly FixedString128Bytes k_NetworkPacketOverflow = "Packet is too large to be allocated by the transport.";
-        private static readonly FixedString128Bytes k_NetworkSendQueueFull = "Unable to queue packet in the transport. Likely caused by send queue size ('Max Send Queue Size') being too small.";
+        private static readonly FixedString128Bytes k_NetworkSendQueueFull = "Unable to queue packet in the transport. Likely caused by packet queue size ('Max Packet Queue Size') being too small.";
 
         /// <summary>
         /// Convert a UTP error code to human-readable error message.


### PR DESCRIPTION
## Purpose of this PR

Backport of PR #3593.

### Changelog

Didn't seem worthy of a changelog entry. Can add one if requested.

## Documentation

No documentation changes necessary.

## Testing & QA

No need to test anything. It's just a string change.

## Backport
https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3593