### PR TITLE
chore: install protocol buffer before building service

### DIFF
--- a/Tools/CI/run_cmb_service.sh
+++ b/Tools/CI/run_cmb_service.sh
@@ -60,6 +60,36 @@ echo "Starting with echo server on port: $echo_port and the cmb service on port:
 
 # Setup -------------------------------------------------------------------------
 
+# Protocol Buffer Compiler ------------------------------------------------------
+
+# Install Protocol Buffer Compiler (1st attempt)
+# apt-get install -y protobuf-compiler
+
+# Download the protocol buffer release for linux
+echo "Downloading protocol bufffer compiler..."
+PB_REL="https://github.com/protocolbuffers/protobuf/releases"
+curl -LO $PB_REL/download/v31.1/protoc-31.1-linux-x86_64.zip
+
+# Create target folder to unzip protoc binaries.
+echo "Creating protocol bufffer folder..."
+mkdir -p protoc
+protoc_path="./protoc"
+folder_path=$(realpath "$protoc_path")
+
+echo "Folder path of protoc: $folder_path"
+echo "Unzipping to $folder_path"
+
+# extract binaries to protoc folder
+unzip protoc-31.1-linux-x86_64.zip -d ./protoc
+
+# Add the Protocol Buffer Compiler install PROTOC 
+export PROTOC="$folder_path"
+echo "Set PROTOC = $folder_path"
+
+# Add the Protocol Buffer Compiler install location to the path
+export PATH="$folder_path:$PATH"
+echo "Set PATH = $PATH"
+
 # clone the cmb service repo
 git clone https://github.com/Unity-Technologies/mps-common-multiplayer-backend.git
 # navigate to the cmb service directory
@@ -68,18 +98,8 @@ cd ./mps-common-multiplayer-backend/runtime
 # Install rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
-# Install Protocol Buffer Compiler
-apt-get install -y protobuf-compiler
-
-# Add the Protocol Buffer Compiler install PROTOC 
-export PROTOC="$HOME/.local/bin/protoc"
-
-# Add the Protocol Buffer Compiler install location to the path
-export PATH="$HOME/.local/bin:$PATH"
-
 # Add the cargo bin directory to the PATH
 export PATH="$HOME/.cargo/bin:$PATH"
-
 
 # Echo server -------------------------------------------------------------------
 
@@ -87,7 +107,6 @@ export PATH="$HOME/.cargo/bin:$PATH"
 cargo build --example ngo_echo_server
 # Run the echo server in the background
 cargo run --example ngo_echo_server -- --port $echo_port &
-
 
 # CMB Service -------------------------------------------------------------------
 

--- a/Tools/CI/run_cmb_service.sh
+++ b/Tools/CI/run_cmb_service.sh
@@ -67,6 +67,10 @@ cd ./mps-common-multiplayer-backend/runtime
 
 # Install rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+# Install ProtoBuffer Compiler
+apt install -y protobuf-compiler
+
 # Add the cargo bin directory to the PATH
 export PATH="$HOME/.cargo/bin:$PATH"
 

--- a/Tools/CI/run_cmb_service.sh
+++ b/Tools/CI/run_cmb_service.sh
@@ -61,17 +61,19 @@ echo "Starting with echo server on port: $echo_port and the cmb service on port:
 # Setup -------------------------------------------------------------------------
 
 try() {
-   export ThrewError = false
+   BASH_COMMAND = "$@"
+   ThrewError = false
   "$@" || throw
 }
 
 throw() {
-  echo "An error occurred in: $BASH_COMMAND"
-  export ThrewError = true
+  echo "An error occurred executing this command: $BASH_COMMAND \n"
+  ThrewError = true
 }
 
 # Protocol Buffer Compiler ------------------------------------------------------
 
+# Apply any updates 
 echo "Updating modules..."
 sudo apt-get update
 
@@ -79,34 +81,40 @@ sudo apt-get update
 echo "(sudo) Installing protocol bufffer compiler..."
 try sudo apt-get install -y protobuf-compiler
 
+# If the previous command failed, try without sudo
 if $ThrewError; then
-echo "Installing protocol bufffer compiler..."
+echo "(retry no sudo) Installing protocol bufffer compiler..."
 apt-get install -y protobuf-compiler
+else
+echo "Installed using sudo!"
 fi
 
 # Add the PROTOC environment variable for Protocol Buffer Compiler
-try sudo export PROTOC="/usr/bin/protoc"
+export PROTOC=which protoc
+
+# Use the PROTOC env var to see if it is correct by getting the protoc version
+try $PROTOC/protoc --version
+
+# If that failed, then the path is incorrect. Try using the next possible path
 if $ThrewError; then
 export PROTOC="/usr/bin/protoc"
+# Use the PROTOC env var to see if it is correct by getting the protoc version
+try $PROTOC/protoc --version
 fi
-echo "Set PROTOC = $PROTOC"
 
-try $PROTOC/protoc --version
-
+# If that failed, then the path is incorrect. Try using the next possible path
 if $ThrewError; then
-export PROTOC=which protoc
+export PROTOC="/usr/bin"
+# Use the PROTOC env var to see if it is correct by getting the protoc version
 try $PROTOC/protoc --version
+fi
+
 if $ThrewError; then
 echo "Failed to properly run protoc!"
 exit -1
+else
+echo "Protocol Buffer Compiler Installed & ENV variables verified!\n PROTOC path is: $PROTOC"
 fi
-echo "PROTOC path is: $PROTOC"
-
-
-
-# Add the Protocol Buffer Compiler install location to the PATH
-export PATH="$PROTOC:$PATH"
-echo "\n Set PATH = $PATH"
 
 # Download the protocol buffer release for linux
 # echo "Downloading protocol bufffer compiler..."

--- a/Tools/CI/run_cmb_service.sh
+++ b/Tools/CI/run_cmb_service.sh
@@ -60,15 +60,15 @@ echo "Starting with echo server on port: $echo_port and the cmb service on port:
 
 # Setup -------------------------------------------------------------------------
 
+ThrewError=false
 try() {
-   BASH_COMMAND = "$@"
-   ThrewError = false
-  "$@" || throw
+   ThrewError=false
+  "$@" || throw "$@"
 }
 
 throw() {
-  echo "An error occurred executing this command: $BASH_COMMAND \n"
-  ThrewError = true
+  echo "An error occurred executing this command:$@ \n"
+  ThrewError=true
 }
 
 # Protocol Buffer Compiler ------------------------------------------------------
@@ -90,17 +90,10 @@ echo "Installed using sudo!"
 fi
 
 # Add the PROTOC environment variable for Protocol Buffer Compiler
-export PROTOC=which protoc
-
-# Use the PROTOC env var to see if it is correct by getting the protoc version
-try $PROTOC/protoc --version
-
-# If that failed, then the path is incorrect. Try using the next possible path
-if $ThrewError; then
 export PROTOC="/usr/bin/protoc"
+
 # Use the PROTOC env var to see if it is correct by getting the protoc version
 try $PROTOC/protoc --version
-fi
 
 # If that failed, then the path is incorrect. Try using the next possible path
 if $ThrewError; then

--- a/Tools/CI/run_cmb_service.sh
+++ b/Tools/CI/run_cmb_service.sh
@@ -82,8 +82,7 @@ echo "Unzipping to folder path of protoc: $folder_path"
 unzip protoc-31.1-linux-x86_64.zip -d $folder_path
 
 # changing the execute permissions of the protoc folder
-chmod +x ./protoc
-chmod +x ./protoc/bin
+chmod -R 755 ./protoc
 
 # Add the PROTOC environment variable for Protocol Buffer Compiler
 export PROTOC="$folder_path/bin"

--- a/Tools/CI/run_cmb_service.sh
+++ b/Tools/CI/run_cmb_service.sh
@@ -62,35 +62,47 @@ echo "Starting with echo server on port: $echo_port and the cmb service on port:
 
 # Protocol Buffer Compiler ------------------------------------------------------
 
-# Install Protocol Buffer Compiler (1st attempt)
-# apt-get install -y protobuf-compiler
+echo "Updating modules..."
+apt-get update
 
-# Download the protocol buffer release for linux
-echo "Downloading protocol bufffer compiler..."
-PB_REL="https://github.com/protocolbuffers/protobuf/releases"
-curl -LO $PB_REL/download/v31.1/protoc-31.1-linux-x86_64.zip
-
-# Create target folder to unzip protoc binaries.
-echo "Creating protocol bufffer folder..."
-mkdir -p protoc
-protoc_path="./protoc"
-folder_path=$(realpath "$protoc_path")
-
-echo "Unzipping to folder path of protoc: $folder_path"
-
-# extract binaries to protoc folder
-unzip protoc-31.1-linux-x86_64.zip -d $folder_path
-
-# changing the execute permissions of the protoc folder
-chmod -R 755 ./protoc
+# Install Protocol Buffer Compiler (using apt-get)
+echo "Installing protocol bufffer compiler..."
+apt-get install -y protobuf-compiler
 
 # Add the PROTOC environment variable for Protocol Buffer Compiler
-export PROTOC="$folder_path/bin"
+export PROTOC="/usr/bin/protoc"
 echo "Set PROTOC = $PROTOC"
 
 # Add the Protocol Buffer Compiler install location to the PATH
-export PATH="$folder_path/bin:$PATH"
+export PATH="$PROTOC:$PATH"
 echo "\n Set PATH = $PATH"
+
+# Download the protocol buffer release for linux
+# echo "Downloading protocol bufffer compiler..."
+# PB_REL="https://github.com/protocolbuffers/protobuf/releases"
+# curl -LO $PB_REL/download/v31.1/protoc-31.1-linux-x86_64.zip
+
+# Create target folder to unzip protoc binaries.
+# echo "Creating protocol bufffer folder..."
+# mkdir -p protoc
+# protoc_path="./protoc"
+# folder_path=$(realpath "$protoc_path")
+
+# echo "Unzipping to folder path of protoc: $folder_path"
+
+# extract binaries to protoc folder
+# unzip protoc-31.1-linux-x86_64.zip -d $folder_path
+
+# changing the execute permissions of the protoc folder
+# chmod -R 755 ./protoc
+
+# Add the PROTOC environment variable for Protocol Buffer Compiler
+# export PROTOC="$folder_path/bin"
+# echo "Set PROTOC = $PROTOC"
+
+# Add the Protocol Buffer Compiler install location to the PATH
+# export PATH="$folder_path/bin:$PATH"
+# echo "\n Set PATH = $PATH"
 
 # clone the cmb service repo
 git clone https://github.com/Unity-Technologies/mps-common-multiplayer-backend.git

--- a/Tools/CI/run_cmb_service.sh
+++ b/Tools/CI/run_cmb_service.sh
@@ -93,14 +93,7 @@ fi
 export PROTOC="/usr/bin/protoc"
 
 # Use the PROTOC env var to see if it is correct by getting the protoc version
-try $PROTOC/protoc --version
-
-# If that failed, then the path is incorrect. Try using the next possible path
-if $ThrewError; then
-export PROTOC="/usr/bin"
-# Use the PROTOC env var to see if it is correct by getting the protoc version
-try $PROTOC/protoc --version
-fi
+try $PROTOC --version
 
 if $ThrewError; then
 echo "Failed to properly run protoc!"

--- a/Tools/CI/run_cmb_service.sh
+++ b/Tools/CI/run_cmb_service.sh
@@ -60,74 +60,65 @@ echo "Starting with echo server on port: $echo_port and the cmb service on port:
 
 # Setup -------------------------------------------------------------------------
 
+
 ThrewError=false
+
+# Mimics "Try-Catch" where you have to check if an error occurred after invoking
 try() {
    ThrewError=false
   "$@" || throw "$@"
 }
 
+# Invoked by try
 throw() {
-  echo "An error occurred executing this command:$@ \n"
-  ThrewError=true
+    logError "An error occurred executing this command:$@"
+    ThrewError=true
+}
+
+# A way to log messages that are easy to distinguish from the rest of the logs
+logMessage(){
+    printf "\n############################################\n"
+    printf "$@\n"
+    printf "############################################\n"
+}
+
+# A way to log error messages that are easy to distinguish from the rest of the logs
+logError(){
+    printf "\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+    printf "$@\n"
+    printf "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
 }
 
 # Protocol Buffer Compiler ------------------------------------------------------
 
 # Apply any updates 
-echo "Updating modules..."
+logMessage "Updating modules..."
 sudo apt-get update
 
 # Install Protocol Buffer Compiler (using apt-get)
-echo "(sudo) Installing protocol bufffer compiler..."
+logMessage "Installing protocol bufffer compiler as SUDO..."
 try sudo apt-get install -y protobuf-compiler
 
 # If the previous command failed, try without sudo
 if $ThrewError; then
-echo "(retry no sudo) Installing protocol bufffer compiler..."
+logMessage "Installing protocol bufffer compiler as shell assigned account..."
 apt-get install -y protobuf-compiler
 else
-echo "Installed using sudo!"
+logMessage "Protocol bufffer compiler was installed as sudo!"
 fi
 
-# Add the PROTOC environment variable for Protocol Buffer Compiler
+# Add the PROTOC environment variable that points to the Protocol Buffer Compiler binary
 export PROTOC="/usr/bin/protoc"
 
-# Use the PROTOC env var to see if it is correct by getting the protoc version
+# Validate the PROTOC env var by getting the protoc version
 try $PROTOC --version
 
 if $ThrewError; then
-echo "Failed to properly run protoc!"
+logError "Failed to properly run protoc!"
 exit -1
 else
-echo "Protocol Buffer Compiler Installed & ENV variables verified!\n PROTOC path is: $PROTOC"
+logMessage "Protocol Buffer Compiler Installed & ENV variables verified!\n PROTOC path is: $PROTOC"
 fi
-
-# Download the protocol buffer release for linux
-# echo "Downloading protocol bufffer compiler..."
-# PB_REL="https://github.com/protocolbuffers/protobuf/releases"
-# curl -LO $PB_REL/download/v31.1/protoc-31.1-linux-x86_64.zip
-
-# Create target folder to unzip protoc binaries.
-# echo "Creating protocol bufffer folder..."
-# mkdir -p protoc
-# protoc_path="./protoc"
-# folder_path=$(realpath "$protoc_path")
-
-# echo "Unzipping to folder path of protoc: $folder_path"
-
-# extract binaries to protoc folder
-# unzip protoc-31.1-linux-x86_64.zip -d $folder_path
-
-# changing the execute permissions of the protoc folder
-# chmod -R 755 ./protoc
-
-# Add the PROTOC environment variable for Protocol Buffer Compiler
-# export PROTOC="$folder_path/bin"
-# echo "Set PROTOC = $PROTOC"
-
-# Add the Protocol Buffer Compiler install location to the PATH
-# export PATH="$folder_path/bin:$PATH"
-# echo "\n Set PATH = $PATH"
 
 # clone the cmb service repo
 git clone https://github.com/Unity-Technologies/mps-common-multiplayer-backend.git

--- a/Tools/CI/run_cmb_service.sh
+++ b/Tools/CI/run_cmb_service.sh
@@ -60,18 +60,49 @@ echo "Starting with echo server on port: $echo_port and the cmb service on port:
 
 # Setup -------------------------------------------------------------------------
 
+try() {
+   export ThrewError = false
+  "$@" || throw
+}
+
+throw() {
+  echo "An error occurred in: $BASH_COMMAND"
+  export ThrewError = true
+}
+
 # Protocol Buffer Compiler ------------------------------------------------------
 
 echo "Updating modules..."
-apt-get update
+sudo apt-get update
 
 # Install Protocol Buffer Compiler (using apt-get)
+echo "(sudo) Installing protocol bufffer compiler..."
+try sudo apt-get install -y protobuf-compiler
+
+if $ThrewError; then
 echo "Installing protocol bufffer compiler..."
 apt-get install -y protobuf-compiler
+fi
 
 # Add the PROTOC environment variable for Protocol Buffer Compiler
+try sudo export PROTOC="/usr/bin/protoc"
+if $ThrewError; then
 export PROTOC="/usr/bin/protoc"
+fi
 echo "Set PROTOC = $PROTOC"
+
+try $PROTOC/protoc --version
+
+if $ThrewError; then
+export PROTOC=which protoc
+try $PROTOC/protoc --version
+if $ThrewError; then
+echo "Failed to properly run protoc!"
+exit -1
+fi
+echo "PROTOC path is: $PROTOC"
+
+
 
 # Add the Protocol Buffer Compiler install location to the PATH
 export PATH="$PROTOC:$PATH"

--- a/Tools/CI/run_cmb_service.sh
+++ b/Tools/CI/run_cmb_service.sh
@@ -68,8 +68,11 @@ cd ./mps-common-multiplayer-backend/runtime
 # Install rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
-# Install ProtoBuffer Compiler
+# Install Protocol Buffer Compiler
 apt-get install -y protobuf-compiler
+
+# Add the Protocol Buffer Compiler install location to the path
+export PATH="$HOME/.local/bin:$PATH"
 
 # Add the cargo bin directory to the PATH
 export PATH="$HOME/.cargo/bin:$PATH"

--- a/Tools/CI/run_cmb_service.sh
+++ b/Tools/CI/run_cmb_service.sh
@@ -69,7 +69,7 @@ cd ./mps-common-multiplayer-backend/runtime
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 # Install ProtoBuffer Compiler
-apt install -y protobuf-compiler
+apt-get install -y protobuf-compiler
 
 # Add the cargo bin directory to the PATH
 export PATH="$HOME/.cargo/bin:$PATH"

--- a/Tools/CI/run_cmb_service.sh
+++ b/Tools/CI/run_cmb_service.sh
@@ -85,16 +85,17 @@ unzip protoc-31.1-linux-x86_64.zip -d $folder_path
 chmod +x ./protoc
 chmod +x ./protoc/bin
 
-# Add the Protocol Buffer Compiler install PROTOC 
+# Add the PROTOC environment variable for Protocol Buffer Compiler
 export PROTOC="$folder_path/bin"
 echo "Set PROTOC = $PROTOC"
 
-# Add the Protocol Buffer Compiler install location to the path
+# Add the Protocol Buffer Compiler install location to the PATH
 export PATH="$folder_path/bin:$PATH"
 echo "\n Set PATH = $PATH"
 
 # clone the cmb service repo
 git clone https://github.com/Unity-Technologies/mps-common-multiplayer-backend.git
+
 # navigate to the cmb service directory
 cd ./mps-common-multiplayer-backend/runtime
 
@@ -105,7 +106,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 export PATH="$HOME/.cargo/bin:$PATH"
 
 # Echo server -------------------------------------------------------------------
-
+echo "Beginning build..."
 # Build the echo server
 cargo build --example ngo_echo_server
 # Run the echo server in the background

--- a/Tools/CI/run_cmb_service.sh
+++ b/Tools/CI/run_cmb_service.sh
@@ -76,19 +76,22 @@ mkdir -p protoc
 protoc_path="./protoc"
 folder_path=$(realpath "$protoc_path")
 
-echo "Folder path of protoc: $folder_path"
-echo "Unzipping to $folder_path"
+echo "Unzipping to folder path of protoc: $folder_path"
 
 # extract binaries to protoc folder
-unzip protoc-31.1-linux-x86_64.zip -d ./protoc
+unzip protoc-31.1-linux-x86_64.zip -d $folder_path
+
+# changing the execute permissions of the protoc folder
+chmod +x ./protoc
+chmod +x ./protoc/bin
 
 # Add the Protocol Buffer Compiler install PROTOC 
-export PROTOC="$folder_path"
-echo "Set PROTOC = $folder_path"
+export PROTOC="$folder_path/bin"
+echo "Set PROTOC = $PROTOC"
 
 # Add the Protocol Buffer Compiler install location to the path
-export PATH="$folder_path:$PATH"
-echo "Set PATH = $PATH"
+export PATH="$folder_path/bin:$PATH"
+echo "\n Set PATH = $PATH"
 
 # clone the cmb service repo
 git clone https://github.com/Unity-Technologies/mps-common-multiplayer-backend.git

--- a/Tools/CI/run_cmb_service.sh
+++ b/Tools/CI/run_cmb_service.sh
@@ -71,6 +71,9 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 # Install Protocol Buffer Compiler
 apt-get install -y protobuf-compiler
 
+# Add the Protocol Buffer Compiler install PROTOC 
+export PROTOC="$HOME/.local/bin/protoc"
+
 # Add the Protocol Buffer Compiler install location to the path
 export PATH="$HOME/.local/bin:$PATH"
 

--- a/Tools/CI/run_cmb_service.sh
+++ b/Tools/CI/run_cmb_service.sh
@@ -133,20 +133,25 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 export PATH="$HOME/.cargo/bin:$PATH"
 
 # Echo server -------------------------------------------------------------------
-echo "Beginning build..."
+
 # Build the echo server
+logMessage "Beginning echo server build..."
 cargo build --example ngo_echo_server
+
 # Run the echo server in the background
+logMessage "Running echo server tests..."
 cargo run --example ngo_echo_server -- --port $echo_port &
 
 # CMB Service -------------------------------------------------------------------
 
 # Build a release version of the standalone cmb service
+logMessage "Beginning service release build..."
 cargo build --release --locked
 
 # Run the standalone service on an infinite loop in the background.
 # The infinite loop is required as the service will exit each time all connected clients disconnect.
 # This means the service will exit after each test. The infinite loop will immediately restart the service each time it exits.
+logMessage "Running service integration tests..."
 while :; do
   ./target/release/comb-server -l error --metrics-port 5000 standalone --port $service_port -t 60m;
 done & # <- use & to run the entire loop in the background


### PR DESCRIPTION
## Purpose of this PR

The most recent service update added a dependency to the protocol buffer compiler. This PR adds the protocol buffer driver to the CI DA service build script.

### Jira ticket
NA

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation

- No documentation changes or additions were necessary.

## Testing & QA
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [X] `Manual testing done`
  - Via back-end CI.

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?

If any boxes above are checked, please add QA as a PR reviewer.

## Backport
No back port is required (a v2.x.x only update)