### PR TITLE
chore: 6000.3.0a6 updates

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Components/RigidbodyContactEventManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/RigidbodyContactEventManager.cs
@@ -374,7 +374,7 @@ namespace Unity.Netcode.Components
 
                 var result = new JobResultStruct()
                 {
-#if CONTACTPAIRHEADER_OTHERBODYENTITYID
+#if UNITY_6000_3_0A6_OR_HIGHER
                     ThisInstanceID = PairedHeaders[index].bodyEntityId,
                     OtherInstanceID = PairedHeaders[index].otherBodyEntityId,
 #else

--- a/com.unity.netcode.gameobjects/Runtime/Components/RigidbodyContactEventManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/RigidbodyContactEventManager.cs
@@ -375,7 +375,11 @@ namespace Unity.Netcode.Components
                 var result = new JobResultStruct()
                 {
                     ThisInstanceID = PairedHeaders[index].bodyInstanceID,
+#if CONTACTPAIRHEADER_OTHERBODYENTITYID
+                    OtherInstanceID = PairedHeaders[index].otherBodyEntityId,
+#else
                     OtherInstanceID = PairedHeaders[index].otherBodyInstanceID,
+#endif
                     AverageNormal = averageNormal,
                     HasCollisionStay = collisionStaycount != 0,
                     AverageCollisionStayNormal = averageCollisionStay,

--- a/com.unity.netcode.gameobjects/Runtime/Components/RigidbodyContactEventManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/RigidbodyContactEventManager.cs
@@ -374,10 +374,11 @@ namespace Unity.Netcode.Components
 
                 var result = new JobResultStruct()
                 {
-                    ThisInstanceID = PairedHeaders[index].bodyInstanceID,
 #if CONTACTPAIRHEADER_OTHERBODYENTITYID
+                    ThisInstanceID = PairedHeaders[index].bodyEntityId,
                     OtherInstanceID = PairedHeaders[index].otherBodyEntityId,
 #else
+                    ThisInstanceID = PairedHeaders[index].bodyInstanceID,
                     OtherInstanceID = PairedHeaders[index].otherBodyInstanceID,
 #endif
                     AverageNormal = averageNormal,

--- a/com.unity.netcode.gameobjects/Runtime/Unity.Netcode.Runtime.asmdef
+++ b/com.unity.netcode.gameobjects/Runtime/Unity.Netcode.Runtime.asmdef
@@ -82,7 +82,7 @@
             "name": "Unity",
             "expression": "6000.3.0a6",
             "define": "CONTACTPAIRHEADER_OTHERBODYENTITYID"
-        },
+        }
     ],
     "noEngineReferences": false
 }

--- a/com.unity.netcode.gameobjects/Runtime/Unity.Netcode.Runtime.asmdef
+++ b/com.unity.netcode.gameobjects/Runtime/Unity.Netcode.Runtime.asmdef
@@ -81,7 +81,7 @@
         {
             "name": "Unity",
             "expression": "6000.3.0a6",
-            "define": "CONTACTPAIRHEADER_OTHERBODYENTITYID"
+            "define": "UNITY_6000_3_0A6_OR_HIGHER"
         }
     ],
     "noEngineReferences": false

--- a/com.unity.netcode.gameobjects/Runtime/Unity.Netcode.Runtime.asmdef
+++ b/com.unity.netcode.gameobjects/Runtime/Unity.Netcode.Runtime.asmdef
@@ -77,7 +77,12 @@
             "name": "Unity",
             "expression": "6000.1.0a1",
             "define": "HOSTNAME_RESOLUTION_AVAILABLE"
-        }
+        },
+        {
+            "name": "Unity",
+            "expression": "6000.3.0a6",
+            "define": "CONTACTPAIRHEADER_OTHERBODYENTITYID"
+        },
     ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
## Purpose of this PR
Adding asmdef define for 6000.3.0a6 or higher and using that within RigidbodyContactEventManager to switch from using otherBodyInstanceID to otherBodyEntityId.

### Jira ticket
NA

### Changelog
NA

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- No documentation changes or additions were necessary.


## Testing & QA
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [X] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?

If any boxes above are checked, please add QA as a PR reviewer.

## Backport
This is an NGO v2.x.x only update since NGO v1.x.x will not be supported on 6.3.