### PR TITLE
ci: Update of iOS model to 13

### DIFF
--- a/.yamato/mobile-standalone-test.yml
+++ b/.yamato/mobile-standalone-test.yml
@@ -48,6 +48,11 @@ mobile_standalone_build_{{ project.name }}_{{ platform.name }}_{{ editor }}:
 {% if platform.model %}
       model: {{ platform.model }} # This is set only in platforms where we want non-default model to use (more information in project.metafile)
 {% endif %}
+  # Automatic UI interruption handling is available for iPhones running iOS 15 and above (models SE-Gen3 and 13). 
+  # It is enabled by default when using those devices. Otherwise, system alerts (e.g. “Local Network Access” permission alert, introduced in iOS 14) might cause disruptions during test execution.
+  # If building of the test app is done on a separate (“Build”) job, please make sure that that job has environment variable UNITY_HANDLEUIINTERRUPTIONS set to 1.
+  env:
+    UNITY_HANDLEUIINTERRUPTIONS: 1
   commands:
     - unity-downloader-cli --fast --wait -u {{ editor }} -c Editor -c il2cpp {% if platform.base == "mac" %} -c ios {% else %} -c android {% endif %}
     - UnifiedTestRunner --suite=playmode --platform={{ platform.standalone }} --testproject={{ project.path }} --architecture={{ platform.architecture }} --scripting-backend=il2cpp --editor-location=.Editor --artifacts-path=artifacts --testfilter="Unity.Netcode.RuntimeTests.*" --player-save-path=build/players --extra-editor-arg=-batchmode --extra-editor-arg=-nographics --reruncount=1 --clean-library-on-rerun --build-only --timeout=1800

--- a/.yamato/mobile-standalone-test.yml
+++ b/.yamato/mobile-standalone-test.yml
@@ -96,7 +96,7 @@ mobile_standalone_test_{{ project.name }}_{{ platform.name }}_{{ editor }}:
 {% else %}
 
     # Run tests for non-Android devices
-    - UnifiedTestRunner --suite=playmode --platform={{ platform.standalone }} --artifacts-path=test-results --player-load-path=build/players --testproject={{ project.path }} --editor-location=.Editor --fail-on-assert --reruncount=1 --clean-library-on-rerun --timeout=3600
+    - UnifiedTestRunner --suite=playmode --platform={{ platform.standalone }} --artifacts-path=test-results --player-load-path=build/players --testproject={{ project.path }} --editor-location=.Editor --fail-on-assert --reruncount=1 --clean-library-on-rerun --timeout=3600 --device-id=%BOKKEN_DEVICE_ID%
 {% endif %}
   artifacts:
     logs:

--- a/.yamato/mobile-standalone-test.yml
+++ b/.yamato/mobile-standalone-test.yml
@@ -51,7 +51,7 @@ mobile_standalone_build_{{ project.name }}_{{ platform.name }}_{{ editor }}:
   # Automatic UI interruption handling is available for iPhones running iOS 15 and above (models SE-Gen3 and 13). 
   # It is enabled by default when using those devices. Otherwise, system alerts (e.g. “Local Network Access” permission alert, introduced in iOS 14) might cause disruptions during test execution.
   # If building of the test app is done on a separate (“Build”) job, please make sure that that job has environment variable UNITY_HANDLEUIINTERRUPTIONS set to 1.
-  env:
+  variables:
     UNITY_HANDLEUIINTERRUPTIONS: 1
   commands:
     - unity-downloader-cli --fast --wait -u {{ editor }} -c Editor -c il2cpp {% if platform.base == "mac" %} -c ios {% else %} -c android {% endif %}

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -10,7 +10,7 @@
     # image --> Defines the package-ci Bokken image to use for the environment (e.g., package-ci/ubuntu-22.04:v4). This is basically a device configuration
     # flavor --> Determines the VM size/resources (e.g., b1.small, b1.large, m1.mac)
     # standalone --> Specifies the build target platform (e.g., StandaloneLinux64, Android, IOS)
-    # model --> Defines specific hardware model requirements (e.g., rtx2080, SE-Gen3 for iPhone SE-Gen3). Notice that trunk currently (19.08.2025) has 15.0 as minimal iOS version which devices below this are not supporting
+    # model --> Defines specific hardware model requirements (e.g., rtx2080, iPhone model 15). Notice that trunk currently (19.08.2025) has 15.0 as minimal iOS version which devices below this are not supporting
     # base --> Indicates the base operating system for build operations (e.g., win, mac)
     # architecture --> Specifies the target CPU architecture (e.g., armv7, arm64)
 
@@ -89,7 +89,7 @@ test_platforms:
           type: Unity::mobile::iPhone
           image: package-ci/macos-13-arm64:v4
           flavor: m1.mac
-          model: SE-Gen3
+          model: 15
           standalone: IOS
           base: mac
           architecture: arm64

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -10,7 +10,7 @@
     # image --> Defines the package-ci Bokken image to use for the environment (e.g., package-ci/ubuntu-22.04:v4). This is basically a device configuration
     # flavor --> Determines the VM size/resources (e.g., b1.small, b1.large, m1.mac)
     # standalone --> Specifies the build target platform (e.g., StandaloneLinux64, Android, IOS)
-    # model --> Defines specific hardware model requirements (e.g., rtx2080, iPhone model 15). Notice that trunk currently (19.08.2025) has 15.0 as minimal iOS version which devices below this are not supporting
+    # model --> Defines specific hardware model requirements (e.g., rtx2080, iPhone model 13). Notice that trunk currently (19.08.2025) has 13.0 as minimal iOS version which devices below this are not supporting
     # base --> Indicates the base operating system for build operations (e.g., win, mac)
     # architecture --> Specifies the target CPU architecture (e.g., armv7, arm64)
 
@@ -89,7 +89,7 @@ test_platforms:
           type: Unity::mobile::iPhone
           image: package-ci/macos-13-arm64:v4
           flavor: m1.mac
-          model: 15
+          model: 13
           standalone: IOS
           base: mac
           architecture: arm64

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -10,7 +10,7 @@
     # image --> Defines the package-ci Bokken image to use for the environment (e.g., package-ci/ubuntu-22.04:v4). This is basically a device configuration
     # flavor --> Determines the VM size/resources (e.g., b1.small, b1.large, m1.mac)
     # standalone --> Specifies the build target platform (e.g., StandaloneLinux64, Android, IOS)
-    # model --> Defines specific hardware model requirements (e.g., rtx2080, SE-Gen3 for iPhone SE-Gen3)
+    # model --> Defines specific hardware model requirements (e.g., rtx2080, SE-Gen3 for iPhone SE-Gen3). Notice that trunk currently (19.08.2025) has 15.0 as minimal iOS version which devices below this are not supporting
     # base --> Indicates the base operating system for build operations (e.g., win, mac)
     # architecture --> Specifies the target CPU architecture (e.g., armv7, arm64)
 

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -10,7 +10,7 @@
     # image --> Defines the package-ci Bokken image to use for the environment (e.g., package-ci/ubuntu-22.04:v4). This is basically a device configuration
     # flavor --> Determines the VM size/resources (e.g., b1.small, b1.large, m1.mac)
     # standalone --> Specifies the build target platform (e.g., StandaloneLinux64, Android, IOS)
-    # model --> Defines specific hardware model requirements (e.g., rtx2080, SE for iPhone SE)
+    # model --> Defines specific hardware model requirements (e.g., rtx2080, SE-Gen3 for iPhone SE-Gen3)
     # base --> Indicates the base operating system for build operations (e.g., win, mac)
     # architecture --> Specifies the target CPU architecture (e.g., armv7, arm64)
 
@@ -89,7 +89,7 @@ test_platforms:
           type: Unity::mobile::iPhone
           image: package-ci/macos-13-arm64:v4
           flavor: m1.mac
-          model: SE
+          model: SE-Gen3
           standalone: IOS
           base: mac
           architecture: arm64


### PR DESCRIPTION
## Purpose of this PR
This PR aims to address iOS test failures on trunk that are happening because iOS min version was bumped to 15.0 where **SE** model that we were using is supporting 13.6.1 as per documentation.

To address this we will update the model to **13** which supports 16.6 so minimum spec will be satisfied and we will use newer device

Additionally this requires to address an issue of:

> Automatic UI interruption handling is available for iPhones running iOS 15 and above (models SE-Gen3 and 13). It is enabled by default when using those devices. Otherwise, system alerts (e.g. “Local Network Access” permission alert, introduced in iOS 14) might cause disruptions during test execution.
> 
> If building of the test app is done on a separate (“Build”) job, please make sure that that job has environment variable UNITY_HANDLEUIINTERRUPTIONS set to 1.

### Jira ticket
N/A

## Documentation
Added mention in CI comments

## Testing & QA
Green CI for iOS test for trunk will be enough

## Backport
https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3617