### PR TITLE
fix: NetworkTransform fails to sync multiple state updates

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -22,6 +22,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where a client, under above average latency and packet loss conditions, could receive multiple NetworkTransform state updates in one frame and when processing the state updates only the last state update would be applied to the transform if interpolation was disabled. (#3614)
+
 
 ### Security
 

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
@@ -3003,7 +3003,7 @@ namespace Unity.Netcode.Components
         /// <remarks>
         /// Only non-authoritative instances should invoke this
         /// </remarks>
-        private void ApplyUpdatedState(NetworkTransformState newState)
+        internal void ApplyUpdatedState(NetworkTransformState newState)
         {
             // Set the transforms's synchronization modes
             InLocalSpace = newState.InLocalSpace;
@@ -3052,6 +3052,7 @@ namespace Unity.Netcode.Components
 
             if (!Interpolate)
             {
+                ApplyAuthoritativeState();
                 return;
             }
 


### PR DESCRIPTION
## Purpose of this PR
This PR resolves an issue where a client, under above average latency and packet loss conditions, could receive multiple `NetworkTransform` state updates in one frame and when processing the state updates only the last state update would be applied to the transform.

fix: #3571

### Jira ticket

[MTTB-1530](https://jira.unity3d.com/browse/MTTB-1530)

### Changelog
[//]: # (updated with all public facing changes  - API changes, UI/UX changes, behaviour changes, bug fixes. Remove if not relevant.)

- Fixed: Issue where a client, under above average latency and packet loss conditions, could receive multiple `NetworkTransform` state updates in one frame and when processing the state updates only the last state update would be applied to the transform if interpolation was disabled.


<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- No documentation changes or additions were necessary.


## Testing & QA
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [X] `Manual testing done`
  - [PR-46](https://github.cds.internal.unity3d.com/unity/Asteroids-CMB-NGO-Sample/pull/46) manual test.

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [X] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?

If any boxes above are checked, please add QA as a PR reviewer.

## Backport
This is an NGO v2.x only issue.