### PR TITLE
Change sceneLoaded.name comparison against m_SceneToLoad

### DIFF
--- a/testproject/Assets/Scripts/CommandLineHandler.cs
+++ b/testproject/Assets/Scripts/CommandLineHandler.cs
@@ -154,7 +154,7 @@ public class CommandLineProcessor
 
     private void SceneManager_sceneLoaded(Scene sceneLoaded, LoadSceneMode sceneLoadingMode)
     {
-        if (sceneLoaded.name.ToLower() == m_SceneToLoad)
+        if (string.Equals(sceneLoaded.name, m_SceneToLoad, StringComparison.OrdinalIgnoreCase))
         {
             SceneManager.sceneLoaded -= SceneManager_sceneLoaded;
             var connectionModeButtons = GameObject.Find("ConnectionModeButtons");


### PR DESCRIPTION
## Purpose of this PR
Using .ToLower() to compare strings is very inefficient as it allocates a new string. Using string.Equals with StringComparison.OrdinalIgnoreCase is not only a lot faster but also handles some problems that may happen on different cultures, as shown in this video from "Bald. Bearded. Builder.": https://www.youtube.com/watch?v=DNzAoLwXLzc

### Changelog
[//]: # (updated with all public facing changes  - API changes, UI/UX changes, behaviour changes, bug fixes. Remove if not relevant.)

- Fixed: Inefficient string comparison on CommandLineHandler.