### PR TITLE
fix: [Backport] Add help urls

### DIFF
--- a/com.unity.netcode.gameobjects/Components/AnticipatedNetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/AnticipatedNetworkTransform.cs
@@ -1,4 +1,5 @@
 using Unity.Mathematics;
+using Unity.Netcode.Runtime;
 using UnityEngine;
 
 namespace Unity.Netcode.Components
@@ -44,6 +45,7 @@ namespace Unity.Netcode.Components
     [DisallowMultipleComponent]
     [AddComponentMenu("Netcode/Anticipated Network Transform")]
     [DefaultExecutionOrder(100000)] // this is needed to catch the update time after the transform was updated by user scripts
+    [HelpURL(HelpUrls.AnticipatedNetworkTransform)]
     public class AnticipatedNetworkTransform : NetworkTransform
     {
         /// <summary>

--- a/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkAnimator.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
+using Unity.Netcode.Runtime;
 using UnityEngine;
 #if UNITY_EDITOR
 using UnityEditor.Animations;
@@ -164,6 +165,7 @@ namespace Unity.Netcode.Components
     /// NetworkAnimator enables remote synchronization of <see cref="UnityEngine.Animator"/> state for on network objects.
     /// </summary>
     [AddComponentMenu("Netcode/Network Animator")]
+    [HelpURL(HelpUrls.NetworkAnimator)]
     public class NetworkAnimator : NetworkBehaviour, ISerializationCallbackReceiver
     {
         [Serializable]

--- a/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
@@ -1,4 +1,5 @@
 #if COM_UNITY_MODULES_PHYSICS
+using Unity.Netcode.Runtime;
 using UnityEngine;
 
 namespace Unity.Netcode.Components
@@ -10,6 +11,7 @@ namespace Unity.Netcode.Components
     [RequireComponent(typeof(Rigidbody))]
     [RequireComponent(typeof(NetworkTransform))]
     [AddComponentMenu("Netcode/Network Rigidbody")]
+    [HelpURL(HelpUrls.NetworkRigidbody)]
     public class NetworkRigidbody : NetworkBehaviour
     {
         /// <summary>

--- a/com.unity.netcode.gameobjects/Components/NetworkRigidbody2D.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkRigidbody2D.cs
@@ -1,4 +1,5 @@
 #if COM_UNITY_MODULES_PHYSICS2D
+using Unity.Netcode.Runtime;
 using UnityEngine;
 
 namespace Unity.Netcode.Components
@@ -10,6 +11,7 @@ namespace Unity.Netcode.Components
     [RequireComponent(typeof(Rigidbody2D))]
     [RequireComponent(typeof(NetworkTransform))]
     [AddComponentMenu("Netcode/Network Rigidbody 2D")]
+    [HelpURL(HelpUrls.NetworkRigidbody2D)]
     public class NetworkRigidbody2D : NetworkBehaviour
     {
         /// <summary>

--- a/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkTransform.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Unity.Mathematics;
+using Unity.Netcode.Runtime;
 using UnityEngine;
 
 namespace Unity.Netcode.Components
@@ -14,6 +15,7 @@ namespace Unity.Netcode.Components
     [DisallowMultipleComponent]
     [AddComponentMenu("Netcode/Network Transform")]
     [DefaultExecutionOrder(100000)] // this is needed to catch the update time after the transform was updated by user scripts
+    [HelpURL(HelpUrls.NetworkTransform)]
     public class NetworkTransform : NetworkBehaviour
     {
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Unity.Collections;
+using Unity.Netcode.Runtime;
 using UnityEngine;
 #if UNITY_EDITOR
 using UnityEditor;
@@ -14,6 +15,7 @@ namespace Unity.Netcode
     /// The main component of the library
     /// </summary>
     [AddComponentMenu("Netcode/Network Manager", -100)]
+    [HelpURL(HelpUrls.NetworkManager)]
     public class NetworkManager : MonoBehaviour, INetworkUpdateSystem
     {
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -9,6 +9,7 @@ using UnityEditor.SceneManagement;
 using UnityEditor.Experimental.SceneManagement;
 #endif
 #endif
+using Unity.Netcode.Runtime;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -20,6 +21,7 @@ namespace Unity.Netcode
     /// </summary>
     [AddComponentMenu("Netcode/Network Object", -99)]
     [DisallowMultipleComponent]
+    [HelpURL(HelpUrls.NetworkObject)]
     public sealed class NetworkObject : MonoBehaviour
     {
         [HideInInspector]

--- a/com.unity.netcode.gameobjects/Runtime/HelpUrls.cs
+++ b/com.unity.netcode.gameobjects/Runtime/HelpUrls.cs
@@ -1,0 +1,21 @@
+namespace Unity.Netcode.Runtime
+{
+    internal static class HelpUrls
+    {
+        private const string k_BaseUrl = "https://docs.unity3d.com/Packages/com.unity.netcode.gameobjects@latest/?subfolder=/";
+        private const string k_BaseManualUrl = k_BaseUrl + "manual/";
+        private const string k_BaseApiUrl = k_BaseUrl + "api/Unity.Netcode";
+
+        // The HelpUrls have to be defined as public for the test to work
+        public const string NetworkManager = k_BaseManualUrl + "components/core/networkmanager.html";
+        public const string NetworkObject = k_BaseManualUrl + "components/core/networkobject.html";
+        public const string NetworkAnimator = k_BaseManualUrl + "components/helper/networkanimator.html";
+        public const string NetworkRigidbody = k_BaseManualUrl + "advanced-topics/physics.html#networkrigidbody";
+        public const string NetworkRigidbody2D = k_BaseManualUrl + "advanced-topics/physics.html#networkrigidbody2d";
+        public const string NetworkTransform = k_BaseManualUrl + "components/helper/networktransform.html";
+        public const string AnticipatedNetworkTransform = k_BaseManualUrl + "advanced-topics/client-anticipation.html";
+        public const string UnityTransport = k_BaseApiUrl + ".Transports.UTP.UnityTransport.html";
+        public const string SecretsLoaderHelper = k_BaseApiUrl + ".Transports.UTP.SecretsLoaderHelper.html";
+        public const string SinglePlayerTransport = k_BaseApiUrl + ".Transports.SinglePlayer.SinglePlayerTransport.html";
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/HelpUrls.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/HelpUrls.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5f9653e7d00a4ad0aeb89e72cfddb68a
+timeCreated: 1757450738

--- a/com.unity.netcode.gameobjects/Runtime/Transports/SinglePlayer/SinglePlayerTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/SinglePlayer/SinglePlayerTransport.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using Unity.Netcode.Runtime;
+using UnityEngine;
 
 namespace Unity.Netcode.Transports.SinglePlayer
 {
@@ -11,6 +13,8 @@ namespace Unity.Netcode.Transports.SinglePlayer
     /// <remarks>
     /// You can only start as a host when using this transport.
     /// </remarks>
+    [AddComponentMenu("Netcode/Single Player Transport")]
+    [HelpURL(HelpUrls.SinglePlayerTransport)]
     public class SinglePlayerTransport : NetworkTransport
     {
         /// <inheritdoc/>

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/SecretsLoaderHelper.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/SecretsLoaderHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using Unity.Netcode.Runtime;
 using UnityEngine;
 
 namespace Unity.Netcode.Transports.UTP
@@ -13,6 +14,7 @@ namespace Unity.Netcode.Transports.UTP
     /// - SetClientSecrets
     /// directly, instead of relying on this.
     /// </summary>
+    [HelpURL(HelpUrls.SecretsLoaderHelper)]
     public class SecretsLoaderHelper : MonoBehaviour
     {
         internal struct ServerSecrets

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -17,6 +17,7 @@ using Unity.Burst;
 using Unity.Collections.LowLevel.Unsafe;
 using Unity.Collections;
 using Unity.Jobs;
+using Unity.Netcode.Runtime;
 using Unity.Networking.Transport;
 using Unity.Networking.Transport.Relay;
 using Unity.Networking.Transport.Utilities;
@@ -106,6 +107,7 @@ namespace Unity.Netcode.Transports.UTP
     /// Note: This is highly recommended to use over UNet.
     /// </summary>
     [AddComponentMenu("Netcode/Unity Transport")]
+    [HelpURL(HelpUrls.UnityTransport)]
     public partial class UnityTransport : NetworkTransport, INetworkStreamDriverConstructor
     {
         /// <summary>

--- a/com.unity.netcode.gameobjects/Tests/Runtime/HelpUrlTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/HelpUrlTests.cs
@@ -1,0 +1,165 @@
+
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Unity.Netcode.Runtime;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    internal class HelpUrlTests
+    {
+        private const string k_PackageName = "com.unity.netcode.gameobjects";
+        private static readonly HttpClient k_HttpClient = new();
+
+        private bool m_VerboseLogging = false;
+
+        [UnityTest]
+        public IEnumerator ValidateUrlsAreValid()
+        {
+            var names = new List<string>();
+            var allUrls = new List<string>();
+
+            // GetFields() can only see public strings. Ensure each HelpUrl is public.
+            foreach (var constant in typeof(HelpUrls).GetFields())
+            {
+                if (constant.IsLiteral && !constant.IsInitOnly)
+                {
+                    names.Add(constant.Name);
+                    allUrls.Add((string)constant.GetValue(null));
+                }
+            }
+
+            VerboseLog($"Found {allUrls.Count} URLs");
+
+            var tasks = new List<Task<bool>>();
+            foreach (var url in allUrls)
+            {
+                tasks.Add(AreUnityDocsAvailableAt(url));
+            }
+
+            while (tasks.Any(task => !task.IsCompleted))
+            {
+                yield return new WaitForSeconds(0.01f);
+            }
+
+            for (int i = 0; i < allUrls.Count; i++)
+            {
+                Assert.IsTrue(tasks[i].Result, $"HelpUrls.{names[i]} has an invalid path! Path: {allUrls[i]}");
+            }
+        }
+
+        private async Task<bool> AreUnityDocsAvailableAt(string url)
+        {
+            try
+            {
+                var split = url.Split('#');
+                url = split[0];
+
+                var stream = await GetContentFromRemoteFile(url);
+
+                var redirectUrl = CalculateRedirectURl(url, stream);
+                VerboseLog($"Calculated Redirect URL: {redirectUrl}");
+
+                var content = await GetContentFromRemoteFile(redirectUrl);
+
+                // If original url had an anchor part (e.g. some/url.html#anchor)
+                if (split.Length > 1)
+                {
+                    var anchorString = split[1];
+
+                    // All headings will have an id with the anchorstring (e.g. <h2 id="anchor">)
+                    if (!content.Contains($"id=\"{anchorString}\">"))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+            catch (Exception e)
+            {
+                VerboseLog(e.Message);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Checks if a remote file at the <paramref name="url"/> exists, and if access is not restricted.
+        /// </summary>
+        /// <param name="url">URL to a remote file.</param>
+        /// <returns>True if the file at the <paramref name="url"/> is able to be downloaded, false if the file does not exist, or if the file is restricted.</returns>
+        private async Task<string> GetContentFromRemoteFile(string url)
+        {
+            //Checking if URI is well formed is optional
+            var uri = new Uri(url);
+            if (!uri.IsWellFormedOriginalString())
+            {
+                throw new Exception($"URL {url} is not well formed");
+            }
+
+            try
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+                using var response = await k_HttpClient.SendAsync(request);
+                if (!response.IsSuccessStatusCode || response.Content.Headers.ContentLength <= 0)
+                {
+                    throw new Exception($"Failed to get remote file from URL {url}");
+                }
+
+                return await response.Content.ReadAsStringAsync();
+            }
+            catch
+            {
+                throw new Exception($"URL {url} request failed");
+            }
+        }
+
+        private string CalculateRedirectURl(string originalRequest, string content)
+        {
+            var uri = new Uri(originalRequest);
+            var baseRequest = $"{uri.Scheme}://{uri.Host}";
+            foreach (var segment in uri.Segments)
+            {
+                if (segment.Contains(k_PackageName))
+                {
+                    break;
+                }
+                baseRequest += segment;
+            }
+
+            var subfolderRegex = new Regex(@"[?&](\w[\w.]*)=([^?&]+)").Match(uri.Query);
+            var subfolder = "";
+            foreach (Group match in subfolderRegex.Groups)
+            {
+                subfolder = match.Value;
+            }
+
+            string pattern = @"com.unity.netcode.gameobjects\@(\d+.\d+)";
+            var targetDestination = "";
+            foreach (Match match in Regex.Matches(content, pattern))
+            {
+                targetDestination = match.Value;
+                break;
+            }
+
+            return baseRequest + targetDestination + subfolder;
+        }
+
+        private void VerboseLog(string message)
+        {
+            if (m_VerboseLogging)
+            {
+                Debug.unityLogger.Log(message);
+            }
+        }
+
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/HelpUrlTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/HelpUrlTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a44ef45dca794f618ae195832470a7cd
+timeCreated: 1757519683


### PR DESCRIPTION
## Purpose of this PR
Adds help urls to all components that are added to the component menu. This ensures the question mark icon in the inspector view will redirect to a valid page.

### Jira ticket
[MTTB-1452](https://jira.unity3d.com/browse/MTTB-1452)

### Changelog

- Added: Help URLs ensure the inspector redirects to valid web pages.

## Documentation

- No documentation changes or additions were necessary.

## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [x] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [x] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports

This is a backport of #3663 