### PR TITLE
ci: Corrected line encoding in Python scripts

### DIFF
--- a/.yamato/package-pack.yml
+++ b/.yamato/package-pack.yml
@@ -37,6 +37,7 @@ package_pack_-_ngo_{{ platform.name }}:
   variables:
     XRAY_PROFILE: "gold ./pvpExceptions.json"
   commands:
+    - python Tools/scripts/release.py # Needed to ensure that CHANGELOG is properly formatted for this test 
     - upm-pvp pack "com.unity.netcode.gameobjects" --output upm-ci~/packages
     - upm-pvp xray --packages "upm-ci~/packages/com.unity.netcode.gameobjects*.tgz" --results pvp-results
     - upm-pvp require {% if platform.name == "win" %}"%XRAY_PROFILE%"{% else %}"$XRAY_PROFILE"{% endif %} --results pvp-results --allow-missing

--- a/.yamato/package-pack.yml
+++ b/.yamato/package-pack.yml
@@ -37,7 +37,6 @@ package_pack_-_ngo_{{ platform.name }}:
   variables:
     XRAY_PROFILE: "gold ./pvpExceptions.json"
   commands:
-    - python Tools/scripts/release.py # Needed to ensure that CHANGELOG is properly formatted for this test 
     - upm-pvp pack "com.unity.netcode.gameobjects" --output upm-ci~/packages
     - upm-pvp xray --packages "upm-ci~/packages/com.unity.netcode.gameobjects*.tgz" --results pvp-results
     - upm-pvp require {% if platform.name == "win" %}"%XRAY_PROFILE%"{% else %}"$XRAY_PROFILE"{% endif %} --results pvp-results --allow-missing

--- a/.yamato/vetting-test.yml
+++ b/.yamato/vetting-test.yml
@@ -10,6 +10,7 @@ vetting_test:
   name: NGO - Vetting Test (Win, {{editor}} LTS)
   agent: { type: Unity::VM, flavor: b1.large, image: package-ci/win11:v4 }
   commands:
+    - python Tools/scripts/release.py # Needed to ensure that CHANGELOG is properly formatted for this test 
     - npm install -g "upm-ci-utils@stable" --registry https://artifactory.prd.it.unity3d.com/artifactory/api/npm/upm-npm
     - unity-downloader-cli --fast --wait --unity-version {{ editor }} --components editor --arch x64
     - upm-ci package pack --package-path com.unity.netcode.gameobjects

--- a/.yamato/vetting-test.yml
+++ b/.yamato/vetting-test.yml
@@ -1,13 +1,13 @@
 {% metadata_file .yamato/project.metafile %} # All configuration that is used to create different configurations (used in for loops) is taken from this file.
 ---
 # DESCRIPTION--------------------------------------------------------------------------
-# This configuration defines vetting tests for the Tools package which allows to validate if the package is in releasable state. This is important in particular because of API validation that allows to detect if we are introducing any new APIs that will force us to bump package version to new minor
+# This configuration defines vetting tests for the NGO package which allows to validate if the package is in releasable state. This is important in particular because of API validation that allows to detect if we are introducing any new APIs that will force us to bump package version to new minor
 # If this test fails with new API error we should either make those API internal OR bump package version to new minor (note that the package version reflects the current package state)
 
 # Note that we are packing the package only (no project context) so if package have any soft dependencies then project should be used to test it (to enable those APIs)
 {% for editor in validation_editors.minimal -%}
 vetting_test:
-  name: MP Tools - Vetting Test (Win, {{editor}} LTS)
+  name: NGO - Vetting Test (Win, {{editor}} LTS)
   agent: { type: Unity::VM, flavor: b1.large, image: package-ci/win11:v4 }
   commands:
     - npm install -g "upm-ci-utils@stable" --registry https://artifactory.prd.it.unity3d.com/artifactory/api/npm/upm-npm

--- a/.yamato/vetting-test.yml
+++ b/.yamato/vetting-test.yml
@@ -10,7 +10,6 @@ vetting_test:
   name: NGO - Vetting Test (Win, {{editor}} LTS)
   agent: { type: Unity::VM, flavor: b1.large, image: package-ci/win11:v4 }
   commands:
-    - python Tools/scripts/release.py # Needed to ensure that CHANGELOG is properly formatted for this test 
     - npm install -g "upm-ci-utils@stable" --registry https://artifactory.prd.it.unity3d.com/artifactory/api/npm/upm-npm
     - unity-downloader-cli --fast --wait --unity-version {{ editor }} --components editor --arch x64
     - upm-ci package pack --package-path com.unity.netcode.gameobjects

--- a/Tools/scripts/BuildAutomation/connect_services.py
+++ b/Tools/scripts/BuildAutomation/connect_services.py
@@ -35,7 +35,7 @@ def main():
     # Ensure the project is marked as connected
     content = re.sub(r"cloudEnabled:.*", "cloudEnabled: 1", content)
 
-    with open(args.project_settings_path, 'w') as f:
+    with open(args.project_settings_path, 'w', encoding='UTF-8', newline='\n') as f:
         f.write(content)
 
     print(f"[Linker] Successfully updated {args.project_settings_path} with Project ID: {args.cloud_project_ID}, Org ID: {args.organization_ID}, Project Name: {args.project_name}")

--- a/Tools/scripts/BuildAutomation/disable-enable-burst.py
+++ b/Tools/scripts/BuildAutomation/disable-enable-burst.py
@@ -43,7 +43,7 @@ def create_config(settings_path):
     }
 
     data = {'MonoBehaviour': monobehaviour}
-    with open(config_name, 'w') as f:
+    with open(config_name, 'w', encoding='UTF-8', newline='\n') as f:
         json.dump(data, f)
     return config_name
 
@@ -87,7 +87,7 @@ def set_burst_AOT(config_file, status):
     assert config is not None, 'AOT settings not found; did the burst-enabled build finish successfully?'
 
     config['MonoBehaviour']['EnableBurstCompilation'] = status
-    with open(config_file, 'w') as f:
+    with open(config_file, 'w', encoding='UTF-8', newline='\n') as f:
         json.dump(config, f)
 
 

--- a/Tools/scripts/BuildAutomation/manifest_update.py
+++ b/Tools/scripts/BuildAutomation/manifest_update.py
@@ -30,7 +30,7 @@ def main():
         local_path_normalized = args.local_package_path.replace(os.sep, '/')
         manifest_data["dependencies"][args.package_name] = f"file:{local_path_normalized}"
 
-        with open(args.manifest_path, 'w') as f:
+        with open(args.manifest_path, 'w', encoding='UTF-8', newline='\n') as f:
             json.dump(manifest_data, f, indent=4)
 
         print(f"Successfully updated manifest at '{args.manifest_path}'")

--- a/Tools/scripts/Utils/general_utils.py
+++ b/Tools/scripts/Utils/general_utils.py
@@ -69,7 +69,7 @@ def update_package_version_by_patch(package_manifest_path):
 
     package_manifest['version'] = new_package_version
 
-    with open(package_manifest_path, 'w', encoding='UTF-8') as f:
+    with open(package_manifest_path, 'w', encoding='UTF-8', newline='\n') as f:
         json.dump(package_manifest, f, indent=4)
 
     return new_package_version
@@ -166,5 +166,5 @@ def update_changelog(changelog_path, new_version, add_unreleased_template=False)
         )
 
     # Write the changes
-    with open(changelog_path, 'w', encoding='UTF-8') as file:
+    with open(changelog_path, 'w', encoding='UTF-8', newline='\n') as file:
         file.write(final_content)


### PR DESCRIPTION
## Purpose of this PR
This PR follows on https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3677 because even though we don't need to execute release.py when packing the package (due to existing pvp exception) nor vetting test job (uses upm-ci which does not run PVP checks) we should future proof release.py and similar scripts from making this mistake.

The main reason why the release.py was causing the package pack to fail on windows is that when you open a file in text mode ('w') on Windows, Python's default behavior is to convert each newline character (\n) into the platform's standard line separator, which is \r\n (CRLF). This can cause inconsistencies when the file is used in environments that expect \n (LF), such as Git.

The solution was to ensure that we are specifying the newline like
`with open(path, 'w', encoding='UTF-8', newline='\n') as file:`

### Jira ticket
N/A

## Documentation
N/A

## Testing & QA (How your changes can be verified during release Playtest)
PR trigger check was green and I verified that when release.py command was included in pack job the results were green (see **[THIS](https://unity-ci.cds.internal.unity3d.com/job/56280166)** job)

## Backports
Backport to `develop` branch in https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3681
