### PR TITLE
docs: Fix note for custom NetworkVariable

### DIFF
--- a/com.unity.netcode.gameobjects/Documentation~/basics/networkvariable.md
+++ b/com.unity.netcode.gameobjects/Documentation~/basics/networkvariable.md
@@ -475,7 +475,7 @@ Looking closely at the read and write segments of code within `AreaWeaponBooster
 
 ## Custom NetworkVariable Implementations
 
-> [!NOTE] Disclaimer
+> [!NOTE]
 > The `NetworkVariable` and `NetworkList` classes were created as `NetworkVariableBase` class implementation examples. While the `NetworkVariable<T>` class is considered production ready, you might run into scenarios where you have a more advanced implementation in mind. In this case, we encourage you to create your own custom implementation.
 
 To create your own `NetworkVariableBase` derived container, you should:


### PR DESCRIPTION
## Purpose of this PR
The [note here](https://docs.unity3d.com/Packages/com.unity.netcode.gameobjects@2.5/manual/basics/networkvariable.html#custom-networkvariable-implementations) is not formatted correctly. I decided to remove the "Disclaimer" part, as it felt like it doubled the intention of the note.

### Jira ticket
N/A

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- Includes edits to existing public API documentation.

## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports
[//]: # (
This section is REQUIRED and should link to the PR that targets other NGO version which is either develop or develop-2.0.0 branch
Add the following to the PR title: "\[Backport\] ..."
If this is not needed, for example feature specific to NGOv2.X, then just mention this fact.
)
