### PR TITLE
feat: server-enforced RpcInvokePermission and spoof prevention

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -1441,6 +1441,7 @@ namespace Unity.Netcode.Editor.CodeGen
                     }
 
                     var invokePermission = RpcInvokePermission.Anyone;
+
                     foreach (var attrField in rpcAttribute.Fields)
                     {
                         switch (attrField.Name)
@@ -1537,6 +1538,7 @@ namespace Unity.Netcode.Editor.CodeGen
         private CustomAttribute CheckAndGetRpcAttribute(MethodDefinition methodDefinition)
         {
             CustomAttribute rpcAttribute = null;
+
             foreach (var customAttribute in methodDefinition.CustomAttributes)
             {
                 var customAttributeType_FullName = customAttribute.AttributeType.FullName;
@@ -1620,6 +1622,30 @@ namespace Unity.Netcode.Editor.CodeGen
 
                 return null;
             }
+
+            bool hasRequireOwnership = false, hasInvokePermission = false;
+
+            foreach (var argument in rpcAttribute.Fields)
+            {
+                switch (argument.Name)
+                {
+                    case k_ServerRpcAttribute_RequireOwnership:
+                        hasRequireOwnership = true;
+                        break;
+                    case k_RpcAttribute_InvokePermission:
+                        hasInvokePermission = true;
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            if (hasRequireOwnership && hasInvokePermission)
+            {
+                m_Diagnostics.AddError("Rpc attribute cannot declare both RequireOwnership and InvokePermission!");
+                return null;
+            }
+
             // Checks for IsSerializable are moved to later as the check is now done by dynamically seeing if any valid
             // serializer OR extension method exists for it.
             return rpcAttribute;
@@ -2366,6 +2392,7 @@ namespace Unity.Netcode.Editor.CodeGen
                             m_Diagnostics.AddError($"{nameof(RpcAttribute)} contains field {field} which is not present in {nameof(RpcAttribute.RpcAttributeParams)}.");
                         }
                     }
+
                     instructions.Add(processor.Create(OpCodes.Ldloc, rpcAttributeParamsIdx));
 
                     // defaultTarget

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -2865,13 +2865,16 @@ namespace Unity.Netcode.Editor.CodeGen
             var isServerRpc = rpcAttribute.AttributeType.FullName == CodeGenHelpers.ServerRpcAttribute_FullName;
             var isCientRpc = rpcAttribute.AttributeType.FullName == CodeGenHelpers.ClientRpcAttribute_FullName;
             var isGenericRpc = rpcAttribute.AttributeType.FullName == CodeGenHelpers.RpcAttribute_FullName;
-            var invokePermission = RpcInvokePermission.Anyone; // default value MUST be == `ServerRpcAttribute.RequireOwnership`
+            var invokePermission = RpcInvokePermission.Anyone;
             foreach (var attrField in rpcAttribute.Fields)
             {
                 switch (attrField.Name)
                 {
                     case k_ServerRpcAttribute_RequireOwnership:
                         invokePermission = (attrField.Argument.Type == typeSystem.Boolean && (bool)attrField.Argument.Value) ? RpcInvokePermission.Owner : RpcInvokePermission.Anyone;
+                        break;
+                    case k_RpcAttribute_InvokePermission:
+                        invokePermission = (RpcInvokePermission)attrField.Argument.Value;
                         break;
                 }
             }

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -1440,6 +1440,8 @@ namespace Unity.Netcode.Editor.CodeGen
                         callMethod = callMethod.MakeGeneric(genericTypes.ToArray());
                     }
 
+                    var isClientRpc = rpcAttribute.AttributeType.FullName == CodeGenHelpers.ClientRpcAttribute_FullName;
+
                     var invokePermission = RpcInvokePermission.Anyone;
 
                     foreach (var attrField in rpcAttribute.Fields)
@@ -1455,7 +1457,12 @@ namespace Unity.Netcode.Editor.CodeGen
                         }
                     }
 
-                    // __registerRpc(RpcMethodId, HandleFunc, methodName);
+                    if (isClientRpc)
+                    {
+                        invokePermission = RpcInvokePermission.Server;
+                    }
+
+                    // __registerRpc(RpcMethodId, HandleFunc, invokePermission, methodName);
                     instructions.Add(processor.Create(OpCodes.Ldarg_0));
                     instructions.Add(processor.Create(OpCodes.Ldc_I4, unchecked((int)rpcMethodId)));
                     instructions.Add(processor.Create(OpCodes.Ldnull));
@@ -2892,7 +2899,7 @@ namespace Unity.Netcode.Editor.CodeGen
             var processor = rpcHandler.Body.GetILProcessor();
 
             var isServerRpc = rpcAttribute.AttributeType.FullName == CodeGenHelpers.ServerRpcAttribute_FullName;
-            var isCientRpc = rpcAttribute.AttributeType.FullName == CodeGenHelpers.ClientRpcAttribute_FullName;
+            var isClientRpc = rpcAttribute.AttributeType.FullName == CodeGenHelpers.ClientRpcAttribute_FullName;
             var isGenericRpc = rpcAttribute.AttributeType.FullName == CodeGenHelpers.RpcAttribute_FullName;
             var invokePermission = RpcInvokePermission.Anyone;
             foreach (var attrField in rpcAttribute.Fields)
@@ -2906,6 +2913,12 @@ namespace Unity.Netcode.Editor.CodeGen
                         invokePermission = (RpcInvokePermission)attrField.Argument.Value;
                         break;
                 }
+            }
+
+            // legacy ClientRpc should always be RpcInvokePermission.Server
+            if (isClientRpc)
+            {
+                invokePermission = RpcInvokePermission.Server;
             }
 
             rpcHandler.Body.InitLocals = true;

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -1440,12 +1440,14 @@ namespace Unity.Netcode.Editor.CodeGen
                         callMethod = callMethod.MakeGeneric(genericTypes.ToArray());
                     }
 
-                    RpcInvokePermission invokePermission = RpcInvokePermission.Anyone;
-                    
+                    var invokePermission = RpcInvokePermission.Anyone;
                     foreach (var attrField in rpcAttribute.Fields)
                     {
                         switch (attrField.Name)
                         {
+                            case k_ServerRpcAttribute_RequireOwnership:
+                                invokePermission = (attrField.Argument.Type == rpcHandler.Module.TypeSystem.Boolean && (bool)attrField.Argument.Value) ? RpcInvokePermission.Owner : RpcInvokePermission.Anyone;
+                                break;
                             case k_RpcAttribute_InvokePermission:
                                 invokePermission = (RpcInvokePermission)attrField.Argument.Value;
                                 break;

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -609,6 +609,7 @@ namespace Unity.Netcode.Editor.CodeGen
         private const string k_NetworkVariableBase_Initialize = nameof(NetworkVariableBase.Initialize);
 
         private const string k_RpcAttribute_Delivery = nameof(RpcAttribute.Delivery);
+        private const string k_RpcAttribute_InvokePermission = nameof(RpcAttribute.InvokePermission);
         private const string k_ServerRpcAttribute_RequireOwnership = nameof(ServerRpcAttribute.RequireOwnership);
         private const string k_RpcParams_Server = nameof(__RpcParams.Server);
         private const string k_RpcParams_Client = nameof(__RpcParams.Client);
@@ -1311,7 +1312,7 @@ namespace Unity.Netcode.Editor.CodeGen
                     return;
                 }
             }
-            var rpcHandlers = new List<(uint RpcMethodId, MethodDefinition RpcHandler, string RpcMethodName)>();
+            var rpcHandlers = new List<(uint RpcMethodId, MethodDefinition RpcHandler, string RpcMethodName, CustomAttribute rpcAttribute)>();
 
             bool isEditorOrDevelopment = assemblyDefines.Contains("UNITY_EDITOR") || assemblyDefines.Contains("DEVELOPMENT_BUILD");
 
@@ -1342,7 +1343,7 @@ namespace Unity.Netcode.Editor.CodeGen
 
                 InjectWriteAndCallBlocks(methodDefinition, rpcAttribute, rpcMethodId);
 
-                rpcHandlers.Add((rpcMethodId, GenerateStaticHandler(methodDefinition, rpcAttribute, rpcMethodId), methodDefinition.Name));
+                rpcHandlers.Add((rpcMethodId, GenerateStaticHandler(methodDefinition, rpcAttribute, rpcMethodId), methodDefinition.Name, rpcAttribute));
             }
 
             GenerateVariableInitialization(typeDefinition);
@@ -1424,7 +1425,7 @@ namespace Unity.Netcode.Editor.CodeGen
                 var instructions = new List<Instruction>();
                 var processor = initializeRpcsMethodDef.Body.GetILProcessor();
 
-                foreach (var (rpcMethodId, rpcHandler, rpcMethodName) in rpcHandlers)
+                foreach (var (rpcMethodId, rpcHandler, rpcMethodName, rpcAttribute) in rpcHandlers)
                 {
                     typeDefinition.Methods.Add(rpcHandler);
 
@@ -1439,12 +1440,25 @@ namespace Unity.Netcode.Editor.CodeGen
                         callMethod = callMethod.MakeGeneric(genericTypes.ToArray());
                     }
 
+                    RpcInvokePermission invokePermission = RpcInvokePermission.Anyone;
+                    
+                    foreach (var attrField in rpcAttribute.Fields)
+                    {
+                        switch (attrField.Name)
+                        {
+                            case k_RpcAttribute_InvokePermission:
+                                invokePermission = (RpcInvokePermission)attrField.Argument.Value;
+                                break;
+                        }
+                    }
+
                     // __registerRpc(RpcMethodId, HandleFunc, methodName);
                     instructions.Add(processor.Create(OpCodes.Ldarg_0));
                     instructions.Add(processor.Create(OpCodes.Ldc_I4, unchecked((int)rpcMethodId)));
                     instructions.Add(processor.Create(OpCodes.Ldnull));
                     instructions.Add(processor.Create(OpCodes.Ldftn, callMethod));
                     instructions.Add(processor.Create(OpCodes.Newobj, m_NetworkHandlerDelegateCtor_MethodRef));
+                    instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)invokePermission));
                     instructions.Add(processor.Create(OpCodes.Ldstr, rpcMethodName));
                     instructions.Add(processor.Create(OpCodes.Call, m_NetworkBehaviour___registerRpc_MethodRef));
                 }
@@ -2851,13 +2865,13 @@ namespace Unity.Netcode.Editor.CodeGen
             var isServerRpc = rpcAttribute.AttributeType.FullName == CodeGenHelpers.ServerRpcAttribute_FullName;
             var isCientRpc = rpcAttribute.AttributeType.FullName == CodeGenHelpers.ClientRpcAttribute_FullName;
             var isGenericRpc = rpcAttribute.AttributeType.FullName == CodeGenHelpers.RpcAttribute_FullName;
-            var requireOwnership = true; // default value MUST be == `ServerRpcAttribute.RequireOwnership`
+            var invokePermission = RpcInvokePermission.Anyone; // default value MUST be == `ServerRpcAttribute.RequireOwnership`
             foreach (var attrField in rpcAttribute.Fields)
             {
                 switch (attrField.Name)
                 {
                     case k_ServerRpcAttribute_RequireOwnership:
-                        requireOwnership = attrField.Argument.Type == typeSystem.Boolean && (bool)attrField.Argument.Value;
+                        invokePermission = (attrField.Argument.Type == typeSystem.Boolean && (bool)attrField.Argument.Value) ? RpcInvokePermission.Owner : RpcInvokePermission.Anyone;
                         break;
                 }
             }
@@ -2887,7 +2901,7 @@ namespace Unity.Netcode.Editor.CodeGen
                 processor.Append(lastInstr);
             }
 
-            if (isServerRpc && requireOwnership)
+            if (isServerRpc && invokePermission == RpcInvokePermission.Owner)
             {
                 var roReturnInstr = processor.Create(OpCodes.Ret);
                 var roLastInstr = processor.Create(OpCodes.Nop);
@@ -2917,6 +2931,42 @@ namespace Unity.Netcode.Editor.CodeGen
 
                 // Debug.LogError(...);
                 processor.Emit(OpCodes.Ldstr, "Only the owner can invoke a ServerRpc that requires ownership!");
+                processor.Emit(OpCodes.Call, m_Debug_LogError_MethodRef);
+
+                processor.Append(logNextInstr);
+
+                processor.Append(roReturnInstr);
+                processor.Append(roLastInstr);
+            } else if (invokePermission == RpcInvokePermission.Server)
+            {
+                var roReturnInstr = processor.Create(OpCodes.Ret);
+                var roLastInstr = processor.Create(OpCodes.Nop);
+
+                // if (rpcParams.Server.Receive.SenderClientId != NetworkManager.IsServer) { ... } return;
+                processor.Emit(OpCodes.Ldarg_2);
+                processor.Emit(OpCodes.Ldfld, m_RpcParams_Server_FieldRef);
+                processor.Emit(OpCodes.Ldfld, m_ServerRpcParams_Receive_FieldRef);
+                processor.Emit(OpCodes.Ldfld, m_ServerRpcParams_Receive_SenderClientId_FieldRef);
+                processor.Emit(OpCodes.Ldarg_0);
+                processor.Emit(OpCodes.Call, m_NetworkManager_getIsServer_MethodRef);
+                processor.Emit(OpCodes.Ceq);
+                processor.Emit(OpCodes.Ldc_I4, 0);
+                processor.Emit(OpCodes.Ceq);
+                processor.Emit(OpCodes.Brfalse, roLastInstr);
+
+                var logNextInstr = processor.Create(OpCodes.Nop);
+
+                // if (LogLevel.Normal > networkManager.LogLevel)
+                processor.Emit(OpCodes.Ldloc, netManLocIdx);
+                processor.Emit(OpCodes.Ldfld, m_NetworkManager_LogLevel_FieldRef);
+                processor.Emit(OpCodes.Ldc_I4, (int)LogLevel.Normal);
+                processor.Emit(OpCodes.Cgt);
+                processor.Emit(OpCodes.Ldc_I4, 0);
+                processor.Emit(OpCodes.Ceq);
+                processor.Emit(OpCodes.Brfalse, logNextInstr);
+
+                // Debug.LogError(...);
+                processor.Emit(OpCodes.Ldstr, "Only the server can invoke an Rpc with RpcInvokePermission.Server!");
                 processor.Emit(OpCodes.Call, m_Debug_LogError_MethodRef);
 
                 processor.Append(logNextInstr);

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -330,12 +330,13 @@ namespace Unity.Netcode
             {   
                 throw new RpcException("The NetworkBehaviour must be spawned before calling this method.");
             }
-            if (attributeParams.InvokePermission == RpcInvokePermission.Owner && !IsOwner)
-            {
-                throw new RpcException("This RPC can only be sent by its owner.");
-            } else if (attributeParams.InvokePermission == RpcInvokePermission.Server && !IsServer)
+            else if (attributeParams.InvokePermission == RpcInvokePermission.Server && !IsServer)
             {
                 throw new RpcException("This RPC can only be sent by the server.");
+            }
+            else if ((attributeParams.RequireOwnership || attributeParams.InvokePermission == RpcInvokePermission.Owner) && !IsOwner)
+            {
+                throw new RpcException("This RPC can only be sent by its owner.");
             }
             return new FastBufferWriter(k_RpcMessageDefaultSize, Allocator.Temp, k_RpcMessageMaximumSize);
         }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -39,6 +39,7 @@ namespace Unity.Netcode
 
         // RuntimeAccessModifiersILPP will make this `public`
         internal static readonly Dictionary<Type, Dictionary<uint, RpcReceiveHandler>> __rpc_func_table = new Dictionary<Type, Dictionary<uint, RpcReceiveHandler>>();
+        internal static readonly Dictionary<Type, Dictionary<uint, RpcInvokePermission>> __rpc_permission_table = new Dictionary<Type, Dictionary<uint, RpcInvokePermission>>();
 
 #if DEVELOPMENT_BUILD || UNITY_EDITOR || UNITY_MP_TOOLS_NET_STATS_MONITOR_ENABLED_IN_RELEASE
         // RuntimeAccessModifiersILPP will make this `public`
@@ -326,12 +327,15 @@ namespace Unity.Netcode
 #pragma warning restore IDE1006 // restore naming rule violation check
         {
             if (m_NetworkObject == null && !IsSpawned)
-            {
+            {   
                 throw new RpcException("The NetworkBehaviour must be spawned before calling this method.");
             }
-            if (attributeParams.RequireOwnership && !IsOwner)
+            if (attributeParams.InvokePermission == RpcInvokePermission.Owner && !IsOwner)
             {
                 throw new RpcException("This RPC can only be sent by its owner.");
+            } else if (attributeParams.InvokePermission == RpcInvokePermission.Server && !IsServer)
+            {
+                throw new RpcException("This RPC can only be sent by the server.");
             }
             return new FastBufferWriter(k_RpcMessageDefaultSize, Allocator.Temp, k_RpcMessageMaximumSize);
         }
@@ -950,10 +954,11 @@ namespace Unity.Netcode
 
 #pragma warning disable IDE1006 // disable naming rule violation check
         // RuntimeAccessModifiersILPP will make this `protected`
-        internal void __registerRpc(uint hash, RpcReceiveHandler handler, string rpcMethodName)
+        internal void __registerRpc(uint hash, RpcReceiveHandler handler, RpcInvokePermission permission, string rpcMethodName)
 #pragma warning restore IDE1006 // restore naming rule violation check
         {
             __rpc_func_table[GetType()][hash] = handler;
+            __rpc_permission_table[GetType()][hash] = permission;
 #if DEVELOPMENT_BUILD || UNITY_EDITOR || UNITY_MP_TOOLS_NET_STATS_MONITOR_ENABLED_IN_RELEASE
             __rpc_name_table[GetType()][hash] = rpcMethodName;
 #endif
@@ -1000,6 +1005,7 @@ namespace Unity.Netcode
             if (!__rpc_func_table.ContainsKey(GetType()))
             {
                 __rpc_func_table[GetType()] = new Dictionary<uint, RpcReceiveHandler>();
+                __rpc_permission_table[GetType()] = new Dictionary<uint, RpcInvokePermission>();
 #if UNITY_EDITOR || DEVELOPMENT_BUILD || UNITY_MP_TOOLS_NET_STATS_MONITOR_ENABLED_IN_RELEASE
                 __rpc_name_table[GetType()] = new Dictionary<uint, string>();
 #endif

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ProxyMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ProxyMessage.cs
@@ -41,8 +41,30 @@ namespace Unity.Netcode
                 }
                 return;
             }
-
             var observers = networkObject.Observers;
+
+            var networkBehaviour = networkObject.GetNetworkBehaviourAtOrderIndex(WrappedMessage.Metadata.NetworkBehaviourId);
+
+            RpcInvokePermission permission = NetworkBehaviour.__rpc_permission_table[networkBehaviour.GetType()][WrappedMessage.Metadata.NetworkRpcMethodId];
+            bool hasPermission = permission switch
+            {
+                RpcInvokePermission.Anyone => true,
+                RpcInvokePermission.Server => context.SenderId == networkManager.LocalClientId,
+                RpcInvokePermission.Owner => context.SenderId == networkBehaviour.OwnerClientId,
+                _ => false,
+            };
+
+            // Do not handle the message if the sender does not have permission to do so.
+            if (!hasPermission)
+            {
+                return;
+            }
+
+            if (networkManager.IsServer)
+            {
+                WrappedMessage.SenderClientId = context.SenderId;
+            }
+
 
             var nonServerIds = new NativeList<ulong>(Allocator.Temp);
             for (var i = 0; i < TargetClientIds.Length; ++i)

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ProxyMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ProxyMessage.cs
@@ -43,25 +43,26 @@ namespace Unity.Netcode
             }
             var observers = networkObject.Observers;
 
-            var networkBehaviour = networkObject.GetNetworkBehaviourAtOrderIndex(WrappedMessage.Metadata.NetworkBehaviourId);
-
-            RpcInvokePermission permission = NetworkBehaviour.__rpc_permission_table[networkBehaviour.GetType()][WrappedMessage.Metadata.NetworkRpcMethodId];
-            bool hasPermission = permission switch
-            {
-                RpcInvokePermission.Anyone => true,
-                RpcInvokePermission.Server => context.SenderId == networkManager.LocalClientId,
-                RpcInvokePermission.Owner => context.SenderId == networkBehaviour.OwnerClientId,
-                _ => false,
-            };
-
-            // Do not handle the message if the sender does not have permission to do so.
-            if (!hasPermission)
-            {
-                return;
-            }
-
+            // Validate message if server
             if (networkManager.IsServer)
             {
+                var networkBehaviour = networkObject.GetNetworkBehaviourAtOrderIndex(WrappedMessage.Metadata.NetworkBehaviourId);
+
+                RpcInvokePermission permission = NetworkBehaviour.__rpc_permission_table[networkBehaviour.GetType()][WrappedMessage.Metadata.NetworkRpcMethodId];
+                bool hasPermission = permission switch
+                {
+                    RpcInvokePermission.Anyone => true,
+                    RpcInvokePermission.Server => context.SenderId == networkManager.LocalClientId,
+                    RpcInvokePermission.Owner => context.SenderId == networkBehaviour.OwnerClientId,
+                    _ => false,
+                };
+
+                // Do not handle the message if the sender does not have permission to do so.
+                if (!hasPermission)
+                {
+                    return;
+                }
+
                 WrappedMessage.SenderClientId = context.SenderId;
             }
 

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/RpcMessages.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/RpcMessages.cs
@@ -66,12 +66,29 @@ namespace Unity.Netcode
                 {
                     NetworkLog.LogWarning($"[{metadata.NetworkObjectId}, {metadata.NetworkBehaviourId}, {metadata.NetworkRpcMethodId}] An RPC called on a {nameof(NetworkObject)} that is not in the spawned objects list. Please make sure the {nameof(NetworkObject)} is spawned before calling RPCs.");
                 }
-                return;
             }
             var networkBehaviour = networkObject.GetNetworkBehaviourAtOrderIndex(metadata.NetworkBehaviourId);
 
             try
             {
+                Type type = networkBehaviour.GetType();
+                if (networkManager.IsServer)
+                {
+                    RpcInvokePermission permission = NetworkBehaviour.__rpc_permission_table[networkBehaviour.GetType()][metadata.NetworkRpcMethodId];
+                    bool hasPermission = permission switch
+                    {
+                        RpcInvokePermission.Anyone => true,
+                        RpcInvokePermission.Server => context.SenderId == networkManager.LocalClientId,
+                        RpcInvokePermission.Owner => context.SenderId == networkBehaviour.OwnerClientId,
+                        _ => false,
+                    };
+
+                    // Do not handle the message if the sender does not have permission to do so.
+                    if (!hasPermission)
+                    {
+                        return;
+                    }
+                }    
                 NetworkBehaviour.__rpc_func_table[networkBehaviour.GetType()][metadata.NetworkRpcMethodId](networkBehaviour, payload, rpcParams);
             }
             catch (Exception ex)

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/RpcMessages.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/RpcMessages.cs
@@ -196,6 +196,12 @@ namespace Unity.Netcode
 
         public void Handle(ref NetworkContext context)
         {
+            var networkManager = (NetworkManager)context.SystemOwner;
+            if (networkManager.IsServer)
+            {
+                SenderClientId = context.SenderId;
+            }
+            
             var rpcParams = new __RpcParams
             {
                 Ext = new RpcParams

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcAttributes.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcAttributes.cs
@@ -150,7 +150,6 @@ namespace Unity.Netcode
         /// </summary>
         public ClientRpcAttribute() : base(SendTo.NotServer)
         {
-            InvokePermission = RpcInvokePermission.Server;
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcAttributes.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcAttributes.cs
@@ -67,6 +67,8 @@ namespace Unity.Netcode
             /// When true, allows the RPC target to be overridden at runtime
             /// </summary>
             public bool AllowTargetOverride;
+
+            public bool RequireOwnership;
         }
 
         // Must match the fields in RemoteAttributeParams
@@ -79,6 +81,15 @@ namespace Unity.Netcode
         /// Who has network permission to invoke this RPC
         /// </summary>
         public RpcInvokePermission InvokePermission;
+
+        /// <summary>
+        /// When true, only the owner of the object can execute this RPC
+        /// </summary>
+        /// <remarks>
+        /// Deprecated in favor of <see cref="RpcInvokePermission"/>.
+        /// </remarks>
+        [Obsolete]
+        public bool RequireOwnership;
 
         /// <summary>
         /// When true, local execution of the RPC is deferred until the next network tick
@@ -116,7 +127,7 @@ namespace Unity.Netcode
         /// When true, only the owner of the NetworkObject can invoke this ServerRpc.
         /// This property overrides the base RpcAttribute.RequireOwnership.
         /// </summary>
-        public bool RequireOwnership;
+        public new bool RequireOwnership;
 
         /// <summary>
         /// Initializes a new instance of ServerRpcAttribute that targets the server
@@ -139,7 +150,7 @@ namespace Unity.Netcode
         /// </summary>
         public ClientRpcAttribute() : base(SendTo.NotServer)
         {
-
+            InvokePermission = RpcInvokePermission.Server;
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcAttributes.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcAttributes.cs
@@ -19,6 +19,25 @@ namespace Unity.Netcode
     }
 
     /// <summary>
+    /// RPC invoke permissions
+    /// </summary>
+    public enum RpcInvokePermission
+    {
+        /// <summary>
+        /// Anyone can invoke the Rpc.
+        /// </summary>
+        Anyone = 0,
+        /// <summary>
+        /// Rpc can only be invoked by the server.
+        /// </summary>
+        Server,
+        /// <summary>
+        /// Rpc can only be invoked by the owner of the NetworkBehaviour.
+        /// </summary>
+        Owner,
+    }
+
+    /// <summary>
     /// <para>Represents the common base class for Rpc attributes.</para>
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
@@ -35,9 +54,9 @@ namespace Unity.Netcode
             public RpcDelivery Delivery;
 
             /// <summary>
-            /// When true, only the owner of the object can execute this RPC
+            /// Who has network permission to invoke this RPC
             /// </summary>
-            public bool RequireOwnership;
+            public RpcInvokePermission InvokePermission;
 
             /// <summary>
             /// When true, local execution of the RPC is deferred until the next network tick
@@ -57,9 +76,9 @@ namespace Unity.Netcode
         public RpcDelivery Delivery = RpcDelivery.Reliable;
 
         /// <summary>
-        /// When true, only the owner of the object can execute this RPC
+        /// Who has network permission to invoke this RPC
         /// </summary>
-        public bool RequireOwnership;
+        public RpcInvokePermission InvokePermission;
 
         /// <summary>
         /// When true, local execution of the RPC is deferred until the next network tick
@@ -97,7 +116,7 @@ namespace Unity.Netcode
         /// When true, only the owner of the NetworkObject can invoke this ServerRpc.
         /// This property overrides the base RpcAttribute.RequireOwnership.
         /// </summary>
-        public new bool RequireOwnership;
+        public bool RequireOwnership;
 
         /// <summary>
         /// Initializes a new instance of ServerRpcAttribute that targets the server


### PR DESCRIPTION
## Purpose of this PR
When a server receives an RpcMessage, it should update the SenderClientId to match the SenderId provided by the messaging manager. This is to prevent modified clients from spoofing their SenderClientId as other clients.

### Changelog
- Fixed: Modified clients could spoof SenderClientId when sending an Rpc.

## Documentation
No documentation changes or additions were necessary.

## Testing & QA (How your changes can be verified during release Playtest)
Manual testing required.
