### PR TITLE
fix: Update readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Netcode for GameObjects
 
 [![Forums](https://img.shields.io/badge/unity--forums-multiplayer-blue)](https://discussions.unity.com/tag/Netcode-for-GameObjects) [![Discord](https://img.shields.io/discord/449263083769036810.svg?label=discord&logo=discord&color=informational)](https://discord.gg/unity)
-[![Manual](https://img.shields.io/badge/docs-manual-informational.svg)](https://docs.unity3d.com/Manual/com.unity.netcode.gameobjects.html) [![API](https://img.shields.io/badge/docs-api-informational.svg)](https://docs.unity3d.com/Packages/com.unity.netcode.gameobjects@2.6/api/index.html)
+[![Manual](https://img.shields.io/badge/docs-manual-informational.svg)](https://docs.unity3d.com/Packages/com.unity.netcode.gameobjects@latest) [![API](https://img.shields.io/badge/docs-api-informational.svg)](https://docs.unity3d.com/Packages/com.unity.netcode.gameobjects@latest/?subfolder=/api/Unity.Netcode.NetworkManager.html)
 
 [![GitHub Release](https://img.shields.io/github/release/Unity-Technologies/com.unity.netcode.gameobjects.svg?logo=github)](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/releases/latest)
 
@@ -9,13 +9,13 @@
 
 Welcome to the Netcode for GameObjects repository.
 
-Netcode for GameObjects is a Unity package that provides networking capabilities to GameObject & MonoBehaviour workflows. The framework is interoperable with many low-level transports, including the official [Unity Transport Package](https://docs.unity3d.com/Manual/com.unity.transport.html).
+Netcode for GameObjects is a Unity package that provides networking capabilities to GameObject & MonoBehaviour workflows. The framework is interoperable with many low-level transports, including the official [Unity Transport Package](https://docs.unity3d.com/Packages/com.unity.transport@latest).
 
 ### Getting Started
 
 Visit the [Multiplayer Docs Site](https://docs.unity3d.com/Manual/multiplayer.html) for package & API documentation, as well as information about several samples which leverage the Netcode for GameObjects package.
 
-You can also jump right into our [Hello World](https://docs.unity3d.com/Packages/com.unity.netcode.gameobjects@2.6/manual/tutorials/helloworld.html) guide for a taste of how to use the framework for basic networked tasks.
+You can also use our [quickstart guide](https://docs.unity3d.com/Packages/com.unity.netcode.gameobjects@latest/?subfolder=/manual/tutorials/get-started-with-ngo.html) to get a taste of how to use the framework for basic networked tasks.
 
 ### Community and Feedback
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Netcode for GameObjects
 
-[![Forums](https://img.shields.io/badge/unity--forums-multiplayer-blue)](https://forum.unity.com/forums/multiplayer.26/) [![Discord](https://img.shields.io/discord/449263083769036810.svg?label=discord&logo=discord&color=informational)](https://discord.gg/FM8SE9E)
-[![Manual](https://img.shields.io/badge/docs-manual-informational.svg)](https://docs-multiplayer.unity3d.com/netcode/current/about) [![API](https://img.shields.io/badge/docs-api-informational.svg)](https://docs-multiplayer.unity3d.com/netcode/current/api/introduction)
+[![Forums](https://img.shields.io/badge/unity--forums-multiplayer-blue)](https://discussions.unity.com/tag/Netcode-for-GameObjects) [![Discord](https://img.shields.io/discord/449263083769036810.svg?label=discord&logo=discord&color=informational)](https://discord.gg/unity)
+[![Manual](https://img.shields.io/badge/docs-manual-informational.svg)](https://docs.unity3d.com/Manual/com.unity.netcode.gameobjects.html) [![API](https://img.shields.io/badge/docs-api-informational.svg)](https://docs.unity3d.com/Packages/com.unity.netcode.gameobjects@2.6/api/index.html)
 
 [![GitHub Release](https://img.shields.io/github/release/Unity-Technologies/com.unity.netcode.gameobjects.svg?logo=github)](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/releases/latest)
 
@@ -9,17 +9,17 @@
 
 Welcome to the Netcode for GameObjects repository.
 
-Netcode for GameObjects is a Unity package that provides networking capabilities to GameObject & MonoBehaviour workflows. The framework is interoperable with many low-level transports, including the official [Unity Transport Package](https://docs-multiplayer.unity3d.com/transport/current/about).
+Netcode for GameObjects is a Unity package that provides networking capabilities to GameObject & MonoBehaviour workflows. The framework is interoperable with many low-level transports, including the official [Unity Transport Package](https://docs.unity3d.com/Manual/com.unity.transport.html).
 
 ### Getting Started
 
-Visit the [Multiplayer Docs Site](https://docs-multiplayer.unity3d.com/) for package & API documentation, as well as information about several samples which leverage the Netcode for GameObjects package.
+Visit the [Multiplayer Docs Site](https://docs.unity3d.com/Manual/multiplayer.html) for package & API documentation, as well as information about several samples which leverage the Netcode for GameObjects package.
 
-You can also jump right into our [Hello World](https://docs-multiplayer.unity3d.com/netcode/current/tutorials/helloworld) guide for a taste of how to use the framework for basic networked tasks.
+You can also jump right into our [Hello World](https://docs.unity3d.com/Packages/com.unity.netcode.gameobjects@2.6/manual/tutorials/helloworld.html) guide for a taste of how to use the framework for basic networked tasks.
 
 ### Community and Feedback
 
-For general questions, networking advice or discussions about Netcode for GameObjects, please join our [Discord Community](https://discord.gg/FM8SE9E) or create a post in the [Unity Multiplayer Forum](https://forum.unity.com/forums/multiplayer.26/).
+For general questions, networking advice or discussions about Netcode for GameObjects, please join our [Discord Community](https://discord.gg/unity) or create a post in the [Unity Forum's "Netcode for GameObjects" section](https://discussions.unity.com/tag/Netcode-for-GameObjects).
 
 ### Compatibility
 
@@ -48,4 +48,4 @@ We are an open-source project and we encourage and welcome contributions. If you
 
 If you have an issue, bug or feature request, please follow the information in our [contribution guidelines](CONTRIBUTING.md) to submit an issue.
 
-You can also check out our public [roadmap](https://unity.com/roadmap/unity-platform/multiplayer-networking) to get an idea for what we might be working on next!
+You can also check out our public [roadmap](https://unity.com/roadmap#unity-platform-multiplayer) to get an idea for what we might be working on next!


### PR DESCRIPTION
## Purpose of this PR

continues: #3732
fixes #3688 

All links in the README (save for two) were outdated or broken and required updating. Most notably, the link to Unity's Discord was invalid due to pointing at a deprecated Discord server.

### Changelog

- Fixed: Broken Discord links
- Changed: All shield icon links (except "release" link)
- Changed: Links to docs and/or package sites
- Changed: Link to "Hello World" example swapped to instead use the quickstart
- Changed: Link to Multiplayer roadmap

## Jira ticket

- None

## Documentation

- No documentation changes or additions were necessary outside the README.

## Testing & QA (How your changes can be verified during release Playtest)

- All links manually tested in local web browser

## Backports

- None
