### PR TITLE
chore: Add instructions for testing with CMB Service

### DIFF
--- a/.yamato/cmb-service-standalone-tests.yml
+++ b/.yamato/cmb-service-standalone-tests.yml
@@ -54,7 +54,7 @@ cmb_service_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}
 
   commands:
     # run_cmb_service.sh builds and starts a release version of the full CMB service (along with the limited echo server)
-    - ./Tools/CI/run_cmb_service.sh -e $ECHO_SERVER_PORT -s $CMB_SERVICE_PORT
+    - ./Tools/CI/service.cmb/run_cmb_service.sh -e $ECHO_SERVER_PORT -s $CMB_SERVICE_PORT
 
     - unity-downloader-cli --fast --wait -u {{ editor }} -c Editor {% if backend == "il2cpp" %} -c il2cpp {% endif %} {% if platform.name == "mac" %} --arch arm64 {% endif %} # For macOS we use ARM64 models
     - UnifiedTestRunner --suite=playmode --player-load-path=build/players --artifacts-path=test-results --testproject={{ project.path }} --editor-location=.Editor --playergraphicsapi=Null --fail-on-assert --rerun-strategy=Test --retry={{ num_test_retries }} --clean-library-on-rerun --timeout={{ test_timeout }}

--- a/Tools/CI/service.cmb/README.md
+++ b/Tools/CI/service.cmb/README.md
@@ -1,0 +1,58 @@
+# Testing against the CMB Service
+
+The CMB Service is a tool that is external to our repository. The tool is inside the `runtime` folder in the [mps-common-multiplayer-backend](https://github.com/Unity-Technologies/mps-common-multiplayer-backend) repository.
+
+Due to this, there is some more setup needed when running tests against the CMB Service.
+
+## Configuration
+
+The tests are automatically configured to run any `HostOrServer.DAHost` or `NetworkTopologyTypes.DistributedAuthority` test against the CMB server when either the `USE_CMB_SERVICE` scripting define is set, or when an environment variable is passed in with `USE_CMB_SERVICE=true`. When set, all non-distributed authority compatible tests will be ignored.
+
+By default, the tests are configured to look for the service on the local machine (`localhost`/`http://127.0.0.1`) at port `7789`.
+
+## Running against the service
+
+First, ensure the `USE_CMB_SERVICE` scripting define or environment variable is set.
+
+### Download the service
+
+Go to the `CMB Runtime CI` action inside the cmb repo ([link here](https://github.com/Unity-Technologies/mps-common-multiplayer-backend/actions/workflows/runtime.yaml)). Open the most recent job and scroll down to the bottom of the page (You may have to scroll in the sidebar on the left, the centre of the page is not scrollable).
+
+Inside the **Artifacts** section at the bottom of the page, download the `comb-server-<platform>-latest` that matches your computer architecture. This will download a pre-built binary of the most recent CMB Service.
+
+### Run the service locally
+
+Next we'll run the binary on the command line.
+
+> [!NOTE]
+> If you're running on macOS, you'll have to add execution privileges to the binary before running it.
+
+```bash
+xattr -c /path/to/comb-server
+```
+
+To run the service, run the following command:
+
+```bash
+/path/to/download/comb-server -l info --metrics-port 5000 standalone --port 7789 -t 60m
+```
+
+Note that we have set the port to `7789` to match where the tests will be looking.
+
+After each test, all connected clients will disconnect from the service. The service will automatically shut down when that happens. When running multiple tests in a row, it can be more convenient to run the service in a loop:
+
+```bash
+while :; do /path/to/download/file -l info --metrics-port 5000 standalone --port 7789 -t 60m; done
+```
+
+### Run the tests
+
+With `USE_CMB_SERVICE` set, everything should be configured so that running any distributed authority test in the editor should run against the service we have running on the command line. Try running a test to validate that information is logged in the command line.
+
+## Further configuration
+
+The following environment variables allow for further configuration of the setup.
+
+`CMB_SERVICE_PORT` defines the port where the tests will try to connect to the service (defaults to `7789`).
+
+`NGO_HOST` defines the http address where the tests will try to connect to the service (defaults to `127.0.0.1`).

--- a/Tools/CI/service.cmb/run_cmb_service.sh
+++ b/Tools/CI/service.cmb/run_cmb_service.sh
@@ -91,20 +91,20 @@ logError(){
 
 # Protocol Buffer Compiler ------------------------------------------------------
 
-# Apply any updates 
+# Apply any updates
 logMessage "Updating modules..."
 sudo apt-get update
 
 # Install Protocol Buffer Compiler (using apt-get)
-logMessage "Installing protocol bufffer compiler as SUDO..."
+logMessage "Installing protocol buffer compiler as SUDO..."
 try sudo apt-get install -y protobuf-compiler
 
 # If the previous command failed, try without sudo
 if $ThrewError; then
-logMessage "Installing protocol bufffer compiler as shell assigned account..."
+logMessage "Installing protocol buffer compiler as shell assigned account..."
 apt-get install -y protobuf-compiler
 else
-logMessage "Protocol bufffer compiler was installed as sudo!"
+logMessage "Protocol buffer compiler was installed as sudo!"
 fi
 
 # Add the PROTOC environment variable that points to the Protocol Buffer Compiler binary


### PR DESCRIPTION
## Purpose of this PR

Add first pass of instructions on how to test with the CMB Service

### Jira ticket

A QA tried to reproduce [MTTB-1680](https://jira.unity3d.com/browse/MTTB-1680) but we had no instructions for running the DA tests.

### Changelog

- Added: A README file with instructions for locally running the DA tests.

## Documentation

- No documentation changes or additions were necessary.

## Testing & QA (How your changes can be verified during release Playtest)

Doesn't change anything that needs testing.

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [x] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports

No backport needed.
