### PR TITLE
fix: [backport] add better error messages for a couple of error cases

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -13,6 +13,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+- Better error message when using generic IEquatable in a generic INetworkSerializable class and updated documentation with workaround. (#3739)
 - The `NetworkManager` functions `GetTransportIdFromClientId` and `GetClientIdFromTransportId` will now return `ulong.MaxValue` when the clientId or transportId do not exist. (#3721)
 - Changed minimum Unity version supported to 2022.3 LTS
 
@@ -25,6 +26,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Fixed
 
 - Multiple disconnect events from the same transport will no longer disconnect the host. (#3721)
+- Exception when the network prefab list in the network manager has uninitialized elements. (#3739)
 
 ### Security
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -13,7 +13,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
-- Better error message when using generic IEquatable in a generic INetworkSerializable class and updated documentation with workaround. (#3739)
+- Better error message when using generic IEquatable in a generic INetworkSerializable class and updated documentation with workaround. (#3744)
 - The `NetworkManager` functions `GetTransportIdFromClientId` and `GetClientIdFromTransportId` will now return `ulong.MaxValue` when the clientId or transportId do not exist. (#3721)
 - Changed minimum Unity version supported to 2022.3 LTS
 
@@ -26,7 +26,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Fixed
 
 - Multiple disconnect events from the same transport will no longer disconnect the host. (#3721)
-- Exception when the network prefab list in the network manager has uninitialized elements. (#3739)
+- Exception when the network prefab list in the network manager has uninitialized elements. (#3744)
 
 ### Security
 

--- a/com.unity.netcode.gameobjects/Documentation~/advanced-topics/serialization/inetworkserializable.md
+++ b/com.unity.netcode.gameobjects/Documentation~/advanced-topics/serialization/inetworkserializable.md
@@ -181,3 +181,55 @@ public struct MyStructB : MyStructA
     }
 }
 ```
+
+## Generic IEquatable network variables
+
+Generic `INetworkSerializable` types with generic `IEquatable` are not supported, implemented as `public class NotSupported<T> : INetworkSerializable, IEquatable<NotSupported<T>>` where the type would be passed in during declaration like `NetworkVariable<NotSupported<int>> myVar;`.
+
+The recommended workaround for this would be to create the generic class as usual but add a virtual method for handling the serialization of the type. Then wrap this generic `INetworkSerializable` in a derived class which then needs to have a serializable type defined where the implementation for the serialization is provided.
+
+For example:
+
+```csharp
+public class MyGameData<T> : INetworkSerializable
+{
+    // This needs to be a serializable type according to what network variables support
+    public T Data;
+
+    protected virtual void OnNetworkSerialize<T2>(BufferSerializer<T2> serializer) where T2 : IReaderWriter
+    {
+    }
+
+    public void NetworkSerialize<T2>(BufferSerializer<T2> serializer) where T2 : IReaderWriter
+    {
+        OnNetworkSerialize(serializer);
+    }
+}
+
+public class GameDataWithLong : MyGameData<long>, IEquatable<GameDataWithLong>
+{
+    // Potential additional data
+    public int AdditionalData;
+
+    protected virtual bool OnEquals(GameDataWithLong other)
+    {
+        return other.Data.Equals(other);
+    }
+    public bool Equals(GameDataWithLong other)
+    {
+        return OnEquals(other);
+    }
+
+    protected override void OnNetworkSerialize<T2>(BufferSerializer<T2> serializer)
+    {
+        serializer.SerializeValue(ref AdditionalData);
+        serializer.SerializeValue(ref Data);
+    }
+}
+```
+
+Then declare this network variable like so:
+
+```csharp
+NetworkVariable<GameDataWithLong> myVar = new NetworkVariable<GameDataWithLong>();
+```

--- a/com.unity.netcode.gameobjects/Documentation~/advanced-topics/serialization/inetworkserializable.md
+++ b/com.unity.netcode.gameobjects/Documentation~/advanced-topics/serialization/inetworkserializable.md
@@ -184,7 +184,7 @@ public struct MyStructB : MyStructA
 
 ## Generic IEquatable network variables
 
-Generic `INetworkSerializable` types with generic `IEquatable` are not supported, implemented as `public class NotSupported<T> : INetworkSerializable, IEquatable<NotSupported<T>>` where the type would be passed in during declaration like `NetworkVariable<NotSupported<int>> myVar;`.
+Netcode for GameObjects doesn't support generic `INetworkSerializable` types with generic `IEquatable`s when implemented as `public class NotSupported<T> : INetworkSerializable, IEquatable<NotSupported<T>>`, where the type is passed in during declaration like `NetworkVariable<NotSupported<int>> myVar;`.
 
 The recommended workaround for this would be to create the generic class as usual but add a virtual method for handling the serialization of the type. Then wrap this generic `INetworkSerializable` in a derived class which then needs to have a serializable type defined where the implementation for the serialization is provided.
 

--- a/com.unity.netcode.gameobjects/Documentation~/advanced-topics/serialization/inetworkserializable.md
+++ b/com.unity.netcode.gameobjects/Documentation~/advanced-topics/serialization/inetworkserializable.md
@@ -186,7 +186,7 @@ public struct MyStructB : MyStructA
 
 Netcode for GameObjects doesn't support generic `INetworkSerializable` types with generic `IEquatable`s when implemented as `public class NotSupported<T> : INetworkSerializable, IEquatable<NotSupported<T>>`, where the type is passed in during declaration like `NetworkVariable<NotSupported<int>> myVar;`.
 
-The recommended workaround for this would be to create the generic class as usual but add a virtual method for handling the serialization of the type. Then wrap this generic `INetworkSerializable` in a derived class which then needs to have a serializable type defined where the implementation for the serialization is provided.
+You can work around this limitation by creating the generic class as normal and adding a virtual method for handling the serialization of the type. Then wrap the generic `INetworkSerializable` in a derived class that has a serializable type defined where the implementation for the serialization is provided.
 
 For example:
 

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -408,7 +408,14 @@ namespace Unity.Netcode.Editor.CodeGen
                     }
                     else
                     {
-                        m_Diagnostics.AddError($"{type}: Managed type in NetworkVariable must implement IEquatable<{type}>");
+                        foreach (var typeInterface in type.Resolve().Interfaces)
+                        {
+                            if (typeInterface.InterfaceType.Name.Contains(typeof(IEquatable<>).Name) && typeInterface.InterfaceType.IsGenericInstance)
+                            {
+                                m_Diagnostics.AddError($"{type}: A generic IEquatable '{typeInterface.InterfaceType.FullName}' is not supported.");
+                            }
+                        }
+                        m_Diagnostics.AddError($"{type}: Managed type in NetworkVariable must implement IEquatable<{type}>.");
                         equalityMethod = new GenericInstanceMethod(m_NetworkVariableSerializationTypes_InitializeEqualityChecker_ManagedClassEquals_MethodRef);
                     }
 

--- a/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Unity.Netcode.Editor.Configuration;
 using UnityEditor;
 using UnityEngine;
@@ -538,6 +539,10 @@ namespace Unity.Netcode.Editor
                 if (m_NetworkManager.NetworkConfig.Prefabs.NetworkPrefabsLists.Count == 0)
                 {
                     EditorGUILayout.HelpBox("You have no prefab list selected. You will have to add your prefabs manually at runtime for netcode to work.", MessageType.Warning);
+                }
+                else if (m_NetworkManager.NetworkConfig.Prefabs.NetworkPrefabsLists.All(x => x == null))
+                {
+                    EditorGUILayout.HelpBox("All prefab lists selected are uninitialized. You will have to add your prefabs manually at runtime for netcode to work.", MessageType.Warning);
                 }
 
                 EditorGUILayout.PropertyField(m_PrefabsList);

--- a/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkPrefabs.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkPrefabs.cs
@@ -93,6 +93,7 @@ namespace Unity.Netcode
         public void Initialize(bool warnInvalid = true)
         {
             m_Prefabs.Clear();
+            NetworkPrefabsLists.RemoveAll(x => x == null);
             foreach (var list in NetworkPrefabsLists)
             {
                 list.OnAdd += AddTriggeredByNetworkPrefabList;

--- a/com.unity.netcode.gameobjects/Tests/Editor/NetworkManagerConfigurationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/NetworkManagerConfigurationTests.cs
@@ -283,6 +283,22 @@ namespace Unity.Netcode.EditorTests
         }
 
         [Test]
+        public void WhenThereAreUninitializedElementsInPrefabsList_NoErrors()
+        {
+            var networkConfig = new NetworkConfig();
+
+            networkConfig.Prefabs.NetworkPrefabsLists = new List<NetworkPrefabsList> { null };
+
+            networkConfig.InitializePrefabs();
+
+            // Null elements will be removed from the list so it should be empty
+            Assert.IsTrue(networkConfig.Prefabs.NetworkPrefabsLists.Count == 0);
+            Assert.IsTrue(networkConfig.Prefabs.Prefabs.Count == 0);
+
+            networkConfig.Prefabs.Shutdown();
+        }
+
+        [Test]
         public void WhenModifyingPrefabListUsingPrefabsListAPI_ModificationIsShared()
         {
             // Setup

--- a/pvpExceptions.json
+++ b/pvpExceptions.json
@@ -246,6 +246,7 @@
           "Unity.Netcode.EditorTests.NetworkManagerConfigurationTests: void WhenCallingInitializeAfterAddingAPrefabUsingPrefabsAPI_ThePrefabStillExists(): undocumented",
           "Unity.Netcode.EditorTests.NetworkManagerConfigurationTests: void WhenShuttingDownAndReinitializingPrefabs_RuntimeAddedPrefabsStillExists(): undocumented",
           "Unity.Netcode.EditorTests.NetworkManagerConfigurationTests: void WhenCallingInitializeMultipleTimes_NothingBreaks(): undocumented",
+          "Unity.Netcode.EditorTests.NetworkManagerConfigurationTests: void WhenThereAreUninitializedElementsInPrefabsList_NoErrors(): undocumented",
           "Unity.Netcode.EditorTests.NetworkManagerConfigurationTests.NetworkObjectPlacement: undocumented",
           "Unity.Netcode.EditorTests.NetworkManagerConfigurationTests.NetworkObjectPlacement: Root: undocumented",
           "Unity.Netcode.EditorTests.NetworkManagerConfigurationTests.NetworkObjectPlacement: Child: undocumented",


### PR DESCRIPTION
## Purpose of this PR
add better error messages for a couple of error cases
- When using a generic INetworkSerializable+IEquatable combo and update documentation with workaround
- When there are no initialized elements in the network prefab list (fix null reference exception)

Example error printed with the generic IEquatable error is
```
Unity.Netcode.Editor.CodeGen.NetworkBehaviourILPP: (0,0): error  - TestClassNotWorking`1<System.Int32>: A generic IEquatable 'System.IEquatable`1<TestClassNotWorking`1<T>>' is not supported.
```
which is printed in addition to the usual error for not implementing IEquatable.

### Jira ticket
[MTTB-1202](https://jira.unity3d.com/browse/MTTB-1202)
[MTTB-1306](https://jira.unity3d.com/browse/MTTB-1306)

### Changelog
- Fixed: Exception when the network prefab list in the network manager has uninitialized elements.
- Changed: Better error message when using generic IEquatable in a generic INetworkSerializable class and updated documentation with workaround.

## Documentation
- Includes edits to existing public API documentation.

## Testing & QA (How your changes can be verified during release Playtest)
Manually tested the codegen errors with IEquatable.

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [x] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports
This is a backport of [3739](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3739)
