### PR TITLE
fix: Compilation error when using an RpcAttribute with RequireOwnership

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -1654,18 +1654,14 @@ namespace Unity.Netcode.Editor.CodeGen
                 return null;
             }
 
-            var typeSystem = methodDefinition.Module.TypeSystem;
-            var hasInvokePermission = false;
+            bool hasInvokePermission = false, hasRequireOwnership = false;
 
-            CustomAttributeNamedArgument? invokePermissionAttribute = null;
             foreach (var argument in rpcAttribute.Fields)
             {
                 switch (argument.Name)
                 {
                     case k_ServerRpcAttribute_RequireOwnership:
-                        var requireOwnership = argument.Argument.Type == typeSystem.Boolean && (bool)argument.Argument.Value;
-                        var invokePermissionArg = new CustomAttributeArgument(m_RpcInvokePermissions_TypeRef, requireOwnership ? RpcInvokePermission.Owner : RpcInvokePermission.Everyone);
-                        invokePermissionAttribute = new CustomAttributeNamedArgument(k_RpcAttribute_InvokePermission, invokePermissionArg);
+                        hasRequireOwnership = true;
                         break;
                     case k_RpcAttribute_InvokePermission:
                         hasInvokePermission = true;
@@ -1673,15 +1669,10 @@ namespace Unity.Netcode.Editor.CodeGen
                 }
             }
 
-            if (invokePermissionAttribute != null)
+            if (hasInvokePermission && hasRequireOwnership)
             {
-                if (hasInvokePermission)
-                {
-                    m_Diagnostics.AddError($"{methodDefinition.Name} cannot declare both RequireOwnership and InvokePermission!");
-                    return null;
-                }
-
-                rpcAttribute.Fields.Add(invokePermissionAttribute.Value);
+                m_Diagnostics.AddError($"{methodDefinition.Name} cannot declare both RequireOwnership and InvokePermission!");
+                return null;
             }
 
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -335,7 +335,11 @@ namespace Unity.Netcode
                 throw new RpcException("This RPC can only be sent by the server.");
             }
 
-            if (attributeParams.InvokePermission == RpcInvokePermission.Owner && !IsOwner)
+#pragma warning disable CS0618 // Type or member is obsolete
+            var requireOwnership = attributeParams.RequireOwnership;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            if ((requireOwnership || attributeParams.InvokePermission == RpcInvokePermission.Owner) && !IsOwner)
             {
                 throw new RpcException("This RPC can only be sent by its owner.");
             }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Rpc/RpcInvocationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Rpc/RpcInvocationTests.cs
@@ -98,11 +98,13 @@ namespace Unity.Netcode.RuntimeTests
             foreach (var (manager, instance) in m_InvokeInstances)
             {
                 instance.ExpectedCallCounts[nameof(InvokePermissionBehaviour.OwnerInvokePermissionRpc)] = 1;
+                instance.ExpectedCallCounts[nameof(InvokePermissionBehaviour.OwnerRequireOwnershipRpc)] = 1;
 
                 var threwException = false;
                 try
                 {
                     instance.OwnerInvokePermissionRpc();
+                    instance.OwnerRequireOwnershipRpc();
                 }
                 catch (RpcException)
                 {
@@ -167,8 +169,10 @@ namespace Unity.Netcode.RuntimeTests
             foreach (var (manager, instance) in m_InvokeInstances)
             {
                 instance.ExpectedCallCounts[nameof(InvokePermissionBehaviour.OwnerInvokePermissionRpc)] = 1;
+                instance.ExpectedCallCounts[nameof(InvokePermissionBehaviour.OwnerRequireOwnershipRpc)] = 1;
 
                 SendUncheckedMessage(manager, instance, nameof(InvokePermissionBehaviour.OwnerInvokePermissionRpc));
+                SendUncheckedMessage(manager, instance, nameof(InvokePermissionBehaviour.OwnerRequireOwnershipRpc));
             }
 
             yield return WaitForConditionOrTimeOut(AllExpectedCallsReceived);
@@ -441,6 +445,15 @@ namespace Unity.Netcode.RuntimeTests
 
         [Rpc(SendTo.Everyone, InvokePermission = RpcInvokePermission.Server)]
         public void ServerInvokePermissionRpc()
+        {
+            TrackRpcCalled(GetCaller());
+        }
+
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        [Rpc(SendTo.Everyone, RequireOwnership = true)]
+#pragma warning restore CS0618 // Type or member is obsolete
+        public void OwnerRequireOwnershipRpc()
         {
             TrackRpcCalled(GetCaller());
         }


### PR DESCRIPTION
## Purpose of this PR

Fixes the compilation error when using a legacy RpcAttribute with the RequireOwnership parameter.

### Jira ticket

n/a

### Changelog

- Fixed: RpcAttribute now works with the obsolete param again.

## Documentation

- No documentation changes or additions were necessary.

## Testing & QA (How your changes can be verified during release Playtest)

Should be good if astroids compiles.

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [x] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [x] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports

No backport needed.
