### PR TITLE
fix: Disabled Networkbehaviours are not excluded from NetworkObject.ChildNetworkBehaviours

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -2619,6 +2619,11 @@ namespace Unity.Netcode
 
         private List<NetworkBehaviour> m_ChildNetworkBehaviours;
 
+        internal string GenerateDisabledNetworkBehaviourWarning(NetworkBehaviour networkBehaviour)
+        {
+            return $"[{name}][{networkBehaviour.GetType().Name}][{nameof(isActiveAndEnabled)}: {networkBehaviour.isActiveAndEnabled}] Disabled {nameof(NetworkBehaviour)}s are not supported and will be excluded from spawning and synchronization!";
+        }
+
         internal List<NetworkBehaviour> ChildNetworkBehaviours
         {
             get
@@ -2641,7 +2646,7 @@ namespace Unity.Netcode
                     }
                     else if (!networkBehaviours[i].isActiveAndEnabled)
                     {
-                        Debug.LogWarning($"[{name}][{networkBehaviours[i].GetType().Name}][{nameof(isActiveAndEnabled)}: {networkBehaviours[i].isActiveAndEnabled}] Disabled {nameof(NetworkBehaviour)}s are not supported and will be excluded from spawning and synchronization!");
+                        Debug.LogWarning(GenerateDisabledNetworkBehaviourWarning(networkBehaviours[i]));
                         continue;
                     }
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -2639,6 +2639,11 @@ namespace Unity.Netcode
                     {
                         continue;
                     }
+                    else if (!networkBehaviours[i].isActiveAndEnabled)
+                    {
+                        Debug.LogWarning($"[{name}][{networkBehaviours[i].GetType().Name}][{nameof(isActiveAndEnabled)}: {networkBehaviours[i].isActiveAndEnabled}] Disabled {nameof(NetworkBehaviour)}s are not supported and will be excluded from spawning and synchronization!");
+                        continue;
+                    }
 
                     // Set ourselves as the NetworkObject that this behaviour belongs to and add it to the child list
                     var nextIndex = (ushort)m_ChildNetworkBehaviours.Count;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
@@ -67,7 +67,9 @@ namespace Unity.Netcode.RuntimeTests
             // Set the child object to be inactive in the hierarchy
             childObject.SetActive(false);
 
-            LogAssert.Expect(LogType.Warning, $"{childObject.name} is disabled! Netcode for GameObjects does not support spawning disabled NetworkBehaviours! The {childBehaviour.GetType().Name} component was skipped during spawn!");
+            var expectedWarning = parentNetworkObject.GenerateDisabledNetworkBehaviourWarning(childBehaviour);
+
+            LogAssert.Expect(LogType.Warning, $"{expectedWarning}");
 
             parentNetworkObject.Spawn();
             yield return s_DefaultWaitForTick;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
@@ -16,6 +16,8 @@ namespace Unity.Netcode.RuntimeTests
 
         private bool m_AllowServerToStart;
 
+        private GameObject m_PrefabToSpawn;
+
         protected override bool CanStartServerAndClients()
         {
             return m_AllowServerToStart;
@@ -32,47 +34,88 @@ namespace Unity.Netcode.RuntimeTests
             }
         }
 
+        protected override void OnServerAndClientsCreated()
+        {
+            m_PrefabToSpawn = CreateNetworkObjectPrefab("TestPrefab");
+
+            var childObject = new GameObject
+            {
+                name = "ChildObject"
+            };
+            childObject.transform.parent = m_PrefabToSpawn.transform;
+            childObject.AddComponent<NetworkTransform>();
+            base.OnServerAndClientsCreated();
+        }
+
         protected override IEnumerator OnSetup()
         {
             m_AllowServerToStart = false;
             return base.OnSetup();
         }
 
+
+        protected override void OnNewClientCreated(NetworkManager networkManager)
+        {
+            networkManager.NetworkConfig.Prefabs.Add(new NetworkPrefab()
+            {
+                Prefab = m_PrefabToSpawn,
+            });
+            base.OnNewClientCreated(networkManager);
+        }
+
+
         /// <summary>
-        /// This validates the fix for when a child GameObject with a NetworkBehaviour
+        /// This validates:
+        /// - The fix for when a child GameObject with a NetworkBehaviour
         /// is deleted while the parent GameObject with a NetworkObject is spawned and
         /// is not deleted until a later time would cause an exception due to the
         /// NetworkBehaviour not being removed from the NetworkObject.ChildNetworkBehaviours
         /// list.
+        /// - That when a child GameObject is deleted/disabled or a NetworkBehaviour is disabled
+        /// a message is logged and the NetworkObject still can be spawned and synchronized.
         /// </summary>
         [UnityTest]
-        public IEnumerator ValidatedDisableddNetworkBehaviourWarning()
+        public IEnumerator ValidatedDisableddNetworkBehaviourWarning([Values] bool disableGameObject)
         {
             m_AllowServerToStart = true;
-
-            yield return s_DefaultWaitForTick;
 
             // Now just start the Host
             yield return StartServerAndClients();
 
-            var parentObject = new GameObject();
-            var childObject = new GameObject
+            // Now join a new client to make sure a connected client spawns the instance.
+            yield return CreateAndStartNewClient();
+
+            // Adjust the prefab to either have the child GameObject completely disabled or the NetworkBehaviour
+            // disabled.
+            var childBehaviour = m_PrefabToSpawn.GetComponentInChildren<NetworkTransform>(true);
+            if (disableGameObject)
             {
-                name = "ChildObject"
-            };
-            childObject.transform.parent = parentObject.transform;
-            var parentNetworkObject = parentObject.AddComponent<NetworkObject>();
-            var childBehaviour = childObject.AddComponent<NetworkTransform>();
-
-            // Set the child object to be inactive in the hierarchy
-            childObject.SetActive(false);
-
-            var expectedWarning = parentNetworkObject.GenerateDisabledNetworkBehaviourWarning(childBehaviour);
-
+                childBehaviour.enabled = true;
+                childBehaviour.gameObject.SetActive(false);
+            }
+            else
+            {
+                childBehaviour.enabled = false;
+                childBehaviour.gameObject.SetActive(true);
+            }
+            // Now create an instance of the prefab
+            var instance = Object.Instantiate(m_PrefabToSpawn);
+            var instanceNetworkObject = instance.GetComponent<NetworkObject>();
+            // Generate the expected warning message
+            var expectedWarning = instanceNetworkObject.GenerateDisabledNetworkBehaviourWarning(instanceNetworkObject.GetComponentInChildren<NetworkTransform>(true));
+            // Spawn the instance
+            SpawnObjectInstance(instanceNetworkObject, m_ServerNetworkManager);
             LogAssert.Expect(LogType.Warning, $"{expectedWarning}");
+            // Asure the connected client spawned the object first
+            yield return WaitForSpawnedOnAllOrTimeOut(instanceNetworkObject);
+            AssertOnTimeout($"Not all clients spawned {instanceNetworkObject.name}!");
 
-            parentNetworkObject.Spawn();
-            yield return s_DefaultWaitForTick;
+            // Now join a new client to make sure the client synchronizes with the disabled GameObject or NetworkBehaviour component.
+            yield return CreateAndStartNewClient();
+
+            // Asure the newly connected client synchronizes the spawned object correctly
+            yield return WaitForSpawnedOnAllOrTimeOut(instanceNetworkObject);
+            AssertOnTimeout($"Not all clients spawned {instanceNetworkObject.name}!");
         }
 
         /// <summary>


### PR DESCRIPTION
## Purpose of this PR
[//]: # (
Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. 
)

This PR resolves an issue discovered in v2.7.0 where a disabled NetworkBehaviour would cause an exception when trying to synchronize a client.

### Jira ticket
NA

### Changelog
[//]: # (updated with all public facing changes  - API changes, UI/UX changes, behaviour changes, bug fixes. Remove if not relevant.)
NA

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- No documentation changes or additions were necessary.

## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [ X ] `Manual testing done`
  - SpawnAndTeleport (Test-3) detected this issue and was verified to be fixed with these changes.

_Automated tests:_
- [ X ] `Covered by existing automated tests`
  - Updated `ValidatedDisableddNetworkBehaviourWarning` to have a broader coverage and added verification that a NetworkPrefab instance with either an inactive child GameObject (with one or more NetworkBehaviours) or a disabled NetworkBehaviour will still spawn.
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports
No back port needed.
