### PR TITLE
fix: disconnect reason should not duplicate any information

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -132,7 +132,7 @@ namespace Unity.Netcode
         /// server applied <see cref="ServerDisconnectReason"/>.
         /// - If both values are empty or null, then it returns <see cref="string.Empty"/>.
         /// - If either value is valid, then it returns that <see cref="string"/> value.
-        /// - If both values are valid, then it returns <see cref="DisconnectReason"/> followed by a 
+        /// - If both values are valid, then it returns <see cref="DisconnectReason"/> followed by a
         /// new line and then <see cref="ServerDisconnectReason"/>.
         /// </summary>
         /// <returns>A disconnect reason, if any.</returns>

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -103,11 +103,52 @@ namespace Unity.Netcode
         private static ProfilerMarker s_TransportDisconnect = new ProfilerMarker($"{nameof(NetworkManager)}.TransportDisconnect");
 #endif
 
+        private string m_DisconnectReason;
         /// <summary>
         /// When disconnected from the server, the server may send a reason. If a reason was sent, this property will
-        /// tell client code what the reason was. It should be queried after the OnClientDisconnectCallback is called
+        /// provide disconnect information that will be followed by the server's disconnect reason.
         /// </summary>
-        public string DisconnectReason { get; internal set; }
+        /// <remarks>
+        /// On a server or host, this value could no longer exist after all subscribed callbacks are invoked for the
+        /// client that disconnected. It is recommended to copy the message to some other property or field when
+        /// <see cref="OnClientDisconnectCallback"/> is invoked.
+        /// </remarks>
+        public string DisconnectReason
+        {
+            get
+            {
+                // For in-frequent event driven invocations, a method within a getter
+                // is "generally ok".
+                return GetDisconnectReason();
+            }
+            internal set
+            {
+                m_DisconnectReason = value;
+            }
+        }
+
+        /// <summary>
+        /// Returns the conbined result of the locally applied <see cref="DisconnectReason"/> and the
+        /// server applied <see cref="ServerDisconnectReason"/>.
+        /// - If both values are empty or null, then it returns <see cref="string.Empty"/>.
+        /// - If either value is valid, then it returns that <see cref="string"/> value.
+        /// - If both values are valid, then it returns <see cref="DisconnectReason"/> followed by a 
+        /// new line and then <see cref="ServerDisconnectReason"/>.
+        /// </summary>
+        /// <returns>A disconnect reason, if any.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal string GetDisconnectReason(string header = null)
+        {
+            var disconnectReason = string.IsNullOrEmpty(m_DisconnectReason) ? string.Empty : m_DisconnectReason;
+            var serverDisconnectReason = string.IsNullOrEmpty(ServerDisconnectReason) ? string.Empty : $"\n{ServerDisconnectReason}";
+            var headerInfo = string.IsNullOrEmpty(header) ? string.Empty : header;
+            return $"{headerInfo}{disconnectReason}{serverDisconnectReason}";
+        }
+
+        /// <summary>
+        /// Updated by <see cref="DisconnectReasonMessage"/>.
+        /// </summary>
+        internal string ServerDisconnectReason;
 
         /// <summary>
         /// The callback to invoke once a client connects. This callback is only ran on the server and on the local client that connects.
@@ -537,17 +578,15 @@ namespace Unity.Netcode
         private void GenerateDisconnectInformation(ulong clientId, ulong transportClientId, string reason = null)
         {
             var header = $"[Disconnect Event][Client-{clientId}][TransportClientId-{transportClientId}]";
-            var existingDisconnectReason = DisconnectReason;
-
             var defaultMessage = Transport.DisconnectEventMessage;
             if (reason != null)
             {
                 defaultMessage = $"{reason} {defaultMessage}";
             }
+
             // Just go ahead and set this whether client or server so any subscriptions to a disconnect event can check the DisconnectReason
             // to determine why the client disconnected
-            DisconnectReason = $"{header}[{Transport.DisconnectEvent}] {defaultMessage}";
-            DisconnectReason = $"{DisconnectReason}\n{existingDisconnectReason}";
+            m_DisconnectReason = $"{header}[{Transport.DisconnectEvent}] {defaultMessage}";
 
             if (NetworkLog.CurrentLogLevel <= LogLevel.Developer)
             {
@@ -1450,7 +1489,6 @@ namespace Unity.Netcode
             var transportId = ClientIdToTransportId(clientId);
             if (transportId.Item2)
             {
-                DisconnectReason = string.Empty;
                 GenerateDisconnectInformation(clientId, transportId.Item1, reason);
             }
 
@@ -1476,7 +1514,8 @@ namespace Unity.Netcode
             TransportIdToClientIdMap.Clear();
             ClientsToApprove.Clear();
             NetworkObject.OrphanChildren.Clear();
-            DisconnectReason = string.Empty;
+            m_DisconnectReason = string.Empty;
+            ServerDisconnectReason = string.Empty;
 
             NetworkManager = networkManager;
             MessageManager = networkManager.MessageManager;

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/DisconnectReasonMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/DisconnectReasonMessage.cs
@@ -37,7 +37,10 @@ namespace Unity.Netcode
 
         public void Handle(ref NetworkContext context)
         {
-            ((NetworkManager)context.SystemOwner).ConnectionManager.DisconnectReason = Reason;
+            // Always apply the server-side generated disconnect reason to the server specific disconnect reason.
+            // This is combined with the additional disconnect information when getting NetworkManager.DisconnectReason
+            // (NetworkConnectionManager.DisconnectReason).
+            ((NetworkManager)context.SystemOwner).ConnectionManager.ServerDisconnectReason = Reason;
         }
     };
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApproval.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/ConnectionApproval.cs
@@ -92,7 +92,7 @@ namespace Unity.Netcode.RuntimeTests
         private void Client_OnClientDisconnectCallback(ulong clientId)
         {
             m_ClientNetworkManagers[0].OnClientDisconnectCallback -= Client_OnClientDisconnectCallback;
-            m_ClientDisconnectReasonValidated = m_ClientNetworkManagers[0].LocalClientId == clientId && m_ClientNetworkManagers[0].DisconnectReason == k_InvalidToken;
+            m_ClientDisconnectReasonValidated = m_ClientNetworkManagers[0].LocalClientId == clientId && m_ClientNetworkManagers[0].DisconnectReason.Contains(k_InvalidToken);
         }
 
         private bool ClientAndHostValidated()

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Messaging/DisconnectReasonTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Messaging/DisconnectReasonTests.cs
@@ -57,9 +57,8 @@ namespace Unity.Netcode.RuntimeTests
                 yield return null;
             }
 
-            Assert.AreEqual(m_ClientNetworkManagers[0].DisconnectReason, "Bogus reason 1");
-            Assert.AreEqual(m_ClientNetworkManagers[1].DisconnectReason, "Bogus reason 2");
-
+            Assert.True(m_ClientNetworkManagers[0].DisconnectReason.Contains("Bogus reason 1"), $"[Client-{m_ClientNetworkManagers[0].LocalClientId}] Disconnect reason should contain \"Bogus reason 1\" but is: {m_ClientNetworkManagers[0].DisconnectReason}");
+            Assert.True(m_ClientNetworkManagers[1].DisconnectReason.Contains("Bogus reason 2"), $"[Client-{m_ClientNetworkManagers[0].LocalClientId}] Disconnect reason should contain \"Bogus reason 2\" but is: {m_ClientNetworkManagers[1].DisconnectReason}");
             Debug.Assert(m_DisconnectCount == 2);
         }
 


### PR DESCRIPTION
## Purpose of this PR
This PR makes an adjustment to the NetworkConnectionManager.DisconnectReason property where it now adds any server provided disconnect reason after the initial disconnect information.


### Jira ticket
NA

### Changelog
NA

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- Includes edits to existing public API documentation.

## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [ X ] `Manual testing done`
  - Updated Asteroids project to include a key sequence to disconnect with a reason.
  - Verified the original issue during play testing was resolved.

_Automated tests:_
- [ X ] `Covered by existing automated tests`
  - Had to adjust one test's validation logic to check for the server reason within the disconnect reason string.
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports

No back port needed.
