### PR TITLE
fix: disabled NetworkBehaviours vs disabled GameObjects and tests excluded by lack of MP tools

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -761,6 +761,13 @@ namespace Unity.Netcode
 
             UpdateNetworkProperties();
 
+            // Exit early for disabled NetworkBehaviours.
+            // We still want the above values to be set.
+            if (!gameObject.activeInHierarchy)
+            {
+                return;
+            }
+
             try
             {
                 OnNetworkPreSpawn(ref networkManager);

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -2082,6 +2082,12 @@ namespace Unity.Netcode
         {
             for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
             {
+                // Any NetworkBehaviour that is not spawned and the associated GameObject is disabled should be
+                // skipped over (i.e. not supported).
+                if (!ChildNetworkBehaviours[i].IsSpawned && !ChildNetworkBehaviours[i].gameObject.activeInHierarchy)
+                {
+                    continue;
+                }
                 // Invoke internal notification
                 ChildNetworkBehaviours[i].InternalOnNetworkObjectParentChanged(parentNetworkObject);
                 // Invoke public notification
@@ -2217,7 +2223,6 @@ namespace Unity.Netcode
             // DANGO-TODO: Do we want to worry about ownership permissions here?
             // It wouldn't make sense to not allow parenting, but keeping this note here as a reminder.
             var isAuthority = HasAuthority || (AllowOwnerToParent && IsOwner);
-            Debug.Log($"something is broken! isAuthority={isAuthority} | HasAuthority={HasAuthority} | (AllowOwnerToParent && IsOwner)={(AllowOwnerToParent && IsOwner)}");
 
             // If we don't have authority and we are not shutting down, then don't allow any parenting.
             // If we are shutting down and don't have authority then allow it.
@@ -2543,10 +2548,7 @@ namespace Unity.Netcode
             var networkManager = NetworkManager;
             for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
             {
-                if (ChildNetworkBehaviours[i].gameObject.activeInHierarchy)
-                {
-                    ChildNetworkBehaviours[i].NetworkPreSpawn(ref networkManager, this);
-                }
+                ChildNetworkBehaviours[i].NetworkPreSpawn(ref networkManager, this);
             }
         }
 
@@ -2558,10 +2560,9 @@ namespace Unity.Netcode
             {
                 if (!childBehaviour.gameObject.activeInHierarchy)
                 {
-                    Debug.LogWarning($"{childBehaviour.gameObject.name} is disabled! Netcode for GameObjects does not support spawning disabled NetworkBehaviours! The {childBehaviour.GetType().Name} component was skipped during spawn!");
+                    Debug.LogWarning($"{GenerateDisabledNetworkBehaviourWarning(childBehaviour)}");
                     continue;
                 }
-
                 childBehaviour.InternalOnNetworkSpawn();
             }
         }
@@ -2621,7 +2622,7 @@ namespace Unity.Netcode
 
         internal string GenerateDisabledNetworkBehaviourWarning(NetworkBehaviour networkBehaviour)
         {
-            return $"[{name}][{networkBehaviour.GetType().Name}][{nameof(isActiveAndEnabled)}: {networkBehaviour.isActiveAndEnabled}] Disabled {nameof(NetworkBehaviour)}s are not supported and will be excluded from spawning and synchronization!";
+            return $"[{name}][{networkBehaviour.GetType().Name}][{nameof(isActiveAndEnabled)}: {networkBehaviour.isActiveAndEnabled}] Disabled {nameof(NetworkBehaviour)}s will be excluded from spawning and synchronization!";
         }
 
         internal List<NetworkBehaviour> ChildNetworkBehaviours
@@ -2642,11 +2643,6 @@ namespace Unity.Netcode
                     var networkObj = networkBehaviours[i].GetComponentInParent<NetworkObject>();
                     if (networkObj != this)
                     {
-                        continue;
-                    }
-                    else if (!networkBehaviours[i].isActiveAndEnabled)
-                    {
-                        Debug.LogWarning(GenerateDisabledNetworkBehaviourWarning(networkBehaviours[i]));
                         continue;
                     }
 

--- a/com.unity.netcode.gameobjects/Tests/Editor/Build/BuildTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Build/BuildTests.cs
@@ -1,4 +1,3 @@
-#if !MULTIPLAYER_TOOLS
 using System.IO;
 using System.Reflection;
 using NUnit.Framework;
@@ -41,4 +40,3 @@ namespace Unity.Netcode.EditorTests
         }
     }
 }
-#endif

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
@@ -1,4 +1,6 @@
 using System.Collections;
+using System.Linq;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
 using Unity.Netcode.Components;
 using Unity.Netcode.TestHelpers.Runtime;
@@ -71,8 +73,8 @@ namespace Unity.Netcode.RuntimeTests
         /// is not deleted until a later time would cause an exception due to the
         /// NetworkBehaviour not being removed from the NetworkObject.ChildNetworkBehaviours
         /// list.
-        /// - That when a child GameObject is deleted/disabled or a NetworkBehaviour is disabled
-        /// a message is logged and the NetworkObject still can be spawned and synchronized.
+        /// - When a NetworkBehaviour is disabled but the associated GameObject is enabled,
+        /// the object spawns without any issues.
         /// </summary>
         [UnityTest]
         public IEnumerator ValidatedDisableddNetworkBehaviourWarning([Values] bool disableGameObject)
@@ -101,11 +103,18 @@ namespace Unity.Netcode.RuntimeTests
             // Now create an instance of the prefab
             var instance = Object.Instantiate(m_PrefabToSpawn);
             var instanceNetworkObject = instance.GetComponent<NetworkObject>();
-            // Generate the expected warning message
-            var expectedWarning = instanceNetworkObject.GenerateDisabledNetworkBehaviourWarning(instanceNetworkObject.GetComponentInChildren<NetworkTransform>(true));
+            // When the GameObject is disabled, check for the warning.
+            if (disableGameObject)
+            {
+                // Generate the expected warning message
+                var expectedWarning = instanceNetworkObject.GenerateDisabledNetworkBehaviourWarning(instanceNetworkObject.GetComponentInChildren<NetworkTransform>(true));
+                var expectedSplit = expectedWarning.Split(']');
+                var expectedWarningBody = expectedSplit.Last();
+                LogAssert.Expect(LogType.Warning, new Regex($".*{expectedWarningBody}*."));
+            }
+
             // Spawn the instance
             SpawnObjectInstance(instanceNetworkObject, m_ServerNetworkManager);
-            LogAssert.Expect(LogType.Warning, $"{expectedWarning}");
             // Asure the connected client spawned the object first
             yield return WaitForSpawnedOnAllOrTimeOut(instanceNetworkObject);
             AssertOnTimeout($"Not all clients spawned {instanceNetworkObject.name}!");

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformBase.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformBase.cs
@@ -781,7 +781,6 @@ namespace Unity.Netcode.RuntimeTests
 
         protected override void OnAuthorityPushTransformState(ref NetworkTransformState networkTransformState)
         {
-            Debug.Log($"[Auth]{name} State Pushed.");
             StatePushed = true;
             AuthorityLastSentState = networkTransformState;
             AuthorityPushedTransformState?.Invoke(ref networkTransformState);
@@ -792,7 +791,6 @@ namespace Unity.Netcode.RuntimeTests
         public bool StateUpdated { get; internal set; }
         protected override void OnNetworkTransformStateUpdated(ref NetworkTransformState oldState, ref NetworkTransformState newState)
         {
-            Debug.Log($"[Non-Auth]{name} State Updated.");
             StateUpdated = true;
             base.OnNetworkTransformStateUpdated(ref oldState, ref newState);
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformStateTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformStateTests.cs
@@ -1,4 +1,3 @@
-#if !MULTIPLAYER_TOOLS
 using NUnit.Framework;
 using Unity.Netcode.Components;
 using Unity.Netcode.TestHelpers.Runtime;
@@ -916,4 +915,3 @@ namespace Unity.Netcode.RuntimeTests
         }
     }
 }
-#endif

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTests.cs
@@ -13,70 +13,57 @@ namespace Unity.Netcode.RuntimeTests
     [TestFixture(HostOrServer.DAHost, Authority.OwnerAuthority, RotationCompression.None, Rotation.Euler, Precision.Full, NetworkTransform.InterpolationTypes.LegacyLerp)]
     [TestFixture(HostOrServer.DAHost, Authority.OwnerAuthority, RotationCompression.None, Rotation.Euler, Precision.Full, NetworkTransform.InterpolationTypes.Lerp)]
     [TestFixture(HostOrServer.DAHost, Authority.OwnerAuthority, RotationCompression.None, Rotation.Euler, Precision.Full, NetworkTransform.InterpolationTypes.SmoothDampening)]
-#if !MULTIPLAYER_TOOLS
     [TestFixture(HostOrServer.DAHost, Authority.OwnerAuthority, RotationCompression.None, Rotation.Euler, Precision.Half, NetworkTransform.InterpolationTypes.LegacyLerp)]
     [TestFixture(HostOrServer.DAHost, Authority.OwnerAuthority, RotationCompression.None, Rotation.Quaternion, Precision.Full, NetworkTransform.InterpolationTypes.LegacyLerp)]
     [TestFixture(HostOrServer.DAHost, Authority.OwnerAuthority, RotationCompression.None, Rotation.Quaternion, Precision.Half, NetworkTransform.InterpolationTypes.LegacyLerp)]
     [TestFixture(HostOrServer.DAHost, Authority.OwnerAuthority, RotationCompression.QuaternionCompress, Rotation.Quaternion, Precision.Full, NetworkTransform.InterpolationTypes.LegacyLerp)]
     [TestFixture(HostOrServer.DAHost, Authority.OwnerAuthority, RotationCompression.QuaternionCompress, Rotation.Quaternion, Precision.Half, NetworkTransform.InterpolationTypes.LegacyLerp)]
-
     [TestFixture(HostOrServer.DAHost, Authority.OwnerAuthority, RotationCompression.None, Rotation.Euler, Precision.Half, NetworkTransform.InterpolationTypes.Lerp)]
     [TestFixture(HostOrServer.DAHost, Authority.OwnerAuthority, RotationCompression.None, Rotation.Quaternion, Precision.Full, NetworkTransform.InterpolationTypes.Lerp)]
     [TestFixture(HostOrServer.DAHost, Authority.OwnerAuthority, RotationCompression.None, Rotation.Quaternion, Precision.Half, NetworkTransform.InterpolationTypes.Lerp)]
     [TestFixture(HostOrServer.DAHost, Authority.OwnerAuthority, RotationCompression.QuaternionCompress, Rotation.Quaternion, Precision.Full, NetworkTransform.InterpolationTypes.Lerp)]
     [TestFixture(HostOrServer.DAHost, Authority.OwnerAuthority, RotationCompression.QuaternionCompress, Rotation.Quaternion, Precision.Half, NetworkTransform.InterpolationTypes.Lerp)]
-
     [TestFixture(HostOrServer.DAHost, Authority.OwnerAuthority, RotationCompression.None, Rotation.Euler, Precision.Half, NetworkTransform.InterpolationTypes.SmoothDampening)]
     [TestFixture(HostOrServer.DAHost, Authority.OwnerAuthority, RotationCompression.None, Rotation.Quaternion, Precision.Full, NetworkTransform.InterpolationTypes.SmoothDampening)]
     [TestFixture(HostOrServer.DAHost, Authority.OwnerAuthority, RotationCompression.None, Rotation.Quaternion, Precision.Half, NetworkTransform.InterpolationTypes.SmoothDampening)]
     [TestFixture(HostOrServer.DAHost, Authority.OwnerAuthority, RotationCompression.QuaternionCompress, Rotation.Quaternion, Precision.Full, NetworkTransform.InterpolationTypes.SmoothDampening)]
     [TestFixture(HostOrServer.DAHost, Authority.OwnerAuthority, RotationCompression.QuaternionCompress, Rotation.Quaternion, Precision.Half, NetworkTransform.InterpolationTypes.SmoothDampening)]
-
-#endif
     [TestFixture(HostOrServer.Server, Authority.ServerAuthority, RotationCompression.None, Rotation.Euler, Precision.Full, NetworkTransform.InterpolationTypes.LegacyLerp)]
     [TestFixture(HostOrServer.Server, Authority.ServerAuthority, RotationCompression.None, Rotation.Euler, Precision.Full, NetworkTransform.InterpolationTypes.Lerp)]
     [TestFixture(HostOrServer.Server, Authority.ServerAuthority, RotationCompression.None, Rotation.Euler, Precision.Full, NetworkTransform.InterpolationTypes.SmoothDampening)]
-#if !MULTIPLAYER_TOOLS
     [TestFixture(HostOrServer.Server, Authority.ServerAuthority, RotationCompression.None, Rotation.Euler, Precision.Half, NetworkTransform.InterpolationTypes.LegacyLerp)]
     [TestFixture(HostOrServer.Server, Authority.ServerAuthority, RotationCompression.None, Rotation.Quaternion, Precision.Full, NetworkTransform.InterpolationTypes.LegacyLerp)]
     [TestFixture(HostOrServer.Server, Authority.ServerAuthority, RotationCompression.None, Rotation.Quaternion, Precision.Half, NetworkTransform.InterpolationTypes.LegacyLerp)]
     [TestFixture(HostOrServer.Server, Authority.ServerAuthority, RotationCompression.QuaternionCompress, Rotation.Quaternion, Precision.Full, NetworkTransform.InterpolationTypes.LegacyLerp)]
     [TestFixture(HostOrServer.Server, Authority.ServerAuthority, RotationCompression.QuaternionCompress, Rotation.Quaternion, Precision.Half, NetworkTransform.InterpolationTypes.LegacyLerp)]
-
     [TestFixture(HostOrServer.Server, Authority.ServerAuthority, RotationCompression.None, Rotation.Euler, Precision.Half, NetworkTransform.InterpolationTypes.Lerp)]
     [TestFixture(HostOrServer.Server, Authority.ServerAuthority, RotationCompression.None, Rotation.Quaternion, Precision.Full, NetworkTransform.InterpolationTypes.Lerp)]
     [TestFixture(HostOrServer.Server, Authority.ServerAuthority, RotationCompression.None, Rotation.Quaternion, Precision.Half, NetworkTransform.InterpolationTypes.Lerp)]
     [TestFixture(HostOrServer.Server, Authority.ServerAuthority, RotationCompression.QuaternionCompress, Rotation.Quaternion, Precision.Full, NetworkTransform.InterpolationTypes.Lerp)]
     [TestFixture(HostOrServer.Server, Authority.ServerAuthority, RotationCompression.QuaternionCompress, Rotation.Quaternion, Precision.Half, NetworkTransform.InterpolationTypes.Lerp)]
-
     [TestFixture(HostOrServer.Server, Authority.ServerAuthority, RotationCompression.None, Rotation.Euler, Precision.Half, NetworkTransform.InterpolationTypes.SmoothDampening)]
     [TestFixture(HostOrServer.Server, Authority.ServerAuthority, RotationCompression.None, Rotation.Quaternion, Precision.Full, NetworkTransform.InterpolationTypes.SmoothDampening)]
     [TestFixture(HostOrServer.Server, Authority.ServerAuthority, RotationCompression.None, Rotation.Quaternion, Precision.Half, NetworkTransform.InterpolationTypes.SmoothDampening)]
     [TestFixture(HostOrServer.Server, Authority.ServerAuthority, RotationCompression.QuaternionCompress, Rotation.Quaternion, Precision.Full, NetworkTransform.InterpolationTypes.SmoothDampening)]
     [TestFixture(HostOrServer.Server, Authority.ServerAuthority, RotationCompression.QuaternionCompress, Rotation.Quaternion, Precision.Half, NetworkTransform.InterpolationTypes.SmoothDampening)]
-#endif
     [TestFixture(HostOrServer.Host, Authority.OwnerAuthority, RotationCompression.None, Rotation.Euler, Precision.Full, NetworkTransform.InterpolationTypes.LegacyLerp)]
     [TestFixture(HostOrServer.Host, Authority.OwnerAuthority, RotationCompression.None, Rotation.Euler, Precision.Full, NetworkTransform.InterpolationTypes.Lerp)]
     [TestFixture(HostOrServer.Host, Authority.OwnerAuthority, RotationCompression.None, Rotation.Euler, Precision.Full, NetworkTransform.InterpolationTypes.SmoothDampening)]
-#if !MULTIPLAYER_TOOLS
     [TestFixture(HostOrServer.Host, Authority.OwnerAuthority, RotationCompression.None, Rotation.Euler, Precision.Half, NetworkTransform.InterpolationTypes.LegacyLerp)]
     [TestFixture(HostOrServer.Host, Authority.OwnerAuthority, RotationCompression.None, Rotation.Quaternion, Precision.Full, NetworkTransform.InterpolationTypes.LegacyLerp)]
     [TestFixture(HostOrServer.Host, Authority.OwnerAuthority, RotationCompression.None, Rotation.Quaternion, Precision.Half, NetworkTransform.InterpolationTypes.LegacyLerp)]
     [TestFixture(HostOrServer.Host, Authority.OwnerAuthority, RotationCompression.QuaternionCompress, Rotation.Quaternion, Precision.Full, NetworkTransform.InterpolationTypes.LegacyLerp)]
     [TestFixture(HostOrServer.Host, Authority.OwnerAuthority, RotationCompression.QuaternionCompress, Rotation.Quaternion, Precision.Half, NetworkTransform.InterpolationTypes.LegacyLerp)]
-
     [TestFixture(HostOrServer.Host, Authority.OwnerAuthority, RotationCompression.None, Rotation.Euler, Precision.Half, NetworkTransform.InterpolationTypes.Lerp)]
     [TestFixture(HostOrServer.Host, Authority.OwnerAuthority, RotationCompression.None, Rotation.Quaternion, Precision.Full, NetworkTransform.InterpolationTypes.Lerp)]
     [TestFixture(HostOrServer.Host, Authority.OwnerAuthority, RotationCompression.None, Rotation.Quaternion, Precision.Half, NetworkTransform.InterpolationTypes.Lerp)]
     [TestFixture(HostOrServer.Host, Authority.OwnerAuthority, RotationCompression.QuaternionCompress, Rotation.Quaternion, Precision.Full, NetworkTransform.InterpolationTypes.Lerp)]
     [TestFixture(HostOrServer.Host, Authority.OwnerAuthority, RotationCompression.QuaternionCompress, Rotation.Quaternion, Precision.Half, NetworkTransform.InterpolationTypes.Lerp)]
-
     [TestFixture(HostOrServer.Host, Authority.OwnerAuthority, RotationCompression.None, Rotation.Euler, Precision.Half, NetworkTransform.InterpolationTypes.SmoothDampening)]
     [TestFixture(HostOrServer.Host, Authority.OwnerAuthority, RotationCompression.None, Rotation.Quaternion, Precision.Full, NetworkTransform.InterpolationTypes.SmoothDampening)]
     [TestFixture(HostOrServer.Host, Authority.OwnerAuthority, RotationCompression.None, Rotation.Quaternion, Precision.Half, NetworkTransform.InterpolationTypes.SmoothDampening)]
     [TestFixture(HostOrServer.Host, Authority.OwnerAuthority, RotationCompression.QuaternionCompress, Rotation.Quaternion, Precision.Full, NetworkTransform.InterpolationTypes.SmoothDampening)]
     [TestFixture(HostOrServer.Host, Authority.OwnerAuthority, RotationCompression.QuaternionCompress, Rotation.Quaternion, Precision.Half, NetworkTransform.InterpolationTypes.SmoothDampening)]
-#endif
     internal class NetworkTransformTests : NetworkTransformBase
     {
         protected const int k_TickRate = 60;
@@ -161,8 +148,6 @@ namespace Unity.Netcode.RuntimeTests
                 Assert.True(success, m_InfoMessage.ToString());
             }
         }
-
-#if !MULTIPLAYER_TOOLS
 
         private void UpdateTransformLocal(NetworkTransform networkTransformTestComponent)
         {
@@ -698,7 +683,6 @@ namespace Unity.Netcode.RuntimeTests
                 }
             }
         }
-#endif
 
         /// <summary>
         /// Tests changing all axial values one at a time.

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableTests.cs
@@ -216,9 +216,7 @@ namespace Unity.Netcode.RuntimeTests
         Default,
     }
 
-#if !MULTIPLAYER_TOOLS
     [TestFixture(Serialization.EnsureLengthSafety)]
-#endif
     [TestFixture(Serialization.Default)]
     internal class NetworkVariableTests : NetcodeIntegrationTest
     {
@@ -339,7 +337,6 @@ namespace Unity.Netcode.RuntimeTests
             TimeTravelToNextTick();
         }
 
-#if !MULTIPLAYER_TOOLS
         /// <summary>
         /// Runs generalized tests on all predefined NetworkVariable types
         /// </summary>
@@ -4884,4 +4881,3 @@ namespace Unity.Netcode.RuntimeTests
         }
     }
 }
-#endif

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Rpc/UniversalRpcTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Rpc/UniversalRpcTests.cs
@@ -1,4 +1,4 @@
-#if !MULTIPLAYER_TOOLS && !NGO_MINIMALPROJECT
+#if !NGO_MINIMALPROJECT
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -1231,7 +1231,7 @@ namespace Unity.Netcode.RuntimeTests.UniversalRpcTests
             {
                 foreach (var sendTo in sendToValues)
                 {
-                    UnityEngine.Debug.Log($"[{testType}][{sendTo}]");
+                    VerboseDebug($"[{testType}][{sendTo}]");
                     for (ulong objectOwner = 0; objectOwner <= numberOfClientsULong; objectOwner++)
                     {
                         for (ulong sender = 0; sender <= numberOfClientsULong; sender++)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Timing/TimeIntegrationTest.cs
@@ -1,4 +1,3 @@
-#if !MULTIPLAYER_TOOLS
 using System;
 using System.Collections;
 using NUnit.Framework;
@@ -200,4 +199,3 @@ namespace Unity.Netcode.RuntimeTests
         }
     }
 }
-#endif

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TransformInterpolationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TransformInterpolationTests.cs
@@ -1,4 +1,3 @@
-#if !MULTIPLAYER_TOOLS
 using System.Collections;
 using NUnit.Framework;
 using Unity.Netcode.Components;
@@ -233,4 +232,3 @@ namespace Unity.Netcode.RuntimeTests
         }
     }
 }
-#endif


### PR DESCRIPTION
## Purpose of this PR
This PR resolves 3 issues:

- 10-29 play test issue discovered running BossRoom build.
  - Excluding the weird in-editor input issue we discovered (_could be 6.2+ and Input System related_), standalone developer builds worked as expected.
- While fixing the above issue, noticed we were excluding ~4.5k tests because:
  - The largest tests were originally setup to only be run on a project that did not have the multiplayer tools package installed.
    - This prevented us from running the larger scale tests multiple times on the same editor and platform.
  - We removed the multiplayer tools project from this repository and CI process.
    - This was fine because we still ran the larger scale tests on test project (_i.e. the multiplayer tools package was not added_)
  - We added the multiplayer tools package to testproject,
    - This treated testproject like we treated the multiplayer tools project where it didn't run the larger scale tests.
      - *problem* :hurtrealbad: 
- The PR also removes the `!MULTIPLAYER_TOOLS` wrapper from the larger scale tests.
  - This bumps our total test count from around ~1,600 back up to 7,008 total runtime tests.
- Removed a debugging log within NetworkObject (from a PR related to this version) that was in a relatively high traffic region.

### Jira ticket
NA

### Changelog
NA

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- No documentation changes or additions were necessary.


## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [ X ] `Manual testing done`
  - Verified BossRoom issues were resolved using this branch.

_Automated tests:_
- [ X ] `Covered by existing automated tests`
  - All tests should now run using the default test project.
  - Adjusted the generic NetworkBehaviour tests.
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports

No backport required.
