### PR TITLE
chore: Introduction of u-pr-agent and fix of Updated Dependencies Test

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,2 +1,2 @@
-﻿[github_app]
+[github_app]
 pr_commands = []

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,2 @@
+﻿[github_app]
+pr_commands = []

--- a/.yamato/project-updated-dependencies-test.yml
+++ b/.yamato/project-updated-dependencies-test.yml
@@ -58,12 +58,12 @@ project_pack_-_{{ project.name }}_{{ platform.name }}:
     type: {{ platform.type }}
     image: {{ platform.image }}
     flavor: {{ platform.flavor }}
-commands:
-  - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm # upm-ci is not preinstalled on the image so we need to download it
-  - upm-ci project pack --project-path {{ project.path }}
-artifacts:
-  packages:
-    paths:
-      - "upm-ci~/packages/**/*"
+  commands:
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm # upm-ci is not preinstalled on the image so we need to download it
+    - upm-ci project pack --project-path {{ project.path }}
+  artifacts:
+    packages:
+      paths:
+        - "upm-ci~/packages/**/*"
 {% endfor -%}
 {% endfor -%}

--- a/.yamato/project-updated-dependencies-test.yml
+++ b/.yamato/project-updated-dependencies-test.yml
@@ -42,7 +42,28 @@ updated-dependencies_{{ project.name }}_NGO_{{ platform.name }}_{{ editor }}:
       paths:
         - "upm-ci~/test-results/**/*"
   dependencies:
-    - .yamato/package-pack.yml#package_pack_-_ngo_{{ platform.name }}
+    - .yamato/project-updated-dependencies-test.yml#project_pack_-_{{ project.name }}_{{ platform.name }}
 {% endfor -%}
+{% endfor -%}
+{% endfor -%}
+  
+  
+# TODO: This job was removed on PR-3711 but the above job somehow can find proper artifacts with package pack job. 
+# This job should be removed when issue will be resolved since it's not used anywhere
+{% for project in projects.all -%}
+{% for platform in test_platforms.desktop -%}
+project_pack_-_{{ project.name }}_{{ platform.name }}:
+  name: Project Pack - {{ project.name }} [{{ platform.name }}]
+  agent:
+    type: {{ platform.type }}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor }}
+commands:
+  - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm # upm-ci is not preinstalled on the image so we need to download it
+  - upm-ci project pack --project-path {{ project.path }}
+artifacts:
+  packages:
+    paths:
+      - "upm-ci~/packages/**/*"
 {% endfor -%}
 {% endfor -%}


### PR DESCRIPTION
## Purpose of this PR
This PR follows the introduction of u-pr-agent to the repo 
1. I installed the app as described in https://github.cds.internal.unity3d.com/unity/u-pr-agent
2. I added a modification via .pr-agent.toml file so the bot won't run automatically but needs to be triggered via (for example) `/improve` (see more commands in linked repo)

Additionally I noticed [`Updated Dependencies Test` failures](https://unity-ci.cds.internal.unity3d.com/project/1201/branch/develop-2.0.0/jobDefinition/.yamato%2Fproject-updated-dependencies-test.yml%23updated-dependencies_testproject_NGO_win_6000.0/recent-jobs) which seem to need project-pack job to work properly (the job was removed in https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3711).
This is probably due to some signing that the project pack job were doing. For now I will reintroduce it in this one place but later I will investigate why it happens

### Jira ticket
N/A

## Documentation
N/A

## Testing & QA (How your changes can be verified during release Playtest)
Green pass on `Updated Dependencies Test` and correct bot trigger via comment

## Backports
Backport to `develop` branch in https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3763