### PR TITLE
fix: NetworkAnimator initialization sequencing

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -37,6 +37,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Initialization errors with NetworkAnimator. (#3767)
 - Multiple disconnect events from the same transport will no longer disconnect the host. (#3707)
 - Fixed NetworkTransform state synchronization issue when `NetworkTransform.SwitchTransformSpaceWhenParented` is enabled and the associated NetworkObject is parented multiple times in a single frame or within a couple of frames. (#3664)
 - Fixed issue when spawning, parenting, and immediately re-parenting when `NetworkTransform.SwitchTransformSpaceWhenParented` is enabled. (#3664)

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
@@ -720,13 +720,16 @@ namespace Unity.Netcode.Components
             return m_AnimationMessage;
         }
 
+        internal override void InternalOnNetworkPreSpawn(ref NetworkManager networkManager)
+        {
+            // Save internal state references
+            m_LocalNetworkManager = networkManager;
+            DistributedAuthorityMode = m_LocalNetworkManager.DistributedAuthorityMode;
+        }
+
         /// <inheritdoc/>
         public override void OnNetworkSpawn()
         {
-            // Save internal state references
-            m_LocalNetworkManager = NetworkManager;
-            DistributedAuthorityMode = m_LocalNetworkManager.DistributedAuthorityMode;
-
             // If there is no assigned Animator then generate a server network warning (logged locally and if applicable on the server-host side as well).
             if (m_Animator == null)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -753,6 +753,8 @@ namespace Unity.Netcode
         /// </summary>
         public virtual void OnNetworkPreDespawn() { }
 
+        internal virtual void InternalOnNetworkPreSpawn(ref NetworkManager networkManager) { }
+
         internal void NetworkPreSpawn(ref NetworkManager networkManager, NetworkObject networkObject)
         {
             m_NetworkObject = networkObject;
@@ -760,6 +762,8 @@ namespace Unity.Netcode
             RpcTarget = networkManager.RpcTarget;
 
             UpdateNetworkProperties();
+
+            InternalOnNetworkPreSpawn(ref networkManager);
 
             // Exit early for disabled NetworkBehaviours.
             // We still want the above values to be set.


### PR DESCRIPTION
## Purpose of this PR

Fix NetworkAnimator intialization sequence (ensure all internal references are set before `OnNetworkSpawn`

### Jira ticket
_Link to related jira ticket ([Use the smart commits](https://support.atlassian.com/bitbucket-cloud/docs/use-smart-commits/)). Short version (e.g. MTT-123) also works and gets auto-linked_

### Changelog
[//]: # (updated with all public facing changes  - API changes, UI/UX changes, behaviour changes, bug fixes. Remove if not relevant.)

- Fixed: NetworkAnimator initialization sequence 

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation

- No documentation changes or additions were necessary.

## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports

n/a
