### PR TITLE
fix: 2.7.0 test instabilities

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformBase.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformBase.cs
@@ -230,6 +230,11 @@ namespace Unity.Netcode.RuntimeTests
         {
             var networkTransformTestComponent = m_PlayerPrefab.AddComponent<NetworkTransformTestComponent>();
             networkTransformTestComponent.ServerAuthority = m_Authority == Authority.ServerAuthority;
+            // Handle setting up additional transform settings for the current test here.
+            networkTransformTestComponent.UseUnreliableDeltas = UseUnreliableDeltas();
+            networkTransformTestComponent.UseHalfFloatPrecision = m_Precision == Precision.Half;
+            networkTransformTestComponent.UseQuaternionSynchronization = m_Rotation == Rotation.Quaternion;
+            networkTransformTestComponent.UseQuaternionCompression = m_RotationCompression == RotationCompression.QuaternionCompress;
         }
 
         protected override void OnServerAndClientsCreated()
@@ -291,19 +296,6 @@ namespace Unity.Netcode.RuntimeTests
             // Get the NetworkTransformTestComponent to make sure the client side is ready before starting test
             m_AuthoritativeTransform = m_AuthoritativePlayer.GetComponent<NetworkTransformTestComponent>();
             m_NonAuthoritativeTransform = m_NonAuthoritativePlayer.GetComponent<NetworkTransformTestComponent>();
-
-            // Setup whether we are or are not using unreliable deltas
-            m_AuthoritativeTransform.UseUnreliableDeltas = UseUnreliableDeltas();
-            m_NonAuthoritativeTransform.UseUnreliableDeltas = UseUnreliableDeltas();
-
-            m_AuthoritativeTransform.UseHalfFloatPrecision = m_Precision == Precision.Half;
-            m_AuthoritativeTransform.UseQuaternionSynchronization = m_Rotation == Rotation.Quaternion;
-            m_AuthoritativeTransform.UseQuaternionCompression = m_RotationCompression == RotationCompression.QuaternionCompress;
-            m_NonAuthoritativeTransform.UseHalfFloatPrecision = m_Precision == Precision.Half;
-            m_NonAuthoritativeTransform.UseQuaternionSynchronization = m_Rotation == Rotation.Quaternion;
-            m_NonAuthoritativeTransform.UseQuaternionCompression = m_RotationCompression == RotationCompression.QuaternionCompress;
-
-
             m_OwnerTransform = m_AuthoritativeTransform.IsOwner ? m_AuthoritativeTransform : m_NonAuthoritativeTransform;
         }
 

--- a/testproject/Assets/Tests/Runtime/ObjectParenting/ParentingInSceneObjectsTests.cs
+++ b/testproject/Assets/Tests/Runtime/ObjectParenting/ParentingInSceneObjectsTests.cs
@@ -332,14 +332,6 @@ namespace TestProject.RuntimeTests
             {
                 InSceneParentChildHandler.AuthorityRootParent.DeparentSetValuesAndReparent();
 
-                yield return WaitForConditionOrTimeOut(ValidateClientsAgainstAuthorityTransformValues);
-                if (s_GlobalTimeoutHelper.TimedOut)
-                {
-                    InSceneParentChildHandler.AuthorityRootParent.CheckChildren();
-                    yield return debugWait;
-                }
-                AssertOnTimeout($"[Final Pass][Deparent-Reparent-{i}] Timed out waiting for all clients transform values to match the server transform values!\n {m_ErrorValidationLog}");
-
                 yield return WaitForConditionOrTimeOut(() => ValidateAllChildrenParentingStatus(true));
                 if (s_GlobalTimeoutHelper.TimedOut)
                 {
@@ -347,6 +339,14 @@ namespace TestProject.RuntimeTests
                     yield return debugWait;
                 }
                 AssertOnTimeout($"[Final Pass][Deparent-Reparent-{i}] Timed out waiting for all children to be removed from their parent!\n {m_ErrorValidationLog}");
+
+                yield return WaitForConditionOrTimeOut(ValidateClientsAgainstAuthorityTransformValues);
+                if (s_GlobalTimeoutHelper.TimedOut)
+                {
+                    InSceneParentChildHandler.AuthorityRootParent.CheckChildren();
+                    yield return debugWait;
+                }
+                AssertOnTimeout($"[Final Pass][Deparent-Reparent-{i}] Timed out waiting for all clients transform values to match the server transform values!\n {m_ErrorValidationLog}");
             }
 
             // In the final pass, we remove the second generation nested child


### PR DESCRIPTION
## Purpose of this PR
Resolve test instabilities:

- PeerDisconnectCallbackTests
  - During the server disconnects the client pass, the client disconnect notification could be processed prior to the targeted client's NetworkManager having completely disconnected and shutdown which would result in the targeted client to be processed during the validation pass where it should only be checking the remaining server/host and connected clients for the disconnected client-id and the disconnected client should have no connected clients (in its list).
- ParentingInSceneObjectsTests
  - Hoping to resolve the instability with this test resulting in a failure due to the order of operations:
    - It was checking:
      - First: the transforms for each child's cloned instance are approximately the same.
      - Second: parenting status for each child's cloned instance matched.
    - Now it is checking:
      - First: parenting status for each child's cloned instance matched.
      - Second: the transforms for each child's cloned instance are approximately the same.
- NetworkTransformTests
  - A potential cause for instabilities on this set of tests could be due to the initial network prefab transform settings were not applied to the player prefab's NetworkTransform but to each player instance (including clones).
  - Moving the application of the test specific NetworkTrransform settings into `OnCreatePlayerPrefab` as that is where those settings should be applied anyway. _This could potentially resolve the issues with some instabilities on these tests but went ahead and migrated them to the correct location regardless_.

### Jira ticket
NA
### Changelog
NA

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- No documentation changes or additions were necessary.


## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [ X ] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports

No backport required