### PR TITLE
chore: Small automations update 

### DIFF
--- a/.yamato/ngo-publish.yml
+++ b/.yamato/ngo-publish.yml
@@ -3,8 +3,8 @@ ngo_release_preparation:
   agent: { type: Unity::VM, flavor: b1.small, image: package-ci/ubuntu-22.04:v4 }
   triggers:
     recurring:
-      - branch: develop-2.0.0 # We make new releases from this branch
-        frequency: "10 * * 1" # Runs every Sunday at 10:00 AM
+      - branch: build-automation-update # We make new releases from this branch
+        frequency: "10 * ? 2" # Runs every Sunday at 10:00 AM
   rerun: always
   commands:
     - pip install PyGithub

--- a/.yamato/ngo-publish.yml
+++ b/.yamato/ngo-publish.yml
@@ -4,7 +4,7 @@ ngo_release_preparation:
   triggers:
     recurring:
       - branch: build-automation-update # We make new releases from this branch
-        frequency: "10 * ? 2" # Runs every Sunday at 10:00 AM
+        frequency: "10 ? * 2" # Runs every Sunday at 10:00 AM
   rerun: always
   commands:
     - pip install PyGithub

--- a/.yamato/ngo-publish.yml
+++ b/.yamato/ngo-publish.yml
@@ -4,7 +4,7 @@ ngo_release_preparation:
   triggers:
     recurring:
       - branch: build-automation-update # We make new releases from this branch
-        frequency: "10 ? * 2" # Runs every Sunday at 10:00 AM
+        frequency: "11 ? * 2" # Runs every Sunday at 10:00 AM
   rerun: always
   commands:
     - pip install PyGithub

--- a/.yamato/ngo-publish.yml
+++ b/.yamato/ngo-publish.yml
@@ -4,7 +4,7 @@ ngo_release_preparation:
   triggers:
     recurring:
       - branch: build-automation-update # We make new releases from this branch
-        frequency: "11 ? * 2" # Runs every Sunday at 10:00 AM
+        frequency: "12 ? * 1" # Runs every Sunday at 10:00 AM
   rerun: always
   commands:
     - pip install PyGithub

--- a/.yamato/ngo-publish.yml
+++ b/.yamato/ngo-publish.yml
@@ -4,7 +4,7 @@ ngo_release_preparation:
   triggers:
     recurring:
       - branch: build-automation-update # We make new releases from this branch
-        frequency: "12 ? * 1" # Runs every Sunday at 10:00 AM
+        frequency: "12 ? * 2" # Runs every Sunday at 10:00 AM
   rerun: always
   commands:
     - pip install PyGithub

--- a/.yamato/ngo-publish.yml
+++ b/.yamato/ngo-publish.yml
@@ -3,8 +3,8 @@ ngo_release_preparation:
   agent: { type: Unity::VM, flavor: b1.small, image: package-ci/ubuntu-22.04:v4 }
   triggers:
     recurring:
-      - branch: build-automation-update # We make new releases from this branch
-        frequency: "12 ? * 2" # Runs every Sunday at 10:00 AM
+      - branch: develop-2.0.0 # We make new releases from this branch
+        frequency: "10 ? * 1" # Runs every Sunday at 10:00 AM
   rerun: always
   commands:
     - pip install PyGithub

--- a/.yamato/project-builders/builder.metafile
+++ b/.yamato/project-builders/builder.metafile
@@ -2,20 +2,21 @@
 
 NetcodeProjects:
     # Note that we are using internal Unity repo. This means that we may test with newest changes that are not yet released to our users (there are also public versions)
+    # The parameters specify repo location, default branch to use (since you can modify it via job variable), path to manifest.json file so we can replace package entry and path to the project root folder since it differs between projects
     # Note that for BossRoom 'main' branch supports NGOv1.X and 'develop' branch supports NGOv2.X
     # TODO: For BossRoom correct branch to develop when PR-3736 is merged in their repo
     BossRoom:
         GithubRepo: "https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop.git"
-        branch: ngo-playtest-update
+        defaultBranch: ngo-playtest-update
         manifestPath: Packages/manifest.json
         projectPath: '.'
     Asteroids:
         GithubRepo: "https://github.cds.internal.unity3d.com/unity/Asteroids-CMB-NGO-Sample.git"
-        branch: main
+        defaultBranch: main
         manifestPath: Packages/manifest.json
         projectPath: '.'
     SocialHub:
         GithubRepo: "https://github.com/Unity-Technologies/com.unity.multiplayer.samples.bitesize.git"
-        branch: main
+        defaultBranch: main
         manifestPath: Basic/DistributedAuthoritySocialHub/Packages/manifest.json
         projectPath: 'Basic/DistributedAuthoritySocialHub'

--- a/.yamato/project-builders/project-builders.yml
+++ b/.yamato/project-builders/project-builders.yml
@@ -34,7 +34,7 @@ build_{{ netcodeProject[0] }}_project:
   commands:
     # Validate inputs passed via Yamato variables
     - python Tools/scripts/BuildAutomation/validate_params.py
-    - echo Building {{ netcodeProject[0] }} project with Unity version of %UNITY_VERSION%, Scripting backend %SCRIPTING_BACKEND_IL2CPP_MONO%, Burst %BURST_ON_OFF% for platform %PLATFORM_WIN64_MAC_ANDROID%
+    - echo Building {{ netcodeProject[0] }} project from branch {{ netcodeProject[1].defaultBranch }} with Unity version of %UNITY_VERSION%, Scripting backend %SCRIPTING_BACKEND_IL2CPP_MONO%, Burst %BURST_ON_OFF% for platform %PLATFORM_WIN64_MAC_ANDROID%
 
     # Clone the external project repository into a specific directory. Notice that branch is also specified.
     - git clone --single-branch --branch %SAMPLE_BRANCH% {{ netcodeProject[1].GithubRepo }} C:/ClonedProject

--- a/.yamato/project-builders/project-builders.yml
+++ b/.yamato/project-builders/project-builders.yml
@@ -30,13 +30,14 @@ build_{{ netcodeProject[0] }}_project:
     SCRIPTING_BACKEND_IL2CPP_MONO: il2cpp
     BURST_ON_OFF: on
     PLATFORM_WIN64_MAC_ANDROID: win64
+    SAMPLE_BRANCH: {{ netcodeProject[1].defaultBranch }}
   commands:
     # Validate inputs passed via Yamato variables
     - python Tools/scripts/BuildAutomation/validate_params.py
     - echo Building {{ netcodeProject[0] }} project with Unity version of %UNITY_VERSION%, Scripting backend %SCRIPTING_BACKEND_IL2CPP_MONO%, Burst %BURST_ON_OFF% for platform %PLATFORM_WIN64_MAC_ANDROID%
 
     # Clone the external project repository into a specific directory. Notice that branch is also specified.
-    - git clone --single-branch --branch {{ netcodeProject[1].branch }} {{ netcodeProject[1].GithubRepo }} C:/ClonedProject
+    - git clone --single-branch --branch %SAMPLE_BRANCH% {{ netcodeProject[1].GithubRepo }} C:/ClonedProject
 
     # Modify the external project's manifest to use the local N4E package from current branch on which this Yamato job is running. (requires python that should be preinstalled in the image)
     - python Tools/scripts/BuildAutomation/manifest_update.py --manifest-path C:/ClonedProject/{{ netcodeProject[1].manifestPath }} --local-package-path %YAMATO_SOURCE_DIR%/com.unity.netcode.gameobjects

--- a/.yamato/project-builders/project-builders.yml
+++ b/.yamato/project-builders/project-builders.yml
@@ -62,21 +62,21 @@ build_{{ netcodeProject[0] }}_project:
     # Build the project using Unity Editor. This will call the given static BuilderScripts method.
     # Ideally, it would be nice to parametrize the BuilderScripts (for example to pass scripting backend as parameter) but -executeMethod only calls static methods without parameters so for now we will have multiple configurations
     # Notice that for Android platform even if mono is selected, il2cpp will be used since mono is not supported for Android builds.
-    - IF "%PLATFORM_WIN64_MAC_ANDROID%"=="win64" (
-        IF "%SCRIPTING_BACKEND_IL2CPP_MONO%"=="il2cpp" (
+    - IF /I "%PLATFORM_WIN64_MAC_ANDROID%"=="win64" (
+        IF /I "%SCRIPTING_BACKEND_IL2CPP_MONO%"=="il2cpp" (
           C:/TestingEditor/Unity.exe -projectPath C:/ClonedProject/{{ netcodeProject[1].projectPath }} -buildTarget win64 -executeMethod BuilderScripts.BuildWinIl2cpp -batchmode -logFile ./artifacts/UnityLog.txt -automated -crash-report-folder ./artifacts/CrashArtifacts -quit
         ) ELSE (
           C:/TestingEditor/Unity.exe -projectPath C:/ClonedProject/{{ netcodeProject[1].projectPath }} -buildTarget win64 -executeMethod BuilderScripts.BuildWinMono -batchmode -logFile ./artifacts/UnityLog.txt -automated -crash-report-folder ./artifacts/CrashArtifacts -quit
         )
       )
-      ELSE IF "%PLATFORM_WIN64_MAC_ANDROID%"=="mac" (
-          IF "%SCRIPTING_BACKEND_IL2CPP_MONO%"=="il2cpp" (
+      ELSE IF /I "%PLATFORM_WIN64_MAC_ANDROID%"=="mac" (
+          IF /I "%SCRIPTING_BACKEND_IL2CPP_MONO%"=="il2cpp" (
             C:/TestingEditor/Unity.exe -projectPath C:/ClonedProject/{{ netcodeProject[1].projectPath }} -buildTarget osx -executeMethod BuilderScripts.BuildMacIl2cpp -batchmode -logFile ./artifacts/UnityLog.txt -automated -crash-report-folder ./artifacts/CrashArtifacts -quit
           ) ELSE (
             C:/TestingEditor/Unity.exe -projectPath C:/ClonedProject/{{ netcodeProject[1].projectPath }} -buildTarget osx -executeMethod BuilderScripts.BuildMacMono -batchmode -logFile ./artifacts/UnityLog.txt -automated -crash-report-folder ./artifacts/CrashArtifacts -quit
           )
       )
-      ELSE IF "%PLATFORM_WIN64_MAC_ANDROID%"=="android" (
+      ELSE IF /I "%PLATFORM_WIN64_MAC_ANDROID%"=="android" (
           C:/TestingEditor/Unity.exe -projectPath C:/ClonedProject/{{ netcodeProject[1].projectPath }} -buildTarget android -executeMethod BuilderScripts.BuildAndroidIl2cpp -batchmode -logFile ./artifacts/UnityLog.txt -automated -crash-report-folder ./artifacts/CrashArtifacts -quit
       )
 

--- a/Tools/scripts/BuildAutomation/disable-enable-burst.py
+++ b/Tools/scripts/BuildAutomation/disable-enable-burst.py
@@ -52,7 +52,7 @@ def create_config(settings_path):
 # Note that this jobs uses environment variables to pass parameters to the script.
 def resolve_target():
     # Get the platform value from the environment variable
-    platform_key = os.environ.get('PLATFORM_WIN64_MAC_ANDROID')
+    platform_key = os.environ.get('PLATFORM_WIN64_MAC_ANDROID').lower()
 
     resolved_target = platform_key
     if 'win64' == platform_key:
@@ -95,7 +95,7 @@ def main():
     parse_args()
     config_names = get_or_create_burst_AOT_config()
 
-    platform_key = os.environ.get('PLATFORM_WIN64_MAC_ANDROID')
+    platform_key = os.environ.get('PLATFORM_WIN64_MAC_ANDROID').lower()
     print(f"Burst compilation script: Unity project path is {args.project_path}")
     print(f"Burst compilation script: Target platform is {platform_key}")
 

--- a/Tools/scripts/BuildAutomation/validate_params.py
+++ b/Tools/scripts/BuildAutomation/validate_params.py
@@ -1,4 +1,4 @@
-﻿import os
+import os
 import sys
 
 # --- Configuration ---
@@ -17,13 +17,11 @@ def main():
     """
     all_params_valid = True
 
-    # Iterate through the dictionary of rules.
     for var_name, allowed_values in VALIDATION_RULES.items():
-        # Get the variable's value from the environment.
-        actual_value = os.environ.get(var_name, '')
+        actual_value = os.environ.get(var_name, '').lower()
+        allowed_values_lower = {v.lower() for v in allowed_values}
 
-        # Check if the actual value is in the set of allowed values.
-        if actual_value not in allowed_values:
+        if actual_value not in allowed_values_lower:
             print(
                 f"ERROR: Invalid {var_name}: '{actual_value}'. "
                 f"Allowed values are: {list(allowed_values)}",
@@ -31,9 +29,8 @@ def main():
             )
             all_params_valid = False
 
-    # --- Validation for Invalid Combinations ---
-    platform = os.environ.get('PLATFORM_WIN64_MAC_ANDROID')
-    scripting_backend = os.environ.get('SCRIPTING_BACKEND_IL2CPP_MONO')
+    platform = os.environ.get('PLATFORM_WIN64_MAC_ANDROID', '').lower()
+    scripting_backend = os.environ.get('SCRIPTING_BACKEND_IL2CPP_MONO', '').lower()
 
     if platform == 'mac' and scripting_backend == 'il2cpp':
         print(
@@ -51,10 +48,8 @@ def main():
         )
         all_params_valid = False
 
-    # --- Final Result ---
     if not all_params_valid:
         print("\nOne or more parameters failed validation. Halting build.", file=sys.stderr)
-        # Exit with a non-zero code to fail the Yamato job.
         sys.exit(1)
 
     print("All parameters are valid. Proceeding with the build.")


### PR DESCRIPTION
## Purpose of this PR
This PR add a QOL improvements to build automation which are

1. It allows for choosing the sample branch from which the build will be made. By default it's still the main (suggested) branch but now it can be modified
2. Added lower() check to variables so now values of (for example for **PLATFORM_WIN64_MAC_ANDROID**) `mac` and `Mac` will both be valid

I also corrected frequency for release automation because I noticed that syntax was invalid

### Jira ticket
N/A, but can be related to MTT-12823

## Documentation
Added comment in the logs and in the code

## Testing & QA (How your changes can be verified during release Playtest)
I will run builds with different parameter spelling and from different branches. For release automation I temporarely modified the branch so it should run locally here (and fail silently) if implementation is correct


## Backports
Backport to `develop` is in https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3775
