### PR TITLE
editor: Update Mono API calls to CoreCLR-compatible API calls

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkManagerEditor.cs
@@ -60,7 +60,7 @@ namespace Unity.Netcode.Editor
         {
             m_TransportTypes.Clear();
 
-            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            var assemblies = CurrentAssemblies.GetLoadedAssemblies();
 
             foreach (var assembly in assemblies)
             {


### PR DESCRIPTION
## Purpose of this PR
This PR replaces all instances of `Mono` API calls with `CoreCLR`-compatible API calls in this repo, and is part of Epic [SCP-1555](https://jira.unity3d.com/browse/SCP-1555).

**Note:** 
More PRs dealing with [SCP-1555](https://jira.unity3d.com/browse/SCP-1555) may come in the future. In some cases we cannot replace all `Mono` API calls with `CoreCLR` API calls yet, as some `CoreCLR` APIs are still being worked on/are not yet public (see for example [SCP-1542](https://jira.unity3d.com/browse/SCP-1542), and [SCP-1544](https://jira.unity3d.com/browse/SCP-1544)). In these cases we suppress warnings for those particular APIs for now. Later on, once the equivalent `CoreCLR` APIs are made public, we will do a second pass across all packages and replace the suppressed warning/old API with the new public `CoreCLR` API instead.

## Further Context

- Unity is doing work to move away from `Mono` to using `CoreCLR`. 
- With this we need to replace all `Mono` API calls with `CoreCLR`-compatible ones. (here's the [list of APIs being replaced](https://docs.google.com/spreadsheets/d/1YRRfjPShJgaaToFZqFpqcE1Nnj6-BbjyeI5rKVc-omM/edit?gid=1326171865#gid=1326171865), and [here's the list](https://docs.google.com/spreadsheets/d/1YRRfjPShJgaaToFZqFpqcE1Nnj6-BbjyeI5rKVc-omM/edit?gid=0#gid=0) of packages that will get updated).
- Epic [SCP-1555](https://jira.unity3d.com/browse/SCP-1555) tracks the work of replacing all `Mono` API calls across all Unity supported packages with `CoreCLR`-compatible ones. This PR is part of that epic.
- For more information, or if you have _any_ questions, please visit [#code-reload-safe-api-packages-migration](https://unity.enterprise.slack.com/archives/C09N2RM0L4D) and we'll  be happy to help. 🙂 

### Jira ticket
[SCP-1557](https://jira.unity3d.com/browse/SCP-1557)


## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- No documentation changes or additions were necessary.

## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [X] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports
[//]: # (
This section is REQUIRED and should link to the PR that targets other NGO version which is either develop or develop-2.0.0 branch
Add the following to the PR title: "\[Backport\] ..."
If this is not needed, for example feature specific to NGOv2.X, then just mention this fact.
)
Unsure if this PR should be backported. Please do advise and I will create PRs for backports too!

## Comments to Reviewers

If there are any jobs/tests we should run to make sure there are no ripple effects do share and we will kick them off! :) And, if you know of any locations we may have missed updating or any details that we should know about, please do share! 
