### PR TITLE
chore: updates for scene migration synchronization performance

### DIFF
--- a/com.unity.netcode.gameobjects/Documentation~/components/core/networkobject.md
+++ b/com.unity.netcode.gameobjects/Documentation~/components/core/networkobject.md
@@ -113,7 +113,7 @@ Similar to [`NetworkObject.ActiveSceneSynchronization`](#active-scene-synchroniz
 `NetworkObject.ActiveSceneSynchronization` can be used with `NetworkObject.SceneMigrationSynchronization` as long as you take into consideration that if you migrate a NetworkObject into a non-active scene via `SceneManager.MoveGameObjectToScene` and later change the active scene, then the NetworkObject instance will be automatically migrated to the newly set active scene.
 
 > [!NOTE]
-> **Performance Check**
+> **Performance Check**<br />
 > The `NetworkObject.SceneMigrationSynchronization` field is enabled by default! If your project can have many (600-1000+) spawned objects at any given time, this setting can cause performance issues. This setting only provides the ability to automatically synchronize the scene a NetworkObject is migrated to while it is spawned. If your `NetworkObject` does not change scenes and you have no need for automatic scene migration synchronization (_only applies when the integration scene management is enabled_), then it is recommended to disable this property to avoid additional processing overheads.
 
 

--- a/com.unity.netcode.gameobjects/Documentation~/components/core/networkobject.md
+++ b/com.unity.netcode.gameobjects/Documentation~/components/core/networkobject.md
@@ -112,9 +112,10 @@ Similar to [`NetworkObject.ActiveSceneSynchronization`](#active-scene-synchroniz
 
 `NetworkObject.ActiveSceneSynchronization` can be used with `NetworkObject.SceneMigrationSynchronization` as long as you take into consideration that if you migrate a NetworkObject into a non-active scene via `SceneManager.MoveGameObjectToScene` and later change the active scene, then the NetworkObject instance will be automatically migrated to the newly set active scene.
 
-:::warning
-Scene migration synchronization is enabled by default. For NetworkObjects that don't require it, such as those that generate static environmental objects like trees, it's recommended to disable scene migration synchronization to avoid additional processing overheads.
-:::
+> [!NOTE]
+> **Performance Check**
+> The `NetworkObject.SceneMigrationSynchronization` field is enabled by default! If your project can have many (600-1000+) spawned objects at any given time, this setting can cause performance issues. This setting only provides the ability to automatically synchronize the scene a NetworkObject is migrated to while it is spawned. If your `NetworkObject` does not change scenes and you have no need for automatic scene migration synchronization (_only applies when the integration scene management is enabled_), then it is recommended to disable this property to avoid additional processing overheads.
+
 
 ## Additional resources
 

--- a/com.unity.netcode.gameobjects/Documentation~/components/core/networkobject.md
+++ b/com.unity.netcode.gameobjects/Documentation~/components/core/networkobject.md
@@ -113,8 +113,7 @@ Similar to [`NetworkObject.ActiveSceneSynchronization`](#active-scene-synchroniz
 `NetworkObject.ActiveSceneSynchronization` can be used with `NetworkObject.SceneMigrationSynchronization` as long as you take into consideration that if you migrate a NetworkObject into a non-active scene via `SceneManager.MoveGameObjectToScene` and later change the active scene, then the NetworkObject instance will be automatically migrated to the newly set active scene.
 
 > [!NOTE]
-> **Performance Check**<br />
-> The `NetworkObject.SceneMigrationSynchronization` field is enabled by default! If your project can have many (600-1000+) spawned objects at any given time, this setting can cause performance issues. This setting only provides the ability to automatically synchronize the scene a NetworkObject is migrated to while it is spawned. If your `NetworkObject` does not change scenes and you have no need for automatic scene migration synchronization (_only applies when the integration scene management is enabled_), then it is recommended to disable this property to avoid additional processing overheads.
+> The `NetworkObject.SceneMigrationSynchronization` field is enabled by default. If your project can have many (600-1000+) spawned objects at any given time, this setting can cause performance issues. Scene migration synchronization only provides the ability to automatically synchronize the scene a NetworkObject is migrated to while it is spawned. If your NetworkObject doesn't change scenes and you have no need for automatic scene migration synchronization (_only applies when the integration scene management is enabled_), then it's recommended to disable this property to avoid additional processing overheads.
 
 
 ## Additional resources


### PR DESCRIPTION
## Purpose of this PR

Updates to the NetworkObject documentation to better clarify how `SceneMigrationSynchronization` can cause performance issues if left enabled on NetworkObjects that don't use the feature and there are 100's to 1000+ spawned instances.

### Jira ticket

NA

### Changelog

NA

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- Includes edits to existing documentation.


## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing

No testing required.

_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports

No back port required.
