### PR TITLE
chore: EntityId update for UnityTransport and MP Tools

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -361,13 +361,12 @@ namespace Unity.Netcode.Transports.UTP
         /// Multiplayer Tools subscribes to this event and does not have the EntityId udpate.
         /// </summary>
 
-#if UNITY_6000_2_OR_NEWER && MP_TOOLS_2_2_8_OR_HIGHER
-        internal static event Action<EntityId, NetworkDriver> TransportInitialized;
-        internal static event Action<EntityId> TransportDisposed;
-#else
+#if UNITY_6000_2_OR_NEWER
+        internal static event Action<EntityId, NetworkDriver> OnDriverInitialized;
+        internal static event Action<EntityId> OnDisposingDriver;
+#endif
         internal static event Action<int, NetworkDriver> TransportInitialized;
         internal static event Action<int> TransportDisposed;
-#endif
 
         /// <summary>
         /// Provides access to the <see cref="NetworkDriver"/> for this instance.
@@ -445,12 +444,9 @@ namespace Unity.Netcode.Transports.UTP
                 out m_UnreliableSequencedFragmentedPipeline,
                 out m_ReliableSequencedPipeline);
 #if UNITY_6000_2_OR_NEWER
-#if MP_TOOLS_2_2_8_OR_HIGHER
             var entityId = GetEntityId();
-#else
-            var entityId = GetEntityId().GetHashCode();
-#endif
-            TransportInitialized?.Invoke(entityId, m_Driver);
+            OnDriverInitialized?.Invoke(entityId, m_Driver);
+            TransportInitialized?.Invoke(entityId.GetHashCode(), m_Driver);
 #else
             TransportInitialized?.Invoke(GetInstanceID(), m_Driver);
 #endif
@@ -471,12 +467,9 @@ namespace Unity.Netcode.Transports.UTP
             m_SendQueue.Clear();
 
 #if UNITY_6000_2_OR_NEWER
-#if MP_TOOLS_2_2_8_OR_HIGHER
             var entityId = GetEntityId();
-#else
-            var entityId = GetEntityId().GetHashCode();
-#endif
-            TransportDisposed?.Invoke(entityId);
+            OnDisposingDriver?.Invoke(entityId);
+            TransportDisposed?.Invoke(entityId.GetHashCode());
 #else
             TransportDisposed?.Invoke(GetInstanceID());
 #endif

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -356,11 +356,6 @@ namespace Unity.Netcode.Transports.UTP
             public float PacketLoss;
         };
 
-        /// <summary>
-        /// TODO-FIXME:
-        /// Multiplayer Tools subscribes to this event and does not have the EntityId udpate.
-        /// </summary>
-
 #if UNITY_6000_2_OR_NEWER
         internal static event Action<EntityId, NetworkDriver> OnDriverInitialized;
         internal static event Action<EntityId> OnDisposingDriver;

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -360,17 +360,14 @@ namespace Unity.Netcode.Transports.UTP
         /// TODO-FIXME:
         /// Multiplayer Tools subscribes to this event and does not have the EntityId udpate.
         /// </summary>
-#if FIXED
-#if UNITY_6000_2_OR_NEWER
+
+#if UNITY_6000_2_OR_NEWER && MP_TOOLS_2_2_8_OR_HIGHER
         internal static event Action<EntityId, NetworkDriver> TransportInitialized;
         internal static event Action<EntityId> TransportDisposed;
 #else
         internal static event Action<int, NetworkDriver> TransportInitialized;
         internal static event Action<int> TransportDisposed;
 #endif
-#endif
-        internal static event Action<int, NetworkDriver> TransportInitialized;
-        internal static event Action<int> TransportDisposed;
 
         /// <summary>
         /// Provides access to the <see cref="NetworkDriver"/> for this instance.
@@ -448,14 +445,12 @@ namespace Unity.Netcode.Transports.UTP
                 out m_UnreliableSequencedFragmentedPipeline,
                 out m_ReliableSequencedPipeline);
 #if UNITY_6000_2_OR_NEWER
+#if MP_TOOLS_2_2_8_OR_HIGHER
             var entityId = GetEntityId();
-#if UNITY_6000_3_0A6_OR_HIGHER
-            // TODO-FIXME: Since multiplayer tools subscribes to this and we have to validate against any package that
-            // might use this action, we have to cast it down temporarily to avoid being blocked from getting these fixes in place.
-            TransportInitialized?.Invoke((int)entityId.GetRawData(), m_Driver);
 #else
-            TransportInitialized?.Invoke(entityId, m_Driver);
+            var entityId = GetEntityId().GetHashCode();
 #endif
+            TransportInitialized?.Invoke(entityId, m_Driver);
 #else
             TransportInitialized?.Invoke(GetInstanceID(), m_Driver);
 #endif
@@ -476,15 +471,12 @@ namespace Unity.Netcode.Transports.UTP
             m_SendQueue.Clear();
 
 #if UNITY_6000_2_OR_NEWER
+#if MP_TOOLS_2_2_8_OR_HIGHER
             var entityId = GetEntityId();
-#if UNITY_6000_3_0A6_OR_HIGHER
-            // TODO-FIXME: Since multiplayer tools subscribes to this and we have to validate against any package that
-            // might use this action, we have to cast it down temporarily to avoid being blocked from getting these fixes in place.
-            TransportDisposed?.Invoke((int)entityId.GetRawData());
 #else
-            TransportDisposed?.Invoke(entityId, m_Driver);
+            var entityId = GetEntityId().GetHashCode();
 #endif
-
+            TransportDisposed?.Invoke(entityId);
 #else
             TransportDisposed?.Invoke(GetInstanceID());
 #endif

--- a/com.unity.netcode.gameobjects/Runtime/Unity.Netcode.Runtime.asmdef
+++ b/com.unity.netcode.gameobjects/Runtime/Unity.Netcode.Runtime.asmdef
@@ -34,6 +34,11 @@
             "define": "MULTIPLAYER_TOOLS_1_0_0_PRE_7"
         },
         {
+            "name": "com.unity.multiplayer.tools",
+            "expression": "2.2.8",
+            "define": "MP_TOOLS_2_2_8_OR_HIGHER"
+        },
+        {
             "name": "Unity",
             "expression": "2023",
             "define": "UNITY_DEDICATED_SERVER_ARGUMENTS_PRESENT"

--- a/com.unity.netcode.gameobjects/Runtime/Unity.Netcode.Runtime.asmdef
+++ b/com.unity.netcode.gameobjects/Runtime/Unity.Netcode.Runtime.asmdef
@@ -34,11 +34,6 @@
             "define": "MULTIPLAYER_TOOLS_1_0_0_PRE_7"
         },
         {
-            "name": "com.unity.multiplayer.tools",
-            "expression": "2.2.8",
-            "define": "MP_TOOLS_2_2_8_OR_HIGHER"
-        },
-        {
             "name": "Unity",
             "expression": "2023",
             "define": "UNITY_DEDICATED_SERVER_ARGUMENTS_PRESENT"

--- a/com.unity.netcode.gameobjects/Runtime/Unity.Netcode.Runtime.asmdef
+++ b/com.unity.netcode.gameobjects/Runtime/Unity.Netcode.Runtime.asmdef
@@ -89,9 +89,9 @@
             "define": "SCENE_MANAGEMENT_SCENE_HANDLE_NO_INT_CONVERSION"
         },
         {
-          "name": "Unity",
-          "expression": "6000.5.0a1",
-          "define": "SCENE_MANAGEMENT_SCENE_HANDLE_MUST_USE_ULONG"
+            "name": "Unity",
+            "expression": "6000.5.0a1",
+            "define": "SCENE_MANAGEMENT_SCENE_HANDLE_MUST_USE_ULONG"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
## Purpose of this PR

This resolves the circular package/CI vetting process where MP tools required a change on the NGO side but NGO required the change already be applied to pass our standards/vetting checks that includes validating the most current MP tools package compiles with NGO.

### Jira ticket

TBD (WIP)

### Changelog
[//]: # (updated with all public facing changes  - API changes, UI/UX changes, behaviour changes, bug fixes. Remove if not relevant.)


<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- No documentation changes or additions were necessary.

## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [x] `Manual testing done`
  - Refer to [PR-757](https://github.com/Unity-Technologies/com.unity.multiplayer.tools/pull/757) as to testing instructions.

_Automated tests:_
- [x] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports
No backport is required since the `EntityId` update is applied in a version of Unity beyond that supported by NGO v1.x.
