### PR TITLE
fix: players spawned by session owner when scene management disabled don't synchronize

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -22,6 +22,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where spawning a player in distributed authority mode via a client, typically session owner, other than the newly connected client and scene management is disabled then the already spawned players will not properly get synchronized by each owning client due to the newly connected client's identifier already being added prior to synchronization. (#3816)
+
 
 ### Security
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1320,6 +1320,15 @@ namespace Unity.Netcode
 
         internal readonly HashSet<ulong> Observers = new HashSet<ulong>();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void AddObserver(ulong clientId)
+        {
+#if NETCODE_DEBUG_OBSERVERS
+            Debug.Log($"[{nameof(NetworkObject)}][{name}-{NetworkObjectId}] Adding Client-{clientId} as an observer.");
+#endif
+            Observers.Add(clientId);
+        }
+
 #if MULTIPLAYER_TOOLS
         private string m_CachedNameForMetrics;
 #endif
@@ -1469,7 +1478,7 @@ namespace Unity.Netcode
                 return;
             }
             NetworkManager.SpawnManager.MarkObjectForShowingTo(this, clientId);
-            Observers.Add(clientId);
+            AddObserver(clientId);
         }
 
 
@@ -3326,7 +3335,7 @@ namespace Unity.Netcode
             {
                 foreach (var observer in sceneObject.Observers)
                 {
-                    networkObject.Observers.Add(observer);
+                    networkObject.AddObserver(observer);
                 }
             }
 
@@ -3346,11 +3355,11 @@ namespace Unity.Netcode
                     if (networkObject.IsPlayerObject)
                     {
                         // If it is another player, then make sure the local player is aware of the player
-                        playerObject.Observers.Add(networkObject.OwnerClientId);
+                        playerObject.AddObserver(networkObject.OwnerClientId);
                     }
 
                     // Assure the local player has observability
-                    networkObject.Observers.Add(playerObject.OwnerClientId);
+                    networkObject.AddObserver(playerObject.OwnerClientId);
 
                     // If it is a player object, then add it to all known spawned NetworkObjects that spawn with observers
                     if (networkObject.IsPlayerObject)
@@ -3359,7 +3368,7 @@ namespace Unity.Netcode
                         {
                             if (netObject.Value.SpawnWithObservers)
                             {
-                                netObject.Value.Observers.Add(networkObject.OwnerClientId);
+                                netObject.Value.AddObserver(networkObject.OwnerClientId);
                             }
                         }
                     }
@@ -3371,7 +3380,7 @@ namespace Unity.Netcode
                         // Add all known players to the observers list if they don't already exist
                         foreach (var player in networkManager.SpawnManager.PlayerObjects)
                         {
-                            networkObject.Observers.Add(player.OwnerClientId);
+                            networkObject.AddObserver(player.OwnerClientId);
                         }
                     }
                 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionApprovedMessage.cs
@@ -158,7 +158,7 @@ namespace Unity.Netcode
                 {
                     if (sobj.SpawnWithObservers && (sobj.CheckObjectVisibility == null || sobj.CheckObjectVisibility(OwnerClientId)))
                     {
-                        sobj.Observers.Add(OwnerClientId);
+                        sobj.AddObserver(OwnerClientId);
                         // In distributed authority mode, we send the currently known observers of each NetworkObject to the client being synchronized.
                         var sceneObject = sobj.GetMessageSceneObject(OwnerClientId, IsDistributedAuthority);
                         sceneObject.Serialize(writer);

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/CreateObjectMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/CreateObjectMessage.cs
@@ -208,7 +208,7 @@ namespace Unity.Netcode
                     // Update the observers for this instance
                     for (int i = 0; i < clientList.Count; i++)
                     {
-                        networkObject.Observers.Add(clientList[i]);
+                        networkObject.AddObserver(clientList[i]);
                     }
 
                     // Mock CMB Service and forward to all clients


### PR DESCRIPTION
## Purpose of this PR (WIP)

Fixing issue where spawning a player in distributed authority mode via a client, typically session owner, other than the newly connected client and scene management is disabled then the already spawned players will not properly get synchronized by each owning client due to the newly connected client's identifier already being added prior to synchronization.

### Jira ticket
(WIP)

### Changelog
[//]: # (updated with all public facing changes  - API changes, UI/UX changes, behaviour changes, bug fixes. Remove if not relevant.)

- Fixed: Issue where spawning a player in distributed authority mode via a client, typically session owner, other than the newly connected client and scene management is disabled then the already spawned players will not properly get synchronized by each owning client due to the newly connected client's identifier already being added prior to synchronization.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- No documentation changes or additions were necessary.

## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [x] `Manual testing done`
  - Using modified version of #3779

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [x] `Covered by new automated tests` (WIP)

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports
DA specific, does not require backport.
