### PR TITLE
fix: Update NetworkBehaviour on session owner promotion

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -22,7 +22,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Ensure `NetworkBehaviour.IsSessionOwner` is correctly set when a new session owner is promoted. (#3817)
 
 ### Security
 
@@ -50,6 +49,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Ensure `NetworkBehaviour.IsSessionOwner` is correctly set when a new session owner is promoted. (#3817)
+- Reset extended ownership flags on `NetworkObject` despawn. (#3817)
 - Fixed issues with the "Client-server quickstart for Netcode for GameObjects" script having static methods and properties. (#3787)
 - Fixed issue where a warning message was being logged upon a client disconnecting from a server when the log level is set to developer. (#3786)
 - Fixed issue where the server or host would no longer have access to the transport id to client id table when processing a transport level client disconnect event. (#3786)

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -22,6 +22,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Ensure `NetworkBehaviour.IsSessionOwner` is correctly set when a new session owner is promoted. (#3817)
 
 ### Security
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -1685,15 +1685,12 @@ namespace Unity.Netcode
                 Debug.LogException(ex);
             }
 
-            if (IsSpawned)
+            if (m_NetworkObject != null && m_NetworkObject.IsSpawned && IsSpawned)
             {
-                if (m_NetworkObject != null && m_NetworkObject.IsSpawned)
-                {
-                    // If the associated NetworkObject is still spawned then this
-                    // NetworkBehaviour will be removed from the NetworkObject's
-                    // ChildNetworkBehaviours list.
-                    m_NetworkObject.OnNetworkBehaviourDestroyed(this);
-                }
+                // If the associated NetworkObject is still spawned then this
+                // NetworkBehaviour will be removed from the NetworkObject's
+                // ChildNetworkBehaviours list.
+                m_NetworkObject.OnNetworkBehaviourDestroyed(this);
             }
 
             // this seems odd to do here, but in fact especially in tests we can find ourselves

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -515,7 +515,7 @@ namespace Unity.Netcode
         /// <summary>
         /// Gets whether the client is the distributed authority mode session owner.
         /// </summary>
-        public bool IsSessionOwner { get; private set; }
+        public bool IsSessionOwner { get; internal set; }
 
         /// <summary>
         /// Gets whether the server (local or remote) is a host.
@@ -1685,12 +1685,15 @@ namespace Unity.Netcode
                 Debug.LogException(ex);
             }
 
-            if (m_NetworkObject != null && m_NetworkObject.IsSpawned && IsSpawned)
+            if (IsSpawned)
             {
-                // If the associated NetworkObject is still spawned then this
-                // NetworkBehaviour will be removed from the NetworkObject's
-                // ChildNetworkBehaviours list.
-                m_NetworkObject.OnNetworkBehaviourDestroyed(this);
+                if (m_NetworkObject != null && m_NetworkObject.IsSpawned)
+                {
+                    // If the associated NetworkObject is still spawned then this
+                    // NetworkBehaviour will be removed from the NetworkObject's
+                    // ChildNetworkBehaviours list.
+                    m_NetworkObject.OnNetworkBehaviourDestroyed(this);
+                }
             }
 
             // this seems odd to do here, but in fact especially in tests we can find ourselves

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -216,19 +216,21 @@ namespace Unity.Netcode
 
         internal void SetSessionOwner(ulong sessionOwner)
         {
-            var previousSessionOwner = CurrentSessionOwner;
             CurrentSessionOwner = sessionOwner;
-            LocalClient.IsSessionOwner = LocalClientId == sessionOwner;
-            if (LocalClient.IsSessionOwner)
+            var isSessionOwner = LocalClientId == sessionOwner;
+            LocalClient.IsSessionOwner = isSessionOwner;
+
+            foreach (var networkObject in SpawnManager.SpawnedObjects.Values)
             {
-                foreach (var networkObjectEntry in SpawnManager.SpawnedObjects)
+                if (isSessionOwner)
                 {
-                    var networkObject = networkObjectEntry.Value;
                     if (networkObject.IsOwnershipSessionOwner && networkObject.OwnerClientId != LocalClientId)
                     {
                         SpawnManager.ChangeOwnership(networkObject, LocalClientId, true);
                     }
                 }
+
+                networkObject.InvokeSessionOwnerPromoted(isSessionOwner);
             }
 
             OnSessionOwnerPromoted?.Invoke(sessionOwner);

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -2002,6 +2002,7 @@ namespace Unity.Netcode
             IsSpawned = false;
             DeferredDespawnTick = 0;
             m_LatestParent = null;
+            RemoveOwnershipExtended(OwnershipStatusExtended.Locked | OwnershipStatusExtended.Requested);
         }
 
         /// <summary>
@@ -2075,6 +2076,19 @@ namespace Unity.Netcode
                 {
                     Debug.LogWarning($"{ChildNetworkBehaviours[i].gameObject.name} is disabled! Netcode for GameObjects does not support disabled NetworkBehaviours! The {ChildNetworkBehaviours[i].GetType().Name} component was skipped during ownership assignment!");
                 }
+            }
+        }
+
+        internal void InvokeSessionOwnerPromoted(bool isSessionOwner)
+        {
+            if (!IsSpawned)
+            {
+                return;
+            }
+
+            foreach (var childBehaviour in ChildNetworkBehaviours)
+            {
+                childBehaviour.IsSessionOwner = isSessionOwner;
             }
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/OwnershipPermissionsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DistributedAuthority/OwnershipPermissionsTests.cs
@@ -499,6 +499,108 @@ namespace Unity.Netcode.RuntimeTests
             AssertOnTimeout($"[{newStatus}][Set RequestRequired][Permissions mismatch] {firstClient.name}");
         }
 
+        [UnityTest]
+        public IEnumerator ResetExtendedOwnershipFlagsOnRespawn()
+        {
+            var extendedFlags = (NetworkObject.OwnershipStatusExtended[])Enum.GetValues(typeof(NetworkObject.OwnershipStatusExtended));
+            Assert.That(extendedFlags.Length, Is.LessThan(NumberOfClients), "This test should have at least one more non-authority client than extended flags!");
+
+            var spawnedObjects = new List<NetworkObject>();
+            while (spawnedObjects.Count <= extendedFlags.Length)
+            {
+                var ownerClient = GetNonAuthorityNetworkManager(spawnedObjects.Count);
+                var spawnedObject = SpawnObject(m_PermissionsObject, ownerClient).GetComponent<NetworkObject>();
+                spawnedObject.SetOwnershipStatus(NetworkObject.OwnershipStatus.RequestRequired, true);
+                spawnedObjects.Add(spawnedObject);
+            }
+
+            yield return WaitForSpawnedOnAllOrTimeOut(spawnedObjects);
+            AssertOnTimeout("[InitialSpawn] Not all objects are spawned on all clients!");
+
+            for (int i = 0; i < extendedFlags.Length; i++)
+            {
+                var flag = extendedFlags[i];
+                var obj = spawnedObjects[i];
+                obj.AddOwnershipExtended(flag);
+                obj.SendOwnershipStatusUpdate();
+
+                m_ObjectToValidate = obj;
+                yield return WaitForConditionOrTimeOut(ValidatePermissionsOnAllClients);
+                AssertOnTimeout($"[{flag}] Not all clients have set the permission on the object!");
+            }
+
+            // Despawn the objects
+            foreach (var networkObject in spawnedObjects)
+            {
+                networkObject.Despawn(false);
+            }
+
+            yield return WaitForDespawnedOnAllOrTimeOut(spawnedObjects);
+            AssertOnTimeout("Not all clients have despawned all objects!");
+
+            // Respawn the objects
+            foreach (var networkObject in spawnedObjects)
+            {
+                networkObject.Spawn();
+            }
+
+            yield return WaitForSpawnedOnAllOrTimeOut(spawnedObjects);
+            AssertOnTimeout("[ReSpawn] Not all objects are spawned on all clients!");
+
+            // Requesting ownership should work as expected
+            var nonAuthorityIndex = 1; // Start the index at one more than the initial ownership
+            var objectToOwner = new Dictionary<NetworkObject, NetworkManager>();
+            foreach (var networkObject in spawnedObjects)
+            {
+                var nextOwner = GetNonAuthorityNetworkManager(nonAuthorityIndex++);
+                Assert.That(nextOwner.LocalClientId, Is.Not.EqualTo(networkObject.OwnerClientId));
+                Assert.IsTrue(nextOwner.SpawnManager.SpawnedObjects.TryGetValue(networkObject.NetworkObjectId, out var nextOwnerInstance));
+                Assert.That(nextOwnerInstance, Is.Not.Null);
+
+                var requestStatus = nextOwnerInstance.RequestOwnership();
+                Assert.That(requestStatus, Is.EqualTo(NetworkObject.OwnershipRequestStatus.RequestSent));
+
+                objectToOwner.Add(networkObject, nextOwner);
+            }
+
+            yield return WaitForConditionOrTimeOut(errorLog =>
+            {
+                foreach (var client in m_NetworkManagers)
+                {
+                    foreach (var (networkObject, expectedOwner) in objectToOwner)
+                    {
+                        if (!client.SpawnManager.SpawnedObjects.TryGetValue(networkObject.NetworkObjectId, out var clientInstance))
+                        {
+                            errorLog.AppendLine($"Object-{networkObject.NetworkObjectId} is not spawned on client-{client.LocalClientId}");
+                            return false;
+                        }
+
+                        if (clientInstance.OwnerClientId != expectedOwner.LocalClientId)
+                        {
+                            errorLog.AppendLine($"Client-{client.LocalClientId} has the incorrect owner for Object-{networkObject.NetworkObjectId}");
+                            return false;
+                        }
+
+                        if (clientInstance.IsOwner != (client == expectedOwner))
+                        {
+                            errorLog.AppendLine($"Client-{client.LocalClientId} has the incorrect IsOwner for Object-{networkObject.NetworkObjectId}");
+                            return false;
+                        }
+                    }
+                }
+
+                return true;
+            });
+            AssertOnTimeout("Some ownership requests failed!");
+
+            foreach (var networkObject in spawnedObjects)
+            {
+                m_ObjectToValidate = networkObject;
+                yield return WaitForConditionOrTimeOut(ValidatePermissionsOnAllClients);
+                AssertOnTimeout($"[Object-{networkObject.NetworkObjectId}] Not all clients have set the permission on the object!");
+            }
+        }
+
         internal class OwnershipPermissionsTestHelper : NetworkBehaviour
         {
             public static NetworkObject CurrentOwnedInstance;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
@@ -2002,6 +2002,33 @@ namespace Unity.Netcode.TestHelpers.Runtime
         }
 
         /// <summary>
+        /// Waits until all given NetworkObjects are spawned on all clients or a timeout occurs.
+        /// </summary>
+        /// <param name="networkObjects">The list of <see cref="NetworkObject"/>s to wait for.</param>
+        /// <param name="timeOutHelper">An optional <see cref="TimeoutHelper"/> to control the timeout period. If null, the default timeout is used.</param>
+        /// <returns>An <see cref="IEnumerator"/> for use in Unity coroutines.</returns>
+        protected IEnumerator WaitForDespawnedOnAllOrTimeOut(List<NetworkObject> networkObjects, TimeoutHelper timeOutHelper = null)
+        {
+            bool ValidateObjectsDespawnedOnAllClients(StringBuilder errorLog)
+            {
+                foreach (var client in m_NetworkManagers)
+                {
+                    foreach (var networkObject in networkObjects)
+                    {
+                        if (client.SpawnManager.SpawnedObjects.TryGetValue(networkObject.NetworkObjectId, out NetworkObject clientObj) && clientObj.IsSpawned)
+                        {
+                            errorLog.Append($"Object-{networkObject.NetworkObjectId} is still spawned on Client-{client.LocalClientId}!");
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            }
+
+            yield return WaitForConditionOrTimeOut(ValidateObjectsDespawnedOnAllClients, timeOutHelper);
+        }
+
+        /// <summary>
         /// Validates that all remote clients (i.e. non-server) detect they are connected
         /// to the server and that the server reflects the appropriate number of clients
         /// have connected or it will time out.

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
@@ -255,13 +255,18 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// <returns>The <see cref="NetworkManager"/> instance that is the current authority</returns>
         protected NetworkManager GetAuthorityNetworkManager()
         {
-            if (m_UseCmbService)
+            if (m_DistributedAuthority)
             {
                 // If we haven't even started any NetworkManager, then return the first instance
                 // since it will be the session owner.
                 if (!NetcodeIntegrationTestHelpers.IsStarted)
                 {
-                    return m_NetworkManagers[0];
+                    return m_UseCmbService ? m_NetworkManagers[0] : m_ServerNetworkManager;
+                }
+
+                if (!m_UseCmbService && m_ServerNetworkManager.LocalClient.IsSessionOwner)
+                {
+                    return m_ServerNetworkManager;
                 }
 
                 foreach (var client in m_NetworkManagers)
@@ -1967,6 +1972,33 @@ namespace Unity.Netcode.TestHelpers.Runtime
         {
             var networkObjectId = gameObject.GetComponent<NetworkObject>().NetworkObjectId;
             yield return WaitForSpawnedOnAllOrTimeOut(networkObjectId, timeOutHelper);
+        }
+
+        /// <summary>
+        /// Waits until all given NetworkObjects are spawned on all clients or a timeout occurs.
+        /// </summary>
+        /// <param name="networkObjects">The list of <see cref="NetworkObject"/>s to wait for.</param>
+        /// <param name="timeOutHelper">An optional <see cref="TimeoutHelper"/> to control the timeout period. If null, the default timeout is used.</param>
+        /// <returns>An <see cref="IEnumerator"/> for use in Unity coroutines.</returns>
+        protected IEnumerator WaitForSpawnedOnAllOrTimeOut(List<NetworkObject> networkObjects, TimeoutHelper timeOutHelper = null)
+        {
+            bool ValidateObjectsSpawnedOnAllClients(StringBuilder errorLog)
+            {
+                foreach (var client in m_NetworkManagers)
+                {
+                    foreach (var networkObject in networkObjects)
+                    {
+                        if (!client.SpawnManager.SpawnedObjects.ContainsKey(networkObject.NetworkObjectId))
+                        {
+                            errorLog.Append($"Client-{client.LocalClientId} has not spawned Object-{networkObject.NetworkObjectId}!");
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            }
+
+            yield return WaitForConditionOrTimeOut(ValidateObjectsSpawnedOnAllClients, timeOutHelper);
         }
 
         /// <summary>


### PR DESCRIPTION
## Purpose of this PR

Ensure `NetworkBehaviour.IsSessionOwner` is correctly updated when a new DA session owner is promoted.

### Jira ticket

[MTTB-1775](https://jira.unity3d.com/browse/MTTB-1775)
[MTTB-1776](https://jira.unity3d.com/browse/MTTB-1776)
fixes: #3815 
fixes: #3803 

### Changelog

- Fixed: `NetworkBehaviour.IsSessionOwner` is now updated when a new session owner is promoted.
- Reset extended ownership flags (`Locked`, `Requested`) when NetworkObject is despawned to ensure that they don't stay set on respawn.

## Documentation

- No documentation changes or additions were necessary.

## Testing & QA (How your changes can be verified during release Playtest)

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [x] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports

DA only so no backport needed
