### PR TITLE
fix: issues discovered in v2.8.0 playtest

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
@@ -78,7 +78,7 @@ namespace Unity.Netcode.Components
         private bool HasAuthority()
         {
             var isServerAuthority = m_NetworkAnimator.IsServerAuthoritative();
-            return (!isServerAuthority && m_NetworkAnimator.IsOwner) || (isServerAuthority && (m_NetworkAnimator.IsServer || m_NetworkAnimator.IsOwner));
+            return (!isServerAuthority && m_NetworkAnimator.IsOwner) || (isServerAuthority && (m_NetworkAnimator.IsServer));
         }
 
         /// <inheritdoc />
@@ -95,7 +95,8 @@ namespace Unity.Netcode.Components
 
                         var hasAuthority = HasAuthority();
                         // Only the authority or the server will send messages
-                        if (hasAuthority || m_IsServer)
+                        // The only exception is server authoritative and owners that are sending animation triggers.
+                        if (hasAuthority || m_IsServer || (m_NetworkAnimator.IsServerAuthoritative() && m_NetworkAnimator.IsOwner))
                         {
                             // Flush any pending messages
                             FlushMessages();
@@ -408,7 +409,18 @@ namespace Unity.Netcode.Components
             }
 
             TransitionStateInfoList = new List<TransitionStateinfo>();
-            var animatorController = m_Animator.runtimeAnimatorController as AnimatorController;
+            var animControllerType = m_Animator.runtimeAnimatorController.GetType();
+            var animatorController = (AnimatorController)null;
+
+            if (animControllerType == typeof(AnimatorOverrideController))
+            {
+                animatorController = ((AnimatorOverrideController)m_Animator.runtimeAnimatorController).runtimeAnimatorController as AnimatorController;
+            }
+            else if (animControllerType == typeof(AnimatorController))
+            {
+                animatorController = m_Animator.runtimeAnimatorController as AnimatorController;
+            }
+
             if (animatorController == null)
             {
                 return;
@@ -432,7 +444,22 @@ namespace Unity.Netcode.Components
                 return;
             }
 
-            var parameters = Animator.parameters;
+            var animControllerType = m_Animator.runtimeAnimatorController.GetType();
+            var animatorController = (AnimatorController)null;
+
+            if (animControllerType == typeof(AnimatorOverrideController))
+            {
+                animatorController = ((AnimatorOverrideController)m_Animator.runtimeAnimatorController).runtimeAnimatorController as AnimatorController;
+            }
+            else if (animControllerType == typeof(AnimatorController))
+            {
+                animatorController = m_Animator.runtimeAnimatorController as AnimatorController;
+            }
+            if (animatorController == null)
+            {
+                return;
+            }
+            var parameters = animatorController.parameters;
 
             var parametersToRemove = new List<AnimatorParameterEntry>();
             ParameterToNameLookup.Clear();


### PR DESCRIPTION
## Purpose of this PR
This PR fixes:
- The issue with AnimatorOverrideController not being handled which could cause improper processing of the animator's layers and parameters.

- The issue with clients sending state changes from the NetworkAnimatorStateChangeHandler due to added HasAuthority check. When using a server authoritative animation model, owner Clients should still be able to send trigger updates to the server.

### Jira ticket
NA

### Changelog
NA
<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- No documentation changes or additions were necessary.

## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [x] `Manual testing done`
  - Used boss room and testproject to assure the various animation modes/uses are working as expected.

_Automated tests:_
- [x] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports
This is v2.x specific for v2.8.0 
