### PR TITLE
perf: [Port] Backport of PR-3227 

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -13,6 +13,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+- Improved performance of NetworkBehaviour ILPostProcessor by omitting unnecessary type and assembly resolutions.
 
 ### Deprecated
 


### PR DESCRIPTION
## Purpose of this PR
As noted in https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/3808 it seems like we missed forward porting of **[PR-3227](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3227)** from `develop` (NGOv1.X) to `develop-2.0.0` (NGOv2.X) branch. This PR does the port

Note that there were no conflicts when cherry-picking the PR but still would be worth double checking.
Also I noticed that with the original PR the changelog description was also missed, something that can be clarified

### Jira ticket
N/A

### Changelog
- Changed: Improved performance of NetworkBehaviour ILPostProcessor by omitting unnecessary type and assembly resolutions.

## Documentation
- No documentation changes or additions were necessary.

## Testing & QA (How your changes can be verified during release Playtest)
We should do the same check as was done in the original PR (TBD)

## Backports
This is a port of https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3227
