### PR TITLE
ci: [Backport] Temporarily disabled trigger for release automation

### DIFF
--- a/.yamato/ngo-publish.yml
+++ b/.yamato/ngo-publish.yml
@@ -1,11 +1,10 @@
 ngo_release_preparation:
   name: "NGO release preparation"
   agent: { type: Unity::VM, flavor: b1.small, image: package-ci/ubuntu-22.04:v4 }
-  triggers:
-    recurring:
-      - branch: develop # We make new releases from this branch
-        frequency: "10 ? * 1" # Runs every Sunday at 10:00 AM
-  rerun: always
+  #triggers:
+  #  recurring:
+  #    - branch: develop # We make new releases from this branch
+  #      frequency: "10 ? * 1" # Runs every Sunday at 10:00 AM
   commands:
     - pip install PyGithub
     - pip install GitPython


### PR DESCRIPTION
## Purpose of this PR
This is a backport of https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3829

This PR temporarily disables the trigger for release preparation. This is done since I have changes in https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3828 (After that land I will backport this here) that I would like people to verify that would modify the behavior of this action. Per schedule next release would be next week and because of holidays we moved our schedule by 1 week so running this now could fail again/cause problem about reverting commit on main branch (issue described in linked PR) 

So given this I will disable it here and re-enable it from the linked PR when changes are properly reviewed 

## Jira ticket
N/A

## Documentation
N/A

## Testing & QA (How your changes can be verified during release Playtest)
N/A

## Backports
This is a backport of https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3829
