### PR TITLE
chore: Minimal supported editor correction

### DIFF
--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -75,13 +75,13 @@ pr_code_changes_checks:
     # Run API validation to early-detect all new APIs that would force us to release new minor version of the package. Note that for this to work the package version in package.json must correspond to "actual package state" which means that it should be higher than last released version
     - .yamato/vetting-test.yml#vetting_test
 
-    # Run package EditMode and Playmode package tests on trunk and the minimal supported editor (6000.0.0f1)
+    # Run package EditMode and Playmode package tests on trunk and the minimal supported editor
     - .yamato/package-tests.yml#package_test_-_ngo_trunk_mac
-    - .yamato/package-tests.yml#package_test_-_ngo_6000.0.0f1_win
+    - .yamato/package-tests.yml#package_test_-_ngo_{{ validation_editors.minimal }}_win
 
-    # Run testproject EditMode and Playmode project tests on trunk and the minimal supported editor (6000.0.0f1)
+    # Run testproject EditMode and Playmode project tests on trunk and the minimal supported editor
     - .yamato/project-tests.yml#test_testproject_win_trunk
-    - .yamato/project-tests.yml#test_testproject_mac_6000.0.0f1
+    - .yamato/project-tests.yml#test_testproject_mac_{{ validation_editors.minimal }}
 
     # Run standalone test. We run it only on Ubuntu since it's the fastest machine, and it was noted that for example distribution on macOS is taking 40m since we switched to Apple Silicon
     # Coverage on other standalone machines is present in Nightly job so it's enough to not run all of them for PRs

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -75,13 +75,13 @@ pr_code_changes_checks:
     # Run API validation to early-detect all new APIs that would force us to release new minor version of the package. Note that for this to work the package version in package.json must correspond to "actual package state" which means that it should be higher than last released version
     - .yamato/vetting-test.yml#vetting_test
 
-    # Run package EditMode and Playmode package tests on trunk and an older supported editor (6000.0)
+    # Run package EditMode and Playmode package tests on trunk and the minimal supported editor (6000.0.0f1)
     - .yamato/package-tests.yml#package_test_-_ngo_trunk_mac
-    - .yamato/package-tests.yml#package_test_-_ngo_6000.0_win
+    - .yamato/package-tests.yml#package_test_-_ngo_6000.0.0f1_win
 
-    # Run testproject EditMode and Playmode project tests on trunk and an older supported editor (6000.0)
+    # Run testproject EditMode and Playmode project tests on trunk and the minimal supported editor (6000.0.0f1)
     - .yamato/project-tests.yml#test_testproject_win_trunk
-    - .yamato/project-tests.yml#test_testproject_mac_6000.0
+    - .yamato/project-tests.yml#test_testproject_mac_6000.0.0f1
 
     # Run standalone test. We run it only on Ubuntu since it's the fastest machine, and it was noted that for example distribution on macOS is taking 40m since we switched to Apple Silicon
     # Coverage on other standalone machines is present in Nightly job so it's enough to not run all of them for PRs

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -178,13 +178,13 @@ validation_editors:
     default:
         - trunk
     all:
-        - 6000.0.0f1
+        - 6000.0.23f1
         - 6000.0
         - 6000.3
         - 6000.4
         - trunk
     minimal:
-        - 6000.0.0f1
+        - 6000.0.23f1
 
 
 # Scripting backends used by Standalone RunTimeTests---------------------------------------------------

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -177,13 +177,13 @@ validation_editors:
     default:
         - trunk
     all:
+        - 6000.0.0f1
         - 6000.0
-        - 6000.2
         - 6000.3
         - 6000.4
         - trunk
     minimal:
-        - 6000.0
+        - 6000.0.0f1
 
 
 # Scripting backends used by Standalone RunTimeTests---------------------------------------------------

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -178,13 +178,13 @@ validation_editors:
     default:
         - trunk
     all:
-        - 6000.0.23f1
+        - 6000.0.0f1
         - 6000.0
         - 6000.3
         - 6000.4
         - trunk
     minimal:
-        - 6000.0.23f1
+        - 6000.0.0f1
 
 
 # Scripting backends used by Standalone RunTimeTests---------------------------------------------------

--- a/Tools/scripts/ReleaseAutomation/release_config.py
+++ b/Tools/scripts/ReleaseAutomation/release_config.py
@@ -71,21 +71,21 @@ class ReleaseConfig:
 
         self.yamato_build_automation_configs = [
             {
-                "job_name": "Build Sample for Windows with minimal supported editor (2022.3), burst ON, IL2CPP",
+                "job_name": "Build Sample for Windows with minimal supported editor (6000.0.0f1), burst ON, IL2CPP",
                 "variables": [
                     { "key": "BURST_ON_OFF", "value": "on" },
                     { "key": "PLATFORM_WIN64_MAC_ANDROID", "value": "win64" },
                     { "key": "SCRIPTING_BACKEND_IL2CPP_MONO", "value": "il2cpp" },
-                    { "key": "UNITY_VERSION", "value": "2022.3" } # Minimal supported editor
+                    { "key": "UNITY_VERSION", "value": "6000.0.0f1" } # Minimal supported editor
                 ]
             },
             {
-                "job_name": "Build Sample for Windows with latest functional editor (6000.2), burst ON, IL2CPP",
+                "job_name": "Build Sample for Windows with latest functional editor (6000.3), burst ON, IL2CPP",
                 "variables": [
                     { "key": "BURST_ON_OFF", "value": "on" },
                     { "key": "PLATFORM_WIN64_MAC_ANDROID", "value": "win64" },
                     { "key": "SCRIPTING_BACKEND_IL2CPP_MONO", "value": "il2cpp" },
-                    { "key": "UNITY_VERSION", "value": "6000.2" } # Editor that most our users will use (not alpha). Sometimes when testing on trunk we have weird editor issues not caused by us so the preference will be to test on latest editor that our users will use.
+                    { "key": "UNITY_VERSION", "value": "6000.3" } # Editor that most our users will use (not alpha). Sometimes when testing on trunk we have weird editor issues not caused by us so the preference will be to test on latest editor that our users will use.
                 ]
             },
             {
@@ -98,21 +98,21 @@ class ReleaseConfig:
                 ]
             },
             {
-                "job_name": "Build Sample for MacOS with minimal supported editor (2022.3), burst OFF, Mono",
+                "job_name": "Build Sample for MacOS with minimal supported editor (6000.0.0f1), burst OFF, Mono",
                 "variables": [
                     { "key": "BURST_ON_OFF", "value": "off" },
                     { "key": "PLATFORM_WIN64_MAC_ANDROID", "value": "mac" },
                     { "key": "SCRIPTING_BACKEND_IL2CPP_MONO", "value": "mono" },
-                    { "key": "UNITY_VERSION", "value": "2022.3" } # Minimal supported editor
+                    { "key": "UNITY_VERSION", "value": "6000.0.0f1" } # Minimal supported editor
                 ]
             },
             {
-                "job_name": "Build Sample for MacOS with latest functional editor (6000.2), burst OFF, Mono",
+                "job_name": "Build Sample for MacOS with latest functional editor (6000.3), burst OFF, Mono",
                 "variables": [
                     { "key": "BURST_ON_OFF", "value": "off" },
                     { "key": "PLATFORM_WIN64_MAC_ANDROID", "value": "mac" },
                     { "key": "SCRIPTING_BACKEND_IL2CPP_MONO", "value": "mono" },
-                    { "key": "UNITY_VERSION", "value": "6000.2" } # Editor that most our users will use (not alpha). Sometimes when testing on trunk we have weird editor issues not caused by us so the preference will be to test on latest editor that our users will use.
+                    { "key": "UNITY_VERSION", "value": "6000.3" } # Editor that most our users will use (not alpha). Sometimes when testing on trunk we have weird editor issues not caused by us so the preference will be to test on latest editor that our users will use.
                 ]
             },
             {
@@ -125,21 +125,21 @@ class ReleaseConfig:
                 ]
             },
             {
-                "job_name": "Build Sample for Android with minimal supported editor (2022.3), burst ON, IL2CPP",
+                "job_name": "Build Sample for Android with minimal supported editor (6000.0.0f1), burst ON, IL2CPP",
                 "variables": [
                     { "key": "BURST_ON_OFF", "value": "on" },
                     { "key": "PLATFORM_WIN64_MAC_ANDROID", "value": "android" },
                     { "key": "SCRIPTING_BACKEND_IL2CPP_MONO", "value": "il2cpp" },
-                    { "key": "UNITY_VERSION", "value": "2022.3" } # Minimal supported editor
+                    { "key": "UNITY_VERSION", "value": "6000.0.0f1" } # Minimal supported editor
                 ]
             },
             {
-                "job_name": "Build Sample for Android with latest functional editor (6000.2), burst ON, IL2CPP",
+                "job_name": "Build Sample for Android with latest functional editor (6000.3), burst ON, IL2CPP",
                 "variables": [
                     { "key": "BURST_ON_OFF", "value": "on" },
                     { "key": "PLATFORM_WIN64_MAC_ANDROID", "value": "android" },
                     { "key": "SCRIPTING_BACKEND_IL2CPP_MONO", "value": "il2cpp" },
-                    { "key": "UNITY_VERSION", "value": "6000.2" } # Editor that most our users will use (not alpha). Sometimes when testing on trunk we have weird editor issues not caused by us so the preference will be to test on latest editor that our users will use.
+                    { "key": "UNITY_VERSION", "value": "6000.3" } # Editor that most our users will use (not alpha). Sometimes when testing on trunk we have weird editor issues not caused by us so the preference will be to test on latest editor that our users will use.
                 ]
             },
             {

--- a/Tools/scripts/ReleaseAutomation/release_config.py
+++ b/Tools/scripts/ReleaseAutomation/release_config.py
@@ -98,12 +98,12 @@ class ReleaseConfig:
 
         self.yamato_build_automation_configs = [
             {
-                "job_name": "Build Sample for Windows with minimal supported editor (6000.0.0f1), burst ON, IL2CPP",
+                "job_name": "Build Sample for Windows with minimal supported editor (6000.0.23f1), burst ON, IL2CPP",
                 "variables": [
                     { "key": "BURST_ON_OFF", "value": "on" },
                     { "key": "PLATFORM_WIN64_MAC_ANDROID", "value": "win64" },
                     { "key": "SCRIPTING_BACKEND_IL2CPP_MONO", "value": "il2cpp" },
-                    { "key": "UNITY_VERSION", "value": "6000.0.0f1" } # Minimal supported editor
+                    { "key": "UNITY_VERSION", "value": "6000.0.23f1" } # Minimal supported editor
                 ]
             },
             {
@@ -125,12 +125,12 @@ class ReleaseConfig:
                 ]
             },
             {
-                "job_name": "Build Sample for MacOS with minimal supported editor (6000.0.0f1), burst OFF, Mono",
+                "job_name": "Build Sample for MacOS with minimal supported editor (6000.0.23f1), burst OFF, Mono",
                 "variables": [
                     { "key": "BURST_ON_OFF", "value": "off" },
                     { "key": "PLATFORM_WIN64_MAC_ANDROID", "value": "mac" },
                     { "key": "SCRIPTING_BACKEND_IL2CPP_MONO", "value": "mono" },
-                    { "key": "UNITY_VERSION", "value": "6000.0.0f1" } # Minimal supported editor
+                    { "key": "UNITY_VERSION", "value": "6000.0.23f1" } # Minimal supported editor
                 ]
             },
             {
@@ -152,12 +152,12 @@ class ReleaseConfig:
                 ]
             },
             {
-                "job_name": "Build Sample for Android with minimal supported editor (6000.0.0f1), burst ON, IL2CPP",
+                "job_name": "Build Sample for Android with minimal supported editor (6000.0.23f1), burst ON, IL2CPP",
                 "variables": [
                     { "key": "BURST_ON_OFF", "value": "on" },
                     { "key": "PLATFORM_WIN64_MAC_ANDROID", "value": "android" },
                     { "key": "SCRIPTING_BACKEND_IL2CPP_MONO", "value": "il2cpp" },
-                    { "key": "UNITY_VERSION", "value": "6000.0.0f1" } # Minimal supported editor
+                    { "key": "UNITY_VERSION", "value": "6000.0.23f1" } # Minimal supported editor
                 ]
             },
             {

--- a/Tools/scripts/ReleaseAutomation/release_config.py
+++ b/Tools/scripts/ReleaseAutomation/release_config.py
@@ -98,12 +98,12 @@ class ReleaseConfig:
 
         self.yamato_build_automation_configs = [
             {
-                "job_name": "Build Sample for Windows with minimal supported editor (6000.0.23f1), burst ON, IL2CPP",
+                "job_name": "Build Sample for Windows with minimal supported editor (6000.0.0f1), burst ON, IL2CPP",
                 "variables": [
                     { "key": "BURST_ON_OFF", "value": "on" },
                     { "key": "PLATFORM_WIN64_MAC_ANDROID", "value": "win64" },
                     { "key": "SCRIPTING_BACKEND_IL2CPP_MONO", "value": "il2cpp" },
-                    { "key": "UNITY_VERSION", "value": "6000.0.23f1" } # Minimal supported editor
+                    { "key": "UNITY_VERSION", "value": "6000.0.0f1" } # Minimal supported editor
                 ]
             },
             {
@@ -125,12 +125,12 @@ class ReleaseConfig:
                 ]
             },
             {
-                "job_name": "Build Sample for MacOS with minimal supported editor (6000.0.23f1), burst OFF, Mono",
+                "job_name": "Build Sample for MacOS with minimal supported editor (6000.0.0f1), burst OFF, Mono",
                 "variables": [
                     { "key": "BURST_ON_OFF", "value": "off" },
                     { "key": "PLATFORM_WIN64_MAC_ANDROID", "value": "mac" },
                     { "key": "SCRIPTING_BACKEND_IL2CPP_MONO", "value": "mono" },
-                    { "key": "UNITY_VERSION", "value": "6000.0.23f1" } # Minimal supported editor
+                    { "key": "UNITY_VERSION", "value": "6000.0.0f1" } # Minimal supported editor
                 ]
             },
             {
@@ -152,12 +152,12 @@ class ReleaseConfig:
                 ]
             },
             {
-                "job_name": "Build Sample for Android with minimal supported editor (6000.0.23f1), burst ON, IL2CPP",
+                "job_name": "Build Sample for Android with minimal supported editor (6000.0.0f1), burst ON, IL2CPP",
                 "variables": [
                     { "key": "BURST_ON_OFF", "value": "on" },
                     { "key": "PLATFORM_WIN64_MAC_ANDROID", "value": "android" },
                     { "key": "SCRIPTING_BACKEND_IL2CPP_MONO", "value": "il2cpp" },
-                    { "key": "UNITY_VERSION", "value": "6000.0.23f1" } # Minimal supported editor
+                    { "key": "UNITY_VERSION", "value": "6000.0.0f1" } # Minimal supported editor
                 ]
             },
             {

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -13,6 +13,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+- Minimal supported editor was set to LTS version `0f1` which means that we do not guarantee that the package will work on alpha or beta versions of 6000.0
 
 ### Deprecated
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -13,7 +13,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
-- Minimal supported editor was set to first 6000.0 LTS version `6000.0.23f1` to clarify that we do not guarantee that the package will work on alpha or beta versions of 6000.0
+- Minimal supported editor was set to first 6000.0 LTS version `6000.0.0f1` to clarify that we do not guarantee that the package will work on alpha or beta versions of 6000.0
 
 ### Deprecated
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -13,7 +13,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
-- Minimal supported editor was set to LTS version `0f1` which means that we do not guarantee that the package will work on alpha or beta versions of 6000.0
+- Minimal supported editor was set to first 6000.0 LTS version `6000.0.23f1` to clarify that we do not guarantee that the package will work on alpha or beta versions of 6000.0
 
 ### Deprecated
 

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -4,6 +4,7 @@
     "description": "Netcode for GameObjects is a high-level netcode SDK that provides networking capabilities to GameObject/MonoBehaviour workflows within Unity and sits on top of underlying transport layer.",
     "version": "2.8.1",
     "unity": "6000.0",
+    "unityRelease": "0f1",
     "dependencies": {
         "com.unity.nuget.mono-cecil": "1.11.4",
         "com.unity.transport": "2.6.0"

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -4,7 +4,7 @@
     "description": "Netcode for GameObjects is a high-level netcode SDK that provides networking capabilities to GameObject/MonoBehaviour workflows within Unity and sits on top of underlying transport layer.",
     "version": "2.8.1",
     "unity": "6000.0",
-    "unityRelease": "0f1",
+    "unityRelease": "23f1",
     "dependencies": {
         "com.unity.nuget.mono-cecil": "1.11.4",
         "com.unity.transport": "2.6.0"

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -4,7 +4,7 @@
     "description": "Netcode for GameObjects is a high-level netcode SDK that provides networking capabilities to GameObject/MonoBehaviour workflows within Unity and sits on top of underlying transport layer.",
     "version": "2.8.1",
     "unity": "6000.0",
-    "unityRelease": "23f1",
+    "unityRelease": "0f1",
     "dependencies": {
         "com.unity.nuget.mono-cecil": "1.11.4",
         "com.unity.transport": "2.6.0"

--- a/testproject/Packages/manifest.json
+++ b/testproject/Packages/manifest.json
@@ -12,7 +12,7 @@
     "com.unity.package-validation-suite": "0.49.0-preview",
     "com.unity.services.authentication": "3.5.2",
     "com.unity.services.multiplayer": "1.2.0",
-    "com.unity.test-framework": "1.6.0",
+    "com.unity.test-framework": "1.4.6",
     "com.unity.test-framework.performance": "3.2.0",
     "com.unity.timeline": "1.8.9",
     "com.unity.toolchain.win-x86_64-linux-x86_64": "2.0.11",


### PR DESCRIPTION
## Purpose of this PR
While looking at https://discussions.unity.com/t/problem-with-netcode-1-0-2/1701859/2 I was wondering why package manager was not suggesting updates to latest NGO version and while this is probably related to the fact that user was working un unsupported tech stream of Unity editor and this is not NGO fault I realized one issue that we have

In our package.json we use  `"unity": "6000.0"` and in contrast to Netcode for Entities implementation we are not using `"unityRelease": "23f1"`. The difference is as follows:

> **1. Behavior with unityRelease specified**
> With the configuration "unity": "6000.0" and "unityRelease": "23f1", the Package Manager interprets this as a strict minimum requirement.
> 
> **Minimum Version**: The package explicitly declares that it requires Unity 6000.0.23f1 or higher.
> **Behavior**: If a user tries to install this package on an Editor version lower than this (e.g., 6000.0.0b10), the Package Manager will flag it. Specifically, if installed on an older version, the Package Manager window will display an info icon in the details header indicating that the package version is not recommended for that Unity version.

> **2. Behavior without unityRelease specified**
> If we don't have "unityRelease": "0f1" and leave only "unity": "6000.0", the restriction becomes broader.
> 
> **Minimum Version**: The Package Manager considers the package compatible with the entire 6000.0 cycle (and newer).
> **Behavior**: It effectively sets the "floor" to the beginning of that major/minor version cycle. It will not complain if the user is on a beta or alpha of 6000.0, provided the major.minor matches or exceeds the requirement.

Our issue is that in our CI we specified minimum editor to 6000.0 and while using `unity-downloader-cli -u {{editor}}` command the tool fetches the latest available release for that version stream (e.g., 6000.0.36f1), not the initial release (e.g., 6000.0.0f1).
It is not fair or safe to claim support for 6000.0 (which implies 6000.0.0f1 and up, also alpha and beta versions) while only testing on the latest patch (e.g., 6000.0.36f1).

The risk is that we develop and test only on 6000.0.36f1 and we might inadvertently use an API or a bug fix that was introduced in 6000.0.40f1.
As a consequence the user running 6000.0.0f1 will be able to install our package (because our package.json says 6000.0 is fine), but the package will crash or fail because the API it relies on doesn't exist in their editor version.

To resolve this I specified `"unityRelease": "0f1"` and set minimal test editor to that version (6000.0.0f1). This means that

1. We specifcally offer support to all supported 6000.0 editors while having a safe minimal requirement
2. We perform our validation on PRs with latest (trunk) and proper minimal editor (6000.0.0f1) wile running all other tests daily/weekly (6000.0.0f1, 6000.0, 6000.3 etc)
3. If something will start failing in relation to editor API then we can "simply" increase this minimal patch version as needed
4. We will avoid unexpected failures on our PRs due to API changes in latest 6000.0 editor while we will still be able to catch those via daily/weekly tests. So our tests on PRs should be a bit more stable 

### Jira ticket
https://jira.unity3d.com/browse/MTT-14264

### Changelog

- Changed: Minimal supported editor was set to first 6000.0 LTS version `6000.0.23f1` to clarify that we do not guarantee that the package will work on alpha or beta versions of 6000.0

## Documentation
N/A

## Testing & QA (How your changes can be verified during release Playtest)
I will run our CI triggers to see if everything is executed as expected

## Backports
Will do