### PR TITLE
ci: [Backport] Update of dependencies and bug fixing

### DIFF
--- a/.github/workflows/pr-description-validation.yml
+++ b/.github/workflows/pr-description-validation.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Check PR description
         uses: actions/github-script@v8

--- a/.github/workflows/pr-supervisor.yaml
+++ b/.github/workflows/pr-supervisor.yaml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 720
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Wait and Verify Yamato Job Status
         env:

--- a/.yamato/_run-all.yml
+++ b/.yamato/_run-all.yml
@@ -30,9 +30,9 @@ run_all_package_tests:
 {% endfor -%}
 
 
-# Runs all package tests on 6000.2 editor (latest supported editor)
-run_all_package_tests_6000.2:
-  name: Run All Package Tests [6000.2 only]
+# Runs all package tests on default editor (latest supported editor)
+run_all_package_tests_{{ validation_editors.default }}:
+  name: Run All Package Tests [{{ validation_editors.default }} only]
   dependencies:
 {% for platform in test_platforms.desktop -%}
 {% for editor in validation_editors.default -%}
@@ -40,12 +40,12 @@ run_all_package_tests_6000.2:
 {% endfor -%}
 {% endfor -%}
 
-# Runs all package tests on mimimum supported editor (2022.3 in case of NGOv1.X) (2022.3 will soon be a minimum supported editor)
-run_all_package_tests_2022:
-  name: Run All Package Tests [2022.3]
+# Runs all package tests on minimal supported editor
+run_all_package_tests_{{ validation_editors.minimal }}:
+  name: Run All Package Tests [{{ validation_editors.minimal }}]
   dependencies:
 {% for platform in test_platforms.desktop -%}
-    - .yamato/package-tests.yml#package_test_-_ngo_2022.3_{{ platform.name }}
+    - .yamato/package-tests.yml#package_test_-_ngo_{{ validation_editors.minimal }}_{{ platform.name }}
 {% endfor -%}
 
 
@@ -64,9 +64,9 @@ run_all_project_tests:
 {% endfor -%}
 
 
-# Runs all projects tests on 6000.2 editor (latest supported editor)
-run_all_project_tests_6000.2:
-  name: Run All Project Tests [6000.2 only]
+# Runs all projects tests on default editor (latest supported editor)
+run_all_project_tests_{{ validation_editors.default }}:
+  name: Run All Project Tests [{{ validation_editors.default }} only]
   dependencies:
 {% for project in projects.all -%}
 {% if project.has_tests == "true" -%}
@@ -78,14 +78,14 @@ run_all_project_tests_6000.2:
 {% endif -%}
 {% endfor -%}
 
-# Runs all projects tests on mimimum supported editor (2022.3 in case of NGOv1.X) (2022.3 will soon be a minimum supported editor)
-run_all_project_tests_2022:
-  name: Run All Project Tests [2022.3]
+# Runs all projects tests on minimal supported editor
+run_all_project_tests_{{ validation_editors.minimal }}:
+  name: Run All Project Tests [{{ validation_editors.minimal }}]
   dependencies:
 {% for project in projects.all -%}
 {% if project.has_tests == "true" -%}
 {% for platform in test_platforms.desktop -%}
-    - .yamato/project-tests.yml#test_{{ project.name }}_{{ platform.name }}_2022.3
+    - .yamato/project-tests.yml#test_{{ project.name }}_{{ platform.name }}_{{ validation_editors.minimal }}
 {% endfor -%}
 {% endif -%}
 {% endfor -%}
@@ -117,9 +117,9 @@ run_all_webgl_builds:
 {% endfor -%}
 
 
-# Runs all WebGL builds on 6000.2 editor (latest supported editor)
-run_all_webgl_builds_6000.2:
-  name: Run All WebGl Build [6000.2 only]
+# Runs all WebGL builds on default editor (latest supported editor)
+run_all_webgl_builds_{{ validation_editors.default }}:
+  name: Run All WebGl Build [{{ validation_editors.default }} only]
   dependencies:
 {% for project in projects.default -%}
 {% for platform in test_platforms.desktop -%}
@@ -129,13 +129,13 @@ run_all_webgl_builds_6000.2:
 {% endfor -%}
 {% endfor -%}
 
-# Runs all WebGL builds on 2022.3 editor (2022.3 will soon be a minimum supported editor)
-run_all_webgl_builds_2022:
-  name: Run All WebGl Build [2022.3]
+# Runs all WebGL builds on minimal supported editor
+run_all_webgl_builds_{{ validation_editors.minimal }}:
+  name: Run All WebGl Build [{{ validation_editors.minimal }}]
   dependencies:
 {% for project in projects.default -%}
 {% for platform in test_platforms.desktop -%}
-    - .yamato/webgl-build.yml#webgl_build_{{ project.name }}_{{ platform.name }}_2022.3
+    - .yamato/webgl-build.yml#webgl_build_{{ project.name }}_{{ platform.name }}_{{ validation_editors.minimal }}
 {% endfor -%}
 {% endfor -%}
 
@@ -155,9 +155,9 @@ run_all_project_tests_desktop_standalone:
 {% endfor -%}
 
 
-# Runs all Desktop tests on 6000.2 editor (latest supported editor)
-run_all_project_tests_desktop_standalone_6000.2:
-  name: Run All Standalone Tests - Desktop [6000.2 only]
+# Runs all Desktop tests on default editor (latest supported editor)
+run_all_project_tests_desktop_standalone_{{ validation_editors.default }}:
+  name: Run All Standalone Tests - Desktop [{{ validation_editors.default }} only]
   dependencies:
 {% for project in projects.default -%}
 {% for platform in test_platforms.desktop -%}
@@ -169,14 +169,14 @@ run_all_project_tests_desktop_standalone_6000.2:
 {% endfor -%}
 {% endfor -%}
 
-# Runs all Desktop tests on mimimum supported editor (2022.3 in case of NGOv1.X) (2022.3 will soon be a minimum supported editor)
-run_all_project_tests_desktop_standalone_2022:
-  name: Run All Standalone Tests - Desktop [2022.3]
+# Runs all Desktop tests on minimal supported editor
+run_all_project_tests_desktop_standalone_{{ validation_editors.minimal }}:
+  name: Run All Standalone Tests - Desktop [{{ validation_editors.minimal }}]
   dependencies:
 {% for project in projects.default -%}
 {% for platform in test_platforms.desktop -%}
 {% for backend in scripting_backends -%}
-    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}_2022.3
+    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}_{{ validation_editors.minimal }}
 {% endfor -%}
 {% endfor -%}
 {% endfor -%}
@@ -194,9 +194,9 @@ run_all_project_tests_mobile_standalone:
 {% endfor -%}
 
 
-# Runs all Mobile tests on 6000.2 editor (latest supported editor)
-run_all_project_tests_mobile_standalone_6000.2:
-  name: Run All Standalone Tests - Mobile [6000.2 only]
+# Runs all Mobile tests on default editor (latest supported editor)
+run_all_project_tests_mobile_standalone_{{ validation_editors.default }}:
+  name: Run All Standalone Tests - Mobile [{{ validation_editors.default }} only]
   dependencies:
 {% for project in projects.default -%}
 {% for platform in test_platforms.mobile_test -%}
@@ -206,13 +206,13 @@ run_all_project_tests_mobile_standalone_6000.2:
 {% endfor -%}
 {% endfor -%}
 
-# Runs all Mobile tests on mimimum supported editor (2022.3 in case of NGOv1.X) (2022.3 will soon be a minimum supported editor)
-run_all_project_tests_mobile_standalone_2022:
-  name: Run All Standalone Tests - Mobile [2022.3]
+# Runs all Mobile tests on minimal supported editor
+run_all_project_tests_mobile_standalone_{{ validation_editors.minimal }}:
+  name: Run All Standalone Tests - Mobile [{{ validation_editors.minimal }}]
   dependencies:
 {% for project in projects.default -%}
 {% for platform in test_platforms.mobile_test -%}
-    - .yamato/mobile-standalone-test.yml#mobile_standalone_test_{{ project.name }}_{{ platform.name }}_2022.3
+    - .yamato/mobile-standalone-test.yml#mobile_standalone_test_{{ project.name }}_{{ platform.name }}_{{ validation_editors.minimal }}
 {% endfor -%}
 {% endfor -%}
 
@@ -230,9 +230,9 @@ run_all_project_tests_console_standalone:
 {% endfor -%}
 
 
-# Runs all Console tests on 6000.2 editor (latest supported editor)
-run_all_project_tests_console_standalone_6000.2:
-  name: Run All Standalone Tests - Console [6000.2 only]
+# Runs all Console tests on default editor (latest supported editor)
+run_all_project_tests_console_standalone_{{ validation_editors.default }}:
+  name: Run All Standalone Tests - Console [{{ validation_editors.default }} only]
   dependencies:
 {% for project in projects.default -%}
 {% for platform in test_platforms.console_test -%}
@@ -242,12 +242,12 @@ run_all_project_tests_console_standalone_6000.2:
 {% endfor -%}
 {% endfor -%}
 
-# Runs all Console tests on mimimum supported editor (2022.3 in case of NGOv1.X) (2022.3 will soon be a minimum supported editor)
-run_all_project_tests_console_standalone_2022:
-  name: Run All Standalone Tests - Console [2022.3]
+# Runs all Console tests on minimal supported editor
+run_all_project_tests_console_standalone_{{ validation_editors.minimal }}:
+  name: Run All Standalone Tests - Console [{{ validation_editors.minimal }}]
   dependencies:
 {% for project in projects.default -%}
 {% for platform in test_platforms.console_test -%}
-    - .yamato/console-standalone-test.yml#console_standalone_test_{{ project.name }}_{{ platform.name }}_2022.3
+    - .yamato/console-standalone-test.yml#console_standalone_test_{{ project.name }}_{{ platform.name }}_{{ validation_editors.minimal }}
 {% endfor -%}
 {% endfor -%}

--- a/.yamato/_run-all.yml
+++ b/.yamato/_run-all.yml
@@ -17,7 +17,7 @@ run_quick_checks:
   name: Run Quick Initial Checks
   dependencies:
     - .yamato/package-pack.yml#package_pack_-_ngo_ubuntu
-    - .yamato/project-standards.yml#standards_ubuntu_testproject_6000.2
+    - .yamato/project-standards.yml#standards_ubuntu_testproject_{{ validation_editors.default }}
 
 # Runs all package tests
 run_all_package_tests:

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -49,7 +49,7 @@ pr_minimal_required_checks:
   name: Minimal PR checks
   dependencies:
     - .yamato/package-pack.yml#package_pack_-_ngo_ubuntu
-    - .yamato/project-standards.yml#standards_ubuntu_testproject_6000.2
+    - .yamato/project-standards.yml#standards_ubuntu_testproject_{{ validation_editors.default }}
   triggers:
     expression: |-
       (pull_request.comment eq "ngo" OR
@@ -128,7 +128,7 @@ develop_nightly:
     # Run API validation to early-detect all new APIs that would force us to release new minor version of the package. Note that for this to work the package version in package.json must correspond to "actual package state" which means that it should be higher than last released version
     - .yamato/vetting-test.yml#vetting_test
     # Run project standards to verify package/default project
-    - .yamato/project-standards.yml#standards_ubuntu_testproject_6000.2
+    - .yamato/project-standards.yml#standards_ubuntu_testproject_{{ validation_editors.default }}
     - .yamato/project-standards.yml#standards_ubuntu_testproject_2022.3
     # Run APV jobs to make sure the change won't break any dependants
     - .yamato/wrench/preview-a-p-v.yml#all_preview_apv_jobs
@@ -186,4 +186,4 @@ develop_weekly_trunk:
     # Build player for webgl platform on 6000.2 (latest supported editor)
     - .yamato/_run-all.yml#run_all_webgl_builds
     # Run code coverage test
-    - .yamato/code-coverage.yml#code_coverage_ubuntu_6000.2
+    - .yamato/code-coverage.yml#code_coverage_ubuntu_{{ validation_editors.default }}

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -24,7 +24,7 @@
   # Nightly:
     # This test validates same subset as pull_request_trigger with addition of mobile/console tests and webgl builds
     # Runs daily on develop (local configuration)
-    # Includes all test types but only on 6000.2 (latest supported editor).
+    # Includes all test types but only on {{ validation_editors.default }} (latest supported editor).
     # Adds platform-specific and APV validation
 
   # Weekly:
@@ -72,21 +72,21 @@ pr_code_changes_checks:
     # Run API validation to early-detect all new APIs that would force us to release new minor version of the package. Note that for this to work the package version in package.json must correspond to "actual package state" which means that it should be higher than last released version
     - .yamato/vetting-test.yml#vetting_test
 
-    # Run package EditMode and Playmode package tests on 6000.2 (latest supported editor) and an older supported editor (2022.3) (2022.3 will soon be a minimum supported editor)
-    - .yamato/package-tests.yml#package_test_-_ngo_6000.2_mac
-    - .yamato/package-tests.yml#package_test_-_ngo_2022.3_win
+    # Run package EditMode and Playmode package tests on {{ validation_editors.default }} (latest supported editor) and an {{ validation_editors.minimal }} supported editor
+    - .yamato/package-tests.yml#package_test_-_ngo_{{ validation_editors.default }}_mac
+    - .yamato/package-tests.yml#package_test_-_ngo_{{ validation_editors.minimal }}_win
 
-    # Run testproject EditMode and Playmode project tests on 6000.2 (latest supported editor) and an older supported editor (2022.3) (2022.3 will soon be a minimum supported editor)
-    - .yamato/project-tests.yml#test_testproject_win_6000.2
-    - .yamato/project-tests.yml#test_testproject_mac_2022.3
+    # Run testproject EditMode and Playmode project tests on {{ validation_editors.default }} (latest supported editor) and an {{ validation_editors.minimal }} supported editor
+    - .yamato/project-tests.yml#test_testproject_win_{{ validation_editors.default }}
+    - .yamato/project-tests.yml#test_testproject_mac_{{ validation_editors.minimal }}
 
-    # Run tools integration tests EditMode and Playmode tests on 6000.2 (latest supported editor) and an older supported editor (2022.3) (2022.3 will soon be a minimum supported editor)
-    - .yamato/project-tests.yml#test_testproject-tools-integration_ubuntu_2022.3
-    - .yamato/project-tests.yml#test_testproject-tools-integration_win_6000.2
+    # Run tools integration tests EditMode and Playmode tests on {{ validation_editors.default }} (latest supported editor) and an {{ validation_editors.minimal }} supported editor
+    - .yamato/project-tests.yml#test_testproject-tools-integration_ubuntu_{{ validation_editors.minimal }}
+    - .yamato/project-tests.yml#test_testproject-tools-integration_win_{{ validation_editors.default }}
 
     # Run standalone test. We run it only on Ubuntu since it's the fastest machine, and it was noted that for example distribution on macOS is taking 40m since we switched to Apple Silicon
     # Coverage on other standalone machines is present in Nightly job so it's enough to not run all of them for PRs
-    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_ubuntu_il2cpp_2022.3
+    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_ubuntu_il2cpp_{{ validation_editors.minimal }}
   triggers:
     expression: |-
       (pull_request.comment eq "ngo" OR
@@ -114,11 +114,11 @@ pr_code_changes_checks:
 
 
 
-# Run all tests on 6000.2 (latest supported editor) on nightly basis.
+# Run all tests on {{ validation_editors.default }} (latest supported editor) on nightly basis.
 # Same subset as pull_request_trigger with addition of mobile/desktop/console tests and webgl builds
-# Those tests are all running on 6000.2 (latest supported editor) since it's daily and running all of them would add a lot of overhead
+# Those tests are all running on {{ validation_editors.default }} (latest supported editor) since it's daily and running all of them would add a lot of overhead
 develop_nightly:
-  name: "\U0001F319 [Nightly] Run All Tests [6000.2 and 2022]"
+  name: "\U0001F319 [Nightly] Run All Tests [{{ validation_editors.default }} and {{ validation_editors.minimal }}]"
   triggers:
     recurring:
       - branch: develop
@@ -129,30 +129,30 @@ develop_nightly:
     - .yamato/vetting-test.yml#vetting_test
     # Run project standards to verify package/default project
     - .yamato/project-standards.yml#standards_ubuntu_testproject_{{ validation_editors.default }}
-    - .yamato/project-standards.yml#standards_ubuntu_testproject_2022.3
+    - .yamato/project-standards.yml#standards_ubuntu_testproject_{{ validation_editors.minimal }}
     # Run APV jobs to make sure the change won't break any dependants
     - .yamato/wrench/preview-a-p-v.yml#all_preview_apv_jobs
-    # Run package EditMode and Playmode tests on desktop platforms on 6000.2 (latest supported editor) and 2022.3 (2022.3 will soon be a minimum supported editor)
-    - .yamato/_run-all.yml#run_all_package_tests_6000.2
-    - .yamato/_run-all.yml#run_all_package_tests_2022
-    # Run project EditMode and PLaymode tests on desktop platforms on 6000.2 (latest supported editor) and 2022.3 (2022.3 will soon be a minimum supported editor)
-    - .yamato/_run-all.yml#run_all_project_tests_6000.2
-    - .yamato/_run-all.yml#run_all_project_tests_2022
-    # Run Runtime tests on desktop players on 6000.2 (latest supported editor) and 2022.3 editors (2022.3 will soon be a minimum supported editor)
-    - .yamato/_run-all.yml#run_all_project_tests_desktop_standalone_6000.2
-    - .yamato/_run-all.yml#run_all_project_tests_desktop_standalone_2022
-    # Run Runtime tests on mobile players on 6000.2 (latest supported editor) and 2022.3 editors (2022.3 will soon be a minimum supported editor)
-    - .yamato/_run-all.yml#run_all_project_tests_mobile_standalone_6000.2
-    - .yamato/_run-all.yml#run_all_project_tests_mobile_standalone_2022
-    # Run Runtime tests on console players on 6000.2 (latest supported editor) and 2022.3 editors (2022.3 will soon be a minimum supported editor)
-    - .yamato/_run-all.yml#run_all_project_tests_console_standalone_6000.2
-    - .yamato/_run-all.yml#run_all_project_tests_console_standalone_2022
-    # Build player for webgl platform on 6000.2 (latest supported editor) and 2022.3 editors (2022.3 will soon be a minimum supported editor)
-    - .yamato/_run-all.yml#run_all_webgl_builds_6000.2
-    - .yamato/_run-all.yml#run_all_webgl_builds_2022
-    # Build player for webgl platform on 6000.2 (latest supported editor) and 2022.3 editors (2022.3 will soon be a minimum supported editor)
-    - .yamato/project-updated-dependencies-test.yml#updated-dependencies_testproject_NGO_ubuntu_6000.2
-    - .yamato/project-updated-dependencies-test.yml#updated-dependencies_testproject_NGO_win_2022.3
+    # Run package EditMode and Playmode tests on desktop platforms on {{ validation_editors.default }} (latest supported editor) and {{ validation_editors.minimal }}
+    - .yamato/_run-all.yml#run_all_package_tests_{{ validation_editors.default }}
+    - .yamato/_run-all.yml#run_all_package_tests_{{ validation_editors.minimal }}
+    # Run project EditMode and PLaymode tests on desktop platforms on {{ validation_editors.default }} (latest supported editor) and {{ validation_editors.minimal }}
+    - .yamato/_run-all.yml#run_all_project_tests_{{ validation_editors.default }}
+    - .yamato/_run-all.yml#run_all_project_tests_{{ validation_editors.minimal }}
+    # Run Runtime tests on desktop players on {{ validation_editors.default }} (latest supported editor) and {{ validation_editors.minimal }}
+    - .yamato/_run-all.yml#run_all_project_tests_desktop_standalone_{{ validation_editors.default }}
+    - .yamato/_run-all.yml#run_all_project_tests_desktop_standalone_{{ validation_editors.minimal }}
+    # Run Runtime tests on mobile players on {{ validation_editors.default }} (latest supported editor) and {{ validation_editors.minimal }}
+    - .yamato/_run-all.yml#run_all_project_tests_mobile_standalone_{{ validation_editors.default }}
+    - .yamato/_run-all.yml#run_all_project_tests_mobile_standalone_{{ validation_editors.minimal }}
+    # Run Runtime tests on console players on {{ validation_editors.default }} (latest supported editor) and {{ validation_editors.minimal }}
+    - .yamato/_run-all.yml#run_all_project_tests_console_standalone_{{ validation_editors.default }}
+    - .yamato/_run-all.yml#run_all_project_tests_console_standalone_{{ validation_editors.minimal }}
+    # Build player for webgl platform on {{ validation_editors.default }} (latest supported editor) and {{ validation_editors.minimal }}
+    - .yamato/_run-all.yml#run_all_webgl_builds_{{ validation_editors.default }}
+    - .yamato/_run-all.yml#run_all_webgl_builds_{{ validation_editors.minimal }}
+    # Build player for webgl platform on {{ validation_editors.default }} (latest supported editor) and {{ validation_editors.minimal }}
+    - .yamato/project-updated-dependencies-test.yml#updated-dependencies_testproject_NGO_ubuntu_{{ validation_editors.default }}
+    - .yamato/project-updated-dependencies-test.yml#updated-dependencies_testproject_NGO_win_{{ validation_editors.minimal }}
     # Run API validation to early-detect all new APIs that would force us to release new minor version of the package. Note that for this to work the package version in package.json must correspond to "actual package state" which means that it should be higher than last released version
     - .yamato/vetting-test.yml#vetting_test
 
@@ -160,7 +160,7 @@ develop_nightly:
 # Run all tests on weekly bases
 # Same subset as develop_nightly but runs per all supported editors as well as executes code coverage test and runs project standards per project
 # It's not running wrench jobs since those will run either way in nightly test run
-# This in contrast to nightly checks will run tests on all editors (not only 6000.2). Running those on weekly basis and 6000.2 (latest supported editor) tests nightly should be a good balance between making sure that tests are passing and overhead of running lots of tests
+# This in contrast to nightly checks will run tests on all editors (not only {{ validation_editors.default }}). Running those on weekly basis and {{ validation_editors.default }} (latest supported editor) tests nightly should be a good balance between making sure that tests are passing and overhead of running lots of tests
 develop_weekly_trunk:
   name: "\U0001F319 [Weekly] Run All Tests"
   triggers:
@@ -183,7 +183,7 @@ develop_weekly_trunk:
     - .yamato/_run-all.yml#run_all_project_tests_mobile_standalone
     # Run Runtime tests on console players
     - .yamato/_run-all.yml#run_all_project_tests_console_standalone
-    # Build player for webgl platform on 6000.2 (latest supported editor)
+    # Build player for webgl platform on {{ validation_editors.default }} (latest supported editor)
     - .yamato/_run-all.yml#run_all_webgl_builds
     # Run code coverage test
     - .yamato/code-coverage.yml#code_coverage_ubuntu_{{ validation_editors.default }}

--- a/.yamato/code-coverage.yml
+++ b/.yamato/code-coverage.yml
@@ -12,7 +12,7 @@
 # CONFIGURATION STRUCTURE--------------------------------------------------------------
   # Jobs are generated using nested loops through:
   # 1. For default platform only (Ubuntu) since coverage would not vary between platforms (no need for checks on more platforms)
-  # 2. For default editor version (6000.2) since coverage would not vary between editors (no need for checks on more editors)
+  # 2. For default editor version ({{ validation_editors.default }}) since coverage would not vary between editors (no need for checks on more editors)
 
 #TECHNICAL CONSIDERATIONS---------------------------------------------------------------
   # In theory this job also runs package tests, but we don't want to use it as default since is heavier (because of added coverage analysis) and coverage is not changing that often

--- a/.yamato/project-builders/project-builders.yml
+++ b/.yamato/project-builders/project-builders.yml
@@ -26,7 +26,7 @@ build_{{ netcodeProject[0] }}_project:
     image: package-ci/win10:v4
     flavor: b1.xlarge
   variables:
-    UNITY_VERSION: 6000.2
+    UNITY_VERSION: 6000.0
     SCRIPTING_BACKEND_IL2CPP_MONO: il2cpp
     BURST_ON_OFF: on
     PLATFORM_WIN64_MAC_ANDROID: win64

--- a/.yamato/project-standards.yml
+++ b/.yamato/project-standards.yml
@@ -13,7 +13,7 @@
   # Jobs configurations are generated using nested loops through:
     # 1. For all NGO projects (testproject, testproject-tools-interation, minimalproject)
     # 2. For default platform only (Ubuntu) since standards would not vary between platforms (no need for checks on more platforms)
-    # 3. For default editor version (6000.2) since standards would not vary between editors (no need for checks on more editors)
+    # 3. For default editor version {{ validation_editors.default }} since standards would not vary between editors (no need for checks on more editors)
   
 # TECHNICAL CONSTRAINTS---------------------------------------------------------------
   # Requires .NET SDK installed (should be preinstalled on the image so we just check for version)

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -158,11 +158,10 @@ test_platforms:
 
 validation_editors:
     default:
-        - 6000.2
+        - 6000.0
     all:
         - 2022.3
         - 6000.0
-        - 6000.2
     minimal:
         - 2022.3
 

--- a/.yamato/wrench/api-validation-jobs.yml
+++ b/.yamato/wrench/api-validation-jobs.yml
@@ -51,8 +51,12 @@ api_validation_-_netcode_gameobjects_-_2022_3_-_windows:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_netcode_gameobjects
   variables:
-    UPMPVP_CONTEXT_WRENCH: 1.3.0.0
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
+    UPMPVP_CONTEXT_WRENCH: 1.4.7.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
+    Wrench: 1.4.7.0
 

--- a/.yamato/wrench/package-pack-jobs.yml
+++ b/.yamato/wrench/package-pack-jobs.yml
@@ -24,5 +24,5 @@ package_pack_-_netcode_gameobjects:
     UPMCI_ACK_LARGE_PACKAGE: 1
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
+    Wrench: 1.4.7.0
 

--- a/.yamato/wrench/preview-a-p-v.yml
+++ b/.yamato/wrench/preview-a-p-v.yml
@@ -11,12 +11,9 @@ all_preview_apv_jobs:
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_0_-_macos
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_0_-_ubuntu
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_0_-_windows
-  - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_2_-_macos
-  - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_2_-_ubuntu
-  - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_2_-_windows
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
+    Wrench: 1.4.7.0
 
 # Functional tests for dependents found in the latest 2022.3 manifest (MacOS).
 preview_apv_-_2022_3_-_macos:
@@ -67,10 +64,14 @@ preview_apv_-_2022_3_-_macos:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_netcode_gameobjects
   variables:
-    UPMPVP_CONTEXT_WRENCH: 1.3.0.0
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
+    UPMPVP_CONTEXT_WRENCH: 1.4.7.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
+    Wrench: 1.4.7.0
 
 # Functional tests for dependents found in the latest 2022.3 manifest (Ubuntu).
 preview_apv_-_2022_3_-_ubuntu:
@@ -121,10 +122,14 @@ preview_apv_-_2022_3_-_ubuntu:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_netcode_gameobjects
   variables:
-    UPMPVP_CONTEXT_WRENCH: 1.3.0.0
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
+    UPMPVP_CONTEXT_WRENCH: 1.4.7.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
+    Wrench: 1.4.7.0
 
 # Functional tests for dependents found in the latest 2022.3 manifest (Windows).
 preview_apv_-_2022_3_-_windows:
@@ -176,10 +181,14 @@ preview_apv_-_2022_3_-_windows:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_netcode_gameobjects
   variables:
-    UPMPVP_CONTEXT_WRENCH: 1.3.0.0
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
+    UPMPVP_CONTEXT_WRENCH: 1.4.7.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
+    Wrench: 1.4.7.0
 
 # Functional tests for dependents found in the latest 6000.0 manifest (MacOS).
 preview_apv_-_6000_0_-_macos:
@@ -230,10 +239,14 @@ preview_apv_-_6000_0_-_macos:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_netcode_gameobjects
   variables:
-    UPMPVP_CONTEXT_WRENCH: 1.3.0.0
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
+    UPMPVP_CONTEXT_WRENCH: 1.4.7.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
+    Wrench: 1.4.7.0
 
 # Functional tests for dependents found in the latest 6000.0 manifest (Ubuntu).
 preview_apv_-_6000_0_-_ubuntu:
@@ -284,10 +297,14 @@ preview_apv_-_6000_0_-_ubuntu:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_netcode_gameobjects
   variables:
-    UPMPVP_CONTEXT_WRENCH: 1.3.0.0
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
+    UPMPVP_CONTEXT_WRENCH: 1.4.7.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
+    Wrench: 1.4.7.0
 
 # Functional tests for dependents found in the latest 6000.0 manifest (Windows).
 preview_apv_-_6000_0_-_windows:
@@ -339,171 +356,12 @@ preview_apv_-_6000_0_-_windows:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_netcode_gameobjects
   variables:
-    UPMPVP_CONTEXT_WRENCH: 1.3.0.0
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
+    UPMPVP_CONTEXT_WRENCH: 1.4.7.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
-
-# Functional tests for dependents found in the latest 6000.2 manifest (MacOS).
-preview_apv_-_6000_2_-_macos:
-  name: Preview APV - 6000.2 - macos
-  agent:
-    image: package-ci/macos-13:default
-    type: Unity::VM::osx
-    flavor: b1.xlarge
-  commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-0_3978eda62a03e3dbc469ab77590d20f8832032d8e0b586550597b7f590baefec.zip -o wrench-localapv.zip
-  - command: 7z x -aoa wrench-localapv.zip
-  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
-  - command: python PythonScripts/print_machine_info.py
-  - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    timeout: 20
-    retries: 10
-  - command: unity-downloader-cli -u 6000.2/staging -c editor --path .Editor --fast
-    timeout: 10
-    retries: 3
-  - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.2 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
-  - command: echo 'Skipping Editor Manifest Validator as it is only supported on Windows'
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
-  artifacts:
-    Crash Dumps:
-      paths:
-      - CrashDumps/**
-    logs:
-      paths:
-      - '*.log'
-      - '*.xml'
-      - upm-ci~/test-results/**/*
-      - upm-ci~/temp/*/Logs/**
-      - upm-ci~/temp/*/Library/*.log
-      - upm-ci~/temp/*/*.log
-      - upm-ci~/temp/Builds/*.log
-    packages:
-      paths:
-      - upm-ci~/packages/**/*
-    PreviewAPVResults:
-      paths:
-      - PreviewApvArtifacts~/**
-      - APVTest/**/manifest.json
-    pvp-results:
-      paths:
-      - upm-ci~/pvp/**/*
-      browsable: onDemand
-  dependencies:
-  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_netcode_gameobjects
-  variables:
-    UPMPVP_CONTEXT_WRENCH: 1.3.0.0
-  metadata:
-    Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
-
-# Functional tests for dependents found in the latest 6000.2 manifest (Ubuntu).
-preview_apv_-_6000_2_-_ubuntu:
-  name: Preview APV - 6000.2 - ubuntu
-  agent:
-    image: package-ci/ubuntu-22.04:v4
-    type: Unity::VM
-    flavor: b1.large
-  commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-0_3978eda62a03e3dbc469ab77590d20f8832032d8e0b586550597b7f590baefec.zip -o wrench-localapv.zip
-  - command: 7z x -aoa wrench-localapv.zip
-  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
-  - command: python PythonScripts/print_machine_info.py
-  - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    timeout: 20
-    retries: 10
-  - command: unity-downloader-cli -u 6000.2/staging -c editor --path .Editor --fast
-    timeout: 10
-    retries: 3
-  - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.2 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
-  - command: echo 'Skipping Editor Manifest Validator as it is only supported on Windows'
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
-  artifacts:
-    Crash Dumps:
-      paths:
-      - CrashDumps/**
-    logs:
-      paths:
-      - '*.log'
-      - '*.xml'
-      - upm-ci~/test-results/**/*
-      - upm-ci~/temp/*/Logs/**
-      - upm-ci~/temp/*/Library/*.log
-      - upm-ci~/temp/*/*.log
-      - upm-ci~/temp/Builds/*.log
-    packages:
-      paths:
-      - upm-ci~/packages/**/*
-    PreviewAPVResults:
-      paths:
-      - PreviewApvArtifacts~/**
-      - APVTest/**/manifest.json
-    pvp-results:
-      paths:
-      - upm-ci~/pvp/**/*
-      browsable: onDemand
-  dependencies:
-  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_netcode_gameobjects
-  variables:
-    UPMPVP_CONTEXT_WRENCH: 1.3.0.0
-  metadata:
-    Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
-
-# Functional tests for dependents found in the latest 6000.2 manifest (Windows).
-preview_apv_-_6000_2_-_windows:
-  name: Preview APV - 6000.2 - windows
-  agent:
-    image: package-ci/win10:default
-    type: Unity::VM
-    flavor: b1.large
-  commands:
-  - command: gsudo reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-0_3978eda62a03e3dbc469ab77590d20f8832032d8e0b586550597b7f590baefec.zip -o wrench-localapv.zip
-  - command: 7z x -aoa wrench-localapv.zip
-  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
-  - command: python PythonScripts/print_machine_info.py
-  - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    timeout: 20
-    retries: 10
-  - command: unity-downloader-cli -u 6000.2/staging -c editor --path .Editor --fast
-    timeout: 10
-    retries: 3
-  - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.2 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
-  - command: python PythonScripts/editor_manifest_validator.py --version=6000.2 --wrench-config=.yamato/wrench/wrench_config.json
-  after:
-  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
-  artifacts:
-    Crash Dumps:
-      paths:
-      - CrashDumps/**
-    logs:
-      paths:
-      - '*.log'
-      - '*.xml'
-      - upm-ci~/test-results/**/*
-      - upm-ci~/temp/*/Logs/**
-      - upm-ci~/temp/*/Library/*.log
-      - upm-ci~/temp/*/*.log
-      - upm-ci~/temp/Builds/*.log
-    packages:
-      paths:
-      - upm-ci~/packages/**/*
-    PreviewAPVResults:
-      paths:
-      - PreviewApvArtifacts~/**
-      - APVTest/**/manifest.json
-    pvp-results:
-      paths:
-      - upm-ci~/pvp/**/*
-      browsable: onDemand
-  dependencies:
-  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_netcode_gameobjects
-  variables:
-    UPMPVP_CONTEXT_WRENCH: 1.3.0.0
-  metadata:
-    Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
+    Wrench: 1.4.7.0
 

--- a/.yamato/wrench/promotion-jobs.yml
+++ b/.yamato/wrench/promotion-jobs.yml
@@ -28,100 +28,70 @@ publish_dry_run_netcode_gameobjects:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_netcode_gameobjects
   - path: .yamato/wrench/validation-jobs.yml#validate_-_netcode_gameobjects_-_2022_3_-_macos
     specific_options:
-      UTR:
-        location: results/UTR/validate-netcode.gameobjects-2022.3-macos
-        unzip: true
+      packages:
+        ignore_artifact: true
       pvp-results:
         location: results/pvp/validate-netcode.gameobjects-2022.3-macos
         unzip: true
-      packages:
-        ignore_artifact: true
+      UTR:
+        location: results/UTR/validate-netcode.gameobjects-2022.3-macos
+        unzip: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_netcode_gameobjects_-_2022_3_-_ubuntu
     specific_options:
-      UTR:
-        location: results/UTR/validate-netcode.gameobjects-2022.3-ubuntu
-        unzip: true
+      packages:
+        ignore_artifact: true
       pvp-results:
         location: results/pvp/validate-netcode.gameobjects-2022.3-ubuntu
         unzip: true
-      packages:
-        ignore_artifact: true
+      UTR:
+        location: results/UTR/validate-netcode.gameobjects-2022.3-ubuntu
+        unzip: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_netcode_gameobjects_-_2022_3_-_windows
     specific_options:
-      UTR:
-        location: results/UTR/validate-netcode.gameobjects-2022.3-windows
-        unzip: true
+      packages:
+        ignore_artifact: true
       pvp-results:
         location: results/pvp/validate-netcode.gameobjects-2022.3-windows
         unzip: true
-      packages:
-        ignore_artifact: true
+      UTR:
+        location: results/UTR/validate-netcode.gameobjects-2022.3-windows
+        unzip: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_netcode_gameobjects_-_6000_0_-_macos
     specific_options:
-      UTR:
-        location: results/UTR/validate-netcode.gameobjects-6000.0-macos
-        unzip: true
+      packages:
+        ignore_artifact: true
       pvp-results:
         location: results/pvp/validate-netcode.gameobjects-6000.0-macos
         unzip: true
-      packages:
-        ignore_artifact: true
+      UTR:
+        location: results/UTR/validate-netcode.gameobjects-6000.0-macos
+        unzip: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_netcode_gameobjects_-_6000_0_-_ubuntu
     specific_options:
-      UTR:
-        location: results/UTR/validate-netcode.gameobjects-6000.0-ubuntu
-        unzip: true
+      packages:
+        ignore_artifact: true
       pvp-results:
         location: results/pvp/validate-netcode.gameobjects-6000.0-ubuntu
         unzip: true
-      packages:
-        ignore_artifact: true
+      UTR:
+        location: results/UTR/validate-netcode.gameobjects-6000.0-ubuntu
+        unzip: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_netcode_gameobjects_-_6000_0_-_windows
     specific_options:
-      UTR:
-        location: results/UTR/validate-netcode.gameobjects-6000.0-windows
-        unzip: true
+      packages:
+        ignore_artifact: true
       pvp-results:
         location: results/pvp/validate-netcode.gameobjects-6000.0-windows
         unzip: true
-      packages:
-        ignore_artifact: true
-  - path: .yamato/wrench/validation-jobs.yml#validate_-_netcode_gameobjects_-_6000_2_-_macos
-    specific_options:
       UTR:
-        location: results/UTR/validate-netcode.gameobjects-6000.2-macos
+        location: results/UTR/validate-netcode.gameobjects-6000.0-windows
         unzip: true
-      pvp-results:
-        location: results/pvp/validate-netcode.gameobjects-6000.2-macos
-        unzip: true
-      packages:
-        ignore_artifact: true
-  - path: .yamato/wrench/validation-jobs.yml#validate_-_netcode_gameobjects_-_6000_2_-_ubuntu
-    specific_options:
-      UTR:
-        location: results/UTR/validate-netcode.gameobjects-6000.2-ubuntu
-        unzip: true
-      pvp-results:
-        location: results/pvp/validate-netcode.gameobjects-6000.2-ubuntu
-        unzip: true
-      packages:
-        ignore_artifact: true
-  - path: .yamato/wrench/validation-jobs.yml#validate_-_netcode_gameobjects_-_6000_2_-_windows
-    specific_options:
-      UTR:
-        location: results/UTR/validate-netcode.gameobjects-6000.2-windows
-        unzip: true
-      pvp-results:
-        location: results/pvp/validate-netcode.gameobjects-6000.2-windows
-        unzip: true
-      packages:
-        ignore_artifact: true
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 1.3.0.0
+    UPMPVP_CONTEXT_WRENCH: 1.4.7.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
+    Wrench: 1.4.7.0
 
 # Publish  for netcode.gameobjects to https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-npm
 publish_netcode_gameobjects:
@@ -150,98 +120,68 @@ publish_netcode_gameobjects:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_netcode_gameobjects
   - path: .yamato/wrench/validation-jobs.yml#validate_-_netcode_gameobjects_-_2022_3_-_macos
     specific_options:
-      UTR:
-        location: results/UTR/validate-netcode.gameobjects-2022.3-macos
-        unzip: true
+      packages:
+        ignore_artifact: true
       pvp-results:
         location: results/pvp/validate-netcode.gameobjects-2022.3-macos
         unzip: true
-      packages:
-        ignore_artifact: true
+      UTR:
+        location: results/UTR/validate-netcode.gameobjects-2022.3-macos
+        unzip: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_netcode_gameobjects_-_2022_3_-_ubuntu
     specific_options:
-      UTR:
-        location: results/UTR/validate-netcode.gameobjects-2022.3-ubuntu
-        unzip: true
+      packages:
+        ignore_artifact: true
       pvp-results:
         location: results/pvp/validate-netcode.gameobjects-2022.3-ubuntu
         unzip: true
-      packages:
-        ignore_artifact: true
+      UTR:
+        location: results/UTR/validate-netcode.gameobjects-2022.3-ubuntu
+        unzip: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_netcode_gameobjects_-_2022_3_-_windows
     specific_options:
-      UTR:
-        location: results/UTR/validate-netcode.gameobjects-2022.3-windows
-        unzip: true
+      packages:
+        ignore_artifact: true
       pvp-results:
         location: results/pvp/validate-netcode.gameobjects-2022.3-windows
         unzip: true
-      packages:
-        ignore_artifact: true
+      UTR:
+        location: results/UTR/validate-netcode.gameobjects-2022.3-windows
+        unzip: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_netcode_gameobjects_-_6000_0_-_macos
     specific_options:
-      UTR:
-        location: results/UTR/validate-netcode.gameobjects-6000.0-macos
-        unzip: true
+      packages:
+        ignore_artifact: true
       pvp-results:
         location: results/pvp/validate-netcode.gameobjects-6000.0-macos
         unzip: true
-      packages:
-        ignore_artifact: true
+      UTR:
+        location: results/UTR/validate-netcode.gameobjects-6000.0-macos
+        unzip: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_netcode_gameobjects_-_6000_0_-_ubuntu
     specific_options:
-      UTR:
-        location: results/UTR/validate-netcode.gameobjects-6000.0-ubuntu
-        unzip: true
+      packages:
+        ignore_artifact: true
       pvp-results:
         location: results/pvp/validate-netcode.gameobjects-6000.0-ubuntu
         unzip: true
-      packages:
-        ignore_artifact: true
+      UTR:
+        location: results/UTR/validate-netcode.gameobjects-6000.0-ubuntu
+        unzip: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_netcode_gameobjects_-_6000_0_-_windows
     specific_options:
-      UTR:
-        location: results/UTR/validate-netcode.gameobjects-6000.0-windows
-        unzip: true
+      packages:
+        ignore_artifact: true
       pvp-results:
         location: results/pvp/validate-netcode.gameobjects-6000.0-windows
         unzip: true
-      packages:
-        ignore_artifact: true
-  - path: .yamato/wrench/validation-jobs.yml#validate_-_netcode_gameobjects_-_6000_2_-_macos
-    specific_options:
       UTR:
-        location: results/UTR/validate-netcode.gameobjects-6000.2-macos
+        location: results/UTR/validate-netcode.gameobjects-6000.0-windows
         unzip: true
-      pvp-results:
-        location: results/pvp/validate-netcode.gameobjects-6000.2-macos
-        unzip: true
-      packages:
-        ignore_artifact: true
-  - path: .yamato/wrench/validation-jobs.yml#validate_-_netcode_gameobjects_-_6000_2_-_ubuntu
-    specific_options:
-      UTR:
-        location: results/UTR/validate-netcode.gameobjects-6000.2-ubuntu
-        unzip: true
-      pvp-results:
-        location: results/pvp/validate-netcode.gameobjects-6000.2-ubuntu
-        unzip: true
-      packages:
-        ignore_artifact: true
-  - path: .yamato/wrench/validation-jobs.yml#validate_-_netcode_gameobjects_-_6000_2_-_windows
-    specific_options:
-      UTR:
-        location: results/UTR/validate-netcode.gameobjects-6000.2-windows
-        unzip: true
-      pvp-results:
-        location: results/pvp/validate-netcode.gameobjects-6000.2-windows
-        unzip: true
-      packages:
-        ignore_artifact: true
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 1.3.0.0
+    UPMPVP_CONTEXT_WRENCH: 1.4.7.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
+    Wrench: 1.4.7.0
 

--- a/.yamato/wrench/recipe-regeneration.yml
+++ b/.yamato/wrench/recipe-regeneration.yml
@@ -26,5 +26,5 @@ test_-_wrench_jobs_up_to_date:
     cancel_old_ci: true
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
+    Wrench: 1.4.7.0
 

--- a/.yamato/wrench/validation-jobs.yml
+++ b/.yamato/wrench/validation-jobs.yml
@@ -59,11 +59,15 @@ validate_-_netcode_gameobjects_-_2022_3_-_macos:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_netcode_gameobjects
   variables:
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 1.3.0.0
+    UPMPVP_CONTEXT_WRENCH: 1.4.7.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
+    Wrench: 1.4.7.0
   labels:
   - Packages:netcode.gameobjects
 
@@ -125,11 +129,15 @@ validate_-_netcode_gameobjects_-_2022_3_-_ubuntu:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_netcode_gameobjects
   variables:
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 1.3.0.0
+    UPMPVP_CONTEXT_WRENCH: 1.4.7.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
+    Wrench: 1.4.7.0
   labels:
   - Packages:netcode.gameobjects
 
@@ -191,11 +199,15 @@ validate_-_netcode_gameobjects_-_2022_3_-_windows:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_netcode_gameobjects
   variables:
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 1.3.0.0
+    UPMPVP_CONTEXT_WRENCH: 1.4.7.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
+    Wrench: 1.4.7.0
   labels:
   - Packages:netcode.gameobjects
 
@@ -257,11 +269,15 @@ validate_-_netcode_gameobjects_-_6000_0_-_macos:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_netcode_gameobjects
   variables:
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 1.3.0.0
+    UPMPVP_CONTEXT_WRENCH: 1.4.7.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
+    Wrench: 1.4.7.0
   labels:
   - Packages:netcode.gameobjects
 
@@ -323,11 +339,15 @@ validate_-_netcode_gameobjects_-_6000_0_-_ubuntu:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_netcode_gameobjects
   variables:
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 1.3.0.0
+    UPMPVP_CONTEXT_WRENCH: 1.4.7.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
+    Wrench: 1.4.7.0
   labels:
   - Packages:netcode.gameobjects
 
@@ -389,209 +409,15 @@ validate_-_netcode_gameobjects_-_6000_0_-_windows:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_netcode_gameobjects
   variables:
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 1.3.0.0
+    UPMPVP_CONTEXT_WRENCH: 1.4.7.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
-  labels:
-  - Packages:netcode.gameobjects
-
-# PVP Editor and Playmode tests for Validate - netcode.gameobjects - 6000.2 - macos (6000.2 - MacOS).
-validate_-_netcode_gameobjects_-_6000_2_-_macos:
-  name: Validate - netcode.gameobjects - 6000.2 - macos
-  agent:
-    image: package-ci/macos-13:default
-    type: Unity::VM::osx
-    flavor: b1.xlarge
-  commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-0_3978eda62a03e3dbc469ab77590d20f8832032d8e0b586550597b7f590baefec.zip -o wrench-localapv.zip
-  - command: 7z x -aoa wrench-localapv.zip
-  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
-  - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.2/staging -c editor --path .Editor --fast
-    timeout: 10
-    retries: 3
-  - command: upm-pvp create-test-project testproject --packages "upm-ci~/packages/*.tgz" --filter "com.unity.netcode.gameobjects com.unity.netcode.gameobjects.tests" --unity .Editor
-    timeout: 10
-    retries: 1
-  - command: echo No internal packages to add.
-  - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 180
-    retries: 0
-  - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
-    timeout: 5
-    retries: 0
-  - command: upm-pvp require "rme PVP-160-1 supported" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
-    timeout: 10
-    retries: 0
-  - command: 'UnifiedTestRunner --testproject=testproject --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
-    timeout: 180
-    retries: 1
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
-  artifacts:
-    Crash Dumps:
-      paths:
-      - CrashDumps/**
-    packages:
-      paths:
-      - upm-ci~/packages/**/*
-    pvp-results:
-      paths:
-      - upm-ci~/pvp/**/*
-      browsable: onDemand
-    UTR:
-      paths:
-      - '*.log'
-      - '*.xml'
-      - artifacts/**/*
-      - testproject/Logs/**
-      - testproject/Library/*.log
-      - testproject/*.log
-      - testproject/Builds/*.log
-      - build/test-results/**
-      browsable: onDemand
-  dependencies:
-  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_netcode_gameobjects
-  variables:
-    UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 1.3.0.0
-  metadata:
-    Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
-  labels:
-  - Packages:netcode.gameobjects
-
-# PVP Editor and Playmode tests for Validate - netcode.gameobjects - 6000.2 - ubuntu (6000.2 - Ubuntu).
-validate_-_netcode_gameobjects_-_6000_2_-_ubuntu:
-  name: Validate - netcode.gameobjects - 6000.2 - ubuntu
-  agent:
-    image: package-ci/ubuntu-22.04:v4
-    type: Unity::VM
-    flavor: b1.large
-  commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-0_3978eda62a03e3dbc469ab77590d20f8832032d8e0b586550597b7f590baefec.zip -o wrench-localapv.zip
-  - command: 7z x -aoa wrench-localapv.zip
-  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
-  - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.2/staging -c editor --path .Editor --fast
-    timeout: 10
-    retries: 3
-  - command: upm-pvp create-test-project testproject --packages "upm-ci~/packages/*.tgz" --filter "com.unity.netcode.gameobjects com.unity.netcode.gameobjects.tests" --unity .Editor
-    timeout: 10
-    retries: 1
-  - command: echo No internal packages to add.
-  - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 180
-    retries: 0
-  - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
-    timeout: 5
-    retries: 0
-  - command: upm-pvp require "rme PVP-160-1 supported" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
-    timeout: 10
-    retries: 0
-  - command: 'UnifiedTestRunner --testproject=testproject --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
-    timeout: 180
-    retries: 1
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
-  artifacts:
-    Crash Dumps:
-      paths:
-      - CrashDumps/**
-    packages:
-      paths:
-      - upm-ci~/packages/**/*
-    pvp-results:
-      paths:
-      - upm-ci~/pvp/**/*
-      browsable: onDemand
-    UTR:
-      paths:
-      - '*.log'
-      - '*.xml'
-      - artifacts/**/*
-      - testproject/Logs/**
-      - testproject/Library/*.log
-      - testproject/*.log
-      - testproject/Builds/*.log
-      - build/test-results/**
-      browsable: onDemand
-  dependencies:
-  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_netcode_gameobjects
-  variables:
-    UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 1.3.0.0
-  metadata:
-    Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
-  labels:
-  - Packages:netcode.gameobjects
-
-# PVP Editor and Playmode tests for Validate - netcode.gameobjects - 6000.2 - windows (6000.2 - Windows).
-validate_-_netcode_gameobjects_-_6000_2_-_windows:
-  name: Validate - netcode.gameobjects - 6000.2 - windows
-  agent:
-    image: package-ci/win10:default
-    type: Unity::VM
-    flavor: b1.large
-  commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-0_3978eda62a03e3dbc469ab77590d20f8832032d8e0b586550597b7f590baefec.zip -o wrench-localapv.zip
-  - command: 7z x -aoa wrench-localapv.zip
-  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
-  - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.2/staging -c editor --path .Editor --fast
-    timeout: 10
-    retries: 3
-  - command: upm-pvp create-test-project testproject --packages "upm-ci~/packages/*.tgz" --filter "com.unity.netcode.gameobjects com.unity.netcode.gameobjects.tests" --unity .Editor
-    timeout: 10
-    retries: 1
-  - command: echo No internal packages to add.
-  - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 180
-    retries: 0
-  - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
-    timeout: 5
-    retries: 0
-  - command: upm-pvp require "rme PVP-160-1 supported" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
-    timeout: 10
-    retries: 0
-  - command: 'UnifiedTestRunner.exe --testproject=testproject --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
-    timeout: 180
-    retries: 1
-  after:
-  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
-  artifacts:
-    Crash Dumps:
-      paths:
-      - CrashDumps/**
-    packages:
-      paths:
-      - upm-ci~/packages/**/*
-    pvp-results:
-      paths:
-      - upm-ci~/pvp/**/*
-      browsable: onDemand
-    UTR:
-      paths:
-      - '*.log'
-      - '*.xml'
-      - artifacts/**/*
-      - testproject/Logs/**
-      - testproject/Library/*.log
-      - testproject/*.log
-      - testproject/Builds/*.log
-      - build/test-results/**
-      browsable: onDemand
-  dependencies:
-  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_netcode_gameobjects
-  variables:
-    UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 1.3.0.0
-  metadata:
-    Job Maintainers: '#rm-packageworks'
-    Wrench: 1.3.0.0
+    Wrench: 1.4.7.0
   labels:
   - Packages:netcode.gameobjects
 

--- a/.yamato/wrench/wrench_config.json
+++ b/.yamato/wrench/wrench_config.json
@@ -16,7 +16,8 @@
       "coverageCommands": [
         "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:ASSEMBLY_NAME;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:YAMATO_SOURCE_DIR/Packages;"
       ],
-      "dependantsToIgnoreInPreviewApv": {}
+      "dependantsToIgnoreInPreviewApv": {},
+      "postPackCommands": []
     }
   },
   "releasing_packages": [
@@ -31,7 +32,7 @@
   },
   "publishing_job": ".yamato/wrench/promotion-jobs.yml#publish_netcode_gameobjects",
   "branch_pattern": "ReleaseSlash",
-  "wrench_version": "1.3.0.0",
+  "wrench_version": "1.4.7.0",
   "pvp_exemption_path": ".yamato/wrench/pvp-exemptions.json",
   "cs_project_path": "Tools/CI/NGO.Cookbook.csproj"
 }

--- a/Tools/CI/NGO.Cookbook.csproj
+++ b/Tools/CI/NGO.Cookbook.csproj
@@ -8,11 +8,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="RecipeEngine" Version="7.3.0" />
-        <PackageReference Include="RecipeEngine.Api" Version="12.0.0" />
-        <PackageReference Include="RecipeEngine.Api.Extensions" Version="7.2.0" />
+        <PackageReference Include="RecipeEngine" Version="7.3.2" />
+        <PackageReference Include="RecipeEngine.Api" Version="12.2.0" />
+        <PackageReference Include="RecipeEngine.Api.Extensions" Version="7.2.1" />
         <PackageReference Include="RecipeEngine.Modules.Api" Version="5.1.0" />
-        <PackageReference Include="RecipeEngine.Modules.Wrench" Version="1.3.0" />
+        <PackageReference Include="RecipeEngine.Modules.Wrench" Version="1.4.7" />
     </ItemGroup>
 
 </Project>

--- a/Tools/scripts/ReleaseAutomation/release_config.py
+++ b/Tools/scripts/ReleaseAutomation/release_config.py
@@ -99,12 +99,12 @@ class ReleaseConfig:
                 ]
             },
             {
-                "job_name": "Build Sample for Windows with latest functional editor (6000.2), burst ON, IL2CPP",
+                "job_name": "Build Sample for Windows with latest functional editor (6000.3), burst ON, IL2CPP",
                 "variables": [
                     { "key": "BURST_ON_OFF", "value": "on" },
                     { "key": "PLATFORM_WIN64_MAC_ANDROID", "value": "win64" },
                     { "key": "SCRIPTING_BACKEND_IL2CPP_MONO", "value": "il2cpp" },
-                    { "key": "UNITY_VERSION", "value": "6000.2" } # Editor that most our users will use (not alpha). Sometimes when testing on trunk we have weird editor issues not caused by us so the preference will be to test on latest editor that our users will use.
+                    { "key": "UNITY_VERSION", "value": "6000.3" } # Editor that most our users will use (not alpha). Sometimes when testing on trunk we have weird editor issues not caused by us so the preference will be to test on latest editor that our users will use.
                 ]
             },
             {
@@ -117,12 +117,12 @@ class ReleaseConfig:
                 ]
             },
             {
-                "job_name": "Build Sample for MacOS with latest functional editor (6000.2), burst OFF, Mono",
+                "job_name": "Build Sample for MacOS with latest functional editor (6000.3), burst OFF, Mono",
                 "variables": [
                     { "key": "BURST_ON_OFF", "value": "off" },
                     { "key": "PLATFORM_WIN64_MAC_ANDROID", "value": "mac" },
                     { "key": "SCRIPTING_BACKEND_IL2CPP_MONO", "value": "mono" },
-                    { "key": "UNITY_VERSION", "value": "6000.2" } # Editor that most our users will use (not alpha). Sometimes when testing on trunk we have weird editor issues not caused by us so the preference will be to test on latest editor that our users will use.
+                    { "key": "UNITY_VERSION", "value": "6000.3" } # Editor that most our users will use (not alpha). Sometimes when testing on trunk we have weird editor issues not caused by us so the preference will be to test on latest editor that our users will use.
                 ]
             },
             {
@@ -135,12 +135,12 @@ class ReleaseConfig:
                 ]
             },
             {
-                "job_name": "Build Sample for Android with latest functional editor (6000.2), burst ON, IL2CPP",
+                "job_name": "Build Sample for Android with latest functional editor (6000.3), burst ON, IL2CPP",
                 "variables": [
                     { "key": "BURST_ON_OFF", "value": "on" },
                     { "key": "PLATFORM_WIN64_MAC_ANDROID", "value": "android" },
                     { "key": "SCRIPTING_BACKEND_IL2CPP_MONO", "value": "il2cpp" },
-                    { "key": "UNITY_VERSION", "value": "6000.2" } # Editor that most our users will use (not alpha). Sometimes when testing on trunk we have weird editor issues not caused by us so the preference will be to test on latest editor that our users will use.
+                    { "key": "UNITY_VERSION", "value": "6000.3" } # Editor that most our users will use (not alpha). Sometimes when testing on trunk we have weird editor issues not caused by us so the preference will be to test on latest editor that our users will use.
                 ]
             }
         ]

--- a/com.unity.netcode.gameobjects/Editor/HiddenScriptEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/HiddenScriptEditor.cs
@@ -1,4 +1,3 @@
-using Unity.Netcode.Components;
 #if UNITY_UNET_PRESENT
 using Unity.Netcode.Transports.UNET;
 #endif

--- a/com.unity.netcode.gameobjects/Editor/HiddenScriptEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/HiddenScriptEditor.cs
@@ -1,9 +1,12 @@
+#pragma warning disable IDE0005
+using Unity.Netcode.Components;
 #if UNITY_UNET_PRESENT
 using Unity.Netcode.Transports.UNET;
 #endif
 using Unity.Netcode.Transports.UTP;
 using UnityEditor;
 using UnityEngine;
+#pragma warning restore IDE0005
 
 namespace Unity.Netcode.Editor
 {


### PR DESCRIPTION
## Purpose of this PR
This is partially a backport of https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3824 but with adjustments for NGOv1.X. It aims to update our general CI dependencies. I intend to close all other PRs created by renovate and mentioned in the list below when the Full CI is green and I have a green light to merge this

1. I updated some typos and editors to reflect current state (for example building for 6000.0 instead of 6000.2 for Playtest since 6000.2 is not supported anymore)
2. Updated handling of default and minimal editors where I removed hardcoded values and use project.metafile to control those
3. https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3818
4. https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3806
5. https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3796
6. https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3752
7. https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3790

### Jira ticket
N/A

### Changelog
N/A

## Documentation
N/A

## Testing & QA (How your changes can be verified during release Playtest)
I will run Full CI to catch any other CI issues. I want to make sure that the CI will be green/fixed after this PR

## Backports
This is a backport of https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3824
