### PR TITLE
fix: NetworkList resets after spawn on client-server when using owner write

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -24,7 +24,9 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue when using a client-server topology where a NetworkList with owner write permissions was resetting sent time and dirty flags on owning clients that were not the spawn authority. (#3850)
 - Fixed an integer overflow that occurred when configuring a large disconnect timeout with Unity Transport. (#3810)
+
 
 ### Security
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -24,7 +24,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Fixed issue when using a client-server topology where a NetworkList with owner write permissions was resetting sent time and dirty flags on owning clients that were not the spawn authority. (#3850)
+- Fixed issue when using a client-server topology where a `NetworkList` with owner write permissions was resetting sent time and dirty flags after having been spawned on owning clients that were not the spawn authority. (#3850)
 - Fixed an integer overflow that occurred when configuring a large disconnect timeout with Unity Transport. (#3810)
 
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -80,7 +80,7 @@ namespace Unity.Netcode
         /// Set to true if this instance is the original/first instance created and spawned which
         /// means the <see cref="CreateObjectMessage"/> was generated from this instance and sent
         /// to all other clients.
-        /// 
+        ///
         /// Client-Server: This will be true for all instances on the server or host.
         /// Distributed Authority: This will be true on the client that created the first instance
         /// and spawned it (even if spawning with ownership being assigned to a different client).

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -76,6 +76,16 @@ namespace Unity.Netcode
         /// </remarks>
         public List<NetworkTransform> NetworkTransforms { get; private set; }
 
+        /// <summary>
+        /// Set to true if this instance is the original/first instance created and spawned which
+        /// means the <see cref="CreateObjectMessage"/> was generated from this instance and sent
+        /// to all other clients.
+        /// 
+        /// Client-Server: This will be true for all instances on the server or host.
+        /// Distributed Authority: This will be true on the client that created the first instance
+        /// and spawned it (even if spawning with ownership being assigned to a different client).
+        /// </summary>
+        internal bool IsSpawnAuthority;
 
 #if COM_UNITY_MODULES_PHYSICS || COM_UNITY_MODULES_PHYSICS2D
         /// <summary>
@@ -2008,6 +2018,7 @@ namespace Unity.Netcode
         {
             // Always clear out the observers list when despawned
             Observers.Clear();
+            IsSpawnAuthority = false;
             IsSpawned = false;
             DeferredDespawnTick = 0;
             m_LatestParent = null;

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -71,7 +71,7 @@ namespace Unity.Netcode
             // the dirty related properties and last sent time to prevent duplicate entries from
             // being sent (i.e. CreateObjectMessage will contain the changes so we don't need to
             // send a proceeding NetworkVariableDeltaMessage).
-            if (IsDirty() && CanSend() && m_NetworkBehaviour.HasAuthority)
+            if (IsDirty() && CanSend() && m_NetworkObject.IsSpawnAuthority)
             {
                 UpdateLastSentTime();
                 ResetDirty();

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -61,10 +61,12 @@ namespace Unity.Netcode
         internal override void OnSpawned()
         {
             // If we are dirty and have write permissions by the time the NetworkObject
-            // is finished spawning (same frame), then go ahead and reset the dirty related
-            // properties for NetworkList in the event user script has made changes when
-            // spawning to prevent duplicate entries.
-            if (IsDirty() && CanSend())
+            // is finished spawning (same frame) and the instance is on the spawn authority
+            // side, then go ahead and reset the dirty related properties for NetworkList
+            // in the event user script has made changes when spawning to prevent duplicate
+            // entries (i.e. they are sent via CreateObjectMessage so we don't need to send
+            // the NetworkVariableDeltaMessage.
+            if (IsDirty() && CanSend() && m_NetworkBehaviour.HasAuthority)
             {
                 UpdateLastSentTime();
                 ResetDirty();

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -67,10 +67,10 @@ namespace Unity.Netcode
             // -- The last sent time plus the max send time period is less than the current time.
             // - User script has modified the list during spawn.
             // - This instance is on the spawn authority side.
-            // Then by the time the NetworkObject is finished spawning (on the same frame), then go
-            // ahead and reset the dirty related properties and last sent time to prevent duplicate
-            // entries from being sent (i.e. CreateObjectMessage will contain the changes so we
-            // don't need to send a proceeding NetworkVariableDeltaMessage).
+            // When the NetworkObject is finished spawning (on the same frame), go ahead and reset
+            // the dirty related properties and last sent time to prevent duplicate entries from
+            // being sent (i.e. CreateObjectMessage will contain the changes so we don't need to
+            // send a proceeding NetworkVariableDeltaMessage).
             if (IsDirty() && CanSend() && m_NetworkBehaviour.HasAuthority)
             {
                 UpdateLastSentTime();

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -60,12 +60,17 @@ namespace Unity.Netcode
 
         internal override void OnSpawned()
         {
-            // If we are dirty and have write permissions by the time the NetworkObject
-            // is finished spawning (same frame) and the instance is on the spawn authority
-            // side, then go ahead and reset the dirty related properties for NetworkList
-            // in the event user script has made changes when spawning to prevent duplicate
-            // entries (i.e. they are sent via CreateObjectMessage so we don't need to send
-            // the NetworkVariableDeltaMessage.
+            // If the NetworkList is:
+            // - Dirty
+            // - State updates can be sent:
+            // -- The instance has write permissions.
+            // -- The last sent time plus the max send time period is less than the current time.
+            // - User script has modified the list during spawn.
+            // - This instance is on the spawn authority side.
+            // Then by the time the NetworkObject is finished spawning (on the same frame), then go
+            // ahead and reset the dirty related properties and last sent time to prevent duplicate
+            // entries from being sent (i.e. CreateObjectMessage will contain the changes so we
+            // don't need to send a proceeding NetworkVariableDeltaMessage).
             if (IsDirty() && CanSend() && m_NetworkBehaviour.HasAuthority)
             {
                 UpdateLastSentTime();

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1054,6 +1054,9 @@ namespace Unity.Netcode
                     Debug.LogError("Spawning NetworkObjects with nested NetworkObjects is only supported for scene objects. Child NetworkObjects will not be spawned over the network!");
                 }
             }
+
+            networkObject.IsSpawnAuthority = true;
+
             // Invoke NetworkBehaviour.OnPreSpawn methods
             networkObject.NetworkManagerOwner = NetworkManager;
             networkObject.InvokeBehaviourNetworkPreSpawn();

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkListTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkListTests.cs
@@ -294,7 +294,7 @@ namespace Unity.Netcode.RuntimeTests
 
         private List<NetworkObject> m_SpawnedObjects = new List<NetworkObject>();
         internal const int ValueCount = 10;
-        internal bool IsOwnerWriteTest;
+        internal static bool IsOwnerWriteTest;
         internal NetworkManager LateJoinedClient;
         internal static List<int> OwnerWriteExpectedValues = new List<int>();
 
@@ -473,7 +473,7 @@ namespace Unity.Netcode.RuntimeTests
 
         public override void OnNetworkSpawn()
         {
-            if (IsOwner)
+            if (NetworkListTests.IsOwnerWriteTest && IsOwner)
             {
                 for (int i = 0; i < NetworkListTests.ValueCount; i++)
                 {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkListTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkListTests.cs
@@ -27,6 +27,12 @@ namespace Unity.Netcode.RuntimeTests
 
         private ulong m_TestObjectId;
 
+        protected override IEnumerator OnSetup()
+        {
+            IsOwnerWriteTest = false;
+            return base.OnSetup();
+        }
+
         protected override void OnServerAndClientsCreated()
         {
             m_ListObjectPrefab = CreateNetworkObjectPrefab("ListObject");
@@ -285,6 +291,136 @@ namespace Unity.Netcode.RuntimeTests
             // This will do a shuffle of the list
             return list.OrderBy(_ => rng.Next()).ToArray();
         }
+
+        private List<NetworkObject> m_SpawnedObjects = new List<NetworkObject>();
+        internal const int SpawnCount = 10;
+        internal bool IsOwnerWriteTest;
+        internal NetworkManager LateJoinedClient;
+
+        protected override void OnNewClientCreated(NetworkManager networkManager)
+        {
+            if (IsOwnerWriteTest)
+            {
+                LateJoinedClient = networkManager;
+            }
+            else
+            {
+                LateJoinedClient = null;
+            }
+            base.OnNewClientCreated(networkManager);
+        }
+
+        [UnityTest]
+        public IEnumerator OwnerWriteTests()
+        {
+            IsOwnerWriteTest = true;
+            var authorityBetworkManager = GetAuthorityNetworkManager();
+            m_SpawnedObjects.Clear();
+            m_ExpectedValues.Clear();
+            // Set our initial expected values as 0 - 9
+            for (int i = 0; i < SpawnCount; i++)
+            {
+                m_ExpectedValues.Add(i);
+            }
+
+            // Each spawned instance will be owned by each NetworkManager instance in order
+            // to validate owner write NetworkLists.
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                m_SpawnedObjects.Add(SpawnObject(m_ListObjectPrefab, networkManager).GetComponent<NetworkObject>());
+            }
+
+            // Verify all NetworkManager instances spawned the objects
+            yield return WaitForSpawnedOnAllOrTimeOut(m_SpawnedObjects);
+            AssertOnTimeout("Not all instances were spawned on all clients!");
+
+            // Verify all spawned object instances have the expected owner write NetworkList values
+            yield return WaitForConditionOrTimeOut(OnVerifyOwnerWriteData);
+            AssertOnTimeout("Detected invalid count or value on one of the spawned instances!");
+
+            // Late join a client 
+            yield return CreateAndStartNewClient();
+
+            // Spawn an instance with the new client being the owner
+            m_SpawnedObjects.Add(SpawnObject(m_ListObjectPrefab, LateJoinedClient).GetComponent<NetworkObject>());
+
+            // Verify all NetworkManager instances spawned the objects
+            yield return WaitForSpawnedOnAllOrTimeOut(m_SpawnedObjects);
+            AssertOnTimeout("Not all instances were spawned on all clients!");
+
+            // Verify all spawned object instances have the expected owner write NetworkList values
+            yield return WaitForConditionOrTimeOut(OnVerifyOwnerWriteData);
+            AssertOnTimeout("Detected invalid count or value on one of the spawned instances!");
+
+            // Now have all of the clients update their list values to randomly assigned values
+            // in order to verify changes to owner write NetworkLists are synchronized properly.
+            m_ExpectedValues.Clear();
+            for (int i = 0; i < SpawnCount; i++)
+            {
+                m_ExpectedValues.Add(Random.Range(10, 100));
+            }
+            UpdateOwnerWriteValues();
+
+            // Verify all spawned object instances have the expected owner write NetworkList values
+            yield return WaitForConditionOrTimeOut(OnVerifyOwnerWriteData);
+            AssertOnTimeout("Detected invalid count or value on one of the spawned instances!");
+        }
+
+        private void UpdateOwnerWriteValues()
+        {
+            foreach (var spawnedObject in m_SpawnedObjects)
+            {
+                var owningNetworkManager = m_NetworkManagers.Where((c) => c.LocalClientId == spawnedObject.OwnerClientId).First();
+                var networkObjectId = spawnedObject.NetworkObjectId;
+                var listComponent = owningNetworkManager.SpawnManager.SpawnedObjects[networkObjectId].GetComponent<NetworkListTest>();
+                for (int i = 0; i < SpawnCount; i++)
+                {
+                    listComponent.OwnerWriteList[i] = m_ExpectedValues[i];
+                }
+            }
+        }
+
+        private bool OnVerifyOwnerWriteData(StringBuilder errorLog)
+        {
+            foreach (var spawnedObject in m_SpawnedObjects)
+            {
+                var networkObjectId = spawnedObject.NetworkObjectId;
+                foreach (var networkManager in m_NetworkManagers)
+                {
+                    if (!networkManager.SpawnManager.SpawnedObjects.ContainsKey(networkObjectId))
+                    {
+                        errorLog.Append($"[Client-{networkManager.LocalClientId}] Does not have an instance of spawned object NetworkObjectId: {networkObjectId}");
+                        return false;
+                    }
+                    var listComponent = networkManager.SpawnManager.SpawnedObjects[networkObjectId].GetComponent<NetworkListTest>();
+
+                    if (listComponent == null)
+                    {
+                        errorLog.Append($"[Client-{networkManager.LocalClientId}] List component was not found");
+                        return false;
+                    }
+
+                    if (listComponent.OwnerWriteList.Count != SpawnCount)
+                    {
+                        errorLog.Append($"[Client-{networkManager.LocalClientId}] List component has the incorrect number of items. Expected: {SpawnCount}, Have: {listComponent.TheList.Count}");
+                        return false;
+                    }
+
+                    for (int i = 0; i < SpawnCount; i++)
+                    {
+                        var actual = listComponent.OwnerWriteList[i];
+                        var expected = m_ExpectedValues[i];
+                        if (expected != actual)
+                        {
+                            errorLog.Append($"[Client-{networkManager.LocalClientId}] Incorrect value at index {i}, expected: {expected}, actual: {actual}");
+                            return false;
+                        }
+                    }
+                }
+            }
+
+            return true;
+        }
     }
 
     internal class NetworkListTest : NetworkBehaviour
@@ -292,6 +428,7 @@ namespace Unity.Netcode.RuntimeTests
         public readonly NetworkList<int> TheList = new();
         public readonly NetworkList<StructUsedOnlyInNetworkList> TheStructList = new();
         public readonly NetworkList<FixedString128Bytes> TheLargeList = new();
+        public readonly NetworkList<int> OwnerWriteList = new NetworkList<int>(default, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
 
         private void ListChanged(NetworkListEvent<int> e)
         {
@@ -307,6 +444,18 @@ namespace Unity.Netcode.RuntimeTests
         {
             TheList.OnListChanged -= ListChanged;
             base.OnDestroy();
+        }
+
+        public override void OnNetworkSpawn()
+        {
+            if (IsOwner)
+            {
+                for (int i = 0; i < NetworkListTests.SpawnCount; i++)
+                {
+                    OwnerWriteList.Add(i);
+                }
+            }
+            base.OnNetworkSpawn();
         }
 
         public bool ListDelegateTriggered;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkListTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkListTests.cs
@@ -293,9 +293,10 @@ namespace Unity.Netcode.RuntimeTests
         }
 
         private List<NetworkObject> m_SpawnedObjects = new List<NetworkObject>();
-        internal const int SpawnCount = 10;
+        internal const int ValueCount = 10;
         internal bool IsOwnerWriteTest;
         internal NetworkManager LateJoinedClient;
+        internal static List<int> OwnerWriteExpectedValues = new List<int>();
 
         protected override void OnNewClientCreated(NetworkManager networkManager)
         {
@@ -314,13 +315,13 @@ namespace Unity.Netcode.RuntimeTests
         public IEnumerator OwnerWriteTests()
         {
             IsOwnerWriteTest = true;
-            var authorityBetworkManager = GetAuthorityNetworkManager();
+            var authorityNetworkManager = GetAuthorityNetworkManager();
             m_SpawnedObjects.Clear();
-            m_ExpectedValues.Clear();
+            OwnerWriteExpectedValues.Clear();
             // Set our initial expected values as 0 - 9
-            for (int i = 0; i < SpawnCount; i++)
+            for (int i = 0; i < ValueCount; i++)
             {
-                m_ExpectedValues.Add(i);
+                OwnerWriteExpectedValues.Add(i);
             }
 
             // Each spawned instance will be owned by each NetworkManager instance in order
@@ -354,16 +355,40 @@ namespace Unity.Netcode.RuntimeTests
 
             // Now have all of the clients update their list values to randomly assigned values
             // in order to verify changes to owner write NetworkLists are synchronized properly.
-            m_ExpectedValues.Clear();
-            for (int i = 0; i < SpawnCount; i++)
+            OwnerWriteExpectedValues.Clear();
+            for (int i = 0; i < ValueCount; i++)
             {
-                m_ExpectedValues.Add(Random.Range(10, 100));
+                OwnerWriteExpectedValues.Add(Random.Range(10, 100));
             }
             UpdateOwnerWriteValues();
 
             // Verify all spawned object instances have the expected owner write NetworkList values
             yield return WaitForConditionOrTimeOut(OnVerifyOwnerWriteData);
             AssertOnTimeout("Detected invalid count or value on one of the spawned instances!");
+
+            // Verifies that spawning with ownership in distributed authority mode work properly.
+            // Where:
+            // Client-A spawns with ownership assigned to Client-B
+            // Client-B applies values at spawn.
+            // All clients then should be updated with those new values applied.
+            if (m_DistributedAuthority)
+            {
+                var prefabNetworkObject = m_ListObjectPrefab.GetComponent<NetworkObject>();
+                foreach (var networkManager in m_NetworkManagers)
+                {
+                    var instance = Object.Instantiate(m_ListObjectPrefab).GetComponent<NetworkObject>();
+                    SpawnInstanceWithOwnership(instance, authorityNetworkManager, networkManager.LocalClientId);
+                    m_SpawnedObjects.Add(instance);
+                }
+
+                // Verify all NetworkManager instances spawned the objects
+                yield return WaitForSpawnedOnAllOrTimeOut(m_SpawnedObjects);
+                AssertOnTimeout("Not all instances were spawned on all clients!");
+
+                // Verify all spawned object instances have the expected owner write NetworkList values
+                yield return WaitForConditionOrTimeOut(OnVerifyOwnerWriteData);
+                AssertOnTimeout("Detected invalid count or value on one of the spawned instances!");
+            }
         }
 
         private void UpdateOwnerWriteValues()
@@ -373,9 +398,9 @@ namespace Unity.Netcode.RuntimeTests
                 var owningNetworkManager = m_NetworkManagers.Where((c) => c.LocalClientId == spawnedObject.OwnerClientId).First();
                 var networkObjectId = spawnedObject.NetworkObjectId;
                 var listComponent = owningNetworkManager.SpawnManager.SpawnedObjects[networkObjectId].GetComponent<NetworkListTest>();
-                for (int i = 0; i < SpawnCount; i++)
+                for (int i = 0; i < ValueCount; i++)
                 {
-                    listComponent.OwnerWriteList[i] = m_ExpectedValues[i];
+                    listComponent.OwnerWriteList[i] = OwnerWriteExpectedValues[i];
                 }
             }
         }
@@ -400,16 +425,16 @@ namespace Unity.Netcode.RuntimeTests
                         return false;
                     }
 
-                    if (listComponent.OwnerWriteList.Count != SpawnCount)
+                    if (listComponent.OwnerWriteList.Count != ValueCount)
                     {
-                        errorLog.Append($"[Client-{networkManager.LocalClientId}] List component has the incorrect number of items. Expected: {SpawnCount}, Have: {listComponent.TheList.Count}");
+                        errorLog.Append($"[Client-{networkManager.LocalClientId}] List component has the incorrect number of items. Expected: {ValueCount}, Have: {listComponent.TheList.Count}");
                         return false;
                     }
 
-                    for (int i = 0; i < SpawnCount; i++)
+                    for (int i = 0; i < ValueCount; i++)
                     {
                         var actual = listComponent.OwnerWriteList[i];
-                        var expected = m_ExpectedValues[i];
+                        var expected = OwnerWriteExpectedValues[i];
                         if (expected != actual)
                         {
                             errorLog.Append($"[Client-{networkManager.LocalClientId}] Incorrect value at index {i}, expected: {expected}, actual: {actual}");
@@ -450,9 +475,9 @@ namespace Unity.Netcode.RuntimeTests
         {
             if (IsOwner)
             {
-                for (int i = 0; i < NetworkListTests.SpawnCount; i++)
+                for (int i = 0; i < NetworkListTests.ValueCount; i++)
                 {
-                    OwnerWriteList.Add(i);
+                    OwnerWriteList.Add(NetworkListTests.OwnerWriteExpectedValues[i]);
                 }
             }
             base.OnNetworkSpawn();
@@ -473,8 +498,6 @@ namespace Unity.Netcode.RuntimeTests
         private readonly NetworkListTest m_AuthorityInstance;
 
         private readonly NetworkListTest m_NonAuthorityInstance;
-
-        private string m_TestStageFailedMessage;
 
         /// <summary>
         /// Determines if the condition has been reached for the current NetworkListTestState

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkListTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkListTests.cs
@@ -338,7 +338,7 @@ namespace Unity.Netcode.RuntimeTests
             yield return WaitForConditionOrTimeOut(OnVerifyOwnerWriteData);
             AssertOnTimeout("Detected invalid count or value on one of the spawned instances!");
 
-            // Late join a client 
+            // Late join a client
             yield return CreateAndStartNewClient();
 
             // Spawn an instance with the new client being the owner


### PR DESCRIPTION
**This is a regression bug and will need to be cherry picked into a release/2.8.1 hot-patch fix branch**

## Purpose of this PR
Only the spawn authority should reset the sent time and reset the dirty flag for NetworkList changes to avoid sending both the CreateObjectMessage (which would contain the changes) plus the NetworkVariableDeltaMessage.

### Jira ticket

[UUM-132685](https://jira.unity3d.com/browse/UUM-132685)

fix: #3848

### Changelog
[//]: # (updated with all public facing changes  - API changes, UI/UX changes, behaviour changes, bug fixes. Remove if not relevant.)

- Fixed: Issue when using a client-server topology where a `NetworkList` with owner write permissions was resetting sent time and dirty flags after having been spawned on owning clients that were not the spawn authority.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation

- No documentation changes or additions were necessary.

## Testing & QA (How your changes can be verified during release Playtest)

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [x] `Manual testing done`
  - [PR-3850-ManualTest.zip](https://github.com/user-attachments/files/24776811/PR-3850-ManualTest.zip)
  - _Once merged, the manifest needs to point to the develop-2.0.0 branch._

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [x] `Covered by new automated tests` 
  - Added `NetworkListTests.OwnerWriteTests`.

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports
No backport required.
