### PR TITLE
chore: Updated aspects of Netcode package in anticipation of v1.15.1 release

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -22,13 +22,18 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- general documentation update
 
 ### Security
 
 
 ### Obsolete
 
+
+## [1.15.1] - 2026-01-21
+
+### Fixed
+
+- general documentation update
 
 ## [1.15.0] - 2025-11-14
 

--- a/com.unity.netcode.gameobjects/ValidationExceptions.json
+++ b/com.unity.netcode.gameobjects/ValidationExceptions.json
@@ -1,9 +1,9 @@
-﻿{
+{
   "ErrorExceptions": [
     {
       "ValidationTest": "API Validation",
       "ExceptionMessage": "Breaking changes require a new major version.",
-      "PackageVersion": "1.15.0"
+      "PackageVersion": "1.15.2"
     }
   ],
   "WarningExceptions": []

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -2,7 +2,7 @@
     "name": "com.unity.netcode.gameobjects",
     "displayName": "Netcode for GameObjects",
     "description": "Netcode for GameObjects is a high-level netcode SDK that provides networking capabilities to GameObject/MonoBehaviour workflows within Unity and sits on top of underlying transport layer.",
-    "version": "1.15.1",
+    "version": "1.15.2",
     "unity": "2022.3",
     "dependencies": {
         "com.unity.nuget.mono-cecil": "1.11.6",


### PR DESCRIPTION
This PR was created in sync with branching of release/1.15.1. It includes changes that should land on the default Netcode branch (develop) to reflect the new state of the package after the v1.15.1 release:
1) Updated CHANGELOG.md by adding new [Unreleased] section template at the top and cleaning the Changelog for the current release.
2) Updated package version in package.json by incrementing the patch version to signify the current state of the package.
3) Updated package version in ValidationExceptions.json to match the new package version.

Please review and merge this PR to keep the default branch up to date with the latest package state after the release. Those changes can land immediately OR after the release was finalized but make sure that the Changelog will be merged correctly as sometimes some discrepancies may be introduced due to new entries being introduced meantime
