### PR TITLE
fix: Ensure transport connection events don't act if duplicated

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -28,6 +28,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Duplicate transport connection events for the same connection will now do nothing. (#3863)
 - Fixed issue when using a client-server topology where a `NetworkList` with owner write permissions was resetting sent time and dirty flags after having been spawned on owning clients that were not the spawn authority. (#3850)
 - Fixed an integer overflow that occurred when configuring a large disconnect timeout with Unity Transport. (#3810)
 

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -494,10 +494,12 @@ namespace Unity.Netcode
 
         internal ulong LocalClientTransportId => m_LocalClientTransportId;
 
+        private bool m_IsTransportConnected = false;
+
         /// <summary>
         /// Handles a <see cref="NetworkEvent.Connect"/> event.
         /// </summary>
-        internal void ConnectEventHandler(ulong transportClientId)
+        internal void ConnectEventHandler(ulong transportId)
         {
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
             s_TransportConnect.Begin();
@@ -507,20 +509,45 @@ namespace Unity.Netcode
             // - When client receives one, it *must be* the server
             // Client's can't connect to or talk to other clients.
             // Server is a sentinel so only one exists, if we are server, we can't be connecting to it.
-            var clientId = transportClientId;
+
+            ulong clientId;
+
+            // If we're the server, then this connect event is firing for a new incoming client connection
             if (LocalClient.IsServer)
             {
+                var (_, alreadyConnected) = TransportIdToClientId(transportId);
+                if (alreadyConnected)
+                {
+                    if (NetworkLog.CurrentLogLevel <= LogLevel.Developer)
+                    {
+                        NetworkLog.LogError($"[TransportApproval][Server] TransportId {transportId} is already connected to this server!");
+                    }
+                    return;
+                }
+
                 clientId = m_NextClientId++;
             }
+            // Otherwise this connect event is an approved connection from the server
             else
             {
+                if (m_IsTransportConnected)
+                {
+                    if (NetworkLog.CurrentLogLevel <= LogLevel.Developer)
+                    {
+                        NetworkLog.LogError("[TransportApproval][Client] Client received a transport connection event after already connecting!");
+                    }
+                    return;
+                }
+
+                m_IsTransportConnected = true;
+
                 // Cache the local client's transport id.
-                m_LocalClientTransportId = transportClientId;
+                m_LocalClientTransportId = transportId;
                 clientId = NetworkManager.ServerClientId;
             }
 
-            ClientIdToTransportIdMap[clientId] = transportClientId;
-            TransportIdToClientIdMap[transportClientId] = clientId;
+            ClientIdToTransportIdMap[clientId] = transportId;
+            TransportIdToClientIdMap[transportId] = clientId;
             MessageManager.ClientConnected(clientId);
 
             if (LocalClient.IsServer)
@@ -1540,6 +1567,7 @@ namespace Unity.Netcode
             ConnectedClientIds.Clear();
             ClientIdToTransportIdMap.Clear();
             TransportIdToClientIdMap.Clear();
+            m_IsTransportConnected = false;
             ClientsToApprove.Clear();
             NetworkObject.OrphanChildren.Clear();
             m_DisconnectReason = string.Empty;

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/NetworkManagerHooks.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/NetworkManagerHooks.cs
@@ -104,7 +104,7 @@ namespace Unity.Netcode
                     if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
                     {
                         var transportErrorMsg = GetTransportErrorMessage(messageContent, m_NetworkManager);
-                        NetworkLog.LogError($"A {nameof(ConnectionApprovedMessage)} was received from the server when the connection has already been established. {transportErrorMsg}");
+                        NetworkLog.LogError($"A {nameof(ConnectionApprovedMessage)} was received from the server when a connection has already been established. {transportErrorMsg}");
                     }
 
                     return false;
@@ -118,11 +118,11 @@ namespace Unity.Netcode
         {
             if (networkManager.NetworkConfig.NetworkTransport is not UnityTransport)
             {
-                return $"NetworkTransport: {networkManager.NetworkConfig.NetworkTransport.GetType()}. Please report this to the maintainer of transport layer.";
+                return $"NetworkTransport: {networkManager.NetworkConfig.NetworkTransport.GetType()}. Please report this to the maintainer of the transport layer.";
             }
 
             var transportVersion = GetTransportVersion(networkManager);
-            return $"{transportVersion}. This should not happen. Please report this to the Netcode for GameObjects team at https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues and include the following data: Message Size: {messageContent.Length}. Message Content: {NetworkMessageManager.ByteArrayToString(messageContent.ToArray(), 0, messageContent.Length)}";
+            return $"{transportVersion}. This should not happen. Further information: Message Size: {messageContent.Length}. Message Content: {NetworkMessageManager.ByteArrayToString(messageContent.ToArray(), 0, messageContent.Length)}";
         }
 
         private static string GetTransportVersion(NetworkManager networkManager)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/InvalidConnectionEventsTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/InvalidConnectionEventsTest.cs
@@ -96,7 +96,7 @@ namespace Unity.Netcode.RuntimeTests
 
             m_ClientNetworkManagers[0].ConnectionManager.MessageManager.Hook(new Hooks<ConnectionApprovedMessage>());
 
-            LogAssert.Expect(LogType.Error, new Regex($"A {nameof(ConnectionApprovedMessage)} was received from the server when the connection has already been established\\. NetworkTransport: Unity.Netcode.Transports.UTP.UnityTransport UnityTransportProtocol: UnityTransport. This should not happen\\."));
+            LogAssert.Expect(LogType.Error, new Regex($"A {nameof(ConnectionApprovedMessage)} was received from the server when a connection has already been established\\. NetworkTransport: Unity.Netcode.Transports.UTP.UnityTransport UnityTransportProtocol: UnityTransport. This should not happen\\."));
 
             yield return WaitForMessageReceived<UnnamedMessage>(m_ClientNetworkManagers.ToList());
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/MockTransport.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/MockTransport.cs
@@ -19,7 +19,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         public override ulong ServerClientId { get; } = 0;
 
         public static ulong HighTransportId = 0;
-        public ulong TransportId = 0;
+        public ulong TransportId = ulong.MaxValue;
         public float SimulatedLatencySeconds;
         public float PacketDropRate;
         public float LatencyJitter;
@@ -75,15 +75,23 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
         public override bool StartClient()
         {
-            TransportId = ++HighTransportId;
-            s_MessageQueue[TransportId] = new Queue<MessageData>();
+            // TransportId will be the max if it hasn't already been set.
+            if (TransportId == ulong.MaxValue)
+            {
+                TransportId = ++HighTransportId;
+                s_MessageQueue[TransportId] = new Queue<MessageData>();
+            }
             s_MessageQueue[ServerClientId].Enqueue(new MessageData { Event = NetworkEvent.Connect, FromClientId = TransportId, Payload = new ArraySegment<byte>() });
             return true;
         }
 
         public override bool StartServer()
         {
-            s_MessageQueue[ServerClientId] = new Queue<MessageData>();
+            if (TransportId == ulong.MaxValue)
+            {
+                TransportId = ServerClientId;
+                s_MessageQueue[ServerClientId] = new Queue<MessageData>();
+            }
             return true;
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/MockTransport.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/MockTransport.cs
@@ -112,6 +112,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
         public override void Shutdown()
         {
+            TransportId = ulong.MaxValue;
         }
 
         protected override NetworkTopologyTypes OnCurrentTopology()

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/TransportTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/TransportTests.cs
@@ -40,8 +40,27 @@ namespace Unity.Netcode.RuntimeTests
             var newExpectedClients = m_UseHost ? NumberOfClients + 1 : NumberOfClients;
             yield return WaitForConditionOrTimeOut(() => otherClient.ConnectedClientsIds.Count == newExpectedClients);
             AssertOnTimeout($"Incorrect number of connected clients. Expected: {newExpectedClients}, have: {otherClient.ConnectedClientsIds.Count}");
+        }
 
+        [UnityTest]
+        public IEnumerator MultipleConnectMessagesNoop()
+        {
+            var clientToConnect = GetNonAuthorityNetworkManager(0);
+            var clientTransport = clientToConnect.NetworkConfig.NetworkTransport;
 
+            var otherClient = GetNonAuthorityNetworkManager(1);
+
+            var currentConnectedClients = m_UseHost ? NumberOfClients + 1 : NumberOfClients;
+
+            clientTransport.StartClient();
+            clientTransport.StartClient();
+
+            // Start a new client to ensure everything is still working
+            yield return CreateAndStartNewClient();
+
+            var newExpectedClients = currentConnectedClients + 1;
+            yield return WaitForConditionOrTimeOut(() => otherClient.ConnectedClientsIds.Count == newExpectedClients);
+            AssertOnTimeout($"Incorrect number of connected clients. Expected: {newExpectedClients}, have: {otherClient.ConnectedClientsIds.Count}");
         }
     }
 }


### PR DESCRIPTION
## Purpose of this PR

Ensures duplicate events are ignored if the transport layer:
1. Sends the server multiple connection events for the same client
2. Sends a client multiple connection events from the server

### Jira ticket

[UUM-131553](https://jira.unity3d.com/browse/UUM-131553)

### Changelog
[//]: # (updated with all public facing changes  - API changes, UI/UX changes, behaviour changes, bug fixes. Remove if not relevant.)

- Fixed: Duplicate connection events for the same connection will do nothing.


## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- No documentation changes or additions were necessary.
## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [x] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports
No backport needed