### PR TITLE
fix: Fixed issue of RpcTarget not being properly disposed

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -28,6 +28,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed memory leak in `NetworkAnimator` on clients where `RpcTarget` groups were not being properly disposed due to incorrect type casting of `ProxyRpcTargetGroup` to `RpcTargetGroup`.
 - Fixed issue when using a client-server topology where a `NetworkList` with owner write permissions was resetting sent time and dirty flags after having been spawned on owning clients that were not the spawn authority. (#3850)
 - Fixed an integer overflow that occurred when configuring a large disconnect timeout with Unity Transport. (#3810)
 

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
@@ -933,7 +933,6 @@ namespace Unity.Netcode.Components
             {
                 Send = new RpcSendParams()
                 {
-                    // FIX: Use m_TargetGroup.Target to get the BaseRpcTarget
                     Target = m_TargetGroup?.Target
                 }
             };

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
@@ -709,7 +709,7 @@ namespace Unity.Netcode.Components
         private static byte[] s_EmptyArray = new byte[] { };
         private List<int> m_ParametersToUpdate;
         private RpcParams m_RpcParams;
-        private RpcTargetGroup m_TargetGroup;
+        private IGroupRpcTarget m_TargetGroup;
         private AnimationMessage m_AnimationMessage;
         private NetworkAnimatorStateChangeHandler m_NetworkAnimatorStateChangeHandler;
 
@@ -762,7 +762,7 @@ namespace Unity.Netcode.Components
         {
             SpawnCleanup();
 
-            m_TargetGroup?.Dispose();
+            m_TargetGroup?.Target?.Dispose();
 
             if (m_CachedAnimatorParameters != null && m_CachedAnimatorParameters.IsCreated)
             {
@@ -928,12 +928,13 @@ namespace Unity.Netcode.Components
                 NetworkLog.LogWarningServer($"[{gameObject.name}][{nameof(NetworkAnimator)}] {nameof(Animator)} is not assigned! Animation synchronization will not work for this instance!");
             }
 
-            m_TargetGroup = RpcTarget.Group(new List<ulong>(128), RpcTargetUse.Persistent) as RpcTargetGroup;
+            m_TargetGroup = RpcTarget.Group(new List<ulong>(128), RpcTargetUse.Persistent) as IGroupRpcTarget;
             m_RpcParams = new RpcParams()
             {
                 Send = new RpcSendParams()
                 {
-                    Target = m_TargetGroup
+                    // FIX: Use m_TargetGroup.Target to get the BaseRpcTarget
+                    Target = m_TargetGroup?.Target
                 }
             };
 
@@ -1219,7 +1220,7 @@ namespace Unity.Netcode.Components
                         }
                         m_TargetGroup.Add(clientId);
                     }
-                    m_RpcParams.Send.Target = m_TargetGroup;
+                    m_RpcParams.Send.Target = m_TargetGroup.Target;
                     SendClientAnimStateRpc(m_AnimationMessage, m_RpcParams);
                 }
             }
@@ -1555,7 +1556,7 @@ namespace Unity.Netcode.Components
                     m_TargetGroup.Add(clientId);
                 }
 
-                m_RpcParams.Send.Target = m_TargetGroup;
+                m_RpcParams.Send.Target = m_TargetGroup.Target;
                 m_NetworkAnimatorStateChangeHandler.SendParameterUpdate(parametersUpdate, m_RpcParams);
             }
         }
@@ -1621,7 +1622,7 @@ namespace Unity.Netcode.Components
                     }
                     m_TargetGroup.Add(clientId);
                 }
-                m_RpcParams.Send.Target = m_TargetGroup;
+                m_RpcParams.Send.Target = m_TargetGroup.Target;
                 m_NetworkAnimatorStateChangeHandler.SendAnimationUpdate(animationMessage, m_RpcParams);
             }
         }


### PR DESCRIPTION
## Purpose of this PR
This PR aims to resolve a memory leak issue reported in https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/3852

The bug was a memory leak in NetworkAnimator on clients due to RpcTarget not being properly disposed. 
The cause of it was that in `NetworkAnimator.OnNetworkSpawn()`, the code cast the result of `RpcTarget.Group()` to `RpcTargetGroup`. On clients, `RpcTarget.Group()` returns a `ProxyRpcTargetGroup` (not `RpcTargetGroup`), so the cast returned null. The `ProxyRpcTargetGroup` with its `NativeList<ulong>` (allocated with `Allocator.Persistent`) was then leaked.
The fix was to change `m_TargetGroup` to use the `IGroupRpcTarget` interface (which both `RpcTargetGroup` and `ProxyRpcTargetGroup` implement)

By using IGroupRpcTarget (the interface both implement), m_TargetGroup can now hold:

- RpcTargetGroup when running on server
- ProxyRpcTargetGroup when running on client

The code only uses interface methods (Add(), Clear(), Target), so it works correctly regardless of which concrete class is stored.

### Jira ticket
https://jira.unity3d.com/browse/UUM-133278

### Changelog

- Fixed: memory leak in `NetworkAnimator` on clients where `RpcTarget` groups were not being properly disposed due to incorrect type casting of `ProxyRpcTargetGroup` to `RpcTargetGroup`.

## Documentation
N/A

## Testing & QA (How your changes can be verified during release Playtest)
I confirmed that when using latest `develop-2.0.0` the issue was reproducible in the project but is not reproducible when using this branch

## Backports
N/A
