### PR TITLE
fix: networkvariable not synchronizing changes made during spawn or post-spawn.

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -24,6 +24,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where `NetworkVariable` was not properly synchronizing to changes made by the spawn and write authority during `OnNetworkSpawn` and `OnNetworkPostSpawn`. (#3878)
 - Fixed issue where `NetworkManager` was not cleaning itself up if an exception was thrown while starting. (#3864)
 - Prevented a `NullReferenceException` in `UnityTransport` when using a custom `INetworkStreamDriverConstructor` that doesn't use all the default pipelines and the multiplayer tools package is installed. (#3853)
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -838,7 +838,7 @@ namespace Unity.Netcode
             // all spawn related methods have been invoked.
             for (int i = 0; i < NetworkVariableFields.Count; i++)
             {
-                NetworkVariableFields[i].OnSpawned();
+                NetworkVariableFields[i].InternalOnSpawned();
             }
         }
 
@@ -891,7 +891,7 @@ namespace Unity.Netcode
             // all spawn related methods have been invoked.
             for (int i = 0; i < NetworkVariableFields.Count; i++)
             {
-                NetworkVariableFields[i].OnPreDespawn();
+                NetworkVariableFields[i].InternalOnPreDespawn();
             }
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -61,17 +61,17 @@ namespace Unity.Netcode
         internal override void OnSpawned()
         {
             // If the NetworkList is:
+            // - On the spawn authority side.
             // - Dirty
             // - State updates can be sent:
             // -- The instance has write permissions.
             // -- The last sent time plus the max send time period is less than the current time.
             // - User script has modified the list during spawn.
-            // - This instance is on the spawn authority side.
             // When the NetworkObject is finished spawning (on the same frame), go ahead and reset
             // the dirty related properties and last sent time to prevent duplicate entries from
             // being sent (i.e. CreateObjectMessage will contain the changes so we don't need to
             // send a proceeding NetworkVariableDeltaMessage).
-            if (IsDirty() && CanSend() && m_NetworkObject.IsSpawnAuthority)
+            if (m_NetworkObject.IsSpawnAuthority && IsDirty() && CanWrite() && CanSend())
             {
                 UpdateLastSentTime();
                 ResetDirty();

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -58,28 +58,6 @@ namespace Unity.Netcode
             Dispose();
         }
 
-        internal override void OnSpawned()
-        {
-            // If the NetworkList is:
-            // - On the spawn authority side.
-            // - Dirty
-            // - State updates can be sent:
-            // -- The instance has write permissions.
-            // -- The last sent time plus the max send time period is less than the current time.
-            // - User script has modified the list during spawn.
-            // When the NetworkObject is finished spawning (on the same frame), go ahead and reset
-            // the dirty related properties and last sent time to prevent duplicate entries from
-            // being sent (i.e. CreateObjectMessage will contain the changes so we don't need to
-            // send a proceeding NetworkVariableDeltaMessage).
-            if (m_NetworkObject.IsSpawnAuthority && IsDirty() && CanWrite() && CanSend())
-            {
-                UpdateLastSentTime();
-                ResetDirty();
-                SetDirty(false);
-            }
-            base.OnSpawned();
-        }
-
         /// <inheritdoc cref="NetworkVariable{T}.ResetDirty"/>
         public override void ResetDirty()
         {

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -413,7 +413,7 @@ namespace Unity.Netcode
         /// </summary>
         internal override void OnSpawned()
         {
-            // Assure any changes made to any NetworkVariable during spawn or post-spawn are
+            // Assure any changes made to this NetworkVariable during spawn or post-spawn are
             // serialized with the CreateObjectMessage.
             if (IsDirty() && CanSend())
             {

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -407,30 +407,5 @@ namespace Unity.Netcode
                 base.WriteFieldSynchronization(writer);
             }
         }
-
-        /// <summary>
-        /// Notification we have fully spawned the associated <see cref="NetworkObject"/>.
-        /// </summary>
-        internal override void OnSpawned()
-        {
-            // If the NetworkVariable is:
-            // - On the spawn authority side.
-            // - Dirty.
-            // - State updates can be sent:
-            // -- The instance has write permissions.
-            // -- The last sent time plus the max send time period is less than the current time.
-            // - User script has modified the list during spawn.
-            // When the NetworkObject is finished spawning (on the same frame), go ahead and reset
-            // the dirty related properties and last sent time to prevent duplicate updates from
-            // being sent (i.e. CreateObjectMessage will contain the changes so we don't need to
-            // send a proceeding NetworkVariableDeltaMessage).
-            if (m_NetworkObject.IsSpawnAuthority && IsDirty() && CanWrite() && CanSend())
-            {
-                UpdateLastSentTime();
-                ResetDirty();
-                SetDirty(false);
-            }
-            base.OnSpawned();
-        }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -415,7 +415,12 @@ namespace Unity.Netcode
         {
             // Assure any changes made to any NetworkVariable during spawn or post-spawn are
             // serialized with the CreateObjectMessage.
-            m_NetworkBehaviour.PostNetworkVariableWrite(true);
+            if (IsDirty() && CanSend())
+            {
+                UpdateLastSentTime();
+                ResetDirty();
+                SetDirty(false);
+            }
             base.OnSpawned();
         }
     }

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -407,5 +407,11 @@ namespace Unity.Netcode
                 base.WriteFieldSynchronization(writer);
             }
         }
+
+        internal override void OnSpawned()
+        {
+            m_NetworkBehaviour.PostNetworkVariableWrite(true);
+            base.OnSpawned();
+        }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -413,9 +413,18 @@ namespace Unity.Netcode
         /// </summary>
         internal override void OnSpawned()
         {
-            // Assure any changes made to this NetworkVariable during spawn or post-spawn are
-            // serialized with the CreateObjectMessage.
-            if (IsDirty() && CanSend())
+            // If the NetworkVariable is:
+            // - On the spawn authority side.
+            // - Dirty.
+            // - State updates can be sent:
+            // -- The instance has write permissions.
+            // -- The last sent time plus the max send time period is less than the current time.
+            // - User script has modified the list during spawn.
+            // When the NetworkObject is finished spawning (on the same frame), go ahead and reset
+            // the dirty related properties and last sent time to prevent duplicate updates from
+            // being sent (i.e. CreateObjectMessage will contain the changes so we don't need to
+            // send a proceeding NetworkVariableDeltaMessage).
+            if (m_NetworkObject.IsSpawnAuthority && IsDirty() && CanWrite() && CanSend())
             {
                 UpdateLastSentTime();
                 ResetDirty();

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariable.cs
@@ -408,8 +408,13 @@ namespace Unity.Netcode
             }
         }
 
+        /// <summary>
+        /// Notification we have fully spawned the associated <see cref="NetworkObject"/>.
+        /// </summary>
         internal override void OnSpawned()
         {
+            // Assure any changes made to any NetworkVariable during spawn or post-spawn are
+            // serialized with the CreateObjectMessage.
             m_NetworkBehaviour.PostNetworkVariableWrite(true);
             base.OnSpawned();
         }

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableBase.cs
@@ -140,27 +140,37 @@ namespace Unity.Netcode
             }
         }
 
-        /// TODO-API: After further vetting and alignment on these, we might make them part of the public API.
-        /// Could actually be like an interface that gets automatically registered for these kinds of notifications
-        /// without having to be a NetworkBehaviour.
-        #region OnSpawn and OnPreDespawn (ETC)
-
         /// <summary>
         /// Invoked after the associated <see cref="NetworkBehaviour.OnNetworkPostSpawn"/> has been invoked.
         /// </summary>
-        internal virtual void OnSpawned()
+        internal void InternalOnSpawned()
         {
-
+            // If the NetworkVariableBase derived class is:
+            // - On the spawn authority side.
+            // - Dirty.
+            // - State updates can be sent:
+            // -- The instance has write permissions.
+            // -- The last sent time plus the max send time period is less than the current time.
+            // - User script has modified the list during spawn.
+            // When the NetworkObject is finished spawning (on the same frame), go ahead and reset
+            // the dirty related properties and last sent time to prevent duplicate updates from
+            // being sent (i.e. CreateObjectMessage will contain the changes so we don't need to
+            // send a proceeding NetworkVariableDeltaMessage).
+            if (m_NetworkObject.IsSpawnAuthority && IsDirty() && CanWrite() && CanSend())
+            {
+                UpdateLastSentTime();
+                ResetDirty();
+                SetDirty(false);
+            }
         }
 
         /// <summary>
         /// Invoked after the associated <see cref="NetworkBehaviour.OnNetworkPreDespawn"/> has been invoked.
         /// </summary>
-        internal virtual void OnPreDespawn()
+        internal void InternalOnPreDespawn()
         {
 
         }
-        #endregion
 
         /// <summary>
         /// Deinitialize is invoked when a NetworkObject is despawned.

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableCollectionsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableCollectionsTests.cs
@@ -781,6 +781,12 @@ namespace Unity.Netcode.RuntimeTests
             }
 
             m_CurrentKey = 1000;
+            // Temporarily enabling debug mode on host only.
+            // TODO: Need to track down why host is the only failing test.
+            // NOTES: It seems the tracked changes get adjusted for only a host which would have the player object.
+            // This could be due to when the player is spawned on the host relative to the other clients.
+            m_EnableDebug = m_ServerNetworkManager.IsHost;
+            m_EnableVerboseDebug = m_ServerNetworkManager.IsHost;
             if (m_EnableDebug)
             {
                 VerboseDebug(">>>>>>>>>>>>>>>>>>>>>>>>>>>>> Init Values <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<");
@@ -831,7 +837,7 @@ namespace Unity.Netcode.RuntimeTests
                 {
                     // Server-side add same key and SerializableObject prior to being added to the owner side
                     compDictionaryServer.ListCollectionOwner.Value.Add(newEntry.Item1, newEntry.Item2);
-                    // Checking if dirty on server side should revert back to origina known current dictionary state
+                    // Checking if dirty on server side should revert back to original known current dictionary state
                     compDictionaryServer.ListCollectionOwner.IsDirty();
                     yield return WaitForConditionOrTimeOut(() => compDictionaryServer.CompareTrackedChanges(ListTestHelperBase.Targets.Owner));
                     AssertOnTimeout($"Server add to owner write collection property failed to restore on {className} {compDictionaryServer.name}! {compDictionaryServer.GetLog()}");
@@ -840,7 +846,6 @@ namespace Unity.Netcode.RuntimeTests
                     // Server-side add a completely new key and SerializableObject to to owner write permission property
                     compDictionaryServer.ListCollectionOwner.Value.Add(GetNextKey(), SerializableObject.GetRandomObject());
                     // Both should be overridden by the owner-side update
-
                 }
                 VerboseDebug($"[{compDictionary.name}][Owner] Adding Key: {newEntry.Item1}");
                 // Add key and SerializableObject to owner side
@@ -857,7 +862,7 @@ namespace Unity.Netcode.RuntimeTests
                 {
                     // Client-side add same key and SerializableObject to server write permission property
                     compDictionary.ListCollectionServer.Value.Add(newEntry.Item1, newEntry.Item2);
-                    // Checking if dirty on client side should revert back to origina known current dictionary state
+                    // Checking if dirty on client side should revert back to original known current dictionary state
                     compDictionary.ListCollectionServer.IsDirty();
                     yield return WaitForConditionOrTimeOut(() => compDictionary.CompareTrackedChanges(ListTestHelperBase.Targets.Server));
                     AssertOnTimeout($"Client-{client.LocalClientId} add to server write collection property failed to restore on {className} {compDictionary.name}! {compDictionary.GetLog()}");
@@ -892,7 +897,6 @@ namespace Unity.Netcode.RuntimeTests
 
                 yield return WaitForConditionOrTimeOut(() => compDictionaryServer.ValidateInstances());
                 AssertOnTimeout($"[Server] Not all instances of client-{compDictionaryServer.OwnerClientId}'s {className} {compDictionaryServer.name} component match! {compDictionaryServer.GetLog()}");
-
                 ValidateClientsFlat(client);
                 ////////////////////////////////////
                 // Owner Change SerializableObject Entry
@@ -915,7 +919,7 @@ namespace Unity.Netcode.RuntimeTests
                     {
                         // Server-side update same key value prior to being updated to the owner side
                         compDictionaryServer.ListCollectionOwner.Value[valueInt] = randomObject;
-                        // Checking if dirty on server side should revert back to origina known current dictionary state
+                        // Checking if dirty on server side should revert back to original known current dictionary state
                         compDictionaryServer.ListCollectionOwner.IsDirty();
                         yield return WaitForConditionOrTimeOut(() => compDictionaryServer.CompareTrackedChanges(ListTestHelperBase.Targets.Owner));
                         AssertOnTimeout($"Server update collection entry value to local owner write collection property failed to restore on {className} {compDictionaryServer.name}! {compDictionaryServer.GetLog()}");
@@ -956,7 +960,7 @@ namespace Unity.Netcode.RuntimeTests
                     {
                         // Owner-side update same key value prior to being updated to the server side
                         compDictionary.ListCollectionServer.Value[valueInt] = randomObject;
-                        // Checking if dirty on owner side should revert back to origina known current dictionary state
+                        // Checking if dirty on owner side should revert back to original known current dictionary state
                         compDictionary.ListCollectionServer.IsDirty();
                         yield return WaitForConditionOrTimeOut(() => compDictionary.CompareTrackedChanges(ListTestHelperBase.Targets.Server));
                         AssertOnTimeout($"Client-{client.LocalClientId} update collection entry value to local server write collection property failed to restore on {className} {compDictionary.name}! {compDictionary.GetLog()}");
@@ -1014,6 +1018,9 @@ namespace Unity.Netcode.RuntimeTests
                     m_Stage = 0;
                 }
             }
+
+            m_EnableDebug = false;
+            m_EnableVerboseDebug = false;
         }
 
         [UnityTest]
@@ -1844,7 +1851,7 @@ namespace Unity.Netcode.RuntimeTests
                 LogMessage($"Comparing {deltaType}:");
                 if (local[deltaType].Count != other[deltaType].Count)
                 {
-                    LogMessage($"{deltaType}s count did not match!");
+                    LogMessage($"[Client-{clientId}] {deltaType}s count {other[deltaType].Count} did not match the local count {local[deltaType].Count}!");
                     return false;
                 }
                 if (!CompareDictionaries(clientId, local[deltaType], other[deltaType]))

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableCollectionsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableCollectionsTests.cs
@@ -780,11 +780,6 @@ namespace Unity.Netcode.RuntimeTests
                 m_Clients.Insert(0, m_ServerNetworkManager);
             }
 
-            foreach (var client in m_Clients)
-            {
-                client.LogLevel = LogLevel.Developer;
-            }
-
             m_CurrentKey = 1000;
             if (m_EnableDebug)
             {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableCollectionsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableCollectionsTests.cs
@@ -859,29 +859,8 @@ namespace Unity.Netcode.RuntimeTests
                     compDictionary.ListCollectionServer.Value.Add(newEntry.Item1, newEntry.Item2);
                     // Checking if dirty on client side should revert back to original known current dictionary state
                     compDictionary.ListCollectionServer.IsDirty();
-                    if (!m_ServerNetworkManager.IsHost)
-                    {
-                        yield return WaitForConditionOrTimeOut(() => compDictionary.CompareTrackedChanges(ListTestHelperBase.Targets.Server));
-                        AssertOnTimeout($"Client-{client.LocalClientId} add to server write collection property failed to restore on {className} {compDictionary.name}! {compDictionary.GetLog()}");
-                    }
-                    else // Host, for some reason, does not have changes tracked but the dictionaries match... ????
-                    {
-                        // TODO: Need to track down why host is the only failing test.
-                        // NOTES: It seems only the host doesn't track changes made on the owner write permissions (i.e. issue with test itself?),
-                        // but when comparing the values of the dictionaries everything passes (i.e. dictionaries are synchronized)
-                        var compDictionaryTest = (DictionaryTestHelper)null;
-                        var compDictionaryServerTest = (DictionaryTestHelper)null;
-                        var classNameTest = $"{nameof(DictionaryTestHelper)}";
-                        foreach (var clientTest in m_Clients)
-                        {
-                            ///////////////////////////////////////////////////////////////////////////
-                            // Dictionary<int, Dictionary<int,SerializableObject>> nested dictionaries
-                            compDictionaryTest = clientTest.LocalClient.PlayerObject.GetComponent<DictionaryTestHelper>();
-                            compDictionaryServerTest = m_PlayerNetworkObjects[NetworkManager.ServerClientId][clientTest.LocalClientId].GetComponent<DictionaryTestHelper>();
-                            Assert.True(compDictionaryTest.ValidateInstances(), $"[Owner] Not all instances of client-{compDictionaryTest.OwnerClientId}'s {classNameTest} {compDictionaryTest.name} component match! {compDictionaryTest.GetLog()}");
-                            Assert.True(compDictionaryServerTest.ValidateInstances(), $"[Server] Not all instances of client-{compDictionaryServerTest.OwnerClientId}'s {classNameTest} {compDictionaryServerTest.name} component match! {compDictionaryServerTest.GetLog()}");
-                        }
-                    }
+                    yield return WaitForConditionOrTimeOut(() => compDictionary.CompareTrackedChanges(ListTestHelperBase.Targets.Server));
+                    AssertOnTimeout($"Client-{client.LocalClientId} add to server write collection property failed to restore on {className} {compDictionary.name}! {compDictionary.GetLog()}");
 
                     // Client-side add the same key and SerializableObject to server write permission property (would throw key exists exception too if previous failed)
                     compDictionary.ListCollectionServer.Value.Add(newEntry.Item1, newEntry.Item2);
@@ -1865,7 +1844,7 @@ namespace Unity.Netcode.RuntimeTests
             var deltaTypes = Enum.GetValues(typeof(DeltaTypes)).OfType<DeltaTypes>().ToList();
             foreach (var deltaType in deltaTypes)
             {
-                LogMessage($"Comparing {deltaType}:");
+                LogMessage($"[Comparing {deltaType}] Local: {local[deltaType].Count} | Other: {other[deltaType].Count}");
                 if (local[deltaType].Count != other[deltaType].Count)
                 {
                     LogMessage($"[Client-{clientId}] Local {deltaType}s count of {local[deltaType].Count} did not match the other's count of {other[deltaType].Count}!");
@@ -1994,6 +1973,18 @@ namespace Unity.Netcode.RuntimeTests
             contextTable[DeltaTypes.Removed] = whatWasRemoved;
             contextTable[DeltaTypes.Changed] = whatChanged;
             contextTable[DeltaTypes.UnChanged] = whatRemainedTheSame;
+
+            // Log all incoming changes when debug mode is enabled
+            if (!IsOwner && IsDebugMode)
+            {
+                LogMessage($"[{NetworkManager.name}][TrackChanges-> Client-{OwnerClientId}] Collection was updated!");
+                LogMessage($"Added: {whatWasAdded.Count} ");
+                LogMessage($"Removed: {whatWasRemoved.Count} ");
+                LogMessage($"Changed: {whatChanged.Count} ");
+                LogMessage($"UnChanged: {whatRemainedTheSame.Count} ");
+                UnityEngine.Debug.Log($"{GetLog()}");
+                LogStart();
+            }
         }
 
         public void OnServerListValuesChanged(Dictionary<int, SerializableObject> previous, Dictionary<int, SerializableObject> current)
@@ -2058,13 +2049,24 @@ namespace Unity.Netcode.RuntimeTests
             if (IsServer)
             {
                 ListCollectionServer.Value = OnSetServerValues();
-                //ListCollectionOwner.CheckDirtyState();
+                ListCollectionServer.CheckDirtyState();
             }
 
             if (IsOwner)
             {
                 ListCollectionOwner.Value = OnSetOwnerValues();
-                //ListCollectionOwner.CheckDirtyState();
+                ListCollectionOwner.CheckDirtyState();
+            }
+
+            // When running a host, the changes being tracked will not match because clients will be synchronized with changes
+            // already applied. This fixing this issue by injecting "added" server targeted changes during initialization on
+            // the connected clients' side.
+            if (!IsServer)
+            {
+                if (ListCollectionServer.Value.Count > 0 && NetworkVariableChanges[Targets.Server][DeltaTypes.Added].Count == 0)
+                {
+                    TrackChanges(Targets.Server, new Dictionary<int, SerializableObject>(), ListCollectionServer.Value);
+                }
             }
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableCollectionsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableCollectionsTests.cs
@@ -1014,9 +1014,6 @@ namespace Unity.Netcode.RuntimeTests
                     m_Stage = 0;
                 }
             }
-
-            m_EnableDebug = false;
-            m_EnableVerboseDebug = false;
         }
 
         [UnityTest]

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableCollectionsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableCollectionsTests.cs
@@ -780,13 +780,12 @@ namespace Unity.Netcode.RuntimeTests
                 m_Clients.Insert(0, m_ServerNetworkManager);
             }
 
+            foreach (var client in m_Clients)
+            {
+                client.LogLevel = LogLevel.Developer;
+            }
+
             m_CurrentKey = 1000;
-            // Temporarily enabling debug mode on host only.
-            // TODO: Need to track down why host is the only failing test.
-            // NOTES: It seems the tracked changes get adjusted for only a host which would have the player object.
-            // This could be due to when the player is spawned on the host relative to the other clients.
-            m_EnableDebug = m_ServerNetworkManager.IsHost;
-            m_EnableVerboseDebug = m_ServerNetworkManager.IsHost;
             if (m_EnableDebug)
             {
                 VerboseDebug(">>>>>>>>>>>>>>>>>>>>>>>>>>>>> Init Values <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<");
@@ -857,6 +856,7 @@ namespace Unity.Netcode.RuntimeTests
                 //////////////////////////////////
                 // Server Add SerializableObject Entry
                 newEntry = (GetNextKey(), SerializableObject.GetRandomObject());
+
                 // Only test restore on non-host clients (otherwise a host is both server and client/owner)
                 if (!client.IsServer)
                 {
@@ -864,8 +864,30 @@ namespace Unity.Netcode.RuntimeTests
                     compDictionary.ListCollectionServer.Value.Add(newEntry.Item1, newEntry.Item2);
                     // Checking if dirty on client side should revert back to original known current dictionary state
                     compDictionary.ListCollectionServer.IsDirty();
-                    yield return WaitForConditionOrTimeOut(() => compDictionary.CompareTrackedChanges(ListTestHelperBase.Targets.Server));
-                    AssertOnTimeout($"Client-{client.LocalClientId} add to server write collection property failed to restore on {className} {compDictionary.name}! {compDictionary.GetLog()}");
+                    if (!m_ServerNetworkManager.IsHost)
+                    {
+                        yield return WaitForConditionOrTimeOut(() => compDictionary.CompareTrackedChanges(ListTestHelperBase.Targets.Server));
+                        AssertOnTimeout($"Client-{client.LocalClientId} add to server write collection property failed to restore on {className} {compDictionary.name}! {compDictionary.GetLog()}");
+                    }
+                    else // Host, for some reason, does not have changes tracked but the dictionaries match... ????
+                    {
+                        // TODO: Need to track down why host is the only failing test.
+                        // NOTES: It seems only the host doesn't track changes made on the owner write permissions (i.e. issue with test itself?),
+                        // but when comparing the values of the dictionaries everything passes (i.e. dictionaries are synchronized)
+                        var compDictionaryTest = (DictionaryTestHelper)null;
+                        var compDictionaryServerTest = (DictionaryTestHelper)null;
+                        var classNameTest = $"{nameof(DictionaryTestHelper)}";
+                        foreach (var clientTest in m_Clients)
+                        {
+                            ///////////////////////////////////////////////////////////////////////////
+                            // Dictionary<int, Dictionary<int,SerializableObject>> nested dictionaries
+                            compDictionaryTest = clientTest.LocalClient.PlayerObject.GetComponent<DictionaryTestHelper>();
+                            compDictionaryServerTest = m_PlayerNetworkObjects[NetworkManager.ServerClientId][clientTest.LocalClientId].GetComponent<DictionaryTestHelper>();
+                            Assert.True(compDictionaryTest.ValidateInstances(), $"[Owner] Not all instances of client-{compDictionaryTest.OwnerClientId}'s {classNameTest} {compDictionaryTest.name} component match! {compDictionaryTest.GetLog()}");
+                            Assert.True(compDictionaryServerTest.ValidateInstances(), $"[Server] Not all instances of client-{compDictionaryServerTest.OwnerClientId}'s {classNameTest} {compDictionaryServerTest.name} component match! {compDictionaryServerTest.GetLog()}");
+                        }
+                    }
+
                     // Client-side add the same key and SerializableObject to server write permission property (would throw key exists exception too if previous failed)
                     compDictionary.ListCollectionServer.Value.Add(newEntry.Item1, newEntry.Item2);
                     // Client-side add a completely new key and SerializableObject to to server write permission property
@@ -1851,7 +1873,7 @@ namespace Unity.Netcode.RuntimeTests
                 LogMessage($"Comparing {deltaType}:");
                 if (local[deltaType].Count != other[deltaType].Count)
                 {
-                    LogMessage($"[Client-{clientId}] {deltaType}s count {other[deltaType].Count} did not match the local count {local[deltaType].Count}!");
+                    LogMessage($"[Client-{clientId}] Local {deltaType}s count of {local[deltaType].Count} did not match the other's count of {other[deltaType].Count}!");
                     return false;
                 }
                 if (!CompareDictionaries(clientId, local[deltaType], other[deltaType]))
@@ -2023,8 +2045,8 @@ namespace Unity.Netcode.RuntimeTests
 
         protected override void OnNetworkPostSpawn()
         {
-            TrackRelativeInstances();
 
+            TrackRelativeInstances();
             ListCollectionServer.OnValueChanged += OnServerListValuesChanged;
             ListCollectionOwner.OnValueChanged += OnOwnerListValuesChanged;
 
@@ -2032,6 +2054,8 @@ namespace Unity.Netcode.RuntimeTests
             {
                 InitValues();
             }
+
+            base.OnNetworkPostSpawn();
         }
 
         public void InitValues()
@@ -2039,13 +2063,13 @@ namespace Unity.Netcode.RuntimeTests
             if (IsServer)
             {
                 ListCollectionServer.Value = OnSetServerValues();
-                ListCollectionOwner.CheckDirtyState();
+                //ListCollectionOwner.CheckDirtyState();
             }
 
             if (IsOwner)
             {
                 ListCollectionOwner.Value = OnSetOwnerValues();
-                ListCollectionOwner.CheckDirtyState();
+                //ListCollectionOwner.CheckDirtyState();
             }
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableGeneralTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableGeneralTests.cs
@@ -1,0 +1,168 @@
+using System.Collections;
+using System.Text;
+using NUnit.Framework;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    /// <summary>
+    /// General <see cref="NetworkVariable{T}"/> integration tests.
+    /// </summary>
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.DAHost)]
+    [TestFixture(HostOrServer.Server)]
+    internal class NetworkVariableGeneralTests : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 2;
+
+        private GameObject m_PrefabToSpawn;
+        private GeneralNetVarTest m_AuthorityNetVarTest;
+
+        internal class GeneralNetVarTest : NetworkBehaviour
+        {
+            /// <summary>
+            /// NetworkVariable that is set by the authority during spawn.
+            /// </summary>
+            public NetworkVariable<float> TestValueOnSpawn = new NetworkVariable<float>(default);
+            /// <summary>
+            /// NetworkVariable that is set by the authority during post spawn.
+            /// </summary>
+            public NetworkVariable<float> TestValueOnPostSpawn = new NetworkVariable<float>(default);
+
+            /// <summary>
+            /// Field value set to <see cref="TestValueOnSpawn.Value"/> during <see cref="NetworkBehaviour.OnNetworkSpawn"/>.
+            /// </summary>
+            public float OnNetworkSpawnValue;
+
+            /// <summary>
+            /// Field value set to <see cref="TestValueOnPostSpawn.Value"/> during <see cref="NetworkBehaviour.OnNetworkSpawn"/>.
+            /// </summary>
+            public float OnNetworkPostSpawnValue;
+
+            public override void OnNetworkSpawn()
+            {
+                if (HasAuthority)
+                {
+                    TestValueOnSpawn.Value = Random.Range(0.01f, 100.0f);
+                }
+                else
+                {
+                    // Only set these values during OnNetworkSpawn to 
+                    // verify this value is valid for non-authority instances.
+                    OnNetworkSpawnValue = TestValueOnSpawn.Value;
+                    OnNetworkPostSpawnValue = TestValueOnPostSpawn.Value;
+                }
+                base.OnNetworkSpawn();
+            }
+
+            protected override void OnNetworkPostSpawn()
+            {
+                if (HasAuthority)
+                {
+                    TestValueOnPostSpawn.Value = Random.Range(0.01f, 100.0f);
+                }
+                base.OnNetworkPostSpawn();
+            }
+        }
+
+        public NetworkVariableGeneralTests(HostOrServer host) : base(host) { }
+
+        protected override void OnServerAndClientsCreated()
+        {
+            m_PrefabToSpawn = CreateNetworkObjectPrefab("TestNetVar");
+            m_PrefabToSpawn.AddComponent<GeneralNetVarTest>();
+            base.OnServerAndClientsCreated();
+        }
+
+        /// <summary>
+        /// Verifies that upon spawn or post spawn the value is set within OnNetworkSpawn on the
+        /// non-authority instances.
+        /// </summary>
+        private bool SpawnValuesMatch(StringBuilder errorLog)
+        {
+            var authority = GetAuthorityNetworkManager();
+            var authorityOnSpawnValue = m_AuthorityNetVarTest.TestValueOnSpawn.Value;
+            var authorityOnPostSpawnValue = m_AuthorityNetVarTest.TestValueOnPostSpawn.Value;
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                if (authority)
+                {
+                    continue;
+                }
+                if (!networkManager.SpawnManager.SpawnedObjects.ContainsKey(m_AuthorityNetVarTest.NetworkObjectId))
+                {
+                    errorLog.AppendLine($"[{networkManager.name}] Does not have a spawned instance of {m_AuthorityNetVarTest.name}!");
+                    continue;
+                }
+                var netVarTest = networkManager.SpawnManager.SpawnedObjects[m_AuthorityNetVarTest.NetworkObjectId].GetComponent<GeneralNetVarTest>();
+                if (netVarTest.OnNetworkSpawnValue != authorityOnSpawnValue)
+                {
+                    errorLog.AppendLine($"[{networkManager.name}][OnNetworkSpawn Value] Non-authority value: {netVarTest.OnNetworkSpawnValue} does not match " +
+                        $"the authority value: {authorityOnSpawnValue}!");
+                }
+                if (netVarTest.OnNetworkPostSpawnValue != authorityOnPostSpawnValue)
+                {
+                    errorLog.AppendLine($"[{networkManager.name}][OnNetworkPostSpawn Value] Non-authority value: {netVarTest.OnNetworkPostSpawnValue} does not match " +
+                        $"the authority value: {authorityOnPostSpawnValue}!");
+                }
+            }
+            return errorLog.Length == 0;
+        }
+
+        /// <summary>
+        /// Verifies that changing the value synchronizes properly.
+        /// </summary>
+        private bool ChangedValueMatches(StringBuilder errorLog)
+        {
+            var authority = GetAuthorityNetworkManager();
+            var authorityValue = m_AuthorityNetVarTest.TestValueOnSpawn.Value;
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                if (authority)
+                {
+                    continue;
+                }
+                var netVarTest = networkManager.SpawnManager.SpawnedObjects[m_AuthorityNetVarTest.NetworkObjectId].GetComponent<GeneralNetVarTest>();
+                if (netVarTest.TestValueOnSpawn.Value != authorityValue)
+                {
+                    errorLog.AppendLine($"[{networkManager.name}][Changed] Non-auhoroty value: {netVarTest.TestValueOnSpawn.Value} does not match " +
+                        $"the authority value: {authorityValue}!");
+                }
+            }
+            return errorLog.Length == 0;
+        }
+
+        /// <summary>
+        /// Validates when the authority applies a <see cref="NetworkVariable{T}"/> value during spawn or
+        /// post spawn of a newly instantiated and spawned object the value is set by the time non-authority
+        /// instances invoke <see cref="NetworkBehaviour.OnNetworkSpawn"/>.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ApplyValueDuringSpawnSequence()
+        {
+            var authority = GetAuthorityNetworkManager();
+            m_AuthorityNetVarTest = SpawnObject(m_PrefabToSpawn, authority).GetComponent<GeneralNetVarTest>();
+            yield return WaitForSpawnedOnAllOrTimeOut(m_AuthorityNetVarTest.gameObject);
+            AssertOnTimeout($"Not all clients spawned {m_AuthorityNetVarTest.name}!");
+
+            yield return WaitForConditionOrTimeOut(SpawnValuesMatch);
+            AssertOnTimeout($"Values did not match for {m_AuthorityNetVarTest.name}!");
+
+            // Verify late joined clients synchronize correctly
+            yield return CreateAndStartNewClient();
+
+            yield return WaitForSpawnedOnAllOrTimeOut(m_AuthorityNetVarTest.gameObject);
+            AssertOnTimeout($"Not all clients spawned {m_AuthorityNetVarTest.name}!");
+
+            yield return WaitForConditionOrTimeOut(SpawnValuesMatch);
+            AssertOnTimeout($"Values did not match for {m_AuthorityNetVarTest.name}!");
+
+            // Verify changing the value synchronizes properly
+            m_AuthorityNetVarTest.TestValueOnSpawn.Value += Random.Range(0.01f, 100.0f);
+            yield return WaitForConditionOrTimeOut(ChangedValueMatches);
+            AssertOnTimeout($"Values did not match for {m_AuthorityNetVarTest.name}!");
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableGeneralTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableGeneralTests.cs
@@ -49,7 +49,7 @@ namespace Unity.Netcode.RuntimeTests
                 }
                 else
                 {
-                    // Only set these values during OnNetworkSpawn to 
+                    // Only set these values during OnNetworkSpawn to
                     // verify this value is valid for non-authority instances.
                     OnNetworkSpawnValue = TestValueOnSpawn.Value;
                     OnNetworkPostSpawnValue = TestValueOnPostSpawn.Value;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableGeneralTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableGeneralTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e5a5c7d93dfa81642a2138c3cc5e3300

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/OwnerModifiedTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/OwnerModifiedTests.cs
@@ -154,20 +154,26 @@ namespace Unity.Netcode.RuntimeTests
             Assert.True(OwnerModifiedObject.Updates > 20);
         }
 
-
-        private ChangeValueOnAuthority m_SessionAuthorityInstance;
         private ChangeValueOnAuthority m_InstanceAuthority;
 
         private bool NetworkVariablesMatch(StringBuilder errorLog)
         {
             foreach (var networkManager in m_NetworkManagers)
             {
+                var changeValue = networkManager.SpawnManager.SpawnedObjects[m_InstanceAuthority.NetworkObjectId].GetComponent<ChangeValueOnAuthority>();
                 if (networkManager == m_InstanceAuthority.NetworkManager)
                 {
+                    if (m_InstanceAuthority.SomeIntValue.Value != 2)
+                    {
+                        errorLog.AppendLine($"[Client-{networkManager.LocalClientId}] {changeValue.name} value is {changeValue.SomeIntValue.Value} but was expecting 2!");
+                    }
                     continue;
                 }
+                if (changeValue.SomeIntValue.Value != 2)
+                {
+                    errorLog.AppendLine($"[Client-{networkManager.LocalClientId}] {changeValue.name} value is {changeValue.SomeIntValue.Value} but was expecting 2!");
+                }
 
-                var changeValue = networkManager.SpawnManager.SpawnedObjects[m_InstanceAuthority.NetworkObjectId].GetComponent<ChangeValueOnAuthority>();
                 if (changeValue.SomeIntValue.Value != m_InstanceAuthority.SomeIntValue.Value)
                 {
                     errorLog.AppendLine($"[Client-{networkManager.LocalClientId}] {changeValue.name} value is {changeValue.SomeIntValue.Value} but was expecting {m_InstanceAuthority.SomeIntValue.Value}!");
@@ -185,19 +191,15 @@ namespace Unity.Netcode.RuntimeTests
         {
             var authority = GetAuthorityNetworkManager();
             var nonAuthority = GetNonAuthorityNetworkManager();
-            m_SessionAuthorityInstance = Object.Instantiate(m_SpawnObject).GetComponent<ChangeValueOnAuthority>();
+            // If running in distributed authority mode, we use the nonauthority (i.e. not SessionOwner) instance to spawn.
+            var spawnAuthority = m_DistributedAuthority ? nonAuthority : authority;
+            m_InstanceAuthority = SpawnObject(m_SpawnObject, spawnAuthority).GetComponent<ChangeValueOnAuthority>();
 
-            SpawnInstanceWithOwnership(m_SessionAuthorityInstance.GetComponent<NetworkObject>(), authority, nonAuthority.LocalClientId);
-            yield return WaitForSpawnedOnAllOrTimeOut(m_SessionAuthorityInstance.NetworkObjectId);
-            AssertOnTimeout($"Failed to spawn {m_SessionAuthorityInstance.name} on all clients!");
-
-            m_InstanceAuthority = nonAuthority.SpawnManager.SpawnedObjects[m_SessionAuthorityInstance.NetworkObjectId].GetComponent<ChangeValueOnAuthority>();
+            yield return WaitForSpawnedOnAllOrTimeOut(m_InstanceAuthority.NetworkObjectId);
+            AssertOnTimeout($"Failed to spawn {m_InstanceAuthority.name} on all clients!");
 
             yield return WaitForConditionOrTimeOut(NetworkVariablesMatch);
             AssertOnTimeout($"The {nameof(ChangeValueOnAuthority.SomeIntValue)} failed to synchronize on all clients!");
-
-            Assert.IsTrue(m_SessionAuthorityInstance.SomeIntValue.Value == 2, "No values were updated on the spawn authority instance!");
-            Assert.IsTrue(m_InstanceAuthority.SomeIntValue.Value == 2, "No values were updated on the owner's instance!");
         }
     }
 }


### PR DESCRIPTION
**This is a regression bug introduced in #3664**

## Purpose of this PR
This PR fixes the issue where `NetworkVariable` was not properly synchronizing to changes made by the spawn and write authority during `OnNetworkSpawn` and `OnNetworkPostSpawn`.

### Jira ticket
[UUM-134322](https://jira.unity3d.com/browse/UUM-134322)
fix: #3876

### Changelog
[//]: # (updated with all public facing changes  - API changes, UI/UX changes, behaviour changes, bug fixes. Remove if not relevant.)

- Fixed: Issue where `NetworkVariable` was not properly synchronizing to changes made by the spawn and write authority during `OnNetworkSpawn` and `OnNetworkPostSpawn`.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation

- No documentation changes or additions were necessary.

## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [x] `Manual testing done`
  - Used local project and test project.

_Automated tests:_
- [x] `Covered by new automated tests`
  - `NetworkVariableGeneralTests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports

This does not require a backport.