### PR TITLE
feat: Make NetworkTransport update methods public

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,7 +10,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
-- `NetworkTransport.EarlyUpdate` and `NetworkTransport.PostLateUpdate` are now public. For the vast majority of users, there's really no point in ever calling those methods directly (the `NetworkManager` handles it). It's only useful if wrapping transports outside of NGO.
+- `NetworkTransport.EarlyUpdate` and `NetworkTransport.PostLateUpdate` are now public. For the vast majority of users, there's really no point in ever calling those methods directly (the `NetworkManager` handles it). It's only useful if wrapping transports outside of NGO. (#3890)
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,6 +10,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
+- `NetworkTransport.EarlyUpdate` and `NetworkTransport.PostLateUpdate` are now public. For the vast majority of users, there's really no point in ever calling those methods directly (the `NetworkManager` handles it). It's only useful if wrapping transports outside of NGO.
 
 ### Changed
 

--- a/com.unity.netcode.gameobjects/Runtime/Transports/NetworkTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/NetworkTransport.cs
@@ -126,7 +126,7 @@ namespace Unity.Netcode
         /// <summary>
         /// Invoked by NetworkManager at the beginning of its EarlyUpdate
         /// </summary>
-        internal void EarlyUpdate()
+        public void EarlyUpdate()
         {
             OnEarlyUpdate();
         }
@@ -146,7 +146,7 @@ namespace Unity.Netcode
         /// <summary>
         /// Invoked by NetworkManager towards the end of the PostLateUpdate
         /// </summary>
-        internal void PostLateUpdate()
+        public void PostLateUpdate()
         {
             OnPostLateUpdate();
         }

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -2,7 +2,7 @@
     "name": "com.unity.netcode.gameobjects",
     "displayName": "Netcode for GameObjects",
     "description": "Netcode for GameObjects is a high-level netcode SDK that provides networking capabilities to GameObject/MonoBehaviour workflows within Unity and sits on top of underlying transport layer.",
-    "version": "2.10.1",
+    "version": "2.11.0",
     "unity": "6000.0",
     "dependencies": {
         "com.unity.nuget.mono-cecil": "1.11.4",


### PR DESCRIPTION
## Purpose of this PR

This PR makes the `EarlyUpdate` and `PostLateUpdate` methods of `NetworkTransport` public. To be able to reuse NGO transports elsewhere, one needs access to those since that might be where most of the work is happening. (It's actually not so much the case for most of the community transports that rely mostly on regular `Update` to work, but still better to do things right.)

The alternative would be giving internal access to the assembly reusing NGO transports. I don't have any strong opinion regarding which option is preferable. If you prefer internal access, I'll submit a PR that does that instead.

### Jira ticket

None (yet).

### Changelog

- Added: `NetworkTransport.EarlyUpdate` and `NetworkTransport.PostLateUpdate` are now public. For the vast majority of users, there's really no point in ever calling those methods directly (the `NetworkManager` handles it). It's only useful if wrapping transports outside of NGO.

## Documentation

- No documentation changes or additions were necessary.

## Testing & QA

No need for testing.

### Functional Testing

_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

## Backports

N/A