### PR TITLE
feat: Add support for WebSocket path in UnityTransport

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,7 +10,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
-- Added a `WebSocketPath` field to `UnityTransport.ConnectionData` (which also shows up in the inspector if "Use WebSockets" is checked) that controls the path clients will connect to and servers/hosts will listen on when using WebSockets.
+- Added a `WebSocketPath` field to `UnityTransport.ConnectionData` (which also shows up in the inspector if "Use WebSockets" is checked) that controls the path clients will connect to and servers/hosts will listen on when using WebSockets. (#3901)
 - `NetworkTransport.EarlyUpdate` and `NetworkTransport.PostLateUpdate` are now public. For the vast majority of users, there's really no point in ever calling those methods directly (the `NetworkManager` handles it). It's only useful if wrapping transports outside of NGO. (#3890)
 
 ### Changed

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,6 +10,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
+- Added a `WebSocketPath` field to `UnityTransport.ConnectionData` (which also shows up in the inspector if "Use WebSockets" is checked) that controls the path clients will connect to and servers/hosts will listen on when using WebSockets.
 - `NetworkTransport.EarlyUpdate` and `NetworkTransport.PostLateUpdate` are now public. For the vast majority of users, there's really no point in ever calling those methods directly (the `NetworkManager` handles it). It's only useful if wrapping transports outside of NGO. (#3890)
 
 ### Changed

--- a/com.unity.netcode.gameobjects/Editor/HiddenScriptEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/HiddenScriptEditor.cs
@@ -42,6 +42,7 @@ namespace Unity.Netcode.Editor
 
         private SerializedProperty m_ServerAddressProperty;
         private SerializedProperty m_ServerPortProperty;
+        private SerializedProperty m_WebSocketPathProperty;
 
         private const string k_LoopbackIpv4 = "127.0.0.1";
         private const string k_LoopbackIpv6 = "::1";
@@ -62,6 +63,7 @@ namespace Unity.Netcode.Editor
 
             m_ServerAddressProperty = connectionDataProperty.FindPropertyRelative(nameof(UnityTransport.ConnectionAddressData.Address));
             m_ServerPortProperty = connectionDataProperty.FindPropertyRelative(nameof(UnityTransport.ConnectionAddressData.Port));
+            m_WebSocketPathProperty = connectionDataProperty.FindPropertyRelative(nameof(UnityTransport.ConnectionAddressData.WebSocketPath));
         }
 
         /// <summary>
@@ -78,6 +80,11 @@ namespace Unity.Netcode.Editor
 
             EditorGUILayout.PropertyField(m_ServerAddressProperty);
             EditorGUILayout.PropertyField(m_ServerPortProperty);
+
+            if (m_UnityTransport.UseWebSockets)
+            {
+                EditorGUILayout.PropertyField(m_WebSocketPathProperty);
+            }
 
             serializedObject.ApplyModifiedProperties();
 

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -68,7 +68,7 @@ namespace Unity.Netcode.Transports.UTP
         // frame at 60 FPS. This will be a large over-estimation in any realistic scenario.
         private const int k_MaxReliableThroughput = (NetworkParameterConstants.MTU * 64 * 60) / 1000; // bytes per millisecond
 
-        private static ConnectionAddressData s_DefaultConnectionAddressData = new ConnectionAddressData { Address = "127.0.0.1", Port = 7777, ServerListenAddress = string.Empty };
+        private static ConnectionAddressData s_DefaultConnectionAddressData = new ConnectionAddressData { Address = "127.0.0.1", Port = 7777, WebSocketPath = "/", ServerListenAddress = string.Empty };
 
 #pragma warning disable IDE1006 // Naming Styles
         /// <summary>
@@ -227,6 +227,13 @@ namespace Unity.Netcode.Transports.UTP
             [Tooltip("UDP port of the server.")]
             [SerializeField]
             public ushort Port;
+
+            /// <summary>
+            /// Path of the URL when using WebSockets.
+            /// </summary>
+            [Tooltip("Path to connect to or listen on when using WebSockets. Defaults to \"/\" if not set.")]
+            [SerializeField]
+            public string WebSocketPath;
 
             /// <summary>
             /// IP address the server will listen on. If not provided, will use localhost.
@@ -511,6 +518,12 @@ namespace Unity.Netcode.Transports.UTP
                 {
                     settings.WithRelayParameters(ref m_RelayServerData, m_HeartbeatTimeoutMS);
                 }
+            }
+
+            // Set up the WebSocket path if configured and if using WebSockets.
+            if (m_UseWebSockets && m_ProtocolType != ProtocolType.RelayUnityTransport && !string.IsNullOrWhiteSpace(ConnectionData.WebSocketPath))
+            {
+                settings.WithWebSocketParameters(path: ConnectionData.WebSocketPath);
             }
 
 #if UNITY_MP_TOOLS_NETSIM_IMPLEMENTATION_ENABLED

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportConnectionTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportConnectionTests.cs
@@ -79,6 +79,56 @@ namespace Unity.Netcode.RuntimeTests
             yield return null;
         }
 
+        // Check connection with a single WebSocket client (IP address).
+        [UnityTest]
+        public IEnumerator ConnectSingleClient_WebSocket_IPAddress()
+        {
+            InitializeTransport(out m_Server, out m_ServerEvents);
+            InitializeTransport(out m_Clients[0], out m_ClientsEvents[0]);
+
+            m_Server.UseWebSockets = true;
+            m_Clients[0].UseWebSockets = true;
+
+            m_Clients[0].SetConnectionData("127.0.0.1", 7777);
+
+            m_Server.StartServer();
+            m_Clients[0].StartClient();
+
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[0]);
+
+            // Check we've received Connect event on server too.
+            Assert.AreEqual(1, m_ServerEvents.Count);
+            Assert.AreEqual(NetworkEvent.Connect, m_ServerEvents[0].Type);
+
+            yield return null;
+        }
+
+        // Check connection with a single WebSocket client (IP address and path).
+        [UnityTest]
+        public IEnumerator ConnectSingleClient_WebSocket_IPAddressAndPath()
+        {
+            InitializeTransport(out m_Server, out m_ServerEvents);
+            InitializeTransport(out m_Clients[0], out m_ClientsEvents[0]);
+
+            m_Server.UseWebSockets = true;
+            m_Clients[0].UseWebSockets = true;
+
+            m_Clients[0].SetConnectionData("127.0.0.1", 7777);
+            m_Clients[0].ConnectionData.WebSocketPath = "/test";
+            m_Server.ConnectionData.WebSocketPath = "/test";
+
+            m_Server.StartServer();
+            m_Clients[0].StartClient();
+
+            yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[0]);
+
+            // Check we've received Connect event on server too.
+            Assert.AreEqual(1, m_ServerEvents.Count);
+            Assert.AreEqual(NetworkEvent.Connect, m_ServerEvents[0].Type);
+
+            yield return null;
+        }
+
 #if HOSTNAME_RESOLUTION_AVAILABLE
         // Check connection with a single client (hostname).
         [UnityTest]


### PR DESCRIPTION
## Purpose of this PR

For a few versions now UTP has supported setting the URL path that's going to be used for WebSockets (e.g. if you want to connect to `wss://foobar.com/somewhere` instead of just `wss://foobar.com`). That capability has not been exposed to NGO however. It was possible to still get access to this setting by using a custom driver constructor, but that's a bit of a heavy solution for such a simple thing.

This PR remedies that by allowing users to directly set the URL path on the `UnityTransport` component. This is done through a new field in `ConnectionData` that only shows up in the inspector if using WebSockets. This is just then routed to the appropriate setting in UTP.

This was suggested by a user [here](https://discussions.unity.com/t/networkmanager-how-to-set-path-of-unitytransport-websocket-tcp/1594491), showing that there is some interest for this feature.

### Jira ticket

None. Didn't want to bother creating one.

### Changelog

- Added: Added a `WebSocketPath` field to `UnityTransport.ConnectionData` (which also shows up in the inspector if "Use WebSockets" is checked) that controls the path clients will connect to and servers/hosts will listen on when using WebSockets.

## Documentation

- Includes edits to existing public API documentation.

## Testing & QA (How your changes can be verified during release Playtest)

### Functional Testing

_Manual testing :_
- [x] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [x] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

## Backports

No. Couldn't backport even if I wanted to since WebSockets are UTP 2.X+.
