### PR TITLE
chore: Switch PR testing from trunk to 6.5

### DIFF
--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -75,20 +75,20 @@ pr_code_changes_checks:
     # Run API validation to early-detect all new APIs that would force us to release new minor version of the package. Note that for this to work the package version in package.json must correspond to "actual package state" which means that it should be higher than last released version
     - .yamato/vetting-test.yml#vetting_test
 
-    # Run package EditMode and Playmode package tests on trunk and an older supported editor (6000.0)
-    - .yamato/package-tests.yml#package_test_-_ngo_trunk_mac
+    # Run package EditMode and Playmode package tests on 6000.5 and an older supported editor (6000.0)
+    - .yamato/package-tests.yml#package_test_-_ngo_6000.5_mac
     - .yamato/package-tests.yml#package_test_-_ngo_6000.0_win
 
-    # Run testproject EditMode and Playmode project tests on trunk and an older supported editor (6000.0)
-    - .yamato/project-tests.yml#test_testproject_win_trunk
+    # Run testproject EditMode and Playmode project tests on 6000.5 and an older supported editor (6000.0)
+    - .yamato/project-tests.yml#test_testproject_win_6000.5
     - .yamato/project-tests.yml#test_testproject_mac_6000.0
 
     # Run standalone test. We run it only on Ubuntu since it's the fastest machine, and it was noted that for example distribution on macOS is taking 40m since we switched to Apple Silicon
     # Coverage on other standalone machines is present in Nightly job so it's enough to not run all of them for PRs
     # desktop_standalone_test and cmb_service_standalone_test are both reusing desktop_standalone_build dependency so we run those in the same configuration on PRs to reduce waiting time.
-    # Note that our daily tests will anyway run both test configurations in "minimal supported" and "trunk" configurations
-    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_ubuntu_il2cpp_trunk
-    - .yamato/cmb-service-standalone-tests.yml#cmb_service_standalone_test_testproject_ubuntu_il2cpp_trunk
+    # Note that our daily tests will anyway run both test configurations in "minimal supported" and "6000.5" configurations
+    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_ubuntu_il2cpp_6000.5
+    - .yamato/cmb-service-standalone-tests.yml#cmb_service_standalone_test_testproject_ubuntu_il2cpp_6000.5
   triggers:
     expression: |-
       (pull_request.comment eq "ngo" OR

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -181,6 +181,7 @@ validation_editors:
         - 6000.0
         - 6000.3
         - 6000.4
+        - 6000.5
         - trunk
     minimal:
         - 6000.0


### PR DESCRIPTION
## Purpose of this PR

Trunk is currently integrating a lot of new features and so introduces some instabilities into our testing. This PR moves our PR trigger tests from trunk to 6.5.

### Jira ticket

n/a

### Changelog

Internal changes only

## Documentation

- No documentation changes or additions were necessary.

## Testing & QA (How your changes can be verified during release Playtest)

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [x] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports

n/a