### PR TITLE
chore: Updated aspects of Netcode package in anticipation of v2.11.0 release

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,14 +10,31 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
-- Added a `WebSocketPath` field to `UnityTransport.ConnectionData` (which also shows up in the inspector if "Use WebSockets" is checked) that controls the path clients will connect to and servers/hosts will listen on when using WebSockets. (#3901)
-- `NetworkTransport.EarlyUpdate` and `NetworkTransport.PostLateUpdate` are now public. For the vast majority of users, there's really no point in ever calling those methods directly (the `NetworkManager` handles it). It's only useful if wrapping transports outside of NGO. (#3890)
 
 ### Changed
 
 
 ### Deprecated
 
+
+### Removed
+
+
+### Fixed
+
+
+### Security
+
+
+### Obsolete
+
+
+## [2.11.0] - 2026-03-19
+
+### Added
+
+- Added a `WebSocketPath` field to `UnityTransport.ConnectionData` (which also shows up in the inspector if "Use WebSockets" is checked) that controls the path clients will connect to and servers/hosts will listen on when using WebSockets. (#3901)
+- `NetworkTransport.EarlyUpdate` and `NetworkTransport.PostLateUpdate` are now public. For the vast majority of users, there's really no point in ever calling those methods directly (the `NetworkManager` handles it). It's only useful if wrapping transports outside of NGO. (#3890)
 
 ### Removed
 - Removed un-needed exceptions on `NetworkObject.cs`. (#3867)
@@ -27,9 +44,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Fixed issue where an attachable could log an error upon being de-spawned during shutdown. (#3895)
 - NestedNetworkVariables initialized with no value no longer throw an error. (#3891)
 - Fixed `NetworkShow` behavior when it is called twice. (#3867)
-
-### Security
-
 
 ### Obsolete
 - `NotListeningException` is now marked as obsolete as it is no longer used internally. (#3867)

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -2,7 +2,7 @@
     "name": "com.unity.netcode.gameobjects",
     "displayName": "Netcode for GameObjects",
     "description": "Netcode for GameObjects is a high-level netcode SDK that provides networking capabilities to GameObject/MonoBehaviour workflows within Unity and sits on top of underlying transport layer.",
-    "version": "2.11.0",
+    "version": "2.11.1",
     "unity": "6000.0",
     "dependencies": {
         "com.unity.nuget.mono-cecil": "1.11.4",


### PR DESCRIPTION
This PR was created in sync with branching of release/2.11.0. It includes changes that should land on the default Netcode branch (develop-2.0.0) to reflect the new state of the package after the v2.11.0 release:
1) Updated CHANGELOG.md by adding new [Unreleased] section template at the top and cleaning the Changelog for the current release.
2) Updated package version in package.json by incrementing the patch version to signify the current state of the package.
3) Updated package version in ValidationExceptions.json to match the new package version.

Please review and merge this PR to keep the default branch up to date with the latest package state after the release. Those changes can land immediately OR after the release was finalized but make sure that the Changelog will be merged correctly as sometimes some discrepancies may be introduced due to new entries being introduced meantime
