### PR TITLE
fix: Attachables destroy order of operations

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -26,6 +26,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where either an `AttachableBehaviour` or an `AttachableNode` can throw an exception if they are attached during a scene unload where one of the two persists the scene unload event and the other does not. (#3931)
 - Fixed issue where attempts to use `NetworkLog` when there is no `NetworkManager` instance would result in an exception. (#3917)
 
 ### Security

--- a/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableBehaviour.cs
@@ -205,6 +205,8 @@ namespace Unity.Netcode.Components
         private Vector3 m_OriginalLocalPosition;
         private Quaternion m_OriginalLocalRotation;
 
+        internal bool IsDestroying { get; private set; }
+
         /// <inheritdoc/>
         protected override void OnSynchronize<T>(ref BufferSerializer<T> serializer)
         {
@@ -236,6 +238,37 @@ namespace Unity.Netcode.Components
             m_AttachState = AttachState.Detached;
             m_AttachableNode = null;
             OnAwake();
+        }
+
+        protected override void OnNetworkPreSpawn(ref NetworkManager networkManager)
+        {
+            IsDestroying = false;
+            // When attached to something else, the attachable needs to know if the
+            // default parent has been destroyed in order to not attempt to re-parent
+            // when detached (especially if it is being detatched because it should be destroyed).
+            NetworkObject.OnDestroying += OnDefaultParentDestroying;
+
+            base.OnNetworkPreSpawn(ref networkManager);
+        }
+
+        private void OnDefaultParentDestroying()
+        {
+            NetworkObject.OnDestroying -= OnDefaultParentDestroying;
+            // Exit early if we are already being destroyed
+            if (IsDestroying)
+            {
+                return;
+            }
+            IsDestroying = true;
+            // Just destroy the GameObject for this attachable since
+            // the associated NetworkObject is being destroyed.
+            Destroy(gameObject);
+        }
+
+        internal override void InternalOnDestroy()
+        {
+            IsDestroying = true;
+            base.InternalOnDestroy();
         }
 
         /// <inheritdoc/>
@@ -458,16 +491,9 @@ namespace Unity.Netcode.Components
         /// </summary>
         internal void InternalDetach()
         {
-            if (m_AttachableNode)
+            if (!IsDestroying && m_AttachableNode && !m_AttachableNode.IsDestroying)
             {
-                // TODO-FIX: We might track if something has been "destroyed" in order
-                // to be able to be 100% sure in the event a user disables the world item
-                // when detatched. Otherwise, we keep this in place and make note of it
-                // in documentation.
-                // Issue:
-                // Edge-case where the parent could be in the middle of being destroyed.
-                // If not active in the hierarchy, then don't attempt to set the parent.
-                if (m_DefaultParent && m_DefaultParent.activeInHierarchy)
+                if (m_DefaultParent)
                 {
                     // Set the original parent and origianl local position and rotation
                     transform.SetParent(m_DefaultParent.transform, false);

--- a/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableBehaviour.cs
@@ -245,7 +245,7 @@ namespace Unity.Netcode.Components
             IsDestroying = false;
             // When attached to something else, the attachable needs to know if the
             // default parent has been destroyed in order to not attempt to re-parent
-            // when detached (especially if it is being detatched because it should be destroyed).
+            // when detached (especially if it is being detached because it should be destroyed).
             NetworkObject.OnDestroying += OnDefaultParentDestroying;
 
             base.OnNetworkPreSpawn(ref networkManager);
@@ -260,9 +260,13 @@ namespace Unity.Netcode.Components
                 return;
             }
             IsDestroying = true;
-            // Just destroy the GameObject for this attachable since
-            // the associated NetworkObject is being destroyed.
-            Destroy(gameObject);
+            // If not completely detached, then destroy the GameObject for
+            // this attachable since the associated NetworkObject is being
+            // destroyed.
+            if (m_AttachState != AttachState.Detached)
+            {
+                Destroy(gameObject);
+            }
         }
 
         internal override void InternalOnDestroy()
@@ -319,7 +323,7 @@ namespace Unity.Netcode.Components
         }
 
         /// <summary>
-        /// This will apply the final attach or detatch state based on the current value of <see cref="m_AttachedNodeReference"/>.
+        /// This will apply the final attach or detach state based on the current value of <see cref="m_AttachedNodeReference"/>.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void UpdateAttachedState()

--- a/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableBehaviour.cs
@@ -467,6 +467,8 @@ namespace Unity.Netcode.Components
         /// </summary>
         internal void InternalDetach()
         {
+            // If this instance is not in the middle of being destroyed, the attachable node is not null, and the node is not destroying
+            // =or= the scene it is located in is in the middle of being unloaded, then re-parent under the default parent.
             if (!IsDestroying && m_AttachableNode && (!m_AttachableNode.IsDestroying || m_AttachableNode.gameObject.scene.isLoaded))
             {
                 if (m_DefaultParent)

--- a/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableBehaviour.cs
@@ -261,18 +261,17 @@ namespace Unity.Netcode.Components
             ForceComponentChange(false, true);
 
             InternalDetach();
-            // Notify of the changed attached state
-            NotifyAttachedStateChanged(m_AttachState, m_AttachableNode);
+
+            if (m_AttachableNode != null && !m_AttachableNode.IsDestroying)
+            {
+                // Notify of the changed attached state
+                NotifyAttachedStateChanged(m_AttachState, m_AttachableNode);
+                // Only notify of the detach if the node is still valid.
+                m_AttachableNode.Detach(this);
+            }
 
             m_AttachedNodeReference = new NetworkBehaviourReference(null);
-
-            // When detaching, we want to make our final action
-            // the invocation of the AttachableNode's Detach method.
-            if (m_AttachableNode)
-            {
-                m_AttachableNode.Detach(this);
-                m_AttachableNode = null;
-            }
+            m_AttachableNode = null;
         }
 
         /// <inheritdoc/>
@@ -312,16 +311,18 @@ namespace Unity.Netcode.Components
                 return;
             }
 
-            // If we are attached to some other AttachableNode, then detach from that before attaching to a new one.
+            // If we are attaching and already attached to some other AttachableNode,
+            // then detach from that before attaching to a new one.
             if (isAttaching && m_AttachableNode != null && m_AttachState == AttachState.Attached)
             {
-                // Run through the same process without being triggerd by a NetVar update.
+                // Detach the current attachable
                 NotifyAttachedStateChanged(AttachState.Detaching, m_AttachableNode);
                 InternalDetach();
                 NotifyAttachedStateChanged(AttachState.Detached, m_AttachableNode);
-
                 m_AttachableNode.Detach(this);
                 m_AttachableNode = null;
+
+                // Now attach the new attachable
             }
 
             // Change the state to attaching or detaching
@@ -466,7 +467,7 @@ namespace Unity.Netcode.Components
         /// </summary>
         internal void InternalDetach()
         {
-            if (!IsDestroying && m_AttachableNode && !m_AttachableNode.IsDestroying)
+            if (!IsDestroying && m_AttachableNode && (!m_AttachableNode.IsDestroying || m_AttachableNode.gameObject.scene.isLoaded))
             {
                 if (m_DefaultParent)
                 {
@@ -562,12 +563,33 @@ namespace Unity.Netcode.Components
         /// </summary>
         internal void OnAttachNodeDestroy()
         {
-            // If this instance should force a detach on destroy
-            if (AutoDetach.HasFlag(AutoDetachTypes.OnAttachNodeDestroy))
+            // We force a detach on destroy if there is a flag =or= if we are attached to a node that is being destroyed.
+            if (AutoDetach.HasFlag(AutoDetachTypes.OnAttachNodeDestroy) ||
+                (AutoDetach.HasFlag(AutoDetachTypes.OnDespawn) && m_AttachState == AttachState.Attached && m_AttachableNode && m_AttachableNode.IsDestroying))
             {
-                // Force a detach
                 ForceDetach();
             }
+        }
+
+
+        /// <summary>
+        /// When we know this instance is being destroyed or will be destroyed
+        /// by something outside of NGO's realm of control, this gets invoked.
+        /// We should detach from any AttachableNode when this is invoked.
+        /// </summary>
+        protected internal override void OnIsDestroying()
+        {
+            // If we are not already marked as being destroyed, attached, this instance is the authority instance, and the node we are attached
+            // to is not in the middle of being destroyed...detach normally.
+            if (!IsDestroying && HasAuthority && m_AttachState == AttachState.Attached && m_AttachableNode && !m_AttachableNode.IsDestroying)
+            {
+                Detach();
+            }
+            else // Otherwise force the detach.
+            {
+                ForceDetach();
+            }
+            base.OnIsDestroying();
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableBehaviour.cs
@@ -205,8 +205,6 @@ namespace Unity.Netcode.Components
         private Vector3 m_OriginalLocalPosition;
         private Quaternion m_OriginalLocalRotation;
 
-        internal bool IsDestroying { get; private set; }
-
         /// <inheritdoc/>
         protected override void OnSynchronize<T>(ref BufferSerializer<T> serializer)
         {
@@ -238,42 +236,6 @@ namespace Unity.Netcode.Components
             m_AttachState = AttachState.Detached;
             m_AttachableNode = null;
             OnAwake();
-        }
-
-        /// <inheritdoc/>
-        protected override void OnNetworkPreSpawn(ref NetworkManager networkManager)
-        {
-            IsDestroying = false;
-            // When attached to something else, the attachable needs to know if the
-            // default parent has been destroyed in order to not attempt to re-parent
-            // when detached (especially if it is being detached because it should be destroyed).
-            NetworkObject.OnDestroying += OnDefaultParentDestroying;
-
-            base.OnNetworkPreSpawn(ref networkManager);
-        }
-
-        private void OnDefaultParentDestroying()
-        {
-            NetworkObject.OnDestroying -= OnDefaultParentDestroying;
-            // Exit early if we are already being destroyed
-            if (IsDestroying)
-            {
-                return;
-            }
-            IsDestroying = true;
-            // If not completely detached, then destroy the GameObject for
-            // this attachable since the associated NetworkObject is being
-            // destroyed.
-            if (m_AttachState != AttachState.Detached)
-            {
-                Destroy(gameObject);
-            }
-        }
-
-        internal override void InternalOnDestroy()
-        {
-            IsDestroying = true;
-            base.InternalOnDestroy();
         }
 
         /// <inheritdoc/>
@@ -316,6 +278,14 @@ namespace Unity.Netcode.Components
         /// <inheritdoc/>
         public override void OnNetworkPreDespawn()
         {
+            // If the NetworkObject is being destroyed and not completely detached, then destroy the GameObject for
+            // this attachable since the associated default parent is being destroyed.
+            if (IsDestroying && m_AttachState != AttachState.Detached)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
             if (NetworkManager.ShutdownInProgress || AutoDetach.HasFlag(AutoDetachTypes.OnDespawn))
             {
                 ForceDetach();

--- a/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableBehaviour.cs
@@ -240,6 +240,7 @@ namespace Unity.Netcode.Components
             OnAwake();
         }
 
+        /// <inheritdoc/>
         protected override void OnNetworkPreSpawn(ref NetworkManager networkManager)
         {
             IsDestroying = false;

--- a/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableBehaviour.cs
@@ -392,7 +392,8 @@ namespace Unity.Netcode.Components
 
             foreach (var componentControllerEntry in ComponentControllers)
             {
-                if (componentControllerEntry.AutoTrigger.HasFlag(triggerType))
+                // Only if the component controller still exists and has the appropriate flag.
+                if (componentControllerEntry.ComponentController && componentControllerEntry.AutoTrigger.HasFlag(triggerType))
                 {
                     componentControllerEntry.ComponentController.ForceChangeEnabled(componentControllerEntry.EnableOnAttach ? isAttaching : !isAttaching, forcedChange);
                 }
@@ -459,7 +460,14 @@ namespace Unity.Netcode.Components
         {
             if (m_AttachableNode)
             {
-                if (m_DefaultParent)
+                // TODO-FIX: We might track if something has been "destroyed" in order
+                // to be able to be 100% sure in the event a user disables the world item
+                // when detatched. Otherwise, we keep this in place and make note of it
+                // in documentation.
+                // Issue:
+                // Edge-case where the parent could be in the middle of being destroyed.
+                // If not active in the hierarchy, then don't attempt to set the parent.
+                if (m_DefaultParent && m_DefaultParent.activeInHierarchy)
                 {
                     // Set the original parent and origianl local position and rotation
                     transform.SetParent(m_DefaultParent.transform, false);

--- a/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableNode.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableNode.cs
@@ -24,7 +24,7 @@ public class AttachableNode : NetworkBehaviour
     /// </summary>
     public bool DetachOnDespawn = true;
 
-    internal bool IsDestroying  { get; private set; }
+    internal bool IsDestroying { get; private set; }
 
     /// <summary>
     /// A <see cref="List{T}"/> of the currently attached <see cref="AttachableBehaviour"/>s.

--- a/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableNode.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableNode.cs
@@ -76,23 +76,15 @@ public class AttachableNode : NetworkBehaviour
                 {
                     continue;
                 }
-                // If we don't have authority but should detach on despawn,
-                // then proceed to detach.
-                if (!attachable.HasAuthority)
+
+                if (attachable.HasAuthority && attachable.IsSpawned)
+                {
+                    // Detach the normal way with authority
+                    attachable.Detach();
+                }
+                else if (!attachable.HasAuthority || !attachable.IsDestroying)
                 {
                     attachable.ForceDetach();
-                }
-                else
-                {
-                    if (attachable.IsSpawned)
-                    {
-                        // Detach the normal way with authority
-                        attachable.Detach();
-                    }
-                    else if (!attachable.IsDestroying)
-                    {
-                        attachable.ForceDetach();
-                    }
                 }
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableNode.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableNode.cs
@@ -24,8 +24,6 @@ public class AttachableNode : NetworkBehaviour
     /// </summary>
     public bool DetachOnDespawn = true;
 
-    internal bool IsDestroying { get; private set; }
-
     /// <summary>
     /// A <see cref="List{T}"/> of the currently attached <see cref="AttachableBehaviour"/>s.
     /// </summary>
@@ -34,7 +32,6 @@ public class AttachableNode : NetworkBehaviour
     /// <inheritdoc/>
     protected override void OnNetworkPreSpawn(ref NetworkManager networkManager)
     {
-        IsDestroying = false;
         m_AttachedBehaviours.Clear();
         base.OnNetworkPreSpawn(ref networkManager);
     }
@@ -104,7 +101,6 @@ public class AttachableNode : NetworkBehaviour
 
     internal override void InternalOnDestroy()
     {
-        IsDestroying = true;
         // Notify any attached behaviours that this node is being destroyed.
         for (int i = m_AttachedBehaviours.Count - 1; i >= 0; i--)
         {

--- a/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableNode.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableNode.cs
@@ -24,6 +24,8 @@ public class AttachableNode : NetworkBehaviour
     /// </summary>
     public bool DetachOnDespawn = true;
 
+    internal bool IsDestroying  { get; private set; }
+
     /// <summary>
     /// A <see cref="List{T}"/> of the currently attached <see cref="AttachableBehaviour"/>s.
     /// </summary>
@@ -32,6 +34,7 @@ public class AttachableNode : NetworkBehaviour
     /// <inheritdoc/>
     protected override void OnNetworkPreSpawn(ref NetworkManager networkManager)
     {
+        IsDestroying = false;
         m_AttachedBehaviours.Clear();
         base.OnNetworkPreSpawn(ref networkManager);
     }
@@ -84,22 +87,14 @@ public class AttachableNode : NetworkBehaviour
                 }
                 else
                 {
-                    // TODO-FIX: We might track if something has been "destroyed" in order
-                    // to be able to be 100% sure this is specific to being destroyed.
-                    // Otherwise, we keep this in place and make note of it
-                    // in documentation that you cannot detatch from something already despawned.
-                    // Issue: When trying to detatch if the thing attached is no longer 
-                    // spawned. Instantiation order recently changed such that
-                    // the attachable =or= the attach node target could be despawned 
-                    // and in the middle of being destroyed. Resolution for this 
-                    // is to skip over destroyed object (default) and then only sort
-                    // through the things the local NetworkManager instance has authority
-                    // over. Even then, we have to check if the attached object is still
-                    // spawned before attempting to detatch it.
                     if (attachable.IsSpawned)
                     {
                         // Detach the normal way with authority
                         attachable.Detach();
+                    }
+                    else if (!attachable.IsDestroying)
+                    {
+                        attachable.ForceDetach();
                     }
                 }
             }
@@ -109,6 +104,7 @@ public class AttachableNode : NetworkBehaviour
 
     internal override void InternalOnDestroy()
     {
+        IsDestroying = true;
         // Notify any attached behaviours that this node is being destroyed.
         for (int i = m_AttachedBehaviours.Count - 1; i >= 0; i--)
         {

--- a/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableNode.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableNode.cs
@@ -71,20 +71,36 @@ public class AttachableNode : NetworkBehaviour
         {
             for (int i = m_AttachedBehaviours.Count - 1; i >= 0; i--)
             {
-                if (!m_AttachedBehaviours[i])
+                var attachable = m_AttachedBehaviours[i];
+                if (!attachable)
                 {
                     continue;
                 }
                 // If we don't have authority but should detach on despawn,
                 // then proceed to detach.
-                if (!m_AttachedBehaviours[i].HasAuthority)
+                if (!attachable.HasAuthority)
                 {
-                    m_AttachedBehaviours[i].ForceDetach();
+                    attachable.ForceDetach();
                 }
                 else
                 {
-                    // Detach the normal way with authority
-                    m_AttachedBehaviours[i].Detach();
+                    // TODO-FIX: We might track if something has been "destroyed" in order
+                    // to be able to be 100% sure this is specific to being destroyed.
+                    // Otherwise, we keep this in place and make note of it
+                    // in documentation that you cannot detatch from something already despawned.
+                    // Issue: When trying to detatch if the thing attached is no longer 
+                    // spawned. Instantiation order recently changed such that
+                    // the attachable =or= the attach node target could be despawned 
+                    // and in the middle of being destroyed. Resolution for this 
+                    // is to skip over destroyed object (default) and then only sort
+                    // through the things the local NetworkManager instance has authority
+                    // over. Even then, we have to check if the attached object is still
+                    // spawned before attempting to detatch it.
+                    if (attachable.IsSpawned)
+                    {
+                        // Detach the normal way with authority
+                        attachable.Detach();
+                    }
                 }
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableNode.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Helpers/AttachableNode.cs
@@ -93,12 +93,10 @@ public class AttachableNode : NetworkBehaviour
 
     internal override void InternalOnDestroy()
     {
-        // Notify any attached behaviours that this node is being destroyed.
-        for (int i = m_AttachedBehaviours.Count - 1; i >= 0; i--)
+        if (m_AttachedBehaviours.Count > 0)
         {
-            m_AttachedBehaviours[i]?.OnAttachNodeDestroy();
+            OnIsDestroying();
         }
-        m_AttachedBehaviours.Clear();
         base.InternalOnDestroy();
     }
 
@@ -140,5 +138,22 @@ public class AttachableNode : NetworkBehaviour
         }
         m_AttachedBehaviours.Remove(attachableBehaviour);
         OnDetached(attachableBehaviour);
+    }
+
+    /// <summary>
+    /// When we know this instance is being destroyed or will be destroyed
+    /// by something outside of NGO's realm of control, this gets invoked.
+    /// We should notify any attached AttachableBehaviour that this node
+    /// is being destroyed.
+    /// </summary>
+    protected internal override void OnIsDestroying()
+    {
+        // Notify any attached behaviours that this node is being destroyed.
+        for (int i = m_AttachedBehaviours.Count - 1; i >= 0; i--)
+        {
+            m_AttachedBehaviours[i]?.OnAttachNodeDestroy();
+        }
+        m_AttachedBehaviours.Clear();
+        base.OnIsDestroying();
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -644,11 +644,10 @@ namespace Unity.Netcode
         public ulong OwnerClientId { get; internal set; }
 
         /// <summary>
-        /// Returns true if the NetworkObject is in the middle of being destroyed or
-        /// if there is no valid assigned NetworkObject.
+        /// Returns true if the NetworkObject is in the middle of being destroyed.
         /// </summary>
         /// <remarks>
-        /// <see cref="NetworkObject.IsDestroying"/>
+        /// <see cref="SetIsDestroying"/>
         /// </remarks>
         internal bool IsDestroying { get; private set; }
 
@@ -675,6 +674,7 @@ namespace Unity.Netcode
         /// </remarks>
         internal void SetIsDestroying()
         {
+            // We intentionally invoke this before setting the IsDestroying flag.
             OnIsDestroying();
             IsDestroying = true;
         }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -644,6 +644,20 @@ namespace Unity.Netcode
         public ulong OwnerClientId { get; internal set; }
 
         /// <summary>
+        /// Returns true if the NetworkObject is in the middle of being destroyed or
+        /// if there is no valid assigned NetworkObject.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="NetworkObject.IsDestroying"/>
+        /// </remarks>
+        internal bool IsDestroying { get; private set; }
+
+        internal void SetDestroying()
+        {
+            IsDestroying = true;
+        }
+
+        /// <summary>
         /// Updates properties with network session related
         /// dependencies such as a NetworkObject's spawned
         /// state or NetworkManager's session state.

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -652,8 +652,31 @@ namespace Unity.Netcode
         /// </remarks>
         internal bool IsDestroying { get; private set; }
 
-        internal void SetDestroying()
+        /// <summary>
+        /// This provides us with a way to track when something is in the middle
+        /// of being destroyed or will be destroyed by something like SceneManager.
+        /// root <see cref="GameObject"/> is 
+        /// </summary>
+        protected internal virtual void OnIsDestroying()
         {
+        }
+
+        /// <summary>
+        /// Invoked by <see cref="NetworkObject.SetIsDestroying"/>.
+        /// </summary>
+        /// <remarks>
+        /// We want to invoke the virtual method prior to setting the
+        /// IsDestroying flag to be able to distinguish between knowing
+        /// when something will be destroyed (i.e. scene manager unload
+        /// or load in single mode) or is in the middle of being
+        /// destroyed.
+        /// Setting the flag provides a way for other instances or internals
+        /// to determine if this <see cref="NetworkBehaviour"/> instance is
+        /// in the middle of being destroyed.
+        /// </remarks>
+        internal void SetIsDestroying()
+        {
+            OnIsDestroying();
             IsDestroying = true;
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -655,7 +655,6 @@ namespace Unity.Netcode
         /// <summary>
         /// This provides us with a way to track when something is in the middle
         /// of being destroyed or will be destroyed by something like SceneManager.
-        /// root <see cref="GameObject"/> is 
         /// </summary>
         protected internal virtual void OnIsDestroying()
         {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1713,7 +1713,7 @@ namespace Unity.Netcode
                 return;
             }
 
-            foreach(var childBehaviour in m_ChildNetworkBehaviours)
+            foreach (var childBehaviour in m_ChildNetworkBehaviours)
             {
                 // Just ignore and continue processing through the entries
                 if (!childBehaviour)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1689,13 +1689,50 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// Invoked when the NetworkObject is destroyed.
+        /// Returns true if the NetworkObject is in the middle of being destroyed.
         /// </summary>
-        internal event Action OnDestroying;
+        /// <remarks>
+        /// This is particularly useful when determining if something is being de-spawned
+        /// normally or if it is being de-spawned because the NetworkObject/GameObject is
+        /// being destroyed.
+        /// </remarks>
+        internal bool IsDestroying { get; private set; }
+
+        /// <summary>
+        /// Applies the despawning flag for the local instance and
+        /// its child NetworkBehaviours. Private to assure this is
+        /// only invoked from within OnDestroy.
+        /// </summary>
+        private void SetIsDestroying()
+        {
+            IsDestroying = true;
+
+            // Exit early if null
+            if (m_ChildNetworkBehaviours == null)
+            {
+                return;
+            }
+
+            foreach(var childBehaviour in m_ChildNetworkBehaviours)
+            {
+                // Just ignore and continue processing through the entries
+                if (!childBehaviour)
+                {
+                    continue;
+                }
+
+                // Keeping the property a private set to assure this is
+                // the only way it can be set as it should never be reset
+                // back to false once invoked.
+                childBehaviour.SetDestroying();
+            }
+        }
 
         private void OnDestroy()
         {
-            OnDestroying?.Invoke();
+            // Apply the is destroying flag
+            SetIsDestroying();
+
             var networkManager = NetworkManager;
             // If no NetworkManager is assigned, then just exit early
             if (!networkManager)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1688,8 +1688,14 @@ namespace Unity.Netcode
             }
         }
 
+        /// <summary>
+        /// Invoked when the NetworkObject is destroyed.
+        /// </summary>
+        internal event Action OnDestroying;
+
         private void OnDestroy()
         {
+            OnDestroying?.Invoke();
             var networkManager = NetworkManager;
             // If no NetworkManager is assigned, then just exit early
             if (!networkManager)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1703,29 +1703,30 @@ namespace Unity.Netcode
         /// its child NetworkBehaviours. Private to assure this is
         /// only invoked from within OnDestroy.
         /// </summary>
-        private void SetIsDestroying()
+        internal void SetIsDestroying()
         {
-            IsDestroying = true;
-
-            // Exit early if null
-            if (m_ChildNetworkBehaviours == null)
+            if (IsDestroying)
             {
                 return;
             }
 
-            foreach (var childBehaviour in m_ChildNetworkBehaviours)
+            if (m_ChildNetworkBehaviours != null)
             {
-                // Just ignore and continue processing through the entries
-                if (!childBehaviour)
+                foreach (var childBehaviour in m_ChildNetworkBehaviours)
                 {
-                    continue;
-                }
+                    // Just ignore and continue processing through the entries
+                    if (!childBehaviour)
+                    {
+                        continue;
+                    }
 
-                // Keeping the property a private set to assure this is
-                // the only way it can be set as it should never be reset
-                // back to false once invoked.
-                childBehaviour.SetDestroying();
+                    // Keeping the property a private set to assure this is
+                    // the only way it can be set as it should never be reset
+                    // back to false once invoked.
+                    childBehaviour.SetIsDestroying();
+                }
             }
+            IsDestroying = true;
         }
 
         private void OnDestroy()

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/DefaultSceneManagerHandler.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/DefaultSceneManagerHandler.cs
@@ -318,10 +318,19 @@ namespace Unity.Netcode
                 }
                 else if (networkObject.HasAuthority)
                 {
+                    // We know this instance is going to be destroyed (when it receives the destroy object message).
+                    // We have to invoke this prior to invoking despawn in order to know that we are de-spawning in
+                    // preparation of being destroyed by the SceneManager.
+                    networkObject.SetIsDestroying();
+                    // This sends a de-spawn message prior to the scene event.
                     networkObject.Despawn();
                 }
                 else // We are a client, migrate the object into the DDOL temporarily until it receives the destroy command from the server
                 {
+                    // We know this instance is going to be destroyed (when it receives the destroy object message).
+                    // We have to invoke this prior to invoking despawn in order to know that we are de-spawning in
+                    // preparation of being destroyed by the SceneManager.
+                    networkObject.SetIsDestroying();
                     UnityEngine.Object.DontDestroyOnLoad(networkObject.gameObject);
                 }
             }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -2709,7 +2709,11 @@ namespace Unity.Netcode
                 }
                 else if (networkObject.HasAuthority)
                 {
-                    networkObject.Despawn();
+                    networkObject.SetIsDestroying();
+                    var isSceneObject = networkObject.IsSceneObject;
+                    // Only destroy non-scene placed NetworkObjects to avoid warnings about destroying in-scene placed NetworkObjects.
+                    // (MoveObjectsToDontDestroyOnLoad is only invoked during a scene event type of load and the load scene mode is single)
+                    networkObject.Despawn(isSceneObject.HasValue && isSceneObject.Value == false);
                 }
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -164,10 +164,16 @@ namespace Unity.Netcode
                     m_PlayerObjectsTable.Remove(playerObject.OwnerClientId);
                 }
             }
-
+            // If the client exists locally and we are destroying...
             if (NetworkManager.ConnectionManager.ConnectedClients.ContainsKey(playerObject.OwnerClientId) && destroyingObject)
             {
-                NetworkManager.ConnectionManager.ConnectedClients[playerObject.OwnerClientId].PlayerObject = null;
+                var client = NetworkManager.ConnectionManager.ConnectedClients[playerObject.OwnerClientId];
+                // and the client's currently assigned player object is what is being destroyed...
+                if (client != null && client.PlayerObject == playerObject)
+                {
+                    // then clear out the clients currently assigned player object.
+                    client.PlayerObject = null;
+                }
             }
         }
 
@@ -1380,21 +1386,31 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// Gets called only by NetworkSceneManager.SwitchScene
+        /// Gets called only by <see cref="NetworkManager.Load"/> and the load scene mode
+        /// is set to <see cref="UnityEngine.SceneManagement.LoadSceneMode.Single"/>.
         /// </summary>
         internal void ServerDestroySpawnedSceneObjects()
         {
-            // This Allocation is "OK" for now because this code only executes when a new scene is switched to
-            // We need to create a new copy the HashSet of NetworkObjects (SpawnedObjectsList) so we can remove
-            // objects from the HashSet (SpawnedObjectsList) without causing a list has been modified exception to occur.
+            // This Allocation is "OK" for now because this code only executes when transitioning to a new scene (i.e. lots of allocations and de-allocations).
+            // We create new copy of the NetworkObjects (SpawnedObjectsList) HashSet so we can remove from the original list as needed.
             var spawnedObjects = SpawnedObjectsList.ToList();
 
-            foreach (var sobj in spawnedObjects)
+            foreach (var networkObject in spawnedObjects)
             {
-                if (sobj.IsSceneObject != null && sobj.IsSceneObject.Value && sobj.DestroyWithScene && sobj.gameObject.scene != NetworkManager.SceneManager.DontDestroyOnLoadScene)
+                if (networkObject.IsSceneObject != null && networkObject.IsSceneObject.Value && networkObject.DestroyWithScene
+                    && networkObject.gameObject.scene != NetworkManager.SceneManager.DontDestroyOnLoadScene)
                 {
-                    SpawnedObjectsList.Remove(sobj);
-                    UnityEngine.Object.Destroy(sobj.gameObject);
+                    if (networkObject.IsSpawned && networkObject.HasAuthority)
+                    {
+                        networkObject.Despawn(false);
+                    }
+                    else // Non-authority objects should just be destroyed (i.e. DAHost)
+                    {
+                        // Mark the object and associated NetworkBehaviours as in the process (or will be) destroyed.
+                        networkObject.SetIsDestroying();
+                        UnityEngine.Object.Destroy(networkObject.gameObject);
+                        SpawnedObjectsList.Remove(networkObject);
+                    }
                 }
             }
         }
@@ -1630,6 +1646,10 @@ namespace Unity.Netcode
                 }
             }
 
+            if (destroyGameObject)
+            {
+                networkObject.SetIsDestroying();
+            }
             networkObject.InvokeBehaviourNetworkDespawn();
 
             // Whether we are in distributedAuthority mode and have authority on this object

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1579,7 +1579,7 @@ namespace Unity.Netcode
                     {
                         // Mark the object and associated NetworkBehaviours as in the process (or will be) destroyed.
                         networkObject.SetIsDestroying();
-                        UnityEngine.Object.Destroy(networkObject.gameObject);
+                        Object.Destroy(networkObject.gameObject);
                         SpawnedObjectsList.Remove(networkObject);
                     }
                 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/AttachableBehaviourTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/AttachableBehaviourTests.cs
@@ -653,9 +653,11 @@ namespace Unity.Netcode.RuntimeTests
                     attachable.AutoDetach = AttachableBehaviour.AutoDetachTypes.OnAttachNodeDestroy;
                 }
                 var attachableNodeName = m_AttachableNodeInstance.name;
+                var attachableBehaviourName = m_AttachableBehaviourInstance.name;
+
                 Object.Destroy(m_TargetInstance.gameObject);
                 yield return WaitForConditionOrTimeOut(AllInstancesDetached);
-                AssertOnTimeout($"[OnAttachNodeDestroy] Timed out waiting for all clients to detach {m_AttachableBehaviourInstance.name} from {attachableNodeName}!\n {m_ErrorLog}");
+                AssertOnTimeout($"[OnAttachNodeDestroy] Timed out waiting for all clients to detach {attachableBehaviourName} from {attachableNodeName}!\n {m_ErrorLog}");
             }
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/AttachableBehaviourTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/AttachableBehaviourTests.cs
@@ -55,7 +55,7 @@ namespace Unity.Netcode.RuntimeTests
             attachableNetworkObject.SetOwnershipStatus(NetworkObject.OwnershipStatus.Transferable);
 
             // The target prefab that the source prefab will attach
-            // will be parented under the target prefab.
+            // to will be parented under the target prefab.
             m_TargetNodePrefabA = CreateNetworkObjectPrefab("TargetA");
             m_TargetNodePrefabB = CreateNetworkObjectPrefab("TargetB");
             var sourceChild = new GameObject("SourceChild");
@@ -676,10 +676,13 @@ namespace Unity.Netcode.RuntimeTests
             public GameObject DefaultParent => m_DefaultParent;
             public AttachState State => m_AttachState;
 
+            public bool DestroyWithScene;
+
             public override void OnNetworkSpawn()
             {
                 AttachStateChange += OnAttachStateChangeEvent;
                 name = $"{name}-{NetworkManager.LocalClientId}";
+                NetworkObject.DestroyWithScene = DestroyWithScene;
                 base.OnNetworkSpawn();
             }
 
@@ -780,8 +783,15 @@ namespace Unity.Netcode.RuntimeTests
         /// </summary>
         internal class TestNode : AttachableNode
         {
+            public bool DestroyWithScene;
             public bool OnAttachedInvoked { get; private set; }
             public bool OnDetachedInvoked { get; private set; }
+
+            public override void OnNetworkSpawn()
+            {
+                NetworkObject.DestroyWithScene = DestroyWithScene;
+                base.OnNetworkSpawn();
+            }
 
             public bool IsAttached(AttachableBehaviour attachableBehaviour)
             {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/IntegrationTestSceneHandler.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/IntegrationTestSceneHandler.cs
@@ -761,17 +761,29 @@ namespace Unity.Netcode.TestHelpers.Runtime
                     if (networkObject.HasAuthority && networkObject.NetworkManager == networkManager)
                     {
                         VerboseDebug($"[MoveObjects from {scene.name} | {scene.handle}] Destroying {networkObject.gameObject.name} because it is in scene {networkObject.gameObject.scene.name} with DWS = {networkObject.DestroyWithScene}.");
+                        // We know this instance is going to be destroyed (when it receives the destroy object message).
+                        // We have to invoke this prior to invoking despawn in order to know that we are de-spawning in
+                        // preparation of being destroyed by the SceneManager.
+                        networkObject.SetIsDestroying();
                         networkObject.Despawn();
                     }
                     else //For integration testing purposes, migrate remaining into DDOL
                     {
                         if (networkObject.DestroyPendingSceneEvent)
                         {
+                            // We know this instance is going to be destroyed (for integration testing we simulate the destroy).
+                            // We have to invoke this prior to invoking despawn in order to know that we are de-spawning in
+                            // preparation of being destroyed by the SceneManager.
+                            networkObject.SetIsDestroying();
                             Object.Destroy(networkObject.gameObject);
                         }
                         else
                         {
                             VerboseDebug($"[MoveObjects from {scene.name} | {scene.handle}] Temporarily migrating {networkObject.gameObject.name} into DDOL to await server destroy message.");
+                            // We know this instance is going to be destroyed (when it receives the destroy object message).
+                            // We have to invoke this prior to invoking despawn in order to know that we are de-spawning in
+                            // preparation of being destroyed by the SceneManager.
+                            networkObject.SetIsDestroying();
                             Object.DontDestroyOnLoad(networkObject.gameObject);
                         }
                     }

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/AttachableBehaviourSceneLoadTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/AttachableBehaviourSceneLoadTests.cs
@@ -1,0 +1,413 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+using Unity.Netcode;
+using Unity.Netcode.Components;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+using static Unity.Netcode.RuntimeTests.AttachableBehaviourTests;
+
+namespace TestProject.RuntimeTests
+{
+    /// <summary>
+    /// Validates that attachables do not log errors or throw exceptions
+    /// during a scene transition (or unload) where either the attachable
+    /// or the node persists and the other does not but they are attached
+    /// to each other prior to the scene being unloaded.
+    /// </summary>
+    [TestFixture(HostOrServer.Host, Persists.AttachableBehaviour)]
+    [TestFixture(HostOrServer.Server, Persists.AttachableBehaviour)]
+    [TestFixture(HostOrServer.DAHost, Persists.AttachableBehaviour)]
+    [TestFixture(HostOrServer.Host, Persists.AttachableNode)]
+    [TestFixture(HostOrServer.Server, Persists.AttachableNode)]
+    [TestFixture(HostOrServer.DAHost, Persists.AttachableNode)]
+    internal class AttachableBehaviourSceneLoadTests : NetcodeIntegrationTest
+    {
+        public enum Persists
+        {
+            AttachableBehaviour,
+            AttachableNode
+        }
+
+        protected override int NumberOfClients => 2;
+
+        private const string k_SceneToLoad = "EmptyScene";
+
+        private GameObject m_AttachablePrefab;
+        private GameObject m_TargetNodePrefabA;
+        private TestAttachable m_PrefabAttachableBehaviour;
+        private TestNode m_PrefabAttachableNode;
+
+        private NetworkObject m_SourceInstance;
+        private NetworkObject m_TargetInstance;
+        private TestAttachable m_AttachableBehaviourInstance;
+        private AttachableNode m_AttachableNodeInstance;
+
+        private List<ulong> m_DoesNotPersistNetworkObjectIds = new List<ulong>();
+
+        private Scene m_AuthoritySceneLoaded;
+        private Scene m_TestRunnerScene;
+
+        private bool m_SceneLoadCompleted;
+
+        private Persists m_Persists;
+        public AttachableBehaviourSceneLoadTests(HostOrServer hostOrServer, Persists persists) : base(hostOrServer)
+        {
+            m_Persists = persists;
+        }
+
+        protected override IEnumerator OnSetup()
+        {
+            m_TestRunnerScene = SceneManager.GetActiveScene();
+            m_DoesNotPersistNetworkObjectIds.Clear();
+            return base.OnSetup();
+        }
+
+        protected override void OnCreatePlayerPrefab()
+        {
+            var networkObject = m_PlayerPrefab.GetComponent<NetworkObject>();
+            networkObject.ActiveSceneSynchronization = false;
+            base.OnCreatePlayerPrefab();
+        }
+
+        /// <summary>
+        /// Create an attachable with a node that should be destroyed upon
+        /// the scene it currently resides in being unloaded.
+        /// </summary>
+        protected override void OnServerAndClientsCreated()
+        {
+            // The source prefab contains the nested NetworkBehaviour that
+            // will be parented under the target prefab.
+            m_AttachablePrefab = CreateNetworkObjectPrefab("Source");
+            m_AttachablePrefab.AddComponent<SceneSynchronizer>();
+            var attachableNetworkObject = m_AttachablePrefab.GetComponent<NetworkObject>();
+            attachableNetworkObject.DontDestroyWithOwner = false;
+            attachableNetworkObject.SetOwnershipStatus(NetworkObject.OwnershipStatus.Transferable);
+            attachableNetworkObject.ActiveSceneSynchronization = false;
+            attachableNetworkObject.SceneMigrationSynchronization = false;
+
+            // The "attachable" that has a world item (source) as its original root parent.
+            var sourceChild = new GameObject("SourceChild");
+            sourceChild.transform.parent = m_AttachablePrefab.transform;
+            m_PrefabAttachableBehaviour = sourceChild.AddComponent<TestAttachable>();
+            m_PrefabAttachableBehaviour.AutoDetach = AttachableBehaviour.AutoDetachTypes.OnDespawn | AttachableBehaviour.AutoDetachTypes.OnAttachNodeDestroy;
+
+            // This particular test validates that the attachable's world item is destroyed on a scene transition while the attachable
+            // is attached to something that persists through scene loading.
+            m_PrefabAttachableBehaviour.DestroyWithScene = m_Persists != Persists.AttachableBehaviour;
+
+            // The target prefab that the source prefab will attach
+            // to will be parented under the target prefab.
+            m_TargetNodePrefabA = CreateNetworkObjectPrefab("TargetA");
+            m_TargetNodePrefabA.AddComponent<SceneSynchronizer>();
+            var targetNetworkObject = m_TargetNodePrefabA.GetComponent<NetworkObject>();
+            targetNetworkObject.DontDestroyWithOwner = true;
+            targetNetworkObject.SceneMigrationSynchronization = false;
+
+            // The "target node" to attach the source child to
+            var targetChildA = new GameObject("TargetChildA");
+            targetChildA.transform.parent = m_TargetNodePrefabA.transform;
+            m_PrefabAttachableNode = targetChildA.AddComponent<TestNode>();
+            m_PrefabAttachableNode.DetachOnDespawn = true;
+
+            // This particular test validates that the attachable's world item is destroyed on a scene transition while the attachable
+            // is attached to something that persists through scene loading.
+            m_PrefabAttachableNode.DestroyWithScene = m_Persists != Persists.AttachableNode;
+
+            // For this test & only when using a distributed authority topology, we want to switch the default synchronization
+            // mode back to single (even though it still is effectively loaded additively).
+            if (m_DistributedAuthority)
+            {
+                foreach (var networkManager in m_NetworkManagers)
+                {
+                    m_ApplyClientSynchronizationModeInstances.Add(new ApplyClientSynchronizationMode(networkManager, LoadSceneMode.Single));
+                }
+            }
+            base.OnServerAndClientsCreated();
+        }
+
+        #region Silly helper class to handle setting client synchronization mode for all distributed authority clients
+        // TODO: We should be able to apply NetworkSceneManager properties like this within the NetworkConfig.
+        private List<ApplyClientSynchronizationMode> m_ApplyClientSynchronizationModeInstances = new List<ApplyClientSynchronizationMode>();
+        internal class ApplyClientSynchronizationMode
+        {
+            private NetworkManager m_NetworkManager;
+            private LoadSceneMode m_LoadSceneMode;
+            public ApplyClientSynchronizationMode(NetworkManager networkManager, LoadSceneMode loadSceneMode)
+            {
+                m_NetworkManager = networkManager;
+                m_LoadSceneMode = loadSceneMode;
+                m_NetworkManager.OnClientStarted += OnClientStarted;
+            }
+
+            private void OnClientStarted()
+            {
+                m_NetworkManager.OnClientStarted -= OnClientStarted;
+                m_NetworkManager.SceneManager.SetClientSynchronizationMode(m_LoadSceneMode);
+            }
+        }
+        #endregion
+
+        protected override IEnumerator OnServerAndClientsConnected()
+        {
+            m_ApplyClientSynchronizationModeInstances.Clear();
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                networkManager.SceneManager.ActiveSceneSynchronizationEnabled = true;
+            }
+            return base.OnServerAndClientsConnected();
+        }
+
+        /// <summary>
+        /// Conditional that validates a specific spawned attachable instance
+        /// has been attached for the original and all cloned instances.
+        /// </summary>
+        private bool AllInstancesAttachedStateChanged(StringBuilder errorLog)
+        {
+            var target = m_TargetInstance;
+            var targetId = target.NetworkObjectId;
+            // The attachable can move between the two spawned instances so we have to use the appropriate one depending upon the authority's current state.
+            var currentAttachableRoot = m_AttachableBehaviourInstance.State == AttachableBehaviour.AttachState.Attached ? target : m_SourceInstance;
+            var attachable = (TestAttachable)null;
+            var node = (TestNode)null;
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                if (!networkManager.SpawnManager.SpawnedObjects.ContainsKey(currentAttachableRoot.NetworkObjectId))
+                {
+                    errorLog.AppendLine($"[Client-{networkManager.LocalClientId}] Has no spawned instance of {currentAttachableRoot.name}!");
+                    continue;
+                }
+                else
+                {
+                    attachable = networkManager.SpawnManager.SpawnedObjects[currentAttachableRoot.NetworkObjectId].GetComponentInChildren<TestAttachable>();
+                }
+
+                if (!attachable)
+                {
+                    attachable = networkManager.SpawnManager.SpawnedObjects[targetId].GetComponentInChildren<TestAttachable>();
+                    if (!attachable)
+                    {
+                        errorLog.AppendLine($"[Client-{networkManager.LocalClientId}][Attachable] Attachable was not found!");
+                    }
+                    continue;
+                }
+
+                if (!networkManager.SpawnManager.SpawnedObjects.ContainsKey(targetId))
+                {
+                    errorLog.AppendLine($"[Client-{networkManager.LocalClientId}] Has no spawned instance of {target.name}!");
+                    continue;
+                }
+                else
+                {
+                    node = networkManager.SpawnManager.SpawnedObjects[targetId].GetComponentInChildren<TestNode>();
+                }
+
+                if (!attachable.CheckForState(true, false))
+                {
+                    errorLog.AppendLine($"[Client-{networkManager.LocalClientId}][{attachable.name}] Did not have its override invoked!");
+                }
+                if (!attachable.CheckForState(true, true))
+                {
+                    errorLog.AppendLine($"[Client-{networkManager.LocalClientId}][{attachable.name}] Did not have its event invoked!");
+                }
+                if (!node.OnAttachedInvoked)
+                {
+                    errorLog.AppendLine($"[Client-{networkManager.LocalClientId}][{node.name}] Did not have its override invoked!");
+                }
+                if (attachable.transform.parent != node.transform)
+                {
+                    errorLog.AppendLine($"[Client-{networkManager.LocalClientId}][{attachable.name}] {node.name} is not the parent of {attachable.name}!");
+                }
+            }
+            return errorLog.Length == 0;
+        }
+
+        /// <summary>
+        /// Conditional that waits for the expected, scene load non-persistent, spawned objects
+        /// to be despawned.
+        /// </summary>
+        private bool WaitForAllToDespawn(StringBuilder errorLog)
+        {
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                for (int i = 0; i < m_DoesNotPersistNetworkObjectIds.Count; i++)
+                {
+                    if (networkManager.SpawnManager == null)
+                    {
+                        continue;
+                    }
+                    var sourceId = m_DoesNotPersistNetworkObjectIds[i];
+                    if (networkManager.SpawnManager.SpawnedObjects.ContainsKey(sourceId))
+                    {
+                        errorLog.AppendLine($"[{networkManager.name}] Still has NetworkObjectId-{sourceId} spawned!");
+                    }
+                }
+            }
+            return errorLog.Length == 0;
+        }
+
+        /// <summary>
+        /// Since everything spawns in the active scene, we want to assure that these instances are in their
+        /// NetworkManager relative scene so upon receiving a scene unload event each client will handle destroying
+        /// anything still spawned that does not persist a scene loading event.
+        /// This is required to replicate of this issue.
+        /// </summary>
+        private void SynchronizeScene()
+        {
+            var sourceId = m_SourceInstance.NetworkObjectId;
+            var targetId = m_TargetInstance.NetworkObjectId;
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                var synchronizer = networkManager.SpawnManager.SpawnedObjects[sourceId].GetComponent<SceneSynchronizer>();
+                Assert.IsTrue(synchronizer.SynchronizeScene(), $"[{synchronizer.name}] Failed to synchronize instance to local scene!");
+                synchronizer = networkManager.SpawnManager.SpawnedObjects[targetId].GetComponent<SceneSynchronizer>();
+                Assert.IsTrue(synchronizer.SynchronizeScene(), $"[{synchronizer.name}] Failed to synchronize instance to local scene!");
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator AttachedUponSceneTransition([Values] bool detachOnDespawn)
+        {
+            m_SceneLoadCompleted = false;
+
+            // Handle detatch on despawn differently to validate both paths.
+            m_PrefabAttachableNode.DetachOnDespawn = detachOnDespawn;
+
+            var authority = GetAuthorityNetworkManager();
+
+            // Load a scene so all clients load this scene.
+            authority.SceneManager.OnSceneEvent += OnSceneEvent;
+            var response = authority.SceneManager.LoadScene(k_SceneToLoad, LoadSceneMode.Additive);
+            Assert.IsTrue(response == SceneEventProgressStatus.Started, $"Failed to begin scene loading event for {k_SceneToLoad} with a status of {response}!");
+            yield return WaitForConditionOrTimeOut(() => m_AuthoritySceneLoaded.IsValid() && m_AuthoritySceneLoaded.isLoaded && m_SceneLoadCompleted);
+            AssertOnTimeout($"Timed out waiting for all clients to load scene {k_SceneToLoad}!");
+
+            // Now, make the newly loaded scene the currently active scene so everything instantiates in the scene authority's newly loaded scene instance.
+            SceneManager.SetActiveScene(m_AuthoritySceneLoaded);
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                // Spawn our instances for this client
+                m_SourceInstance = SpawnObject(m_AttachablePrefab, networkManager).GetComponent<NetworkObject>();
+                m_TargetInstance = SpawnObject(m_TargetNodePrefabA, networkManager).GetComponent<NetworkObject>();
+
+                yield return WaitForSpawnedOnAllOrTimeOut(m_SourceInstance);
+                AssertOnTimeout($"Timed out waiting for all clients to spawn {m_SourceInstance.name}!");
+
+                yield return WaitForSpawnedOnAllOrTimeOut(m_TargetInstance);
+                AssertOnTimeout($"Timed out waiting for all clients to spawn {m_TargetInstance.name}!");
+
+                m_AttachableBehaviourInstance = m_SourceInstance.GetComponentInChildren<TestAttachable>();
+                Assert.NotNull(m_AttachableBehaviourInstance, $"{m_SourceInstance.name} does not have a nested child {nameof(AttachableBehaviour)}!");
+
+                m_AttachableNodeInstance = m_TargetInstance.GetComponentInChildren<TestNode>();
+                Assert.NotNull(m_AttachableNodeInstance, $"{m_TargetInstance.name} does not have a nested child {nameof(AttachableNode)}!");
+
+                m_AttachableBehaviourInstance.Attach(m_AttachableNodeInstance);
+
+                yield return WaitForConditionOrTimeOut(AllInstancesAttachedStateChanged);
+                AssertOnTimeout($"Timed out waiting for all clients to attach {m_AttachableBehaviourInstance.name} to {m_AttachableNodeInstance.name}!");
+
+                // Now migrate all instances from the scene authority's scene instance to the NetworkManager relative scene.
+                SynchronizeScene();
+
+                // Keep track of the spawned instances we expect to not persist a scene load
+                var doesNotPersist = m_Persists == Persists.AttachableNode ? m_SourceInstance.NetworkObjectId : m_TargetInstance.NetworkObjectId;
+                m_DoesNotPersistNetworkObjectIds.Add(doesNotPersist);
+            }
+
+            // This is the actual validation point where the scene is unloaded and either the attachable or
+            // the node will be destroyed while the other persists (and detects that the other has been despawned and destroyed).
+            response = authority.SceneManager.UnloadScene(m_AuthoritySceneLoaded);
+            Assert.IsTrue(response == SceneEventProgressStatus.Started, $"Failed to begin scene unloading event for {k_SceneToLoad} with a status of {response}!");
+
+            yield return WaitForConditionOrTimeOut(WaitForAllToDespawn);
+            AssertOnTimeout($"Timed out waiting for all clients to despawn NetworkObjects!");
+        }
+
+        private void OnSceneEvent(SceneEvent sceneEvent)
+        {
+            if ((sceneEvent.SceneEventType != SceneEventType.LoadEventCompleted && sceneEvent.SceneEventType != SceneEventType.LoadComplete)
+                || sceneEvent.ClientId != GetAuthorityNetworkManager().LocalClientId)
+            {
+                return;
+            }
+
+            if (sceneEvent.SceneName == k_SceneToLoad)
+            {
+                if (sceneEvent.SceneEventType == SceneEventType.LoadComplete)
+                {
+                    m_AuthoritySceneLoaded = sceneEvent.Scene;
+                }
+
+                if (sceneEvent.SceneEventType == SceneEventType.LoadEventCompleted)
+                {
+                    m_SceneLoadCompleted = true;
+                }
+            }
+        }
+
+        protected override IEnumerator OnTearDown()
+        {
+            // Assure we set the active scene back to the integration test's scene if needed.
+            var currentActiveScene = SceneManager.GetActiveScene();
+            if (m_AuthoritySceneLoaded != null && currentActiveScene == m_AuthoritySceneLoaded && m_AuthoritySceneLoaded.isLoaded && m_AuthoritySceneLoaded.IsValid())
+            {
+                SceneManager.SetActiveScene(m_TestRunnerScene);
+                SceneManager.UnloadSceneAsync(m_AuthoritySceneLoaded);
+            }
+            return base.OnTearDown();
+        }
+    }
+
+    /// <summary>
+    /// This helper class will assure that the spawned object clone
+    /// (or original) instance will be migrated into its appropriate
+    /// NetworkManager relative instance.
+    /// </summary>
+    /// <remarks>
+    /// Since we share the same scene root, there is only 1 active scene
+    /// and all new instances are always instantiated within that.
+    /// If you load a new scene and make that the active scene prior to
+    /// spawning instances, then all instances will reside in the scene
+    /// authority's loaded scene instance.
+    /// This helper assures all instances are migrated into their NetworkManager
+    /// relative scene in order to replicate a more "real world" scenario
+    /// where each spawned clone instance for each connected client will be
+    /// destroyed during that client's processing of the unload scene
+    /// event.
+    /// Without this helper (or similar logic elsewhere), everything would be
+    /// destroyed upon the authority's scene being unloaded while the rest of
+    /// the clients would unload empty scenes.
+    /// </remarks>
+    internal class SceneSynchronizer : NetworkBehaviour
+    {
+        /// <summary>
+        /// We are using the NetworkBehaviour to provide us with the relative
+        /// NetworkManager instance (for this spawned instance) in order to
+        /// then check against the client relative scenes loaded.
+        /// </summary>
+        /// <returns>Success if true. Failed to find the scene if false.</returns>
+        public bool SynchronizeScene()
+        {
+            var scenes = NetworkManager.SceneManager.GetSynchronizedScenes();
+            foreach (var scene in scenes)
+            {
+                // Find the matching scene name
+                if (gameObject.scene.name == scene.name)
+                {
+                    // If the scene handles are different, then migrate to the
+                    // one registered with this NetworkSceneManager instance.
+                    if (scene.handle != gameObject.scene.handle)
+                    {
+                        SceneManager.MoveGameObjectToScene(gameObject, scene);
+                    }
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/AttachableBehaviourSceneLoadTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/AttachableBehaviourSceneLoadTests.cs
@@ -273,7 +273,7 @@ namespace TestProject.RuntimeTests
         {
             m_SceneLoadCompleted = false;
 
-            // Handle detatch on despawn differently to validate both paths.
+            // Handle detach on despawn differently to validate both paths.
             m_PrefabAttachableNode.DetachOnDespawn = detachOnDespawn;
 
             var authority = GetAuthorityNetworkManager();

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/AttachableBehaviourSceneLoadTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/AttachableBehaviourSceneLoadTests.cs
@@ -284,7 +284,7 @@ namespace TestProject.RuntimeTests
             Assert.IsTrue(response == SceneEventProgressStatus.Started, $"Failed to begin scene loading event for {k_SceneToLoad} with a status of {response}!");
             yield return WaitForConditionOrTimeOut(() => m_AuthoritySceneLoaded.IsValid() && m_AuthoritySceneLoaded.isLoaded && m_SceneLoadCompleted);
             AssertOnTimeout($"Timed out waiting for all clients to load scene {k_SceneToLoad}!");
-
+            var persistedObjects = new Dictionary<NetworkManager, ulong>();
             // Now, make the newly loaded scene the currently active scene so everything instantiates in the scene authority's newly loaded scene instance.
             SceneManager.SetActiveScene(m_AuthoritySceneLoaded);
             foreach (var networkManager in m_NetworkManagers)
@@ -315,7 +315,10 @@ namespace TestProject.RuntimeTests
 
                 // Keep track of the spawned instances we expect to not persist a scene load
                 var doesNotPersist = m_Persists == Persists.AttachableNode ? m_SourceInstance.NetworkObjectId : m_TargetInstance.NetworkObjectId;
+                var persists = m_Persists == Persists.AttachableNode ? m_TargetInstance.NetworkObjectId : m_SourceInstance.NetworkObjectId;
                 m_DoesNotPersistNetworkObjectIds.Add(doesNotPersist);
+                persistedObjects.Add(networkManager, persists);
+                Debug.Log($"[{networkManager.name}] Spawned attachable and attached it.");
             }
 
             // This is the actual validation point where the scene is unloaded and either the attachable or

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/AttachableBehaviourSceneLoadTests.cs.meta
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/AttachableBehaviourSceneLoadTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d0fa3eb3f5e1b6f4da462ff095a46f84


### PR DESCRIPTION
## Purpose of this PR
Fixing an issue with attachables where either an `AttachableBehaviour` or an `AttachableNode` can throw an exception or erroneously log an error message if they are attached together prior to a scene unload event where one of the two persists the scene unload event and the other does not.

### Jira ticket

[MTT-14831](https://jira.unity3d.com/browse/MTT-14831)

### Changelog
[//]: # (updated with all public facing changes  - API changes, UI/UX changes, behaviour changes, bug fixes. Remove if not relevant.)

- Fixed: Issue where either an `AttachableBehaviour` or an `AttachableNode` can throw an exception or erroneously log an error message if they are attached during a scene unload where one of the two persists the scene unload event and the other does not.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- No documentation changes or additions were necessary.

## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [x] `Manual testing done`
  - Used internal NGO examples project.

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [x] `Covered by new automated tests`
  - Added `AttachableBehaviourSceneLoadTests`.

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports

This is v2.x.x. specific.
