### PR TITLE
fix: Various bugs causing rust test failures on trunk

### DIFF
--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -75,20 +75,20 @@ pr_code_changes_checks:
     # Run API validation to early-detect all new APIs that would force us to release new minor version of the package. Note that for this to work the package version in package.json must correspond to "actual package state" which means that it should be higher than last released version
     - .yamato/vetting-test.yml#vetting_test
 
-    # Run package EditMode and Playmode package tests on 6000.5 and an older supported editor (6000.0)
-    - .yamato/package-tests.yml#package_test_-_ngo_6000.5_mac
+    # Run package EditMode and Playmode package tests on trunk and an older supported editor (6000.0)
+    - .yamato/package-tests.yml#package_test_-_ngo_trunk_mac
     - .yamato/package-tests.yml#package_test_-_ngo_6000.0_win
 
-    # Run testproject EditMode and Playmode project tests on 6000.5 and an older supported editor (6000.0)
-    - .yamato/project-tests.yml#test_testproject_win_6000.5
+    # Run testproject EditMode and Playmode project tests on trunk and an older supported editor (6000.0)
+    - .yamato/project-tests.yml#test_testproject_win_trunk
     - .yamato/project-tests.yml#test_testproject_mac_6000.0
 
     # Run standalone test. We run it only on Ubuntu since it's the fastest machine, and it was noted that for example distribution on macOS is taking 40m since we switched to Apple Silicon
     # Coverage on other standalone machines is present in Nightly job so it's enough to not run all of them for PRs
     # desktop_standalone_test and cmb_service_standalone_test are both reusing desktop_standalone_build dependency so we run those in the same configuration on PRs to reduce waiting time.
-    # Note that our daily tests will anyway run both test configurations in "minimal supported" and "6000.5" configurations
-    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_ubuntu_il2cpp_6000.5
-    - .yamato/cmb-service-standalone-tests.yml#cmb_service_standalone_test_testproject_ubuntu_il2cpp_6000.5
+    # Note that our daily tests will anyway run both test configurations in "minimal supported" and "trunk" configurations
+    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_ubuntu_il2cpp_trunk
+    - .yamato/cmb-service-standalone-tests.yml#cmb_service_standalone_test_testproject_ubuntu_il2cpp_trunk
   triggers:
     expression: |-
       (pull_request.comment eq "ngo" OR

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -13,6 +13,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+- Hardened error handling and recovery during `NetworkObject` spawn. (#3941)
 - Replaced Debug usage by NetcodeLog on `NetworkSpawnManager` and `NetworkObject`. (#3933)
 - Improved performance of `NetworkBehaviour`. (#3915)
 - Improved performance of `NetworkTransform`. (#3907)

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -972,27 +972,39 @@ namespace Unity.Netcode
             }
 
             // Server-side spawning (only if there is a prefab hash or player prefab provided)
-            if (!NetworkManager.DistributedAuthorityMode && createPlayerObject && (playerPrefabHash.HasValue || NetworkManager.NetworkConfig.PlayerPrefab != null))
+            var idHashToSpawn = playerPrefabHash ?? NetworkManager.NetworkConfig.PlayerPrefab?.GetComponent<NetworkObject>()?.GlobalObjectIdHash;
+            if (!NetworkManager.DistributedAuthorityMode && createPlayerObject && idHashToSpawn.HasValue)
             {
-                var playerObject = playerPrefabHash.HasValue ? NetworkManager.SpawnManager.GetNetworkObjectToSpawn(playerPrefabHash.Value, ownerClientId, playerPosition, playerRotation)
-                : NetworkManager.SpawnManager.GetNetworkObjectToSpawn(NetworkManager.NetworkConfig.PlayerPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash, ownerClientId, playerPosition, playerRotation);
+                var playerObject = NetworkManager.SpawnManager.GetNetworkObjectToSpawn(idHashToSpawn.Value, ownerClientId, playerPosition, playerRotation);
 
                 if (playerObject == null)
                 {
-                    Debug.LogError($"[{nameof(NetworkObject)}] Player prefab is null! Cannot spawn player object!");
+                    if (NetworkManager.LogLevel <= LogLevel.Error)
+                    {
+                        NetworkLog.LogError($"[{nameof(NetworkObject)}] Player prefab is null! Cannot spawn player object!");
+                    }
                 }
                 else
                 {
                     // Spawn the player NetworkObject locally
-                    NetworkManager.SpawnManager.AuthorityLocalSpawn(
+                    if (NetworkManager.SpawnManager.AuthorityLocalSpawn(
                         playerObject,
                         NetworkManager.SpawnManager.GetNetworkObjectId(),
                         sceneObject: false,
                         playerObject: true,
                         ownerClientId,
-                        destroyWithScene: false);
+                        destroyWithScene: false))
+                    {
+                        client.AssignPlayerObject(ref playerObject);
+                    }
+                    else
+                    {
+                        if (NetworkManager.LogLevel <= LogLevel.Developer)
+                        {
+                            NetworkLog.LogError($"[{nameof(NetworkObject)}] Player prefab failed to spawn!");
+                        }
+                    }
 
-                    client.AssignPlayerObject(ref playerObject);
                 }
             }
 
@@ -1122,8 +1134,25 @@ namespace Unity.Netcode
                 }
                 return;
             }
-            var globalObjectIdHash = playerPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash;
-            var networkObject = NetworkManager.SpawnManager.GetNetworkObjectToSpawn(globalObjectIdHash, ownerId, playerPrefab.transform.position, playerPrefab.transform.rotation);
+            var prefabObject = playerPrefab.GetComponent<NetworkObject>();
+            if (prefabObject == null)
+            {
+                if (NetworkManager.LogLevel <= LogLevel.Normal)
+                {
+                    NetworkLog.LogError("Failed to fetch valid player prefab. Ensure PlayerPrefab that is set in NetcodeConfig contains a NetworkObject component.");
+                }
+                return;
+            }
+            var networkObject = NetworkManager.SpawnManager.GetNetworkObjectToSpawn(prefabObject.GlobalObjectIdHash, ownerId, playerPrefab.transform.position, playerPrefab.transform.rotation);
+            if (networkObject == null)
+            {
+                if (NetworkManager.LogLevel <= LogLevel.Normal)
+                {
+                    NetworkLog.LogError("Failed to spawn player prefab!");
+                }
+                return;
+            }
+
             networkObject.IsSceneObject = false;
             networkObject.NetworkManagerOwner = NetworkManager;
             networkObject.SpawnAsPlayerObject(ownerId, networkObject.DestroyWithScene);

--- a/com.unity.netcode.gameobjects/Runtime/Core/FindObjects.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/FindObjects.cs
@@ -21,17 +21,19 @@ namespace Unity.Netcode
         /// <typeparam name="T"></typeparam>
         /// <param name="includeInactive">When true, inactive objects will be included.</param>
         /// <param name="orderByIdentifier">When true, the array returned will be sorted by identifier.</param>
-        /// <returns>Resulst as an <see cref="Array"/> of type T</returns>
+        /// <returns>Results as an <see cref="Array"/> of type T</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T[] ByType<T>(bool includeInactive = false, bool orderByIdentifier = false) where T : Object
         {
             var inactive = includeInactive ? UnityEngine.FindObjectsInactive.Include : UnityEngine.FindObjectsInactive.Exclude;
 #if NGO_FINDOBJECTS_NOSORTING
             var results = Object.FindObjectsByType<T>(inactive);
+#if !NGO_FINDOBJECTS_UNORDERED_IDS
             if (orderByIdentifier)
             {
                 Array.Sort(results, (a, b) => a.GetEntityId().CompareTo(b.GetEntityId()));
             }
+#endif
 #else
             var results = Object.FindObjectsByType<T>(inactive, orderByIdentifier ? UnityEngine.FindObjectsSortMode.InstanceID : UnityEngine.FindObjectsSortMode.None);
 #endif

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -3324,12 +3324,23 @@ namespace Unity.Netcode
         {
             var endOfSynchronizationData = reader.Position + serializedObject.SynchronizationDataSize;
 
+            if (serializedObject.NetworkObjectId == default)
+            {
+                if (networkManager.LogLevel <= LogLevel.Error)
+                {
+                    NetworkLog.LogErrorServer($"[{nameof(GlobalObjectIdHash)}={serializedObject.Hash}] Received spawn request with invalid {nameof(NetworkObjectId)} {serializedObject.NetworkObjectId}. This should not happen!");
+                }
+
+                reader.Seek(endOfSynchronizationData);
+                return null;
+            }
+
             // Do the SpawnManager parts of the object spawn
             var succeeded = networkManager.SpawnManager.NonAuthorityLocalSpawn(in serializedObject, out var networkObject, reader, serializedObject.DestroyWithScene);
 
             // Process any deferred messages once the object is 100% finished spawning
             // Ensure this is done whether the spawn succeeds or fails
-            networkManager.DeferredMessageManager.ProcessTriggers(IDeferredNetworkMessageManager.TriggerType.OnSpawn, networkObject.NetworkObjectId);
+            networkManager.DeferredMessageManager.ProcessTriggers(IDeferredNetworkMessageManager.TriggerType.OnSpawn, serializedObject.NetworkObjectId);
 
             // Ensure that the buffer is completely reset
             if (reader.Position != endOfSynchronizationData)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -3232,7 +3232,10 @@ namespace Unity.Netcode
                 {
                     reader.ReadValueSafe(out ushort networkBehaviourId);
                     var networkBehaviour = GetNetworkBehaviourAtOrderIndex(networkBehaviourId);
-                    networkBehaviour.Synchronize(ref serializer, targetClientId);
+                    if (networkBehaviour != null)
+                    {
+                        networkBehaviour.Synchronize(ref serializer, targetClientId);
+                    }
                 }
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -3232,10 +3232,7 @@ namespace Unity.Netcode
                 {
                     reader.ReadValueSafe(out ushort networkBehaviourId);
                     var networkBehaviour = GetNetworkBehaviourAtOrderIndex(networkBehaviourId);
-                    if (networkBehaviour != null)
-                    {
-                        networkBehaviour.Synchronize(ref serializer, targetClientId);
-                    }
+                    networkBehaviour?.Synchronize(ref serializer, targetClientId);
                 }
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1807,7 +1807,15 @@ namespace Unity.Netcode
                 }
             }
 
-            NetworkManagerOwner.SpawnManager.AuthorityLocalSpawn(this, NetworkManagerOwner.SpawnManager.GetNetworkObjectId(), IsSceneObject.HasValue && IsSceneObject.Value, playerObject, ownerClientId, destroyWithScene);
+            if (!NetworkManagerOwner.SpawnManager.AuthorityLocalSpawn(this, NetworkManagerOwner.SpawnManager.GetNetworkObjectId(), IsSceneObject.HasValue && IsSceneObject.Value, playerObject, ownerClientId, destroyWithScene))
+            {
+                if (NetworkManagerOwner.LogLevel <= LogLevel.Normal)
+                {
+                    NetworkLog.LogWarning($"[{name}] Failed to finish spawning!");
+                }
+                ResetOnDespawn();
+                return;
+            }
 
             if ((NetworkManagerOwner.DistributedAuthorityMode && NetworkManagerOwner.DAHost) || (!NetworkManagerOwner.DistributedAuthorityMode && NetworkManagerOwner.IsServer))
             {
@@ -1865,7 +1873,7 @@ namespace Unity.Netcode
         /// <summary>
         /// This invokes <see cref="NetworkSpawnManager.InstantiateAndSpawn(NetworkObject, ulong, bool, bool, bool, Vector3, Quaternion)"/>.
         /// </summary>
-        /// <param name="networkManager">The local instance of the NetworkManager connected to an session in progress.</param>
+        /// <param name="networkManager">The local instance of the NetworkManager connected to a session in progress.</param>
         /// <param name="ownerClientId">The owner of the <see cref="NetworkObject"/> instance (defaults to server).</param>
         /// <param name="destroyWithScene">Whether the <see cref="NetworkObject"/> instance will be destroyed when the scene it is located within is unloaded (default is false).</param>
         /// <param name="isPlayerObject">Whether the <see cref="NetworkObject"/> instance is a player object or not (default is false).</param>
@@ -2159,6 +2167,11 @@ namespace Unity.Netcode
         {
             m_LatestParent = latestParent;
             m_CachedWorldPositionStays = worldPositionStays;
+        }
+
+        internal void ClearNetworkParenting()
+        {
+            m_LatestParent = null;
         }
 
         /// <summary>
@@ -3304,89 +3317,34 @@ namespace Unity.Netcode
         {
             var endOfSynchronizationData = reader.Position + serializedObject.SynchronizationDataSize;
 
-            byte[] instantiationData = null;
-            if (serializedObject.HasInstantiationData)
+            // Do the SpawnManager parts of the object spawn
+            var succeeded = networkManager.SpawnManager.NonAuthorityLocalSpawn(in serializedObject, out var networkObject, reader, serializedObject.DestroyWithScene);
+
+            // Process any deferred messages once the object is 100% finished spawning
+            // Ensure this is done whether the spawn succeeds or fails
+            networkManager.DeferredMessageManager.ProcessTriggers(IDeferredNetworkMessageManager.TriggerType.OnSpawn, networkObject.NetworkObjectId);
+
+            // If the SpawnManager spawn doesn't succeed, be sure to clean up
+            if (!succeeded)
             {
-                reader.ReadValueSafe(out instantiationData);
-            }
-
-
-            // Attempt to create a local NetworkObject
-            var networkObject = networkManager.SpawnManager.CreateLocalNetworkObject(serializedObject, instantiationData);
-
-
-            if (networkObject == null)
-            {
-                // Log the error that the NetworkObject failed to construct
-                if (networkManager.LogLevel <= LogLevel.Normal)
-                {
-                    NetworkLog.LogError($"Failed to spawn {nameof(NetworkObject)} for Hash {serializedObject.Hash}.");
-                }
-
-                try
-                {
-                    // If we failed to load this NetworkObject, then skip past the Network Variable and (if any) synchronization data
-                    reader.Seek(endOfSynchronizationData);
-                }
-                catch (Exception ex)
-                {
-                    Debug.LogException(ex);
-                }
-
-                // We have nothing left to do here.
-                return null;
-            }
-
-            networkObject.NetworkManagerOwner = networkManager;
-
-            // This will get set again when the NetworkObject is spawned locally, but we set it here ahead of spawning
-            // in order to be able to determine which NetworkVariables the client will be allowed to read.
-            networkObject.OwnerClientId = serializedObject.OwnerClientId;
-
-            // Special Case: Invoke NetworkBehaviour.OnPreSpawn methods here before SynchronizeNetworkBehaviours
-            networkObject.InvokeBehaviourNetworkPreSpawn();
-
-            // Process the remaining synchronization data from the buffer
-            try
-            {
-                // Synchronize NetworkBehaviours
-                var bufferSerializer = new BufferSerializer<BufferSerializerReader>(new BufferSerializerReader(reader));
-                networkObject.SynchronizeNetworkBehaviours(ref bufferSerializer, networkManager.LocalClientId);
-
                 // Ensure that the buffer is completely reset
                 if (reader.Position != endOfSynchronizationData)
                 {
-                    Debug.LogWarning($"[Size mismatch] Expected: {endOfSynchronizationData} Currently At: {reader.Position}!");
+                    if (networkManager.LogLevel <= LogLevel.Normal)
+                    {
+                        NetworkLog.LogWarning($"[{networkObject.name}][Deserialize][Size mismatch] Expected: {endOfSynchronizationData} Currently At: {reader.Position}!");
+                    }
                     reader.Seek(endOfSynchronizationData);
                 }
-            }
-            catch
-            {
-                reader.Seek(endOfSynchronizationData);
-            }
 
-            // If we are an in-scene placed NetworkObject and we originally had a parent but when synchronized we are
-            // being told we do not have a parent, then we want to clear the latest parent so it is not automatically
-            // "re-parented" to the original parent. This can happen if not unloading the scene and the parenting of
-            // the in-scene placed Networkobject changes several times over different sessions.
-            if (serializedObject.IsSceneObject && !serializedObject.HasParent && networkObject.m_LatestParent.HasValue)
-            {
-                networkObject.m_LatestParent = null;
-            }
-
-            // Spawn the NetworkObject
-            if (networkObject.IsSpawned)
-            {
-                if (NetworkManager.Singleton.LogLevel <= LogLevel.Error)
+                // If the networkObject was created but the spawn failed, the created object needs to be destroyed
+                if (networkObject != null)
                 {
-                    NetworkLog.LogErrorServer($"[{networkObject.name}] Object-{networkObject.NetworkObjectId} is already spawned!");
+                    Destroy(networkObject.gameObject);
                 }
+
                 return null;
             }
-
-            // Invoke the non-authority local spawn method
-            // (It also invokes post spawn and handles processing derferred messages)
-            networkManager.SpawnManager.NonAuthorityLocalSpawn(networkObject, serializedObject, serializedObject.DestroyWithScene);
 
             if (serializedObject.SyncObservers)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/DestroyObjectMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/DestroyObjectMessage.cs
@@ -112,7 +112,7 @@ namespace Unity.Netcode
             }
 
             // Client-Server mode we always defer where in distributed authority mode we only defer if it is not a targeted destroy
-            if (!networkManager.DistributedAuthorityMode || (networkManager.DistributedAuthorityMode && !IsTargetedDestroy))
+            if (!networkManager.DistributedAuthorityMode || !networkManager.IsConnectedClient || (networkManager.DistributedAuthorityMode && !IsTargetedDestroy))
             {
                 networkManager.DeferredMessageManager.DeferMessage(IDeferredNetworkMessageManager.TriggerType.OnSpawn, NetworkObjectId, reader, ref context, k_Name);
             }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -2038,7 +2038,6 @@ namespace Unity.Netcode
                 // If we are just a normal client and in distributed authority mode, then always use the known server scene handle
                 if (NetworkManager.DistributedAuthorityMode && NetworkManager.CMBServiceConnection)
                 {
-                    Debug.Log($"[Client-{NetworkManager.LocalClientId}] Adding scene to synchronize: {scene.name}");
                     sceneEventData.AddSceneToSynchronize(SceneHashFromNameOrPath(scene.path), ClientSceneHandleToServerSceneHandle[scene.handle]);
                 }
                 else

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -2303,146 +2303,146 @@ namespace Unity.Netcode
                         break;
                     }
                 case SceneEventType.Synchronize:
-                {
-                    if (sceneEventData.IsStartingSynchronization)
                     {
-                        sceneEventData.IsStartingSynchronization = false;
-
-                        OnSceneEvent?.Invoke(new SceneEvent()
+                        if (sceneEventData.IsStartingSynchronization)
                         {
-                            SceneEventType = SceneEventType.Synchronize,
-                            ClientId = NetworkManager.LocalClientId,
-                        });
+                            sceneEventData.IsStartingSynchronization = false;
 
-                        OnSynchronize?.Invoke(NetworkManager.LocalClientId);
-                    }
-
-                    if (!sceneEventData.IsDoneWithSynchronization())
-                    {
-                        OnClientBeginSync(sceneEventId);
-                    }
-                    else
-                    {
-                        // Include anything in the DDOL scene
-                        PopulateScenePlacedObjects(DontDestroyOnLoadScene, false);
-
-                        // If needed, set the currently active scene
-                        if (HashToBuildIndex.ContainsKey(sceneEventData.ActiveSceneHash))
-                        {
-                            var targetActiveScene = SceneManager.GetSceneByBuildIndex(HashToBuildIndex[sceneEventData.ActiveSceneHash]);
-                            if (targetActiveScene.isLoaded && targetActiveScene.handle != SceneManager.GetActiveScene().handle)
+                            OnSceneEvent?.Invoke(new SceneEvent()
                             {
-                                SceneManager.SetActiveScene(targetActiveScene);
-                            }
+                                SceneEventType = SceneEventType.Synchronize,
+                                ClientId = NetworkManager.LocalClientId,
+                            });
+
+                            OnSynchronize?.Invoke(NetworkManager.LocalClientId);
                         }
 
-                        // Spawn and Synchronize all NetworkObjects
-                        sceneEventData.SynchronizeSceneNetworkObjects(NetworkManager);
-
-                        // If needed, migrate dynamically spawned NetworkObjects to the same scene as they are on the server
-                        SynchronizeNetworkObjectScene();
-
-                        // Process any pending create object messages that the client received during synchronization
-                        ProcessDeferredCreateObjectMessages();
-
-                        sceneEventData.SceneEventType = SceneEventType.SynchronizeComplete;
-                        if (NetworkManager.DistributedAuthorityMode)
+                        if (!sceneEventData.IsDoneWithSynchronization())
                         {
-                            sceneEventData.TargetClientId = NetworkManager.CurrentSessionOwner;
-                            sceneEventData.SenderClientId = NetworkManager.LocalClientId;
-                            var message = new SceneEventMessage
-                            {
-                                EventData = sceneEventData,
-                            };
-                            var target = NetworkManager.DAHost ? NetworkManager.CurrentSessionOwner : NetworkManager.ServerClientId;
-                            var size = NetworkManager.ConnectionManager.SendMessage(ref message, m_NetworkDelivery, target);
-                            NetworkManager.NetworkMetrics.TrackSceneEventSent(target, (uint)sceneEventData.SceneEventType, SceneNameFromHash(sceneEventData.SceneHash), size);
+                            OnClientBeginSync(sceneEventId);
                         }
                         else
                         {
-                            SendSceneEventData(sceneEventId, new ulong[] { NetworkManager.ServerClientId });
+                            // Include anything in the DDOL scene
+                            PopulateScenePlacedObjects(DontDestroyOnLoadScene, false);
+
+                            // If needed, set the currently active scene
+                            if (HashToBuildIndex.ContainsKey(sceneEventData.ActiveSceneHash))
+                            {
+                                var targetActiveScene = SceneManager.GetSceneByBuildIndex(HashToBuildIndex[sceneEventData.ActiveSceneHash]);
+                                if (targetActiveScene.isLoaded && targetActiveScene.handle != SceneManager.GetActiveScene().handle)
+                                {
+                                    SceneManager.SetActiveScene(targetActiveScene);
+                                }
+                            }
+
+                            // Spawn and Synchronize all NetworkObjects
+                            sceneEventData.SynchronizeSceneNetworkObjects(NetworkManager);
+
+                            // If needed, migrate dynamically spawned NetworkObjects to the same scene as they are on the server
+                            SynchronizeNetworkObjectScene();
+
+                            // Process any pending create object messages that the client received during synchronization
+                            ProcessDeferredCreateObjectMessages();
+
+                            sceneEventData.SceneEventType = SceneEventType.SynchronizeComplete;
+                            if (NetworkManager.DistributedAuthorityMode)
+                            {
+                                sceneEventData.TargetClientId = NetworkManager.CurrentSessionOwner;
+                                sceneEventData.SenderClientId = NetworkManager.LocalClientId;
+                                var message = new SceneEventMessage
+                                {
+                                    EventData = sceneEventData,
+                                };
+                                var target = NetworkManager.DAHost ? NetworkManager.CurrentSessionOwner : NetworkManager.ServerClientId;
+                                var size = NetworkManager.ConnectionManager.SendMessage(ref message, m_NetworkDelivery, target);
+                                NetworkManager.NetworkMetrics.TrackSceneEventSent(target, (uint)sceneEventData.SceneEventType, SceneNameFromHash(sceneEventData.SceneHash), size);
+                            }
+                            else
+                            {
+                                SendSceneEventData(sceneEventId, new ulong[] { NetworkManager.ServerClientId });
+                            }
+
+                            // All scenes are synchronized, let the server know we are done synchronizing
+                            NetworkManager.IsConnectedClient = true;
+
+                            // With distributed authority, either the client-side automatically spawns the default assigned player prefab or
+                            // if AutoSpawnPlayerPrefabClientSide is disabled the client-side will determine what player prefab to spawn and
+                            // when it gets spawned.
+                            if (NetworkManager.DistributedAuthorityMode && NetworkManager.AutoSpawnPlayerPrefabClientSide)
+                            {
+                                NetworkManager.ConnectionManager.CreateAndSpawnPlayer(NetworkManager.LocalClientId);
+                            }
+
+                            // Process any SceneEventType.ObjectSceneChanged messages that
+                            // were deferred while synchronizing and migrate the associated
+                            // NetworkObjects to their newly assigned scenes.
+                            sceneEventData.ProcessDeferredObjectSceneChangedEvents();
+
+                            // Only if PostSynchronizationSceneUnloading is set and we are running in client synchronization
+                            // mode additive do we unload any remaining scene that was not synchronized (otherwise any loaded
+                            // scene not synchronized by the server will remain loaded)
+                            if (PostSynchronizationSceneUnloading && ClientSynchronizationMode == LoadSceneMode.Additive)
+                            {
+                                SceneManagerHandler.UnloadUnassignedScenes(NetworkManager);
+                            }
+
+                            // Client is now synchronized and fully "connected".  This also means the client can send "RPCs" at this time
+                            NetworkManager.ConnectionManager.InvokeOnClientConnectedCallback(NetworkManager.LocalClientId);
+
+                            // Notify the client that they have finished synchronizing
+                            OnSceneEvent?.Invoke(new SceneEvent()
+                            {
+                                SceneEventType = sceneEventData.SceneEventType,
+                                ClientId = NetworkManager.LocalClientId, // Client sent this to the server
+                            });
+
+                            OnSynchronizeComplete?.Invoke(NetworkManager.LocalClientId);
+
+                            if (NetworkLog.CurrentLogLevel <= LogLevel.Developer)
+                            {
+                                NetworkLog.LogInfo($"[Client-{NetworkManager.LocalClientId}][Scene Management Enabled] Synchronization complete!");
+                            }
+                            // For convenience, notify all NetworkBehaviours that synchronization is complete.
+                            NetworkManager.SpawnManager.NotifyNetworkObjectsSynchronized();
+
+                            if (NetworkManager.DistributedAuthorityMode && HasSceneAuthority() && IsRestoringSession)
+                            {
+                                IsRestoringSession = false;
+                                PostSynchronizationSceneUnloading = m_OriginalPostSynchronizationSceneUnloading;
+                            }
+
+                            EndSceneEvent(sceneEventId);
                         }
-
-                        // All scenes are synchronized, let the server know we are done synchronizing
-                        NetworkManager.IsConnectedClient = true;
-
-                        // With distributed authority, either the client-side automatically spawns the default assigned player prefab or
-                        // if AutoSpawnPlayerPrefabClientSide is disabled the client-side will determine what player prefab to spawn and
-                        // when it gets spawned.
-                        if (NetworkManager.DistributedAuthorityMode && NetworkManager.AutoSpawnPlayerPrefabClientSide)
-                        {
-                            NetworkManager.ConnectionManager.CreateAndSpawnPlayer(NetworkManager.LocalClientId);
-                        }
-
-                        // Process any SceneEventType.ObjectSceneChanged messages that
-                        // were deferred while synchronizing and migrate the associated
-                        // NetworkObjects to their newly assigned scenes.
-                        sceneEventData.ProcessDeferredObjectSceneChangedEvents();
-
-                        // Only if PostSynchronizationSceneUnloading is set and we are running in client synchronization
-                        // mode additive do we unload any remaining scene that was not synchronized (otherwise any loaded
-                        // scene not synchronized by the server will remain loaded)
-                        if (PostSynchronizationSceneUnloading && ClientSynchronizationMode == LoadSceneMode.Additive)
-                        {
-                            SceneManagerHandler.UnloadUnassignedScenes(NetworkManager);
-                        }
-
-                        // Client is now synchronized and fully "connected".  This also means the client can send "RPCs" at this time
-                        NetworkManager.ConnectionManager.InvokeOnClientConnectedCallback(NetworkManager.LocalClientId);
-
-                        // Notify the client that they have finished synchronizing
+                        break;
+                    }
+                case SceneEventType.ReSynchronize:
+                    {
+                        // Notify the local client that they have been re-synchronized after being synchronized with an in progress game session
                         OnSceneEvent?.Invoke(new SceneEvent()
                         {
                             SceneEventType = sceneEventData.SceneEventType,
-                            ClientId = NetworkManager.LocalClientId, // Client sent this to the server
+                            ClientId = NetworkManager.ServerClientId,  // Server sent this to client
                         });
 
-                        OnSynchronizeComplete?.Invoke(NetworkManager.LocalClientId);
-
-                        if (NetworkLog.CurrentLogLevel <= LogLevel.Developer)
-                        {
-                            NetworkLog.LogInfo($"[Client-{NetworkManager.LocalClientId}][Scene Management Enabled] Synchronization complete!");
-                        }
-                        // For convenience, notify all NetworkBehaviours that synchronization is complete.
-                        NetworkManager.SpawnManager.NotifyNetworkObjectsSynchronized();
-
-                        if (NetworkManager.DistributedAuthorityMode && HasSceneAuthority() && IsRestoringSession)
-                        {
-                            IsRestoringSession = false;
-                            PostSynchronizationSceneUnloading = m_OriginalPostSynchronizationSceneUnloading;
-                        }
+                        EndSceneEvent(sceneEventId);
+                        break;
+                    }
+                case SceneEventType.LoadEventCompleted:
+                case SceneEventType.UnloadEventCompleted:
+                    {
+                        // Notify the local client that all clients have finished loading or unloading
+                        var clientId = NetworkManager.CMBServiceConnection ? NetworkManager.CurrentSessionOwner : NetworkManager.ServerClientId;
+                        InvokeSceneEvents(clientId, sceneEventData);
 
                         EndSceneEvent(sceneEventId);
+                        break;
                     }
-                    break;
-                }
-            case SceneEventType.ReSynchronize:
-                {
-                    // Notify the local client that they have been re-synchronized after being synchronized with an in progress game session
-                    OnSceneEvent?.Invoke(new SceneEvent()
+                default:
                     {
-                        SceneEventType = sceneEventData.SceneEventType,
-                        ClientId = NetworkManager.ServerClientId,  // Server sent this to client
-                    });
-
-                    EndSceneEvent(sceneEventId);
-                    break;
-                }
-            case SceneEventType.LoadEventCompleted:
-            case SceneEventType.UnloadEventCompleted:
-                {
-                    // Notify the local client that all clients have finished loading or unloading
-                    var clientId = NetworkManager.CMBServiceConnection ? NetworkManager.CurrentSessionOwner : NetworkManager.ServerClientId;
-                    InvokeSceneEvents(clientId, sceneEventData);
-
-                    EndSceneEvent(sceneEventId);
-                    break;
-                }
-            default:
-                {
-                    Debug.LogWarning($"{sceneEventData.SceneEventType} is not currently supported!");
-                    break;
-                }
+                        Debug.LogWarning($"{sceneEventData.SceneEventType} is not currently supported!");
+                        break;
+                    }
             }
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1978,6 +1978,7 @@ namespace Unity.Netcode
             sceneEventData.ClientSynchronizationMode = ClientSynchronizationMode;
             sceneEventData.InitializeForSynch();
             sceneEventData.TargetClientId = clientId;
+            sceneEventData.SenderClientId = NetworkManager.LocalClientId;
             sceneEventData.LoadSceneMode = ClientSynchronizationMode;
             var activeScene = SceneManager.GetActiveScene();
             sceneEventData.SceneEventType = SceneEventType.Synchronize;
@@ -2037,6 +2038,7 @@ namespace Unity.Netcode
                 // If we are just a normal client and in distributed authority mode, then always use the known server scene handle
                 if (NetworkManager.DistributedAuthorityMode && NetworkManager.CMBServiceConnection)
                 {
+                    Debug.Log($"[Client-{NetworkManager.LocalClientId}] Adding scene to synchronize: {scene.name}");
                     sceneEventData.AddSceneToSynchronize(SceneHashFromNameOrPath(scene.path), ClientSceneHandleToServerSceneHandle[scene.handle]);
                 }
                 else
@@ -2070,13 +2072,16 @@ namespace Unity.Netcode
 
 
             // Notify the local server that the client has been sent the synchronize event
-            OnSceneEvent?.Invoke(new SceneEvent()
+            if (!synchronizingService)
             {
-                SceneEventType = sceneEventData.SceneEventType,
-                ClientId = clientId
-            });
+                OnSceneEvent?.Invoke(new SceneEvent()
+                {
+                    SceneEventType = SceneEventType.Synchronize,
+                    ClientId = clientId
+                });
 
-            OnSynchronize?.Invoke(clientId);
+                OnSynchronize?.Invoke(clientId);
+            }
 
             EndSceneEvent(sceneEventData.SceneEventId);
         }
@@ -2099,18 +2104,6 @@ namespace Unity.Netcode
             // Store the sceneHandle and hash
             sceneEventData.NetworkSceneHandle = sceneHandle;
             sceneEventData.ClientSceneHash = sceneHash;
-
-            // If this is the beginning of the synchronization event, then send client a notification that synchronization has begun
-            if (sceneHash == sceneEventData.SceneHash)
-            {
-                OnSceneEvent?.Invoke(new SceneEvent()
-                {
-                    SceneEventType = SceneEventType.Synchronize,
-                    ClientId = NetworkManager.LocalClientId,
-                });
-
-                OnSynchronize?.Invoke(NetworkManager.LocalClientId);
-            }
 
             // Always check to see if the scene needs to be validated
             if (!ValidateSceneBeforeLoading(sceneHash, loadSceneMode))
@@ -2311,133 +2304,146 @@ namespace Unity.Netcode
                         break;
                     }
                 case SceneEventType.Synchronize:
+                {
+                    if (sceneEventData.IsStartingSynchronization)
                     {
-                        if (!sceneEventData.IsDoneWithSynchronization())
+                        sceneEventData.IsStartingSynchronization = false;
+
+                        OnSceneEvent?.Invoke(new SceneEvent()
                         {
-                            OnClientBeginSync(sceneEventId);
+                            SceneEventType = SceneEventType.Synchronize,
+                            ClientId = NetworkManager.LocalClientId,
+                        });
+
+                        OnSynchronize?.Invoke(NetworkManager.LocalClientId);
+                    }
+
+                    if (!sceneEventData.IsDoneWithSynchronization())
+                    {
+                        OnClientBeginSync(sceneEventId);
+                    }
+                    else
+                    {
+                        // Include anything in the DDOL scene
+                        PopulateScenePlacedObjects(DontDestroyOnLoadScene, false);
+
+                        // If needed, set the currently active scene
+                        if (HashToBuildIndex.ContainsKey(sceneEventData.ActiveSceneHash))
+                        {
+                            var targetActiveScene = SceneManager.GetSceneByBuildIndex(HashToBuildIndex[sceneEventData.ActiveSceneHash]);
+                            if (targetActiveScene.isLoaded && targetActiveScene.handle != SceneManager.GetActiveScene().handle)
+                            {
+                                SceneManager.SetActiveScene(targetActiveScene);
+                            }
+                        }
+
+                        // Spawn and Synchronize all NetworkObjects
+                        sceneEventData.SynchronizeSceneNetworkObjects(NetworkManager);
+
+                        // If needed, migrate dynamically spawned NetworkObjects to the same scene as they are on the server
+                        SynchronizeNetworkObjectScene();
+
+                        // Process any pending create object messages that the client received during synchronization
+                        ProcessDeferredCreateObjectMessages();
+
+                        sceneEventData.SceneEventType = SceneEventType.SynchronizeComplete;
+                        if (NetworkManager.DistributedAuthorityMode)
+                        {
+                            sceneEventData.TargetClientId = NetworkManager.CurrentSessionOwner;
+                            sceneEventData.SenderClientId = NetworkManager.LocalClientId;
+                            var message = new SceneEventMessage
+                            {
+                                EventData = sceneEventData,
+                            };
+                            var target = NetworkManager.DAHost ? NetworkManager.CurrentSessionOwner : NetworkManager.ServerClientId;
+                            var size = NetworkManager.ConnectionManager.SendMessage(ref message, m_NetworkDelivery, target);
+                            NetworkManager.NetworkMetrics.TrackSceneEventSent(target, (uint)sceneEventData.SceneEventType, SceneNameFromHash(sceneEventData.SceneHash), size);
                         }
                         else
                         {
-                            // Include anything in the DDOL scene
-                            PopulateScenePlacedObjects(DontDestroyOnLoadScene, false);
-
-                            // If needed, set the currently active scene
-                            if (HashToBuildIndex.ContainsKey(sceneEventData.ActiveSceneHash))
-                            {
-                                var targetActiveScene = SceneManager.GetSceneByBuildIndex(HashToBuildIndex[sceneEventData.ActiveSceneHash]);
-                                if (targetActiveScene.isLoaded && targetActiveScene.handle != SceneManager.GetActiveScene().handle)
-                                {
-                                    SceneManager.SetActiveScene(targetActiveScene);
-                                }
-                            }
-
-                            // Spawn and Synchronize all NetworkObjects
-                            sceneEventData.SynchronizeSceneNetworkObjects(NetworkManager);
-
-                            // If needed, migrate dynamically spawned NetworkObjects to the same scene as they are on the server
-                            SynchronizeNetworkObjectScene();
-
-                            // Process any pending create object messages that the client received during synchronization
-                            ProcessDeferredCreateObjectMessages();
-
-                            sceneEventData.SceneEventType = SceneEventType.SynchronizeComplete;
-                            if (NetworkManager.DistributedAuthorityMode)
-                            {
-                                sceneEventData.TargetClientId = NetworkManager.CurrentSessionOwner;
-                                sceneEventData.SenderClientId = NetworkManager.LocalClientId;
-                                var message = new SceneEventMessage
-                                {
-                                    EventData = sceneEventData,
-                                };
-                                var target = NetworkManager.DAHost ? NetworkManager.CurrentSessionOwner : NetworkManager.ServerClientId;
-                                var size = NetworkManager.ConnectionManager.SendMessage(ref message, m_NetworkDelivery, target);
-                                NetworkManager.NetworkMetrics.TrackSceneEventSent(target, (uint)sceneEventData.SceneEventType, SceneNameFromHash(sceneEventData.SceneHash), size);
-                            }
-                            else
-                            {
-                                SendSceneEventData(sceneEventId, new ulong[] { NetworkManager.ServerClientId });
-                            }
-
-                            // All scenes are synchronized, let the server know we are done synchronizing
-                            NetworkManager.IsConnectedClient = true;
-
-                            // With distributed authority, either the client-side automatically spawns the default assigned player prefab or
-                            // if AutoSpawnPlayerPrefabClientSide is disabled the client-side will determine what player prefab to spawn and
-                            // when it gets spawned.
-                            if (NetworkManager.DistributedAuthorityMode && NetworkManager.AutoSpawnPlayerPrefabClientSide)
-                            {
-                                NetworkManager.ConnectionManager.CreateAndSpawnPlayer(NetworkManager.LocalClientId);
-                            }
-
-                            // Process any SceneEventType.ObjectSceneChanged messages that
-                            // were deferred while synchronizing and migrate the associated
-                            // NetworkObjects to their newly assigned scenes.
-                            sceneEventData.ProcessDeferredObjectSceneChangedEvents();
-
-                            // Only if PostSynchronizationSceneUnloading is set and we are running in client synchronization
-                            // mode additive do we unload any remaining scene that was not synchronized (otherwise any loaded
-                            // scene not synchronized by the server will remain loaded)
-                            if (PostSynchronizationSceneUnloading && ClientSynchronizationMode == LoadSceneMode.Additive)
-                            {
-                                SceneManagerHandler.UnloadUnassignedScenes(NetworkManager);
-                            }
-
-                            // Client is now synchronized and fully "connected".  This also means the client can send "RPCs" at this time
-                            NetworkManager.ConnectionManager.InvokeOnClientConnectedCallback(NetworkManager.LocalClientId);
-
-                            // Notify the client that they have finished synchronizing
-                            OnSceneEvent?.Invoke(new SceneEvent()
-                            {
-                                SceneEventType = sceneEventData.SceneEventType,
-                                ClientId = NetworkManager.LocalClientId, // Client sent this to the server
-                            });
-
-                            OnSynchronizeComplete?.Invoke(NetworkManager.LocalClientId);
-
-                            if (NetworkLog.CurrentLogLevel <= LogLevel.Developer)
-                            {
-                                NetworkLog.LogInfo($"[Client-{NetworkManager.LocalClientId}][Scene Management Enabled] Synchronization complete!");
-                            }
-                            // For convenience, notify all NetworkBehaviours that synchronization is complete.
-                            NetworkManager.SpawnManager.NotifyNetworkObjectsSynchronized();
-
-                            if (NetworkManager.DistributedAuthorityMode && HasSceneAuthority() && IsRestoringSession)
-                            {
-                                IsRestoringSession = false;
-                                PostSynchronizationSceneUnloading = m_OriginalPostSynchronizationSceneUnloading;
-                            }
-
-                            EndSceneEvent(sceneEventId);
+                            SendSceneEventData(sceneEventId, new ulong[] { NetworkManager.ServerClientId });
                         }
-                        break;
-                    }
-                case SceneEventType.ReSynchronize:
-                    {
-                        // Notify the local client that they have been re-synchronized after being synchronized with an in progress game session
+
+                        // All scenes are synchronized, let the server know we are done synchronizing
+                        NetworkManager.IsConnectedClient = true;
+
+                        // With distributed authority, either the client-side automatically spawns the default assigned player prefab or
+                        // if AutoSpawnPlayerPrefabClientSide is disabled the client-side will determine what player prefab to spawn and
+                        // when it gets spawned.
+                        if (NetworkManager.DistributedAuthorityMode && NetworkManager.AutoSpawnPlayerPrefabClientSide)
+                        {
+                            NetworkManager.ConnectionManager.CreateAndSpawnPlayer(NetworkManager.LocalClientId);
+                        }
+
+                        // Process any SceneEventType.ObjectSceneChanged messages that
+                        // were deferred while synchronizing and migrate the associated
+                        // NetworkObjects to their newly assigned scenes.
+                        sceneEventData.ProcessDeferredObjectSceneChangedEvents();
+
+                        // Only if PostSynchronizationSceneUnloading is set and we are running in client synchronization
+                        // mode additive do we unload any remaining scene that was not synchronized (otherwise any loaded
+                        // scene not synchronized by the server will remain loaded)
+                        if (PostSynchronizationSceneUnloading && ClientSynchronizationMode == LoadSceneMode.Additive)
+                        {
+                            SceneManagerHandler.UnloadUnassignedScenes(NetworkManager);
+                        }
+
+                        // Client is now synchronized and fully "connected".  This also means the client can send "RPCs" at this time
+                        NetworkManager.ConnectionManager.InvokeOnClientConnectedCallback(NetworkManager.LocalClientId);
+
+                        // Notify the client that they have finished synchronizing
                         OnSceneEvent?.Invoke(new SceneEvent()
                         {
                             SceneEventType = sceneEventData.SceneEventType,
-                            ClientId = NetworkManager.ServerClientId,  // Server sent this to client
+                            ClientId = NetworkManager.LocalClientId, // Client sent this to the server
                         });
 
-                        EndSceneEvent(sceneEventId);
-                        break;
-                    }
-                case SceneEventType.LoadEventCompleted:
-                case SceneEventType.UnloadEventCompleted:
-                    {
-                        // Notify the local client that all clients have finished loading or unloading
-                        var clientId = NetworkManager.CMBServiceConnection ? NetworkManager.CurrentSessionOwner : NetworkManager.ServerClientId;
-                        InvokeSceneEvents(clientId, sceneEventData);
+                        OnSynchronizeComplete?.Invoke(NetworkManager.LocalClientId);
+
+                        if (NetworkLog.CurrentLogLevel <= LogLevel.Developer)
+                        {
+                            NetworkLog.LogInfo($"[Client-{NetworkManager.LocalClientId}][Scene Management Enabled] Synchronization complete!");
+                        }
+                        // For convenience, notify all NetworkBehaviours that synchronization is complete.
+                        NetworkManager.SpawnManager.NotifyNetworkObjectsSynchronized();
+
+                        if (NetworkManager.DistributedAuthorityMode && HasSceneAuthority() && IsRestoringSession)
+                        {
+                            IsRestoringSession = false;
+                            PostSynchronizationSceneUnloading = m_OriginalPostSynchronizationSceneUnloading;
+                        }
 
                         EndSceneEvent(sceneEventId);
-                        break;
                     }
-                default:
+                    break;
+                }
+            case SceneEventType.ReSynchronize:
+                {
+                    // Notify the local client that they have been re-synchronized after being synchronized with an in progress game session
+                    OnSceneEvent?.Invoke(new SceneEvent()
                     {
-                        Debug.LogWarning($"{sceneEventData.SceneEventType} is not currently supported!");
-                        break;
-                    }
+                        SceneEventType = sceneEventData.SceneEventType,
+                        ClientId = NetworkManager.ServerClientId,  // Server sent this to client
+                    });
+
+                    EndSceneEvent(sceneEventId);
+                    break;
+                }
+            case SceneEventType.LoadEventCompleted:
+            case SceneEventType.UnloadEventCompleted:
+                {
+                    // Notify the local client that all clients have finished loading or unloading
+                    var clientId = NetworkManager.CMBServiceConnection ? NetworkManager.CurrentSessionOwner : NetworkManager.ServerClientId;
+                    InvokeSceneEvents(clientId, sceneEventData);
+
+                    EndSceneEvent(sceneEventId);
+                    break;
+                }
+            default:
+                {
+                    Debug.LogWarning($"{sceneEventData.SceneEventType} is not currently supported!");
+                    break;
+                }
             }
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -657,6 +657,12 @@ namespace Unity.Netcode
             {
                 return false;
             }
+
+            if (!NetworkManager.IsConnectedClient)
+            {
+                return true;
+            }
+
             var synchronizeEventDetected = false;
             var loadingEventDetected = false;
             foreach (var entry in SceneEventDataStore)

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Unity.Collections;
+using UnityEngine;
 using UnityEngine.SceneManagement;
 
 namespace Unity.Netcode
@@ -196,6 +197,7 @@ namespace Unity.Netcode
             return SceneHandlesToSynchronize.Dequeue();
         }
 
+        internal bool IsStartingSynchronization;
         /// <summary>
         /// Client Side:
         /// Determines if all scenes have been processed during the synchronization process
@@ -586,6 +588,7 @@ namespace Unity.Netcode
             // Write the scenes we want to load, in the order we want to load them
             writer.WriteValueSafe(ScenesToSynchronize.ToArray());
             writer.WriteValueSafe(SceneHandlesToSynchronize.ToArray());
+            Debug.Log($"[Client-1][WriteSceneSynchronizationData] ScenesToSynchronize={ScenesToSynchronize.Count}, SceneHandlesToSynchronize={SceneHandlesToSynchronize.Count}");
             // Store our current position in the stream to come back and say how much data we have written
             var positionStart = writer.Position;
 
@@ -781,7 +784,8 @@ namespace Unity.Netcode
                         {
                             LogArray(reader.ToArray(), 0, reader.Length);
                         }
-                        CopySceneSynchronizationData(reader);
+                        CopySceneSynchronizationData(reader, TargetClientId);
+                        IsStartingSynchronization = true;
                         break;
                     }
                 case SceneEventType.SynchronizeComplete:
@@ -823,13 +827,15 @@ namespace Unity.Netcode
         /// into the internal buffer to be used throughout the synchronization process.
         /// </summary>
         /// <param name="reader"></param>
-        internal void CopySceneSynchronizationData(FastBufferReader reader)
+        internal void CopySceneSynchronizationData(FastBufferReader reader, ulong targetClientId)
         {
             m_NetworkObjectsSync.Clear();
             reader.ReadValueSafe(out uint[] scenesToSynchronize);
             reader.ReadValueSafe(out NetworkSceneHandle[] sceneHandlesToSynchronize);
             ScenesToSynchronize = new Queue<uint>(scenesToSynchronize);
             SceneHandlesToSynchronize = new Queue<NetworkSceneHandle>(sceneHandlesToSynchronize);
+            Debug.Log($"[Client-{targetClientId}] CopySceneSynchronizationData! ScenesToSynchronize={ScenesToSynchronize.Count}, SceneHandlesToSynchronize={SceneHandlesToSynchronize.Count}");
+
 
             // is not packed!
             reader.ReadValueSafe(out int sizeToCopy);
@@ -916,9 +922,9 @@ namespace Unity.Netcode
                 var networkObjectIdToNetworkObject = new Dictionary<ulong, NetworkObject>();
                 foreach (var networkObject in networkObjects)
                 {
-                    if (!networkObjectIdToNetworkObject.ContainsKey(networkObject.NetworkObjectId))
+                    if (networkObject.IsSpawned)
                     {
-                        networkObjectIdToNetworkObject.Add(networkObject.NetworkObjectId, networkObject);
+                        networkObjectIdToNetworkObject.TryAdd(networkObject.NetworkObjectId, networkObject);
                     }
                 }
 
@@ -940,7 +946,7 @@ namespace Unity.Netcode
                             {
                                 m_NetworkManager.SpawnManager.SpawnedObjectsList.Remove(networkObject);
                             }
-                            NetworkManager.Singleton.PrefabHandler.HandleNetworkPrefabDestroy(networkObject);
+                            m_NetworkManager.PrefabHandler.HandleNetworkPrefabDestroy(networkObject);
                         }
                         else
                         {
@@ -975,7 +981,7 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// Server Side:
+        /// All clients:
         /// Determines if the client needs to be re-synchronized if during the deserialization
         /// process the server finds NetworkObjects that the client still thinks are spawned but
         /// have since been despawned.

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
@@ -919,6 +919,7 @@ namespace Unity.Netcode
                 var networkObjectIdToNetworkObject = new Dictionary<ulong, NetworkObject>();
                 foreach (var networkObject in networkObjects)
                 {
+                    // If the NetworkObject isn't spawned then we don't need to destroy it
                     if (networkObject.IsSpawned)
                     {
                         networkObjectIdToNetworkObject.TryAdd(networkObject.NetworkObjectId, networkObject);
@@ -927,28 +928,13 @@ namespace Unity.Netcode
 
                 foreach (var networkObjectId in networkObjectsToRemove)
                 {
-                    if (networkObjectIdToNetworkObject.ContainsKey(networkObjectId))
+                    if (networkObjectIdToNetworkObject.TryGetValue(networkObjectId, out var networkObject))
                     {
-                        var networkObject = networkObjectIdToNetworkObject[networkObjectId];
-                        networkObjectIdToNetworkObject.Remove(networkObjectId);
-
-                        networkObject.IsSpawned = false;
-                        if (m_NetworkManager.PrefabHandler.ContainsHandler(networkObject))
+                        if (m_NetworkManager.LogLevel <= LogLevel.Developer)
                         {
-                            if (m_NetworkManager.SpawnManager.SpawnedObjects.ContainsKey(networkObjectId))
-                            {
-                                m_NetworkManager.SpawnManager.SpawnedObjects.Remove(networkObjectId);
-                            }
-                            if (m_NetworkManager.SpawnManager.SpawnedObjectsList.Contains(networkObject))
-                            {
-                                m_NetworkManager.SpawnManager.SpawnedObjectsList.Remove(networkObject);
-                            }
-                            m_NetworkManager.PrefabHandler.HandleNetworkPrefabDestroy(networkObject);
+                            NetworkLog.LogWarning($"[ReadClientReSynchronizationData][{networkObject.name}] Despawning and destroying {nameof(NetworkObject)}.");
                         }
-                        else
-                        {
-                            UnityEngine.Object.DestroyImmediate(networkObject.gameObject);
-                        }
+                        m_NetworkManager.SpawnManager.OnDespawnObject(networkObject, true, true);
                     }
                 }
             }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventData.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Unity.Collections;
-using UnityEngine;
 using UnityEngine.SceneManagement;
 
 namespace Unity.Netcode
@@ -588,7 +587,6 @@ namespace Unity.Netcode
             // Write the scenes we want to load, in the order we want to load them
             writer.WriteValueSafe(ScenesToSynchronize.ToArray());
             writer.WriteValueSafe(SceneHandlesToSynchronize.ToArray());
-            Debug.Log($"[Client-1][WriteSceneSynchronizationData] ScenesToSynchronize={ScenesToSynchronize.Count}, SceneHandlesToSynchronize={SceneHandlesToSynchronize.Count}");
             // Store our current position in the stream to come back and say how much data we have written
             var positionStart = writer.Position;
 
@@ -784,7 +782,7 @@ namespace Unity.Netcode
                         {
                             LogArray(reader.ToArray(), 0, reader.Length);
                         }
-                        CopySceneSynchronizationData(reader, TargetClientId);
+                        CopySceneSynchronizationData(reader);
                         IsStartingSynchronization = true;
                         break;
                     }
@@ -827,14 +825,13 @@ namespace Unity.Netcode
         /// into the internal buffer to be used throughout the synchronization process.
         /// </summary>
         /// <param name="reader"></param>
-        internal void CopySceneSynchronizationData(FastBufferReader reader, ulong targetClientId)
+        internal void CopySceneSynchronizationData(FastBufferReader reader)
         {
             m_NetworkObjectsSync.Clear();
             reader.ReadValueSafe(out uint[] scenesToSynchronize);
             reader.ReadValueSafe(out NetworkSceneHandle[] sceneHandlesToSynchronize);
             ScenesToSynchronize = new Queue<uint>(scenesToSynchronize);
             SceneHandlesToSynchronize = new Queue<NetworkSceneHandle>(sceneHandlesToSynchronize);
-            Debug.Log($"[Client-{targetClientId}] CopySceneSynchronizationData! ScenesToSynchronize={ScenesToSynchronize.Count}, SceneHandlesToSynchronize={SceneHandlesToSynchronize.Count}");
 
 
             // is not packed!

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1503,7 +1503,7 @@ namespace Unity.Netcode
                 if (sobj.IsSceneObject != null && sobj.IsSceneObject.Value && sobj.DestroyWithScene && sobj.gameObject.scene != NetworkManager.SceneManager.DontDestroyOnLoadScene)
                 {
                     SpawnedObjectsList.Remove(sobj);
-                    UnityEngine.Object.Destroy(sobj.gameObject);
+                    Object.Destroy(sobj.gameObject);
                 }
             }
         }
@@ -1587,7 +1587,7 @@ namespace Unity.Netcode
                         }
                         else
                         {
-                            UnityEngine.Object.Destroy(networkObjects[i].gameObject);
+                            Object.Destroy(networkObjects[i].gameObject);
                         }
                     }
                 }
@@ -1834,7 +1834,7 @@ namespace Unity.Netcode
                 }
                 else
                 {
-                    UnityEngine.Object.Destroy(gobj);
+                    Object.Destroy(gobj);
                 }
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace Unity.Netcode
 {
@@ -884,20 +885,29 @@ namespace Unity.Netcode
         /// <param name="position">conditional position in place of the network prefab's default position</param>
         /// <param name="rotation">conditional rotation in place of the network prefab's default rotation</param>
         /// <returns>the instance of the <see cref="NetworkObject"/></returns>
-        internal NetworkObject InstantiateNetworkPrefab(GameObject networkPrefab, uint prefabGlobalObjectIdHash, Vector3? position, Quaternion? rotation)
+        internal NetworkObject InstantiateNetworkPrefab([NotNull] GameObject networkPrefab, uint prefabGlobalObjectIdHash, Vector3? position, Quaternion? rotation)
         {
-            var networkObject = UnityEngine.Object.Instantiate(networkPrefab).GetComponent<NetworkObject>();
+            var gameObject = Object.Instantiate(networkPrefab);
+            var networkObject = gameObject.GetComponent<NetworkObject>();
+            if (networkObject == null)
+            {
+                if (NetworkManager.LogLevel <= LogLevel.Error)
+                {
+                    NetworkLog.LogError($"No {nameof(NetworkObject)} found on NetworkPrefab {networkPrefab.name}!");
+                }
+                Object.Destroy(gameObject);
+                return null;
+            }
             networkObject.transform.SetPositionAndRotation(position ?? networkObject.transform.position, rotation ?? networkObject.transform.rotation);
             networkObject.PrefabGlobalObjectIdHash = prefabGlobalObjectIdHash;
             return networkObject;
         }
 
         /// <summary>
-        /// Creates a local NetowrkObject to be spawned.
+        /// Creates a local NetworkObject to be spawned.
         /// </summary>
         /// <remarks>
-        /// For most cases this is client-side only, with the exception of when the server
-        /// is spawning a player.
+        /// For most cases this is client-side only, except when the server is spawning a player.
         /// </remarks>
         internal NetworkObject CreateLocalNetworkObject(NetworkObject.SerializedObject serializedObject, byte[] instantiationData = null)
         {
@@ -923,105 +933,110 @@ namespace Unity.Netcode
                     {
                         NetworkLog.LogError($"{nameof(NetworkPrefab)} hash was not found! In-Scene placed {nameof(NetworkObject)} soft synchronization failure for Hash: {globalObjectIdHash}!");
                     }
+
+                    return null;
                 }
 
                 // Since this NetworkObject is an in-scene placed NetworkObject, if it is disabled then enable it so
                 // NetworkBehaviours will have their OnNetworkSpawn method invoked
-                if (networkObject != null && !networkObject.gameObject.activeInHierarchy)
+                if (!networkObject.gameObject.activeInHierarchy)
                 {
                     networkObject.gameObject.SetActive(true);
                 }
             }
 
-            if (networkObject != null)
+            if (networkObject == null)
             {
-                networkObject.DestroyWithScene = serializedObject.DestroyWithScene;
-                networkObject.NetworkSceneHandle = serializedObject.NetworkSceneHandle;
-                networkObject.DontDestroyWithOwner = serializedObject.DontDestroyWithOwner;
-                networkObject.Ownership = (NetworkObject.OwnershipStatus)serializedObject.OwnershipFlags;
+                return null;
+            }
 
-                var nonNetworkObjectParent = false;
-                // SPECIAL CASE FOR IN-SCENE PLACED:  (only when the parent has a NetworkObject)
-                // This is a special case scenario where a late joining client has joined and loaded one or
-                // more scenes that contain nested in-scene placed NetworkObject children yet the server's
-                // synchronization information does not indicate the NetworkObject in question has a parent =or=
-                // the parent has changed.
-                // For this we will want to remove the parent before spawning and setting the transform values based
-                // on several possible scenarios.
-                if (serializedObject.IsSceneObject && networkObject.transform.parent != null)
+            networkObject.DestroyWithScene = serializedObject.DestroyWithScene;
+            networkObject.NetworkSceneHandle = serializedObject.NetworkSceneHandle;
+            networkObject.DontDestroyWithOwner = serializedObject.DontDestroyWithOwner;
+            networkObject.Ownership = (NetworkObject.OwnershipStatus)serializedObject.OwnershipFlags;
+
+            var nonNetworkObjectParent = false;
+            // SPECIAL CASE FOR IN-SCENE PLACED:  (only when the parent has a NetworkObject)
+            // This is a special case scenario where a late joining client has joined and loaded one or
+            // more scenes that contain nested in-scene placed NetworkObject children yet the server's
+            // synchronization information does not indicate the NetworkObject in question has a parent =or=
+            // the parent has changed.
+            // For this we will want to remove the parent before spawning and setting the transform values based
+            // on several possible scenarios.
+            if (serializedObject.IsSceneObject && networkObject.transform.parent != null)
+            {
+                var parentNetworkObject = networkObject.transform.parent.GetComponent<NetworkObject>();
+
+                // special case to handle being parented under a GameObject with no NetworkObject
+                nonNetworkObjectParent = !parentNetworkObject && serializedObject.HasParent;
+
+                // If the in-scene placed NetworkObject has a parent NetworkObject...
+                if (parentNetworkObject)
                 {
-                    var parentNetworkObject = networkObject.transform.parent.GetComponent<NetworkObject>();
-
-                    // special case to handle being parented under a GameObject with no NetworkObject
-                    nonNetworkObjectParent = !parentNetworkObject && serializedObject.HasParent;
-
-                    // If the in-scene placed NetworkObject has a parent NetworkObject...
-                    if (parentNetworkObject)
+                    // Then remove the parent only if:
+                    // - The authority says we don't have a parent (but locally we do).
+                    // - The auhtority says we have a parent but either of the two are true:
+                    // -- It isn't the same parent.
+                    // -- It was parented using world position stays.
+                    if (!serializedObject.HasParent || (serializedObject.IsLatestParentSet
+                        && (serializedObject.LatestParent.Value != parentNetworkObject.NetworkObjectId || serializedObject.WorldPositionStays)))
                     {
-                        // Then remove the parent only if:
-                        // - The authority says we don't have a parent (but locally we do).
-                        // - The auhtority says we have a parent but either of the two are true:
-                        // -- It isn't the same parent.
-                        // -- It was parented using world position stays.
-                        if (!serializedObject.HasParent || (serializedObject.IsLatestParentSet
-                            && (serializedObject.LatestParent.Value != parentNetworkObject.NetworkObjectId || serializedObject.WorldPositionStays)))
-                        {
-                            // If parenting without notifications then we are temporarily removing the parent to set the transform
-                            // values before reparenting under the current parent.
-                            networkObject.ApplyNetworkParenting(true, true, enableNotification: !serializedObject.HasParent);
-                        }
+                        // If parenting without notifications then we are temporarily removing the parent to set the transform
+                        // values before reparenting under the current parent.
+                        networkObject.ApplyNetworkParenting(true, true, enableNotification: !serializedObject.HasParent);
                     }
-                }
-
-                // Set the transform only if the sceneObject includes transform information.
-                if (serializedObject.HasTransform)
-                {
-                    // If world position stays is true or we have auto object parent synchronization disabled
-                    // then we want to apply the position and rotation values world space relative
-                    if ((worldPositionStays && !nonNetworkObjectParent) || !networkObject.AutoObjectParentSync)
-                    {
-                        networkObject.transform.SetPositionAndRotation(position, rotation);
-                    }
-                    else
-                    {
-                        networkObject.transform.SetLocalPositionAndRotation(position, rotation);
-                    }
-
-                    // SPECIAL CASE:
-                    // Since players are created uniquely we don't apply scale because
-                    // the ConnectionApprovalResponse does not currently provide the
-                    // ability to specify scale. So, we just use the default scale of
-                    // the network prefab used to represent the player.
-                    // Note: not doing this would set the player's scale to zero since
-                    // that is the default value of Vector3.
-                    if (!serializedObject.IsPlayerObject)
-                    {
-                        // Since scale is always applied to local space scale, we do the transform
-                        // space logic during serialization such that it works out whether AutoObjectParentSync
-                        // is enabled or not (see NetworkObject.SceneObject)
-                        networkObject.transform.localScale = scale;
-                    }
-                }
-
-                if (serializedObject.HasParent)
-                {
-                    // Go ahead and set network parenting properties, if the latest parent is not set then pass in null
-                    // (we always want to set worldPositionStays)
-                    ulong? parentId = null;
-                    if (serializedObject.IsLatestParentSet)
-                    {
-                        parentId = parentNetworkId;
-                    }
-                    networkObject.SetNetworkParenting(parentId, worldPositionStays);
-                }
-
-                // Dynamically spawned NetworkObjects that occur during a LoadSceneMode.Single load scene event are migrated into the DDOL
-                // until the scene is loaded. They are then migrated back into the newly loaded and currently active scene.
-                if (!serializedObject.IsSceneObject && NetworkSceneManager.IsSpawnedObjectsPendingInDontDestroyOnLoad)
-                {
-                    UnityEngine.Object.DontDestroyOnLoad(networkObject.gameObject);
                 }
             }
+
+            // Set the transform only if the sceneObject includes transform information.
+            if (serializedObject.HasTransform)
+            {
+                // If world position stays is true or we have auto object parent synchronization disabled
+                // then we want to apply the position and rotation values world space relative
+                if ((worldPositionStays && !nonNetworkObjectParent) || !networkObject.AutoObjectParentSync)
+                {
+                    networkObject.transform.SetPositionAndRotation(position, rotation);
+                }
+                else
+                {
+                    networkObject.transform.SetLocalPositionAndRotation(position, rotation);
+                }
+
+                // SPECIAL CASE:
+                // Since players are created uniquely we don't apply scale because
+                // the ConnectionApprovalResponse does not currently provide the
+                // ability to specify scale. So, we just use the default scale of
+                // the network prefab used to represent the player.
+                // Note: not doing this would set the player's scale to zero since
+                // that is the default value of Vector3.
+                if (!serializedObject.IsPlayerObject)
+                {
+                    // Since scale is always applied to local space scale, we do the transform
+                    // space logic during serialization such that it works out whether AutoObjectParentSync
+                    // is enabled or not (see NetworkObject.SceneObject)
+                    networkObject.transform.localScale = scale;
+                }
+            }
+
+            if (serializedObject.HasParent)
+            {
+                // Go ahead and set network parenting properties, if the latest parent is not set then pass in null
+                // (we always want to set worldPositionStays)
+                ulong? parentId = null;
+                if (serializedObject.IsLatestParentSet)
+                {
+                    parentId = parentNetworkId;
+                }
+                networkObject.SetNetworkParenting(parentId, worldPositionStays);
+            }
+
+            // Dynamically spawned NetworkObjects that occur during a LoadSceneMode.Single load scene event are migrated into the DDOL
+            // until the scene is loaded. They are then migrated back into the newly loaded and currently active scene.
+            if (!serializedObject.IsSceneObject && NetworkSceneManager.IsSpawnedObjectsPendingInDontDestroyOnLoad)
+            {
+                Object.DontDestroyOnLoad(networkObject.gameObject);
+            }
+
             return networkObject;
         }
 
@@ -1037,14 +1052,14 @@ namespace Unity.Netcode
         /// Server is the only instance that invokes this method.
         ///
         /// Distributed Authority:
-        /// DAHost client and standard DA clients invoke this method.
+        /// All clients can invoke this method.
         /// </summary>
-        internal void AuthorityLocalSpawn([NotNull] NetworkObject networkObject, ulong networkId, bool sceneObject, bool playerObject, ulong ownerClientId, bool destroyWithScene)
+        internal bool AuthorityLocalSpawn([NotNull] NetworkObject networkObject, ulong networkId, bool sceneObject, bool playerObject, ulong ownerClientId, bool destroyWithScene)
         {
-            if (networkObject.IsSpawned)
+            if (networkObject.IsSpawned || NetworkManager.SpawnManager.SpawnedObjects.ContainsKey(networkId))
             {
                 Debug.LogError($"{networkObject.name} is already spawned!");
-                return;
+                return false;
             }
 
             if (!sceneObject)
@@ -1092,7 +1107,7 @@ namespace Unity.Netcode
                     }
 
                     // Sanity check to make sure the owner is always included
-                    // Itentionally checking as opposed to just assigning in order to generate notification.
+                    // Intentionally checking as opposed to just assigning in order to generate notification.
                     if (!networkObject.Observers.Contains(ownerClientId))
                     {
                         Debug.LogError($"Client-{ownerClientId} is the owner of {networkObject.name} but is not an observer! Adding owner, but there is a bug in observer synchronization!");
@@ -1101,12 +1116,20 @@ namespace Unity.Netcode
                 }
             }
 
-            SpawnNetworkObjectLocallyCommon(networkObject, networkId, sceneObject, playerObject, ownerClientId, destroyWithScene);
+            if (!SpawnNetworkObjectLocallyCommon(networkObject, networkId, sceneObject, playerObject, ownerClientId, destroyWithScene))
+            {
+                if (NetworkManager.LogLevel <= LogLevel.Error)
+                {
+                    NetworkLog.LogError($"Failed to spawn {nameof(NetworkObject)} {networkObject.name} with Hash {networkObject.GlobalObjectIdHash}.");
+                }
+
+                return false;
+            }
 
             // When done spawning invoke post spawn
             networkObject.InvokeBehaviourNetworkPostSpawn();
 
-            // No need to check for deferred messages since this method is used for authority spawning.
+            return true;
         }
 
         /// <summary>
@@ -1117,35 +1140,105 @@ namespace Unity.Netcode
         /// <remarks>
         /// IMPORTANT: Pre spawn methods need to be invoked from within <see cref="NetworkObject.Deserialize"/>.
         /// </remarks>
-        internal void NonAuthorityLocalSpawn([NotNull] NetworkObject networkObject, in NetworkObject.SerializedObject serializedObject, bool destroyWithScene)
+        /// <returns>boolean indicating whether the spawn succeeded</returns>
+        internal bool NonAuthorityLocalSpawn(in NetworkObject.SerializedObject serializedObject, out NetworkObject networkObject, FastBufferReader reader, bool destroyWithScene)
         {
+            if (SpawnedObjects.ContainsKey(serializedObject.NetworkObjectId))
+            {
+                if (NetworkManager.LogLevel <= LogLevel.Error)
+                {
+                    NetworkLog.LogWarning($"Trying to spawn a {nameof(NetworkObject)} with a {nameof(NetworkObject.NetworkObjectId)} of {serializedObject.NetworkObjectId} but an object with that id already in the spawned list!");
+                }
+                networkObject = null;
+                return false;
+            }
+
+            byte[] instantiationData = null;
+            if (serializedObject.HasInstantiationData)
+            {
+                reader.ReadValueSafe(out instantiationData);
+            }
+
+            // Attempt to create a local NetworkObject
+            networkObject = CreateLocalNetworkObject(serializedObject, instantiationData);
+
+            // Log the error that the NetworkObject failed to construct
+            if (networkObject == null)
+            {
+                if (NetworkManager.LogLevel <= LogLevel.Normal)
+                {
+                    NetworkLog.LogError($"Failed to spawn {nameof(NetworkObject)} for Hash {serializedObject.Hash}.");
+                }
+
+                return false;
+            }
+
+            networkObject.NetworkManagerOwner = NetworkManager;
+
+            // This will get set again when the NetworkObject is spawned locally, but we set it here ahead of spawning
+            // in order to be able to determine which NetworkVariables the client will be allowed to read.
+            networkObject.OwnerClientId = serializedObject.OwnerClientId;
+
+            // Special Case: Invoke NetworkBehaviour.OnPreSpawn methods here before SynchronizeNetworkBehaviours
+            networkObject.InvokeBehaviourNetworkPreSpawn();
+
+            // Process the remaining synchronization data from the buffer
+            try
+            {
+                // Synchronize NetworkBehaviours
+                var bufferSerializer = new BufferSerializer<BufferSerializerReader>(new BufferSerializerReader(reader));
+                networkObject.SynchronizeNetworkBehaviours(ref bufferSerializer, NetworkManager.LocalClientId);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogException(ex);
+                // We can continue processing the NetworkObject spawn even if the NetworkBehaviours failed to synchronize
+            }
+
             if (networkObject.IsSpawned)
             {
-                Debug.LogError($"[{networkObject.name}] Object-{networkObject.NetworkObjectId} is already spawned!");
-                return;
+                if (NetworkManager.LogLevel <= LogLevel.Error)
+                {
+                    NetworkLog.LogErrorServer($"[{networkObject.name}] Object-{networkObject.NetworkObjectId} is already spawned!");
+                }
+
+                // Mark the spawn as a success if the object is already spawned
+                return true;
+            }
+
+            // If we are an in-scene placed NetworkObject and we originally had a parent but when synchronized we are
+            // being told we do not have a parent, then we want to clear the latest parent so it is not automatically
+            // "re-parented" to the original parent. This can happen if not unloading the scene and the parenting of
+            // the in-scene placed Networkobject changes several times over different sessions.
+            if (serializedObject.IsSceneObject && !serializedObject.HasParent && networkObject.GetNetworkParenting().HasValue)
+            {
+                networkObject.ClearNetworkParenting();
             }
 
             // Do not invoke Pre spawn here (SynchronizeNetworkBehaviours needs to be invoked prior to this)
-            SpawnNetworkObjectLocallyCommon(networkObject, serializedObject.NetworkObjectId, serializedObject.IsSceneObject, serializedObject.IsPlayerObject, serializedObject.OwnerClientId, destroyWithScene);
+            var succeeded = SpawnNetworkObjectLocallyCommon(networkObject, serializedObject.NetworkObjectId, serializedObject.IsSceneObject, serializedObject.IsPlayerObject, serializedObject.OwnerClientId, destroyWithScene);
+            if (!succeeded)
+            {
+                Debug.LogError($"Failed to spawn {nameof(NetworkObject)} for Hash {serializedObject.Hash}.");
+                return false;
+            }
 
             // It is ok to invoke NetworkBehaviour.OnPostSpawn methods
             networkObject.InvokeBehaviourNetworkPostSpawn();
 
-            // Process any deferred messages once the object is 100% finished spawning,
-            NetworkManager.DeferredMessageManager.ProcessTriggers(IDeferredNetworkMessageManager.TriggerType.OnSpawn, networkObject.NetworkObjectId);
+            return true;
         }
 
-        internal void SpawnNetworkObjectLocallyCommon(NetworkObject networkObject, ulong networkId, bool sceneObject, bool playerObject, ulong ownerClientId, bool destroyWithScene)
+        /// <summary>
+        /// Handles the all the final setup and spawning needed for
+        /// </summary>
+        /// <returns>boolean indicating whether the spawn succeeded. Internal dev note: THIS IS A CATCH FOR OURSELVES. DON'T PULL OUT</returns>
+        internal bool SpawnNetworkObjectLocallyCommon(NetworkObject networkObject, ulong networkId, bool sceneObject, bool playerObject, ulong ownerClientId, bool destroyWithScene)
         {
             if (networkObject.NetworkManagerOwner == null)
             {
                 Debug.LogError("NetworkManagerOwner should not be null!");
-            }
-
-            if (SpawnedObjects.ContainsKey(networkId))
-            {
-                Debug.LogWarning($"[{NetworkManager.name}] Trying to spawn {networkObject.name} with a {nameof(NetworkObject.NetworkObjectId)} of {networkId} but it is already in the spawned list!");
-                return;
+                return false;
             }
 
             networkObject.IsSceneObject = sceneObject;
@@ -1236,6 +1329,8 @@ namespace Unity.Netcode
             {
                 networkObject.PrefabGlobalObjectIdHash = networkObject.InScenePlacedSourceGlobalObjectIdHash;
             }
+
+            return true;
         }
 
         internal Dictionary<ulong, NetworkObject> NetworkObjectsToSynchronizeSceneChanges = new Dictionary<ulong, NetworkObject>();
@@ -1489,23 +1584,31 @@ namespace Unity.Netcode
         {
             var networkObjects = FindObjects.ByType<NetworkObject>(orderByIdentifier: true);
             var networkObjectsToSpawn = new List<NetworkObject>();
-            for (int i = 0; i < networkObjects.Length; i++)
+            foreach (var networkObject in networkObjects)
             {
-                if (networkObjects[i].NetworkManager == NetworkManager)
+                if (networkObject.NetworkManager != NetworkManager)
                 {
-                    // This used to be two loops.
-                    // The first added all NetworkObjects to a list and the second spawned all NetworkObjects in the list.
-                    // Now, a parent will set its children's IsSceneObject value when spawned, so we check for null or for true.
-                    if (networkObjects[i].IsSceneObject == null || (networkObjects[i].IsSceneObject.HasValue && networkObjects[i].IsSceneObject.Value))
-                    {
-                        var ownerId = networkObjects[i].OwnerClientId;
-                        if (NetworkManager.DistributedAuthorityMode)
-                        {
-                            ownerId = NetworkManager.LocalClientId;
-                        }
+                    continue;
+                }
 
-                        AuthorityLocalSpawn(networkObjects[i], GetNetworkObjectId(), true, false, ownerId, true);
-                        networkObjectsToSpawn.Add(networkObjects[i]);
+                // This used to be two loops.
+                // The first added all NetworkObjects to a list and the second spawned all NetworkObjects in the list.
+                // Now, a parent will set its children's IsSceneObject value when spawned, so we check for null or for true.
+                if (networkObject.IsSceneObject == null || (networkObject.IsSceneObject.HasValue && networkObject.IsSceneObject.Value))
+                {
+                    var ownerId = networkObject.OwnerClientId;
+                    if (NetworkManager.DistributedAuthorityMode)
+                    {
+                        ownerId = NetworkManager.LocalClientId;
+                    }
+
+                    if (AuthorityLocalSpawn(networkObject, GetNetworkObjectId(), true, false, ownerId, true))
+                    {
+                        networkObjectsToSpawn.Add(networkObject);
+                    }
+                    else
+                    {
+                        networkObject.ResetOnDespawn();
                     }
                 }
             }

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1298,7 +1298,7 @@ namespace Unity.Netcode
                 return false;
             }
 
-            if (networkObject.NetworkObjectId == default)
+            if (networkId == default)
             {
                 if (NetworkManager.LogLevel <= LogLevel.Error)
                 {

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -896,7 +896,7 @@ namespace Unity.Netcode
             {
                 if (NetworkLog.CurrentLogLevel <= LogLevel.Error)
                 {
-                    NetworkLog.LogError($"Failed to create object locally. [{nameof(globalObjectIdHash)}={globalObjectIdHash}]. {nameof(NetworkPrefab)} could not be found. Is the prefab registered with {NetworkManager.name}?");
+                    NetworkLog.LogErrorServer($"[{nameof(globalObjectIdHash)}={globalObjectIdHash}] Failed to create object locally. {nameof(NetworkPrefab)} could not be found. Is the prefab registered with {NetworkManager.name}?");
                 }
                 return null;
             }
@@ -1199,7 +1199,7 @@ namespace Unity.Netcode
             {
                 if (NetworkManager.LogLevel <= LogLevel.Error)
                 {
-                    NetworkLog.LogWarning($"Trying to spawn a {nameof(NetworkObject)} with a {nameof(NetworkObject.NetworkObjectId)} of {serializedObject.NetworkObjectId} but an object with that id already in the spawned list!");
+                    NetworkLog.LogWarning($"Trying to spawn a {nameof(NetworkObject)} with a {nameof(NetworkObject.NetworkObjectId)} of {serializedObject.NetworkObjectId} but an object with that id is already in the spawned list. This should not happen!");
                 }
                 networkObject = null;
                 return false;
@@ -1219,7 +1219,7 @@ namespace Unity.Netcode
             {
                 if (NetworkManager.LogLevel <= LogLevel.Normal)
                 {
-                    NetworkLog.LogError($"Failed to spawn {nameof(NetworkObject)} for Hash {serializedObject.Hash}.");
+                    NetworkLog.LogError($"[{nameof(NetworkObject.GlobalObjectIdHash)}={serializedObject.Hash}] Failed to spawn {nameof(NetworkObject)}!");
                 }
 
                 return false;
@@ -1271,7 +1271,7 @@ namespace Unity.Netcode
             var succeeded = SpawnNetworkObjectLocallyCommon(networkObject, serializedObject.NetworkObjectId, serializedObject.IsSceneObject, serializedObject.IsPlayerObject, serializedObject.OwnerClientId, destroyWithScene);
             if (!succeeded)
             {
-                Debug.LogError($"Failed to spawn {nameof(NetworkObject)} for Hash {serializedObject.Hash}.");
+                // Don't need to log here as SpawnNetworkObjectLocallyCommon should log the specific error
                 return false;
             }
 

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1949,8 +1949,8 @@ namespace Unity.Netcode
 
         internal void Shutdown()
         {
-            NetworkObjectsToSynchronizeSceneChanges.Clear();
-            CleanUpDisposedObjects.Clear();
+            NetworkObjectsToSynchronizeSceneChanges?.Clear();
+            CleanUpDisposedObjects?.Clear();
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1287,11 +1287,22 @@ namespace Unity.Netcode
         /// <returns>boolean indicating whether the spawn succeeded. Internal dev note: THIS IS A CATCH FOR OURSELVES. DON'T PULL OUT</returns>
         internal bool SpawnNetworkObjectLocallyCommon(NetworkObject networkObject, ulong networkId, bool sceneObject, bool playerObject, ulong ownerClientId, bool destroyWithScene)
         {
+            // TODO: Replace the following checks with internal Netcode asserts
+            // We want our tests to double check this without impacting users.
             if (networkObject.NetworkManagerOwner == null)
             {
                 if (NetworkManager.LogLevel <= LogLevel.Error)
                 {
                     NetworkLog.LogError($"{networkObject.name}'s NetworkManagerOwner should not be null!");
+                }
+                return false;
+            }
+
+            if (networkObject.NetworkObjectId == default)
+            {
+                if (NetworkManager.LogLevel <= LogLevel.Error)
+                {
+                    NetworkLog.LogError($"[{networkObject.name}] Trying to spawn {nameof(NetworkObject)} with invalid {nameof(NetworkObject.NetworkObjectId)} {networkObject.NetworkObjectId}. This should not happen!");
                 }
                 return false;
             }
@@ -1725,20 +1736,10 @@ namespace Unity.Netcode
         /// <param name="networkObject">The <see cref="NetworkObject"/> to despawn.</param>
         /// <param name="destroyGameObject">Whether to destroy the underlying game object, or to simply despawn the object.</param>
         /// <param name="authorityOverride">Gives the DAHost server permissions. Otherwise, DAHost only has authority on objects it owns.</param>
-        internal void OnDespawnObject(NetworkObject networkObject, bool destroyGameObject, bool authorityOverride = false)
+        internal void OnDespawnObject([NotNull] NetworkObject networkObject, bool destroyGameObject, bool authorityOverride = false)
         {
             if (!NetworkManager)
             {
-                return;
-            }
-
-            // We have to do this check first as subsequent checks assume we can access NetworkObjectId.
-            if (!networkObject)
-            {
-                if (NetworkManager.LogLevel <= LogLevel.Normal)
-                {
-                    NetworkLog.LogWarning("Trying to destroy network object but it is null");
-                }
                 return;
             }
 

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1614,7 +1614,7 @@ namespace Unity.Netcode
                             // and set its parent to root
                             if (childObject.IsSceneObject != null && childObject.IsSceneObject.Value)
                             {
-                                childObject.TryRemoveParent(childObject.WorldPositionStays());
+                                childObject.TryRemoveParentCachedWorldPositionStays();
                             }
                         }
                     }

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1056,18 +1056,30 @@ namespace Unity.Netcode
         /// </summary>
         internal bool AuthorityLocalSpawn([NotNull] NetworkObject networkObject, ulong networkId, bool sceneObject, bool playerObject, ulong ownerClientId, bool destroyWithScene)
         {
-            if (networkObject.IsSpawned || NetworkManager.SpawnManager.SpawnedObjects.ContainsKey(networkId))
+            if (networkObject.IsSpawned)
             {
-                Debug.LogError($"{networkObject.name} is already spawned!");
+                if (NetworkManager.LogLevel <= LogLevel.Error)
+                {
+                    NetworkLog.LogError($"Cannot process spawn of {networkObject.name} as it is already spawned!");
+                }
                 return false;
             }
 
-            if (!sceneObject)
+            if (NetworkManager.SpawnManager.SpawnedObjects.TryGetValue(networkId, out var existingObj))
+            {
+                if (NetworkManager.LogLevel <= LogLevel.Error)
+                {
+                    NetworkLog.LogError($"Cannot spawn {networkObject.name} with {nameof(networkId)}={networkId} as {existingObj.name} has already been spawned using this id!");
+                }
+                return false;
+            }
+
+            if (!sceneObject && NetworkManager.LogLevel <= LogLevel.Error)
             {
                 var networkObjectChildren = networkObject.GetComponentsInChildren<NetworkObject>();
                 if (networkObjectChildren.Length > 1)
                 {
-                    Debug.LogError("Spawning NetworkObjects with nested NetworkObjects is only supported for scene objects. Child NetworkObjects will not be spawned over the network!");
+                    NetworkLog.LogWarning("Spawning NetworkObjects with nested NetworkObjects is only supported for scene objects. Child NetworkObjects will not be spawned over the network!");
                 }
             }
 
@@ -1123,12 +1135,14 @@ namespace Unity.Netcode
                     NetworkLog.LogError($"Failed to spawn {nameof(NetworkObject)} {networkObject.name} with Hash {networkObject.GlobalObjectIdHash}.");
                 }
 
+                networkObject.ResetOnDespawn();
                 return false;
             }
 
             // When done spawning invoke post spawn
             networkObject.InvokeBehaviourNetworkPostSpawn();
 
+            networkObject.IsSpawnAuthority = false;
             return true;
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Unity.Netcode.Runtime.asmdef
+++ b/com.unity.netcode.gameobjects/Runtime/Unity.Netcode.Runtime.asmdef
@@ -97,6 +97,11 @@
             "name": "Unity",
             "expression": "6000.5.0a7",
             "define": "NGO_FINDOBJECTS_NOSORTING"
+        },
+        {
+          "name": "Unity",
+          "expression": "6000.6.0a3",
+          "define": "NGO_FINDOBJECTS_UNORDERED_IDS"
         }
     ],
     "noEngineReferences": false

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
@@ -1543,11 +1543,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 }
             }
 
-            foreach (var networkManager in m_NetworkManagers)
-            {
-                networkManager?.Shutdown();
-            }
-
             // Cleanup any remaining NetworkObjects
             DestroySceneNetworkObjects();
 
@@ -1573,6 +1568,11 @@ namespace Unity.Netcode.TestHelpers.Runtime
             {
                 DeRegisterSceneManagerHandler();
 
+                foreach (var networkManager in m_NetworkManagers)
+                {
+                    networkManager?.Shutdown();
+                }
+
                 NetcodeIntegrationTestHelpers.Destroy();
 
                 m_PlayerNetworkObjects.Clear();
@@ -1580,7 +1580,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             }
             catch (Exception e)
             {
-                throw e;
+                Debug.LogException(e);
             }
             finally
             {
@@ -1589,11 +1589,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
                     Object.DestroyImmediate(m_PlayerPrefab);
                     m_PlayerPrefab = null;
                 }
-            }
-
-            foreach (var networkManager in m_NetworkManagers)
-            {
-                networkManager?.Shutdown();
             }
 
             // Allow time for NetworkManagers to fully shutdown

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
@@ -985,6 +985,12 @@ namespace Unity.Netcode.TestHelpers.Runtime
                     return false;
                 }
 
+                if (playerObjectRelative.Observers.Count != m_NetworkManagers.Length)
+                {
+                    m_InternalErrorLog.Append($"Client-{networkManager.LocalClientId} has an incorrect number of observers for Object-{playerObjectRelative.NetworkObjectId}!");
+                    return false;
+                }
+
                 // Go ahead and create an entry for this new client
                 if (!m_PlayerNetworkObjects[networkManager.LocalClientId].ContainsKey(joinedClient.LocalClientId))
                 {
@@ -1158,7 +1164,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         private void ClientNetworkManagerPostStart(NetworkManager networkManager)
         {
             networkManager.name = $"NetworkManager - Client - {networkManager.LocalClientId}";
-            Assert.NotNull(networkManager.LocalClient.PlayerObject, $"{nameof(StartServerAndClients)} detected that client {networkManager.LocalClientId} does not have an assigned player NetworkObject!");
+            Assert.NotNull(networkManager.LocalClient.PlayerObject, $"{nameof(StartServerAndClients)} detected that Client-{networkManager.LocalClientId} does not have an assigned player NetworkObject!");
 
             // Go ahead and create an entry for this new client
             if (!m_PlayerNetworkObjects.ContainsKey(networkManager.LocalClientId))
@@ -1246,14 +1252,21 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// the session owner.
         /// </remarks>
         /// <returns><see cref="IEnumerator"/></returns>
-        private IEnumerator StartSessionOwner()
+        private IEnumerator StartSessionOwner(NetworkManager networkManager, bool ignoreSessionOwnerCheck = false)
         {
             VerboseDebug("Starting session owner...");
-            NetcodeIntegrationTestHelpers.StartOneClient(m_ClientNetworkManagers[0]);
-            yield return WaitForConditionOrTimeOut(() => m_ClientNetworkManagers[0].IsConnectedClient);
-            AssertOnTimeout($"Timed out waiting for the session owner to connect to CMB Server!");
-            Assert.True(m_ClientNetworkManagers[0].LocalClient.IsSessionOwner, $"Client-{m_ClientNetworkManagers[0].LocalClientId} started session but was not set to be the session owner!");
-            VerboseDebug("Session owner connected and approved.");
+            NetcodeIntegrationTestHelpers.StartOneClient(networkManager);
+            if (!ignoreSessionOwnerCheck)
+            {
+                yield return WaitForConditionOrTimeOut(() => networkManager.IsConnectedClient);
+                AssertOnTimeout($"Timed out waiting for the session owner to connect to CMB Server!");
+                Assert.True(networkManager.LocalClient.IsSessionOwner, $"Client-{networkManager.LocalClientId} started session but was not set to be the session owner!");
+                VerboseDebug("Session owner connected and approved.");
+            }
+            else
+            {
+                yield return k_DefaultTickRate;
+            }
         }
 
         /// <summary>
@@ -1267,24 +1280,49 @@ namespace Unity.Netcode.TestHelpers.Runtime
             {
                 VerboseDebug($"Entering {nameof(StartServerAndClients)}");
 
-                // DANGO-TODO: Renove this when the Rust server connection sequence is fixed and we don't have to pre-start
+                // DANGO-TODO: Remove this when the Rust server connection sequence is fixed and we don't have to pre-start
                 // the session owner.
                 if (m_UseCmbService)
                 {
                     VerboseDebug("Using a distributed authority CMB Server for connection.");
-                    yield return StartSessionOwner();
+                    yield return StartSessionOwner(m_ClientNetworkManagers[0]);
+                }
+
+                for (int i = 1; i < m_ClientNetworkManagers.Length; i++)
+                {
+                    yield return StartSessionOwner(m_ClientNetworkManagers[i], true);
                 }
 
                 // Start the instances and pass in our SceneManagerInitialization action that is invoked immediately after host-server
                 // is started and after each client is started.
-                if (!NetcodeIntegrationTestHelpers.Start(m_UseHost, !m_UseCmbService, m_ServerNetworkManager, m_ClientNetworkManagers))
-                {
-                    Debug.LogError("Failed to start instances");
-                    Assert.Fail("Failed to start instances");
-                }
+                // if (!NetcodeIntegrationTestHelpers.Start(m_UseHost, !m_UseCmbService, m_ServerNetworkManager, m_ClientNetworkManagers))
+                // {
+                //     Debug.LogError("Failed to start instances");
+                //     Assert.Fail("Failed to start instances");
+                // }
 
                 // Get the authority NetworkMananger (Server, Host, or Session Owner)
                 var authorityManager = GetAuthorityNetworkManager();
+                // var authorityPrefabs = authorityManager.NetworkConfig.Prefabs.NetworkPrefabsLists[0].List;
+                foreach (var manager in m_NetworkManagers)
+                {
+                    if (manager == authorityManager)
+                    {
+                        continue;
+                    }
+
+                    Assert.That(authorityManager.NetworkConfig.PlayerPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash, Is.EqualTo(manager.NetworkConfig.PlayerPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash));
+
+                    // if (authorityManager.NetworkConfig.Prefabs.NetworkPrefabsLists.Count > 1)
+                    // {
+                    //     var clientList = manager.NetworkConfig.Prefabs.NetworkPrefabsLists[0].List;
+                    //     Assert.That(clientList.Count, Is.EqualTo(authorityPrefabs.Count));
+                    //     for (int i = 0; i < authorityPrefabs.Count; i++)
+                    //     {
+                    //         Assert.That(clientList[i].Prefab.GetComponent<NetworkObject>().GlobalObjectIdHash, Is.EqualTo(authorityPrefabs[i].Prefab.GetComponent<NetworkObject>().GlobalObjectIdHash));
+                    //     }
+                    // }
+                }
 
                 // When scene management is enabled, we need to re-apply the scenes populated list since we have overriden the ISceneManagerHandler
                 // imeplementation at this point. This assures any pre-loaded scenes will be automatically assigned to the server and force clients
@@ -1536,6 +1574,11 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 }
             }
 
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                networkManager?.Shutdown();
+            }
+
             // Cleanup any remaining NetworkObjects
             DestroySceneNetworkObjects();
 
@@ -1577,6 +1620,11 @@ namespace Unity.Netcode.TestHelpers.Runtime
                     Object.DestroyImmediate(m_PlayerPrefab);
                     m_PlayerPrefab = null;
                 }
+            }
+
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                networkManager?.Shutdown();
             }
 
             // Allow time for NetworkManagers to fully shutdown
@@ -1733,7 +1781,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 // This can sometimes be null depending upon order of operations
                 // when dealing with parented NetworkObjects.  If NetworkObjectB
                 // is a child of NetworkObjectA and NetworkObjectA comes before
-                // NetworkObjectB in the list of NeworkObjects found, then when
+                // NetworkObjectB in the list of NetworkObjects found, then when
                 // NetworkObjectA's GameObject is destroyed it will also destroy
                 // NetworkObjectB's GameObject which will destroy NetworkObjectB.
                 // If there is a null entry in the list, this is the most likely

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
@@ -1164,7 +1164,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         private void ClientNetworkManagerPostStart(NetworkManager networkManager)
         {
             networkManager.name = $"NetworkManager - Client - {networkManager.LocalClientId}";
-            Assert.NotNull(networkManager.LocalClient.PlayerObject, $"{nameof(StartServerAndClients)} detected that Client-{networkManager.LocalClientId} does not have an assigned player NetworkObject!");
+            Assert.NotNull(networkManager.LocalClient.PlayerObject, $"{nameof(StartServerAndClients)} detected that client {networkManager.LocalClientId} does not have an assigned player NetworkObject!");
 
             // Go ahead and create an entry for this new client
             if (!m_PlayerNetworkObjects.ContainsKey(networkManager.LocalClientId))
@@ -1252,21 +1252,14 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// the session owner.
         /// </remarks>
         /// <returns><see cref="IEnumerator"/></returns>
-        private IEnumerator StartSessionOwner(NetworkManager networkManager, bool ignoreSessionOwnerCheck = false)
+        private IEnumerator StartSessionOwner()
         {
             VerboseDebug("Starting session owner...");
-            NetcodeIntegrationTestHelpers.StartOneClient(networkManager);
-            if (!ignoreSessionOwnerCheck)
-            {
-                yield return WaitForConditionOrTimeOut(() => networkManager.IsConnectedClient);
-                AssertOnTimeout($"Timed out waiting for the session owner to connect to CMB Server!");
-                Assert.True(networkManager.LocalClient.IsSessionOwner, $"Client-{networkManager.LocalClientId} started session but was not set to be the session owner!");
-                VerboseDebug("Session owner connected and approved.");
-            }
-            else
-            {
-                yield return k_DefaultTickRate;
-            }
+            NetcodeIntegrationTestHelpers.StartOneClient(m_ClientNetworkManagers[0]);
+            yield return WaitForConditionOrTimeOut(() => m_ClientNetworkManagers[0].IsConnectedClient);
+            AssertOnTimeout($"Timed out waiting for the session owner to connect to CMB Server!");
+            Assert.True(m_ClientNetworkManagers[0].LocalClient.IsSessionOwner, $"Client-{m_ClientNetworkManagers[0].LocalClientId} started session but was not set to be the session owner!");
+            VerboseDebug("Session owner connected and approved.");
         }
 
         /// <summary>
@@ -1285,44 +1278,19 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 if (m_UseCmbService)
                 {
                     VerboseDebug("Using a distributed authority CMB Server for connection.");
-                    yield return StartSessionOwner(m_ClientNetworkManagers[0]);
-                }
-
-                for (int i = 1; i < m_ClientNetworkManagers.Length; i++)
-                {
-                    yield return StartSessionOwner(m_ClientNetworkManagers[i], true);
+                    yield return StartSessionOwner();
                 }
 
                 // Start the instances and pass in our SceneManagerInitialization action that is invoked immediately after host-server
                 // is started and after each client is started.
-                // if (!NetcodeIntegrationTestHelpers.Start(m_UseHost, !m_UseCmbService, m_ServerNetworkManager, m_ClientNetworkManagers))
-                // {
-                //     Debug.LogError("Failed to start instances");
-                //     Assert.Fail("Failed to start instances");
-                // }
+                if (!NetcodeIntegrationTestHelpers.Start(m_UseHost, !m_UseCmbService, m_ServerNetworkManager, m_ClientNetworkManagers))
+                {
+                    Debug.LogError("Failed to start instances");
+                    Assert.Fail("Failed to start instances");
+                }
 
                 // Get the authority NetworkMananger (Server, Host, or Session Owner)
                 var authorityManager = GetAuthorityNetworkManager();
-                // var authorityPrefabs = authorityManager.NetworkConfig.Prefabs.NetworkPrefabsLists[0].List;
-                foreach (var manager in m_NetworkManagers)
-                {
-                    if (manager == authorityManager)
-                    {
-                        continue;
-                    }
-
-                    Assert.That(authorityManager.NetworkConfig.PlayerPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash, Is.EqualTo(manager.NetworkConfig.PlayerPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash));
-
-                    // if (authorityManager.NetworkConfig.Prefabs.NetworkPrefabsLists.Count > 1)
-                    // {
-                    //     var clientList = manager.NetworkConfig.Prefabs.NetworkPrefabsLists[0].List;
-                    //     Assert.That(clientList.Count, Is.EqualTo(authorityPrefabs.Count));
-                    //     for (int i = 0; i < authorityPrefabs.Count; i++)
-                    //     {
-                    //         Assert.That(clientList[i].Prefab.GetComponent<NetworkObject>().GlobalObjectIdHash, Is.EqualTo(authorityPrefabs[i].Prefab.GetComponent<NetworkObject>().GlobalObjectIdHash));
-                    //     }
-                    // }
-                }
 
                 // When scene management is enabled, we need to re-apply the scenes populated list since we have overriden the ISceneManagerHandler
                 // imeplementation at this point. This assures any pre-loaded scenes will be automatically assigned to the server and force clients

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventNotifications.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventNotifications.cs
@@ -103,10 +103,10 @@ namespace TestProject.RuntimeTests
             {
                 // Validates that we sent the proper number of synchronize events to the clients
                 case SceneEventType.Synchronize:
-                {
-                    m_ClientsReceivedSynchronize.Add(sceneEvent.ClientId);
-                    break;
-                }
+                    {
+                        m_ClientsReceivedSynchronize.Add(sceneEvent.ClientId);
+                        break;
+                    }
                 // Validate that the clients finish synchronization and they used the proper synchronization mode
                 case SceneEventType.SynchronizeComplete:
                     {

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventNotifications.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerEventNotifications.cs
@@ -37,6 +37,7 @@ namespace TestProject.RuntimeTests
         }
 
         private List<SceneTestInfo> m_ShouldWaitList = new List<SceneTestInfo>();
+        private List<ulong> m_ServerReceivedSynchronize = new List<ulong>();
         private List<ulong> m_ClientsReceivedSynchronize = new List<ulong>();
 
         public NetworkSceneManagerEventNotifications(HostOrServer hostOrServer) : base(hostOrServer) { }
@@ -58,6 +59,7 @@ namespace TestProject.RuntimeTests
         {
             m_ScenesLoaded.Clear();
             m_CanStartServerOrClients = false;
+            m_ServerReceivedSynchronize.Clear();
             m_ClientsReceivedSynchronize.Clear();
             m_ShouldWaitList.Clear();
             return base.OnSetup();
@@ -70,6 +72,13 @@ namespace TestProject.RuntimeTests
                 SceneManager.SetActiveScene(m_OriginalActiveScene);
             }
             return base.OnTearDown();
+        }
+
+        protected override void OnServerAndClientsCreated()
+        {
+            var authority = GetAuthorityNetworkManager();
+
+            base.OnServerAndClientsCreated();
         }
 
         protected override IEnumerator OnStartedServerAndClients()
@@ -92,6 +101,12 @@ namespace TestProject.RuntimeTests
         {
             switch (sceneEvent.SceneEventType)
             {
+                // Validates that we sent the proper number of synchronize events to the clients
+                case SceneEventType.Synchronize:
+                {
+                    m_ClientsReceivedSynchronize.Add(sceneEvent.ClientId);
+                    break;
+                }
                 // Validate that the clients finish synchronization and they used the proper synchronization mode
                 case SceneEventType.SynchronizeComplete:
                     {
@@ -107,13 +122,13 @@ namespace TestProject.RuntimeTests
         private void ServerSceneManager_OnSceneEvent(SceneEvent sceneEvent)
         {
             var authority = GetAuthorityNetworkManager();
-            VerboseDebug($"[SceneEvent] ClientId:{sceneEvent.ClientId} | EventType: {sceneEvent.SceneEventType}");
+            VerboseLog($"[SceneEvent] ClientId:{sceneEvent.ClientId} | EventType: {sceneEvent.SceneEventType}");
             switch (sceneEvent.SceneEventType)
             {
                 // Validates that we sent the proper number of synchronize events to the clients
                 case SceneEventType.Synchronize:
                     {
-                        m_ClientsReceivedSynchronize.Add(sceneEvent.ClientId);
+                        m_ServerReceivedSynchronize.Add(sceneEvent.ClientId);
                         break;
                     }
                 case SceneEventType.Load:
@@ -238,8 +253,11 @@ namespace TestProject.RuntimeTests
             m_CanStartServerOrClients = true;
             yield return StartServerAndClients();
 
+            yield return WaitForConditionOrTimeOut(() => m_ServerReceivedSynchronize.Count == NumberOfClients);
+            AssertOnTimeout($"Timed out waiting for the authority to receive synchronization events for all clients! Received: {m_ServerReceivedSynchronize.Count} | Expected: {NumberOfClients}");
             yield return WaitForConditionOrTimeOut(() => m_ClientsReceivedSynchronize.Count == NumberOfClients);
             AssertOnTimeout($"Timed out waiting for all clients to receive synchronization event! Received: {m_ClientsReceivedSynchronize.Count} | Expected: {NumberOfClients}");
+
             if (loadSceneMode == LoadSceneMode.Single)
             {
                 m_ClientToTestLoading.SceneManager.OnSceneEvent += SceneManager_OnSceneEvent;

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/SceneManagementSynchronizationTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/SceneManagementSynchronizationTests.cs
@@ -160,6 +160,14 @@ namespace TestProject.RuntimeTests
             // Setup expected events
             m_ExpectedEventQueue.Enqueue(new ExpectedEvent()
             {
+                SceneEvent = new SceneEvent()
+                {
+                    SceneEventType = SceneEventType.Synchronize,
+                    ClientId = expectedClientId,
+                },
+            });
+            m_ExpectedEventQueue.Enqueue(new ExpectedEvent()
+            {
                 ConnectionEvent = new ConnectionEventData()
                 {
                     EventType = ConnectionEvent.ClientConnected,

--- a/testproject/Assets/Tests/Runtime/Support/SpawnRpcDespawnInstanceHandler.cs
+++ b/testproject/Assets/Tests/Runtime/Support/SpawnRpcDespawnInstanceHandler.cs
@@ -49,7 +49,7 @@ namespace TestProject.RuntimeTests.Support
             {
                 if (NetworkLog.CurrentLogLevel <= LogLevel.Error)
                 {
-                    NetworkLog.LogError($"Failed to create object locally. [{nameof(m_PrefabHash)}={m_PrefabHash}]. {nameof(NetworkPrefab)} could not be found. Is the prefab registered with {nameof(NetworkManager)}?");
+                    NetworkLog.LogError($"[{nameof(m_PrefabHash)}={m_PrefabHash}] Failed to create object locally. {nameof(NetworkPrefab)} could not be found. Is the prefab registered with {nameof(NetworkManager)}?");
                 }
                 return null;
             }


### PR DESCRIPTION
## Purpose of this PR

Various overlapping fixes that'll fix the rust tests on trunk.

### Jira ticket

[UUM-131552](https://jira.unity3d.com/browse/UUM-131552)

### Changelog

- Fixed: CreateObject and DestroyObject messages will now be properly deferred while the client is still connecting
- Fixed: Resources will be properly cleaned up when an object spawn fails
- Fixed: Non-authority client will now always have the `OnSceneEvent` callback triggered with the `Synchronize` event when starting to process the `Synchronize` message from the scene authority

## Documentation

- No documentation changes or additions were necessary.

## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [x] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports

n/a
