### PR TITLE
ci: Re-enable ConnectSingleClient_Hostname test

### DIFF
--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportConnectionTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportConnectionTests.cs
@@ -137,9 +137,10 @@ namespace Unity.Netcode.RuntimeTests
             InitializeTransport(out m_Server, out m_ServerEvents);
             InitializeTransport(out m_Clients[0], out m_ClientsEvents[0]);
 
-            // We don't know if localhost will resolve to 127.0.0.1 or ::1, so we wait until we know
-            // before starting the server. Because localhost is pretty much always defined locally
-            // it should resolve immediatly and thus waiting one frame should be enough.
+            // We don't know if localhost will resolve to 127.0.0.1 or ::1 (or even a device LAN
+            // IP on some Android versions), so we wait until we know before starting the server.
+            // We poll until GetLocalEndpoint() returns a valid endpoint rather than assuming one
+            // frame is always enough — resolution may span multiple driver updates on some platforms.
 
             // We'll need to retry connection requests most likely so make this fast.
             m_Clients[0].ConnectTimeoutMS = 50;
@@ -147,11 +148,23 @@ namespace Unity.Netcode.RuntimeTests
             m_Clients[0].SetConnectionData("localhost", 7777);
             m_Clients[0].StartClient();
 
-            yield return null;
+            // Wait until hostname resolution has completed and the driver has bound.
+            // On some Android devices "localhost" can resolve to the device's LAN IP rather than
+            // a loopback address, so we use the actual resolved address instead of hardcoding
+            // "127.0.0.1" or "::1" based solely on the address family.
+            NetworkEndpoint endpoint;
+            var resolutionDeadline = Time.realtimeSinceStartup + 2f;
+            do
+            {
+                yield return null;
+                endpoint = m_Clients[0].GetLocalEndpoint();
+            } while (endpoint.Family == NetworkFamily.Invalid &&
+                     Time.realtimeSinceStartup < resolutionDeadline);
 
-            var endpoint = m_Clients[0].GetLocalEndpoint();
-            var ip = endpoint.Family == NetworkFamily.Ipv4 ? "127.0.0.1" : "::1";
-            m_Server.SetConnectionData(ip, 7777, ip);
+            Assert.AreNotEqual(NetworkFamily.Invalid, endpoint.Family,
+                "Timed out waiting for localhost hostname resolution to complete.");
+
+            m_Server.SetConnectionData(endpoint.Address, 7777, endpoint.Address);
             m_Server.StartServer();
 
             yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[0]);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportConnectionTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportConnectionTests.cs
@@ -132,7 +132,6 @@ namespace Unity.Netcode.RuntimeTests
 #if HOSTNAME_RESOLUTION_AVAILABLE
         // Check connection with a single client (hostname).
         [UnityTest]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.Android })] // Test fails on Android for editors 6000.3+ Tracked in MTT-14757
         public IEnumerator ConnectSingleClient_Hostname()
         {
             InitializeTransport(out m_Server, out m_ServerEvents);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportConnectionTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Transports/UnityTransportConnectionTests.cs
@@ -164,7 +164,12 @@ namespace Unity.Netcode.RuntimeTests
             Assert.AreNotEqual(NetworkFamily.Invalid, endpoint.Family,
                 "Timed out waiting for localhost hostname resolution to complete.");
 
-            m_Server.SetConnectionData(endpoint.Address, 7777, endpoint.Address);
+            // Use the wildcard listen address for the resolved address family. This handles
+            // cases where "localhost" resolves to a non-loopback address (e.g. a device's LAN
+            // IP on some Android versions) and avoids relying on the exact IP in the local
+            // endpoint (which may be a wildcard 0.0.0.0 when UTP binds before routing).
+            var listenAddress = endpoint.Family == NetworkFamily.Ipv6 ? "::" : "0.0.0.0";
+            m_Server.SetConnectionData(listenAddress, 7777, listenAddress);
             m_Server.StartServer();
 
             yield return WaitForNetworkEvent(NetworkEvent.Connect, m_ClientsEvents[0]);


### PR DESCRIPTION
## Purpose of this PR
This PR aims to re-enable ConnectSingleClient_Hostname test for Android platform

### Why the test was failing
The test's strategy was: start the client connecting to "localhost", wait one frame, look at GetLocalEndpoint() to see which address family was resolved, then start the server on the matching loopback address (127.0.0.1 for IPv4, ::1 for IPv6).

This strategy breaks on Android with Unity 6000.3+ because localhost is no longer guaranteed to resolve to a loopback address (see **HOSTNAME_RESOLUTION_AVAILABLE** define usage. This test is passing on previous editors as it's compiled out)

### Solution

1. Poll for resolution completion instead of waiting one frame
GetLocalEndpoint() returns an invalid endpoint until the hostname resolution job runs and the driver binds. One frame was assumed to always be enough, but it seems to not be reliable on all platforms. The fix loops until a valid family is returned, with a 2-second safety timeout.

2. Listen on the wildcard address instead of a hardcoded loopback
Rather than mapping the resolved family to a specific loopback address (127.0.0.1 / ::1), the server now listens on the wildcard for that family. This means the server accepts connections on any interface of the correct family, regardless of what IP localhost actually resolved to on the device.

### Jira ticket
https://jira.unity3d.com/browse/MTT-14757

## Documentation
N/A

## Testing & QA (How your changes can be verified during release Playtest)
Green pass of this test of jobs like 
- **Run testproject Tests - [android, 6000.3, il2cpp]**
- **Run testproject Tests - [android, 6000.4, il2cpp]**
- etc

## Backports
N/A, issue related only to NGOv2.X as 1.X doesn't support editors of 6000.3+ (which are affected)
