### PR TITLE
chore: Swap ChildNetworkBehaviours to a Dictionary

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -13,6 +13,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+- Improve handling of destroyed NetworkBehaviours. (#3953)
 - Hardened error handling and recovery during `NetworkObject` spawn. (#3941)
 - Replaced Debug usage by NetcodeLog on `NetworkSpawnManager` and `NetworkObject`. (#3933)
 - Improved performance of `NetworkBehaviour`. (#3915)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -379,41 +379,21 @@ namespace Unity.Netcode
 
             if (rpcParams.Send.Target == null)
             {
-                switch (defaultTarget)
+                rpcParams.Send.Target = defaultTarget switch
                 {
-                    case SendTo.Everyone:
-                        rpcParams.Send.Target = RpcTarget.Everyone;
-                        break;
-                    case SendTo.Owner:
-                        rpcParams.Send.Target = RpcTarget.Owner;
-                        break;
-                    case SendTo.Server:
-                        rpcParams.Send.Target = RpcTarget.Server;
-                        break;
-                    case SendTo.NotServer:
-                        rpcParams.Send.Target = RpcTarget.NotServer;
-                        break;
-                    case SendTo.NotMe:
-                        rpcParams.Send.Target = RpcTarget.NotMe;
-                        break;
-                    case SendTo.NotOwner:
-                        rpcParams.Send.Target = RpcTarget.NotOwner;
-                        break;
-                    case SendTo.Me:
-                        rpcParams.Send.Target = RpcTarget.Me;
-                        break;
-                    case SendTo.ClientsAndHost:
-                        rpcParams.Send.Target = RpcTarget.ClientsAndHost;
-                        break;
-                    case SendTo.Authority:
-                        rpcParams.Send.Target = RpcTarget.Authority;
-                        break;
-                    case SendTo.NotAuthority:
-                        rpcParams.Send.Target = RpcTarget.NotAuthority;
-                        break;
-                    case SendTo.SpecifiedInParams:
-                        throw new RpcException("This method requires a runtime-specified send target.");
-                }
+                    SendTo.Everyone => RpcTarget.Everyone,
+                    SendTo.Owner => RpcTarget.Owner,
+                    SendTo.Server => RpcTarget.Server,
+                    SendTo.NotServer => RpcTarget.NotServer,
+                    SendTo.NotMe => RpcTarget.NotMe,
+                    SendTo.NotOwner => RpcTarget.NotOwner,
+                    SendTo.Me => RpcTarget.Me,
+                    SendTo.ClientsAndHost => RpcTarget.ClientsAndHost,
+                    SendTo.Authority => RpcTarget.Authority,
+                    SendTo.NotAuthority => RpcTarget.NotAuthority,
+                    SendTo.SpecifiedInParams => throw new RpcException("This method requires a runtime-specified send target."),
+                    _ => throw new RpcException("This method requires a runtime-specified send target."),
+                };
             }
             else if (defaultTarget != SendTo.SpecifiedInParams && !attributeParams.AllowTargetOverride)
             {
@@ -473,15 +453,8 @@ namespace Unity.Netcode
 #pragma warning disable IDE0001
         /// <summary>
         /// Provides access to the various <see cref="SendTo"/> targets at runtime, as well as
-        /// runtime-bound targets like <see cref="Unity.Netcode.RpcTarget.Single"/>,
-        /// <see cref="Unity.Netcode.RpcTarget.Group(NativeArray{ulong})"/>,
-        /// <see cref="Unity.Netcode.RpcTarget.Group(NativeList{ulong})"/>,
-        /// <see cref="Unity.Netcode.RpcTarget.Group(ulong[])"/>,
-        /// <see cref="Unity.Netcode.RpcTarget.Group{T}(T)"/>, <see cref="Unity.Netcode.RpcTarget.Not(ulong)"/>,
-        /// <see cref="Unity.Netcode.RpcTarget.Not(NativeArray{ulong})"/>,
-        /// <see cref="Unity.Netcode.RpcTarget.Not(NativeList{ulong})"/>,
-        /// <see cref="Unity.Netcode.RpcTarget.Not(ulong[])"/>, and
-        /// <see cref="Unity.Netcode.RpcTarget.Not{T}(T)"/>.
+        /// runtime-bound targets like <see cref="RpcTarget.Single"/>, <see cref="RpcTarget.Group{T}"/>, and
+        /// <see cref="RpcTarget.Not{T}"/>.
         /// </summary>
 #pragma warning restore IDE0001
         public RpcTarget RpcTarget { get; private set; }
@@ -624,11 +597,6 @@ namespace Unity.Netcode
         public ushort NetworkBehaviourId { get; internal set; }
 
         /// <summary>
-        /// Internally caches the Id of this behaviour in a NetworkObject. Makes look-up faster
-        /// </summary>
-        internal ushort NetworkBehaviourIdCache = 0;
-
-        /// <summary>
         /// Returns the NetworkBehaviour with a given BehaviourId for the current NetworkObject.
         /// </summary>
         /// <param name="behaviourId">The behaviourId to return</param>
@@ -753,7 +721,7 @@ namespace Unity.Netcode
         /// <summary>
         /// Handles pre-spawn related initializations.
         /// Invokes any <see cref="InternalOnNetworkPreSpawn"/> subscriptions.
-        /// Finally invokes <see cref="OnNetworkPreSpawn(ref NetworkManager)"/>.
+        /// Finally invokes <see cref="OnNetworkPreSpawn"/>.
         /// </summary>
         internal void NetworkPreSpawn(ref NetworkManager networkManager, NetworkObject networkObject)
         {
@@ -1101,14 +1069,14 @@ namespace Unity.Netcode
                 // placed NetworkObject in an already loaded scene that has already been
                 // used within a network session =or= if this is a pooled NetworkObject
                 // that is being repurposed.
-                for (int i = 0; i < NetworkVariableFields.Count; i++)
+                foreach (var variable in NetworkVariableFields)
                 {
                     // If already initialized, then skip
-                    if (NetworkVariableFields[i].HasBeenInitialized)
+                    if (variable.HasBeenInitialized)
                     {
                         continue;
                     }
-                    NetworkVariableFields[i].Initialize(this);
+                    variable.Initialize(this);
                 }
                 // Exit early as we don't need to run through the rest of this initialization
                 // process
@@ -1136,9 +1104,8 @@ namespace Unity.Netcode
                 for (int i = 0; i < NetworkVariableFields.Count; i++)
                 {
                     var networkDelivery = MessageDeliveryType<NetworkVariableDeltaMessage>.DefaultDelivery;
-                    if (!firstLevelIndex.ContainsKey(networkDelivery))
+                    if (firstLevelIndex.TryAdd(networkDelivery, secondLevelCounter))
                     {
-                        firstLevelIndex.Add(networkDelivery, secondLevelCounter);
                         m_DeliveryTypesForNetworkVariableGroups.Add(networkDelivery);
                         secondLevelCounter++;
                     }
@@ -1166,9 +1133,8 @@ namespace Unity.Netcode
             {
                 // Mark every variable as no longer dirty. We just spawned the object and whatever the game code did
                 // during OnNetworkSpawn has been sent and needs to be cleared
-                for (int i = 0; i < NetworkVariableFields.Count; i++)
+                foreach (var networkVariable in NetworkVariableFields)
                 {
-                    var networkVariable = NetworkVariableFields[i];
                     if (networkVariable.IsDirty())
                     {
                         if (networkVariable.CanSend())
@@ -1302,9 +1268,8 @@ namespace Unity.Netcode
         private bool CouldHaveDirtyNetworkVariables()
         {
             // TODO: There should be a better way by reading one dirty variable vs. 'n'
-            for (int i = 0; i < NetworkVariableFields.Count; i++)
+            foreach (var networkVariable in NetworkVariableFields)
             {
-                var networkVariable = NetworkVariableFields[i];
                 if (networkVariable.IsDirty())
                 {
                     if (networkVariable.CanSend())
@@ -1330,12 +1295,12 @@ namespace Unity.Netcode
         /// </remarks>
         internal void UpdateNetworkVariableOnOwnershipChanged()
         {
-            for (int j = 0; j < NetworkVariableFields.Count; j++)
+            foreach (var variable in NetworkVariableFields)
             {
                 // Only invoke OnInitialize on NetworkVariables the owner can write to
-                if (NetworkVariableFields[j].CanClientWrite(OwnerClientId))
+                if (variable.CanClientWrite(OwnerClientId))
                 {
-                    NetworkVariableFields[j].OnInitialize();
+                    variable.OnInitialize();
                 }
             }
         }
@@ -1355,15 +1320,15 @@ namespace Unity.Netcode
         /// </summary>
         internal void MarkOwnerReadDirtyAndCheckOwnerWriteIsDirty()
         {
-            for (int j = 0; j < NetworkVariableFields.Count; j++)
+            foreach (var variable in NetworkVariableFields)
             {
-                if (NetworkVariableFields[j].ReadPerm == NetworkVariableReadPermission.Owner)
+                if (variable.ReadPerm == NetworkVariableReadPermission.Owner)
                 {
-                    NetworkVariableFields[j].SetDirty(true);
+                    variable.SetDirty(true);
                 }
-                if (NetworkVariableFields[j].WritePerm == NetworkVariableWritePermission.Owner)
+                if (variable.WritePerm == NetworkVariableWritePermission.Owner)
                 {
-                    NetworkVariableFields[j].OnCheckIsDirtyState();
+                    variable.OnCheckIsDirtyState();
                 }
             }
         }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
@@ -56,9 +56,9 @@ namespace Unity.Netcode
                 if (m_NetworkManager.DistributedAuthorityMode || dirtyObj.IsNetworkVisibleTo(client.ClientId))
                 {
                     // Sync just the variables for just the objects this client sees
-                    for (int k = 0; k < dirtyObj.ChildNetworkBehaviours.Count; k++)
+                    foreach(var behaviour in dirtyObj.ChildNetworkBehaviours.Values)
                     {
-                        dirtyObj.ChildNetworkBehaviours[k].NetworkVariableUpdate(client.ClientId, forceSend);
+                        behaviour.NetworkVariableUpdate(client.ClientId, forceSend);
                     }
                 }
             }
@@ -73,9 +73,9 @@ namespace Unity.Netcode
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void ProcessDirtyObjectClient(NetworkObject dirtyObj, bool forceSend)
         {
-            for (int k = 0; k < dirtyObj.ChildNetworkBehaviours.Count; k++)
+            foreach(var behaviour in dirtyObj.ChildNetworkBehaviours.Values)
             {
-                dirtyObj.ChildNetworkBehaviours[k].NetworkVariableUpdate(NetworkManager.ServerClientId, forceSend);
+                behaviour.NetworkVariableUpdate(NetworkManager.ServerClientId, forceSend);
             }
         }
 
@@ -86,9 +86,8 @@ namespace Unity.Netcode
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void PostProcessDirtyObject(NetworkObject dirtyObj)
         {
-            for (int k = 0; k < dirtyObj.ChildNetworkBehaviours.Count; k++)
+            foreach(var behaviour in dirtyObj.ChildNetworkBehaviours.Values)
             {
-                var behaviour = dirtyObj.ChildNetworkBehaviours[k];
                 for (int i = 0; i < behaviour.NetworkVariableFields.Count; i++)
                 {
                     // Set to true for NetworkVariable to ignore duplication of the
@@ -114,7 +113,7 @@ namespace Unity.Netcode
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void ResetDirtyObject(NetworkObject dirtyObj, bool forceSend)
         {
-            foreach (var behaviour in dirtyObj.ChildNetworkBehaviours)
+            foreach (var behaviour in dirtyObj.ChildNetworkBehaviours.Values)
             {
                 behaviour.PostNetworkVariableWrite(forceSend);
             }
@@ -164,9 +163,9 @@ namespace Unity.Netcode
             }
 
             // Pre-variable update
-            for (int k = 0; k < networkObject.ChildNetworkBehaviours.Count; k++)
+            foreach (var behaviour in networkObject.ChildNetworkBehaviours.Values)
             {
-                networkObject.ChildNetworkBehaviours[k].PreVariableUpdate();
+                behaviour.PreVariableUpdate();
             }
 
             // Server sends updates to all clients where a client sends updates

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviourUpdater.cs
@@ -56,7 +56,7 @@ namespace Unity.Netcode
                 if (m_NetworkManager.DistributedAuthorityMode || dirtyObj.IsNetworkVisibleTo(client.ClientId))
                 {
                     // Sync just the variables for just the objects this client sees
-                    foreach(var behaviour in dirtyObj.ChildNetworkBehaviours.Values)
+                    foreach (var behaviour in dirtyObj.ChildNetworkBehaviours.Values)
                     {
                         behaviour.NetworkVariableUpdate(client.ClientId, forceSend);
                     }
@@ -73,7 +73,7 @@ namespace Unity.Netcode
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void ProcessDirtyObjectClient(NetworkObject dirtyObj, bool forceSend)
         {
-            foreach(var behaviour in dirtyObj.ChildNetworkBehaviours.Values)
+            foreach (var behaviour in dirtyObj.ChildNetworkBehaviours.Values)
             {
                 behaviour.NetworkVariableUpdate(NetworkManager.ServerClientId, forceSend);
             }
@@ -86,7 +86,7 @@ namespace Unity.Netcode
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void PostProcessDirtyObject(NetworkObject dirtyObj)
         {
-            foreach(var behaviour in dirtyObj.ChildNetworkBehaviours.Values)
+            foreach (var behaviour in dirtyObj.ChildNetworkBehaviours.Values)
             {
                 for (int i = 0; i < behaviour.NetworkVariableFields.Count; i++)
                 {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -426,36 +426,37 @@ namespace Unity.Netcode
 
             var connectionManager = NetworkManagerOwner.ConnectionManager;
 
-            for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
+            foreach (var behaviour in ChildNetworkBehaviours.Values)
             {
-                ChildNetworkBehaviours[i].PreVariableUpdate();
+                behaviour.PreVariableUpdate();
                 // Notify all NetworkBehaviours that the authority is performing a deferred despawn.
                 // This is when user script would update NetworkVariable states that might be needed
                 // for the deferred despawn sequence on non-authoritative instances.
-                ChildNetworkBehaviours[i].OnDeferringDespawn(DeferredDespawnTick);
+                behaviour.OnDeferringDespawn(DeferredDespawnTick);
             }
 
             // DAHost handles sending updates to all clients
             if (NetworkManagerOwner.DAHost)
             {
-                for (int i = 0; i < connectionManager.ConnectedClientsList.Count; i++)
+                foreach (var client in connectionManager.ConnectedClientsList)
                 {
-                    var client = connectionManager.ConnectedClientsList[i];
-                    if (IsNetworkVisibleTo(client.ClientId))
+                    if (!IsNetworkVisibleTo(client.ClientId))
                     {
-                        // Sync just the variables for just the objects this client sees
-                        for (int k = 0; k < ChildNetworkBehaviours.Count; k++)
-                        {
-                            ChildNetworkBehaviours[k].NetworkVariableUpdate(client.ClientId);
-                        }
+                        continue;
+                    }
+
+                    // Sync just the variables for just the objects this client sees
+                    foreach (var behaviour in ChildNetworkBehaviours.Values)
+                    {
+                        behaviour.NetworkVariableUpdate(client.ClientId);
                     }
                 }
             }
             else // Clients just send their deltas to the service or DAHost
             {
-                for (int k = 0; k < ChildNetworkBehaviours.Count; k++)
+                foreach(var behaviour in ChildNetworkBehaviours.Values)
                 {
-                    ChildNetworkBehaviours[k].NetworkVariableUpdate(NetworkManager.ServerClientId);
+                    behaviour.NetworkVariableUpdate(NetworkManager.ServerClientId);
                 }
             }
 
@@ -1995,7 +1996,7 @@ namespace Unity.Netcode
                 return;
             }
 
-            foreach (var behavior in ChildNetworkBehaviours)
+            foreach (var behavior in ChildNetworkBehaviours.Values)
             {
                 behavior.MarkVariablesDirty(false);
             }
@@ -2071,7 +2072,7 @@ namespace Unity.Netcode
                 NetworkManagerOwner.SpawnManager.UpdateOwnershipTable(this, originalOwnerClientId, true);
             }
 
-            foreach (var childBehaviour in ChildNetworkBehaviours)
+            foreach (var childBehaviour in ChildNetworkBehaviours.Values)
             {
                 childBehaviour.UpdateNetworkProperties();
                 if (distributedAuthorityMode || isServer || isPreviousOwner)
@@ -2084,7 +2085,7 @@ namespace Unity.Netcode
 
             if (distributedAuthorityMode || isServer || isNewOwner)
             {
-                foreach (var childBehaviour in ChildNetworkBehaviours)
+                foreach (var childBehaviour in ChildNetworkBehaviours.Values)
                 {
                     if (!childBehaviour.gameObject.activeInHierarchy)
                     {
@@ -2101,17 +2102,17 @@ namespace Unity.Netcode
 
         internal void InvokeOwnershipChanged(ulong previous, ulong next)
         {
-            for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
+            foreach (var child in ChildNetworkBehaviours.Values)
             {
-                if (ChildNetworkBehaviours[i].gameObject.activeInHierarchy)
+                if (child.gameObject.activeInHierarchy)
                 {
-                    ChildNetworkBehaviours[i].InternalOnOwnershipChanged(previous, next);
+                    child.InternalOnOwnershipChanged(previous, next);
                 }
                 else
                 {
                     if (NetworkManagerOwner.LogLevel <= LogLevel.Normal)
                     {
-                        NetworkLog.LogWarning($"[{name}] {ChildNetworkBehaviours[i].gameObject.name} is disabled! Netcode for GameObjects does not support disabled NetworkBehaviours! The {ChildNetworkBehaviours[i].GetType().Name} component was skipped during ownership assignment!");
+                        NetworkLog.LogWarning($"[{name}] {child.gameObject.name} is disabled! Netcode for GameObjects does not support disabled NetworkBehaviours! The {child.GetType().Name} component was skipped during ownership assignment!");
                     }
                 }
             }
@@ -2124,7 +2125,7 @@ namespace Unity.Netcode
                 return;
             }
 
-            foreach (var childBehaviour in ChildNetworkBehaviours)
+            foreach (var childBehaviour in ChildNetworkBehaviours.Values)
             {
                 childBehaviour.IsSessionOwner = isSessionOwner;
             }
@@ -2132,18 +2133,18 @@ namespace Unity.Netcode
 
         internal void InvokeBehaviourOnNetworkObjectParentChanged(NetworkObject parentNetworkObject)
         {
-            for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
+            foreach (var child in ChildNetworkBehaviours.Values)
             {
                 // Any NetworkBehaviour that is not spawned and the associated GameObject is disabled should be
                 // skipped over (i.e. not supported).
-                if (!ChildNetworkBehaviours[i].IsSpawned && !ChildNetworkBehaviours[i].gameObject.activeInHierarchy)
+                if (!child.IsSpawned && !child.gameObject.activeInHierarchy)
                 {
                     continue;
                 }
                 // Invoke internal notification
-                ChildNetworkBehaviours[i].InternalOnNetworkObjectParentChanged(parentNetworkObject);
+                child.InternalOnNetworkObjectParentChanged(parentNetworkObject);
                 // Invoke public notification
-                ChildNetworkBehaviours[i].OnNetworkObjectParentChanged(parentNetworkObject);
+                child.OnNetworkObjectParentChanged(parentNetworkObject);
             }
         }
 
@@ -2591,9 +2592,9 @@ namespace Unity.Netcode
         internal void InvokeBehaviourNetworkPreSpawn()
         {
             var networkManager = NetworkManager;
-            for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
+            foreach (var childBehaviour in ChildNetworkBehaviours.Values)
             {
-                ChildNetworkBehaviours[i].NetworkPreSpawn(ref networkManager, this);
+                childBehaviour.NetworkPreSpawn(ref networkManager, this);
             }
         }
 
@@ -2607,7 +2608,7 @@ namespace Unity.Netcode
             // prior to invoking OnNetworkSpawn so cross NetworkBehaviour:
             // - accessing of NetworkVariables will work correctly.
             // - invocation of RPCs will work properly (and not throw exception under certain scenarios)
-            foreach (var childBehaviour in ChildNetworkBehaviours)
+            foreach (var childBehaviour in ChildNetworkBehaviours.Values)
             {
                 if (!childBehaviour.gameObject.activeInHierarchy)
                 {
@@ -2621,7 +2622,7 @@ namespace Unity.Netcode
             }
 
             // After initialization, we can then invoke OnNetworkSpawn on each child NetworkBehaviour.
-            foreach (var childBehaviour in ChildNetworkBehaviours)
+            foreach (var childBehaviour in ChildNetworkBehaviours.Values)
             {
                 if (!childBehaviour.gameObject.activeInHierarchy)
                 {
@@ -2637,33 +2638,33 @@ namespace Unity.Netcode
 
         internal void InvokeBehaviourNetworkPostSpawn()
         {
-            for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
+            foreach (var childBehaviour in ChildNetworkBehaviours.Values)
             {
-                if (ChildNetworkBehaviours[i].gameObject.activeInHierarchy)
+                if (childBehaviour.gameObject.activeInHierarchy)
                 {
-                    ChildNetworkBehaviours[i].NetworkPostSpawn();
+                    childBehaviour.NetworkPostSpawn();
                 }
             }
         }
 
         internal void InternalNetworkSessionSynchronized()
         {
-            for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
+            foreach (var childBehaviour in ChildNetworkBehaviours.Values)
             {
-                if (ChildNetworkBehaviours[i].gameObject.activeInHierarchy)
+                if (childBehaviour.gameObject.activeInHierarchy)
                 {
-                    ChildNetworkBehaviours[i].NetworkSessionSynchronized();
+                    childBehaviour.NetworkSessionSynchronized();
                 }
             }
         }
 
         internal void InternalInSceneNetworkObjectsSpawned()
         {
-            for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
+            foreach (var childBehaviour in ChildNetworkBehaviours.Values)
             {
-                if (ChildNetworkBehaviours[i].gameObject.activeInHierarchy)
+                if (childBehaviour.gameObject.activeInHierarchy)
                 {
-                    ChildNetworkBehaviours[i].InSceneNetworkObjectsSpawned();
+                    childBehaviour.InSceneNetworkObjectsSpawned();
                 }
             }
         }
@@ -2671,77 +2672,68 @@ namespace Unity.Netcode
         internal void InvokeBehaviourNetworkDespawn()
         {
             // Invoke OnNetworkPreDespawn on all child behaviours
-            for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
+            foreach (var childBehaviour in ChildNetworkBehaviours.Values)
             {
-                ChildNetworkBehaviours[i].InternalOnNetworkPreDespawn();
+                childBehaviour.InternalOnNetworkPreDespawn();
             }
 
             NetworkManagerOwner.SpawnManager.UpdateOwnershipTable(this, OwnerClientId, true);
             NetworkManagerOwner.SpawnManager.RemoveNetworkObjectFromSceneChangedUpdates(this);
 
-            for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
+            foreach (var childBehaviour in ChildNetworkBehaviours.Values)
             {
-                ChildNetworkBehaviours[i].InternalOnNetworkDespawn();
+                childBehaviour.InternalOnNetworkDespawn();
             }
         }
-
-        private List<NetworkBehaviour> m_ChildNetworkBehaviours;
 
         internal string GenerateDisabledNetworkBehaviourWarning(NetworkBehaviour networkBehaviour)
         {
             return $"[{name}][{networkBehaviour.GetType().Name}][{nameof(isActiveAndEnabled)}: {networkBehaviour.isActiveAndEnabled}] Disabled {nameof(NetworkBehaviour)}s will be excluded from spawning and synchronization!";
         }
 
-        internal List<NetworkBehaviour> ChildNetworkBehaviours
+        internal Dictionary<ushort, NetworkBehaviour> ChildNetworkBehaviours;
+        internal bool InitializeChildNetworkBehaviours()
         {
-            get
-            {
-                if (m_ChildNetworkBehaviours != null)
-                {
-                    return m_ChildNetworkBehaviours;
-                }
-
-                m_ChildNetworkBehaviours = new List<NetworkBehaviour>();
-                var networkBehaviours = GetComponentsInChildren<NetworkBehaviour>(true);
-                for (int i = 0; i < networkBehaviours.Length; i++)
-                {
-                    // Find the first parent NetworkObject of this child
-                    // if it's not ourselves, this childBehaviour belongs to a different NetworkObject.
-                    var networkObj = networkBehaviours[i].GetComponentInParent<NetworkObject>();
-                    if (networkObj != this)
-                    {
-                        continue;
-                    }
-
-                    // Set ourselves as the NetworkObject that this behaviour belongs to and add it to the child list
-                    var nextIndex = (ushort)m_ChildNetworkBehaviours.Count;
-                    networkBehaviours[i].SetNetworkObject(this, nextIndex);
-                    m_ChildNetworkBehaviours.Add(networkBehaviours[i]);
-
-                    var type = networkBehaviours[i].GetType();
-                    if (type == typeof(NetworkTransform) || type.IsInstanceOfType(typeof(NetworkTransform)) || type.IsSubclassOf(typeof(NetworkTransform)))
-                    {
-                        if (NetworkTransforms == null)
-                        {
-                            NetworkTransforms = new List<NetworkTransform>();
-                        }
-                        var networkTransform = networkBehaviours[i] as NetworkTransform;
-                        networkTransform.IsNested = i != 0 && networkTransform.gameObject != gameObject;
-                        NetworkTransforms.Add(networkTransform);
-                    }
+            ChildNetworkBehaviours = new Dictionary<ushort, NetworkBehaviour>();
+            NetworkTransforms = new List<NetworkTransform>();
 #if COM_UNITY_MODULES_PHYSICS || COM_UNITY_MODULES_PHYSICS2D
-                    else if (type.IsSubclassOf(typeof(NetworkRigidbodyBase)))
-                    {
-                        if (NetworkRigidbodies == null)
-                        {
-                            NetworkRigidbodies = new List<NetworkRigidbodyBase>();
-                        }
-                        NetworkRigidbodies.Add(networkBehaviours[i] as NetworkRigidbodyBase);
-                    }
+            NetworkRigidbodies = new List<NetworkRigidbodyBase>();
 #endif
+
+            var networkBehaviours = GetComponentsInChildren<NetworkBehaviour>(true);
+            foreach(var behaviour in networkBehaviours)
+            {
+                // Find the first parent NetworkObject of this child
+                // if it's not ourselves, this childBehaviour belongs to a different NetworkObject.
+                var networkObj = behaviour.GetComponentInParent<NetworkObject>();
+                if (networkObj != this)
+                {
+                    continue;
                 }
-                return m_ChildNetworkBehaviours;
+
+                // Set ourselves as the NetworkObject that this behaviour belongs to and add it to the child list
+                var nextIndex = (ushort)ChildNetworkBehaviours.Count;
+                behaviour.SetNetworkObject(this, nextIndex);
+                ChildNetworkBehaviours.Add(nextIndex, behaviour);
+
+                var networkTransform = behaviour as NetworkTransform;
+                if (networkTransform != null)
+                {
+                    networkTransform.IsNested = networkTransform.gameObject != gameObject;
+                    NetworkTransforms.Add(networkTransform);
+                }
+
+#if COM_UNITY_MODULES_PHYSICS || COM_UNITY_MODULES_PHYSICS2D
+
+                var rigidbodyBase = behaviour as NetworkRigidbodyBase;
+                if (rigidbodyBase != null)
+                {
+                    NetworkRigidbodies.Add(behaviour as NetworkRigidbodyBase);
+                }
+#endif
             }
+
+            return true;
         }
 
         /// <summary>
@@ -2761,9 +2753,9 @@ namespace Unity.Netcode
             var currentOwnerId = OwnerClientId;
             OwnerClientId = originalOwnerId;
             PreviousOwnerId = originalPreviousOwnerId;
-            for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
+            foreach (var childBehaviour in ChildNetworkBehaviours.Values)
             {
-                ChildNetworkBehaviours[i].MarkOwnerReadDirtyAndCheckOwnerWriteIsDirty();
+                childBehaviour.MarkOwnerReadDirtyAndCheckOwnerWriteIsDirty();
             }
 
             // Now set the new owner and previous owner identifiers back to their original new values
@@ -2822,29 +2814,7 @@ namespace Unity.Netcode
         /// </returns>
         public ushort GetNetworkBehaviourOrderIndex(NetworkBehaviour instance)
         {
-            // read the cached index, and verify it first
-            if (instance.NetworkBehaviourIdCache < ChildNetworkBehaviours.Count)
-            {
-                if (ChildNetworkBehaviours[instance.NetworkBehaviourIdCache] == instance)
-                {
-                    return instance.NetworkBehaviourIdCache;
-                }
-
-                // invalid cached id reset
-                instance.NetworkBehaviourIdCache = default;
-            }
-
-            for (ushort i = 0; i < ChildNetworkBehaviours.Count; i++)
-            {
-                if (ChildNetworkBehaviours[i] == instance)
-                {
-                    // cache the id, for next query
-                    instance.NetworkBehaviourIdCache = i;
-                    return i;
-                }
-            }
-
-            return 0;
+            return instance.NetworkBehaviourId;
         }
 
         /// <summary>
@@ -2854,28 +2824,26 @@ namespace Unity.Netcode
         /// <returns>The <see cref="NetworkBehaviour"/> at the ordered index value or null if it does not exist.</returns>
         public NetworkBehaviour GetNetworkBehaviourAtOrderIndex(ushort index)
         {
-            if (index >= ChildNetworkBehaviours.Count)
+            if (ChildNetworkBehaviours.TryGetValue(index, out var childBehaviour))
             {
-                if (NetworkLog.CurrentLogLevel <= LogLevel.Error)
-                {
-                    NetworkLog.LogError($"{nameof(NetworkBehaviour)} index {index} was out of bounds for {name}. NetworkBehaviours must be the same, and in the same order, between server and client.");
-                }
-                if (NetworkLog.CurrentLogLevel <= LogLevel.Developer)
-                {
-                    var currentKnownChildren = new StringBuilder();
-                    currentKnownChildren.Append($"Known child {nameof(NetworkBehaviour)}s:");
-                    for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
-                    {
-                        var childNetworkBehaviour = ChildNetworkBehaviours[i];
-                        currentKnownChildren.Append($" [{i}] {childNetworkBehaviour.__getTypeName()}");
-                        currentKnownChildren.Append(i < ChildNetworkBehaviours.Count - 1 ? "," : ".");
-                    }
-                    NetworkLog.LogInfo(currentKnownChildren.ToString());
-                }
-                return null;
+                return childBehaviour;
             }
 
-            return ChildNetworkBehaviours[index];
+            if (NetworkLog.CurrentLogLevel <= LogLevel.Error)
+            {
+                NetworkLog.LogError($"{nameof(NetworkBehaviour)} index {index} was out of bounds for {name}. NetworkBehaviours must be the same, and in the same order, between server and client.");
+            }
+            if (NetworkLog.CurrentLogLevel <= LogLevel.Developer)
+            {
+                var currentKnownChildren = new StringBuilder();
+                currentKnownChildren.Append($"Known child {nameof(NetworkBehaviour)}s:");
+                foreach (var (id, behaviour) in ChildNetworkBehaviours)
+                {
+                    currentKnownChildren.Append($"[{id}] {behaviour.__getTypeName()}, ");
+                }
+                NetworkLog.LogInfo(currentKnownChildren.ToString());
+            }
+            return null;
         }
 
         /// <summary>
@@ -3181,10 +3149,10 @@ namespace Unity.Netcode
                 var writer = serializer.GetFastBufferWriter();
 
                 // Synchronize NetworkVariables
-                foreach (var behavior in ChildNetworkBehaviours)
+                foreach (var childBehaviour in ChildNetworkBehaviours.Values)
                 {
-                    behavior.InitializeVariables();
-                    behavior.WriteNetworkVariableData(writer, targetClientId);
+                    childBehaviour.InitializeVariables();
+                    childBehaviour.WriteNetworkVariableData(writer, targetClientId);
                 }
 
                 // Reserve the NetworkBehaviour synchronization count position
@@ -3195,7 +3163,7 @@ namespace Unity.Netcode
                 // had additional synchronization data written.
                 // (See notes for reading/deserialization below)
                 var synchronizationCount = (byte)0;
-                foreach (var childBehaviour in ChildNetworkBehaviours)
+                foreach (var childBehaviour in ChildNetworkBehaviours.Values)
                 {
                     if (childBehaviour.Synchronize(ref serializer, targetClientId))
                     {
@@ -3216,7 +3184,7 @@ namespace Unity.Netcode
                 var reader = serializer.GetFastBufferReader();
 
                 // Apply the network variable synchronization data
-                foreach (var behaviour in ChildNetworkBehaviours)
+                foreach (var behaviour in ChildNetworkBehaviours.Values)
                 {
                     behaviour.InitializeVariables();
                     behaviour.SetNetworkVariableData(reader, targetClientId);
@@ -3525,11 +3493,8 @@ namespace Unity.Netcode
 
         private void Awake()
         {
-            m_ChildNetworkBehaviours = null;
-            NetworkTransforms?.Clear();
-#if COM_UNITY_MODULES_PHYSICS || COM_UNITY_MODULES_PHYSICS2D
-            NetworkRigidbodies?.Clear();
-#endif
+            InitializeChildNetworkBehaviours();
+
             SetCachedParent(transform.parent);
             SceneOrigin = gameObject.scene;
         }
@@ -3624,7 +3589,7 @@ namespace Unity.Netcode
                 {
                     NetworkLog.LogWarning($"{nameof(NetworkBehaviour)}-{networkBehaviour.name} is being destroyed while {nameof(NetworkObject)}-{name} is still spawned! (could break state synchronization)");
                 }
-                ChildNetworkBehaviours.Remove(networkBehaviour);
+                ChildNetworkBehaviours.Remove(networkBehaviour.NetworkBehaviourId);
             }
         }
     }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -2172,6 +2172,10 @@ namespace Unity.Netcode
 
         internal void InvokeBehaviourOnNetworkObjectParentChanged(NetworkObject parentNetworkObject)
         {
+            if (ChildNetworkBehaviours == null)
+            {
+                InitializeChildNetworkBehaviours();
+            }
             foreach (var child in ChildNetworkBehaviours.Values)
             {
                 // Any NetworkBehaviour that is not spawned and the associated GameObject is disabled should be
@@ -2711,6 +2715,10 @@ namespace Unity.Netcode
 
         internal void InvokeBehaviourNetworkDespawn()
         {
+            if (ChildNetworkBehaviours == null)
+            {
+                InitializeChildNetworkBehaviours();
+            }
             // Invoke OnNetworkPreDespawn on all child behaviours
             foreach (var childBehaviour in ChildNetworkBehaviours.Values)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -2854,6 +2854,10 @@ namespace Unity.Netcode
         /// </returns>
         public ushort GetNetworkBehaviourOrderIndex(NetworkBehaviour instance)
         {
+            if (ChildNetworkBehaviours == null)
+            {
+                InitializeChildNetworkBehaviours();
+            }
             return instance.NetworkBehaviourId;
         }
 
@@ -2864,6 +2868,11 @@ namespace Unity.Netcode
         /// <returns>The <see cref="NetworkBehaviour"/> at the ordered index value or null if it does not exist.</returns>
         public NetworkBehaviour GetNetworkBehaviourAtOrderIndex(ushort index)
         {
+            if (ChildNetworkBehaviours == null)
+            {
+                InitializeChildNetworkBehaviours();
+            }
+
             if (ChildNetworkBehaviours.TryGetValue(index, out var childBehaviour))
             {
                 return childBehaviour;
@@ -3533,8 +3542,6 @@ namespace Unity.Netcode
 
         private void Awake()
         {
-            InitializeChildNetworkBehaviours();
-
             SetCachedParent(transform.parent);
             SceneOrigin = gameObject.scene;
         }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1711,20 +1711,15 @@ namespace Unity.Netcode
                 return;
             }
 
-            if (m_ChildNetworkBehaviours != null)
+            if (ChildNetworkBehaviours != null)
             {
-                foreach (var childBehaviour in m_ChildNetworkBehaviours)
+                foreach (var childBehaviour in ChildNetworkBehaviours.Values)
                 {
-                    // Just ignore and continue processing through the entries
-                    if (!childBehaviour)
-                    {
-                        continue;
-                    }
-
+                    // Tell the childBehaviour that this NetworkObject is being destroyed.
                     // Keeping the property a private set to assure this is
                     // the only way it can be set as it should never be reset
                     // back to false once invoked.
-                    childBehaviour.SetIsDestroying();
+                    childBehaviour?.SetIsDestroying();
                 }
             }
             IsDestroying = true;

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -454,7 +454,7 @@ namespace Unity.Netcode
             }
             else // Clients just send their deltas to the service or DAHost
             {
-                foreach(var behaviour in ChildNetworkBehaviours.Values)
+                foreach (var behaviour in ChildNetworkBehaviours.Values)
                 {
                     behaviour.NetworkVariableUpdate(NetworkManager.ServerClientId);
                 }
@@ -2701,7 +2701,7 @@ namespace Unity.Netcode
 #endif
 
             var networkBehaviours = GetComponentsInChildren<NetworkBehaviour>(true);
-            foreach(var behaviour in networkBehaviours)
+            foreach (var behaviour in networkBehaviours)
             {
                 // Find the first parent NetworkObject of this child
                 // if it's not ourselves, this childBehaviour belongs to a different NetworkObject.

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -2631,6 +2631,7 @@ namespace Unity.Netcode
         internal void InvokeBehaviourNetworkPreSpawn()
         {
             var networkManager = NetworkManager;
+            InitializeChildNetworkBehaviours();
             foreach (var childBehaviour in ChildNetworkBehaviours.Values)
             {
                 childBehaviour.NetworkPreSpawn(ref networkManager, this);

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkTransformMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkTransformMessage.cs
@@ -70,11 +70,9 @@ namespace Unity.Netcode
                 return false;
             }
             var currentPosition = reader.Position;
-            var networkObjectId = (ulong)0;
-            var networkBehaviourId = 0;
 
-            ByteUnpacker.ReadValueBitPacked(reader, out networkObjectId);
-            var isSpawnedLocally = networkManager.SpawnManager.SpawnedObjects.ContainsKey(networkObjectId);
+            ByteUnpacker.ReadValueBitPacked(reader, out ulong networkObjectId);
+            var isSpawnedLocally = networkManager.SpawnManager.SpawnedObjects.TryGetValue(networkObjectId, out var networkObject);
 
             // Only defer if the NetworkObject is not spawned yet and the local NetworkManager is not running as a DAHost.
             if (!isSpawnedLocally && !networkManager.DAHost)
@@ -86,24 +84,22 @@ namespace Unity.Netcode
             // While the below check and assignment might seem out of place, this is specific to running in DAHost mode when a NetworkObject is
             // hidden from the DAHost but is visible to other clients. Since the DAHost needs to forward updates to the clients, we ignore processing
             // this message locally
-            var networkObject = (NetworkObject)null;
             var isServerAuthoritative = false;
             var ownerAuthoritativeServerSide = false;
 
             // Get the behaviour index
-            ByteUnpacker.ReadValueBitPacked(reader, out networkBehaviourId);
+            ByteUnpacker.ReadValueBitPacked(reader, out int networkBehaviourId);
 
             if (isSpawnedLocally)
             {
-                networkObject = networkManager.SpawnManager.SpawnedObjects[networkObjectId];
-                if (networkObject.ChildNetworkBehaviours.Count <= networkBehaviourId || networkObject.ChildNetworkBehaviours[networkBehaviourId] == null)
+                if (!networkObject.ChildNetworkBehaviours.TryGetValue((ushort) networkBehaviourId, out var behaviour) || behaviour == null)
                 {
                     Debug.LogError($"[{nameof(NetworkTransformMessage)}][Invalid] Targeted {nameof(NetworkTransform)}, {nameof(NetworkBehaviour.NetworkBehaviourId)} ({networkBehaviourId}), does not exist! Make sure you are not spawning {nameof(NetworkObject)}s with disabled {nameof(GameObject)}s that have {nameof(NetworkBehaviour)} components on them.");
                     return false;
                 }
 
                 // Get the target NetworkTransform
-                var transform = networkObject.ChildNetworkBehaviours[networkBehaviourId] as NetworkTransform;
+                var transform = behaviour as NetworkTransform;
                 if (transform == null)
                 {
                     Debug.LogError($"[{nameof(NetworkTransformMessage)}][Invalid] Targeted {nameof(NetworkTransform)}, {nameof(NetworkBehaviour.NetworkBehaviourId)} ({networkBehaviourId}), does not exist on {networkObject.name}! Make sure you are not spawning {nameof(NetworkObject)}s with disabled {nameof(GameObject)}s that have {nameof(NetworkBehaviour)} components on them.");

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkTransformMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/NetworkTransformMessage.cs
@@ -92,7 +92,7 @@ namespace Unity.Netcode
 
             if (isSpawnedLocally)
             {
-                if (!networkObject.ChildNetworkBehaviours.TryGetValue((ushort) networkBehaviourId, out var behaviour) || behaviour == null)
+                if (!networkObject.ChildNetworkBehaviours.TryGetValue((ushort)networkBehaviourId, out var behaviour) || behaviour == null)
                 {
                     Debug.LogError($"[{nameof(NetworkTransformMessage)}][Invalid] Targeted {nameof(NetworkTransform)}, {nameof(NetworkBehaviour.NetworkBehaviourId)} ({networkBehaviourId}), does not exist! Make sure you are not spawning {nameof(NetworkObject)}s with disabled {nameof(GameObject)}s that have {nameof(NetworkBehaviour)} components on them.");
                     return false;

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -481,9 +481,9 @@ namespace Unity.Netcode
             // then notify the user they could potentially lose state updates if developer logging is enabled.
             if (NetworkManager.LogLevel == LogLevel.Developer && !distributedAuthorityMode && m_LastChangeInOwnership.ContainsKey(networkObject.NetworkObjectId) && m_LastChangeInOwnership[networkObject.NetworkObjectId] > Time.realtimeSinceStartup)
             {
-                for (int i = 0; i < networkObject.ChildNetworkBehaviours.Count; i++)
+                foreach (var behaviour in networkObject.ChildNetworkBehaviours.Values)
                 {
-                    if (networkObject.ChildNetworkBehaviours[i].NetworkVariableFields.Count > 0)
+                    if (behaviour.NetworkVariableFields.Count > 0)
                     {
                         NetworkLog.LogWarningServer($"[Rapid Ownership Change Detected][Potential Loss in State] Detected a rapid change in ownership that exceeds a frequency less than {k_MaximumTickOwnershipChangeMultiplier}x the current network tick rate! Provide at least {k_MaximumTickOwnershipChangeMultiplier}x the current network tick rate between ownership changes to avoid NetworkVariable state loss.");
                         break;

--- a/com.unity.netcode.gameobjects/Runtime/Timing/AnticipationSystem.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Timing/AnticipationSystem.cs
@@ -67,7 +67,7 @@ namespace Unity.Netcode
             var lastRoundTripTime = m_NetworkManager.LocalTime.Time - LastAnticipationAckTime;
             foreach (var item in ObjectsToReanticipate)
             {
-                foreach (var behaviour in item.OwnerObject.ChildNetworkBehaviours)
+                foreach (var behaviour in item.OwnerObject.ChildNetworkBehaviours.Values)
                 {
                     behaviour.OnReanticipate(lastRoundTripTime);
                 }

--- a/com.unity.netcode.gameobjects/Tests/Editor/NetworkObjectTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/NetworkObjectTests.cs
@@ -33,17 +33,14 @@ namespace Unity.Netcode.EditorTests
         }
 
         [Test]
-        [TestCase(0)]
-        [TestCase(1)]
-        [TestCase(2)]
-        public void GetBehaviourIndexNone(int index)
+        public void GetBehaviourIndexNone()
         {
             var gameObject = new GameObject(nameof(GetBehaviourIndexNone));
             var networkObject = gameObject.AddComponent<NetworkObject>();
 
             LogAssert.Expect(LogType.Error, new Regex(".*out of bounds.*"));
 
-            Assert.That(networkObject.GetNetworkBehaviourAtOrderIndex((ushort)index), Is.Null);
+            Assert.That(networkObject.GetNetworkBehaviourAtOrderIndex(5), Is.Null);
 
             // Cleanup
             Object.DestroyImmediate(gameObject);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformOwnershipTests.cs
@@ -656,6 +656,7 @@ namespace Unity.Netcode.RuntimeTests
         private void RandomizeObjectTransformPositions(GameObject gameObject)
         {
             var networkObject = gameObject.GetComponent<NetworkObject>();
+            networkObject.InitializeChildNetworkBehaviours();
             Assert.True(networkObject.ChildNetworkBehaviours.Count > 0);
 
             foreach (var networkTransform in networkObject.NetworkTransforms)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/Components/ObjectNameIdentifier.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/Components/ObjectNameIdentifier.cs
@@ -106,13 +106,6 @@ namespace Unity.Netcode.TestHelpers.Runtime
             if (m_NetworkObject != null)
             {
                 DeRegisterNetworkObject();
-                // This is required otherwise it will try to continue to update the NetworkBehaviour even if
-                // it has been destroyed (most likely integration test specific)
-                if (m_NetworkObject.ChildNetworkBehaviours != null && m_NetworkObject.ChildNetworkBehaviours.Contains(this))
-                {
-                    NetworkObject.ChildNetworkBehaviours.Remove(this);
-                }
-                m_NetworkObject = null;
             }
             base.OnDestroy();
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
@@ -2650,16 +2650,12 @@ namespace Unity.Netcode.TestHelpers.Runtime
                     {
                         var method = obj.GetType().GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
                         method?.Invoke(obj, new object[] { });
-                        if (obj.ChildNetworkBehaviours == null)
-                        {
-                            obj.InitializeChildNetworkBehaviours();
-                        }
-
-                        foreach (var behaviour in obj.ChildNetworkBehaviours)
-                        {
-                            var behaviourMethod = behaviour.GetType().GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-                            behaviourMethod?.Invoke(behaviour, new object[] { });
-                        }
+                    }
+                    var networkBehaviours = FindObjects.ByType<NetworkBehaviour>();
+                    foreach (var behaviour in networkBehaviours)
+                    {
+                        var behaviourMethod = behaviour.GetType().GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                        behaviourMethod?.Invoke(behaviour, new object[] { });
                     }
                 }
             }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
@@ -2650,6 +2650,11 @@ namespace Unity.Netcode.TestHelpers.Runtime
                     {
                         var method = obj.GetType().GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
                         method?.Invoke(obj, new object[] { });
+                        if (obj.ChildNetworkBehaviours == null)
+                        {
+                            obj.InitializeChildNetworkBehaviours();
+                        }
+
                         foreach (var behaviour in obj.ChildNetworkBehaviours)
                         {
                             var behaviourMethod = behaviour.GetType().GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);


### PR DESCRIPTION
## Purpose of this PR

 - Swap ChildNetworkBehaviours to a Dictionary
 - Swap a bunch of for loops to foreach loops

### Jira ticket

n/a

### Changelog

- Changed: The collection of which NetworkBehaviours belong to a NetworkObject is now a Dictionary giving stable lookup.

## Documentation

- No documentation changes or additions were necessary.

## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [x] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports
n/a
