### PR TITLE
chore: Updated aspects of Netcode package in anticipation of v2.11.1 release

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -13,6 +13,26 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 
+
+### Deprecated
+
+
+### Removed
+
+
+### Fixed
+
+
+### Security
+
+
+### Obsolete
+
+
+## [2.11.1] - 2026-04-26
+
+### Changed
+
 - Improve handling of destroyed NetworkBehaviours. (#3953)
 - Hardened error handling and recovery during `NetworkObject` spawn. (#3941)
 - Replaced Debug usage by NetcodeLog on `NetworkSpawnManager` and `NetworkObject`. (#3933)
@@ -20,9 +40,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 - Improved performance of `NetworkTransform`. (#3907)
 - Improved performance of `NetworkRigidbodyBase`. (#3906)
 - Improved performance of `NetworkAnimator`. (#3905)
-
-### Deprecated
-
 
 ### Removed
 
@@ -32,12 +49,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 - Fixed issue where either an `AttachableBehaviour` or an `AttachableNode` can throw an exception if they are attached during a scene unload where one of the two persists the scene unload event and the other does not. (#3931)
 - Fixed issue where attempts to use `NetworkLog` when there is no `NetworkManager` instance would result in an exception. (#3917)
-
-### Security
-
-
-### Obsolete
-
 
 ## [2.11.0] - 2026-03-19
 

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -2,7 +2,7 @@
     "name": "com.unity.netcode.gameobjects",
     "displayName": "Netcode for GameObjects",
     "description": "Netcode for GameObjects is a high-level netcode SDK that provides networking capabilities to GameObject/MonoBehaviour workflows within Unity and sits on top of underlying transport layer.",
-    "version": "2.11.1",
+    "version": "2.11.2",
     "unity": "6000.0",
     "dependencies": {
         "com.unity.nuget.mono-cecil": "1.11.4",


### PR DESCRIPTION
This PR was created in sync with branching of release/2.11.1. It includes changes that should land on the default Netcode branch (develop-2.0.0) to reflect the new state of the package after the v2.11.1 release:
1) Updated CHANGELOG.md by adding new [Unreleased] section template at the top and cleaning the Changelog for the current release.
2) Updated package version in package.json by incrementing the patch version to signify the current state of the package.
3) Updated package version in ValidationExceptions.json to match the new package version.

Please review and merge this PR to keep the default branch up to date with the latest package state after the release. Those changes can land immediately OR after the release was finalized but make sure that the Changelog will be merged correctly as sometimes some discrepancies may be introduced due to new entries being introduced meantime
