### PR TITLE
fix: Improved OnValueChanged door example

### DIFF
--- a/com.unity.netcode.gameobjects/Documentation~/basics/networkvariable.md
+++ b/com.unity.netcode.gameobjects/Documentation~/basics/networkvariable.md
@@ -148,14 +148,22 @@ The [synchronization and notification example](#synchronization-and-notification
 The `OnValueChanged` example shows a simple server-authoritative `NetworkVariable` being used to track the state of a door (open or closed) using an RPC that's sent to the server. Each time the door is used by a client, the `Door.ToggleStateRpc` is invoked and the server-side toggles the state of the door. When the `Door.State.Value` changes, all connected clients are synchronized to the (new) current `Value` and the `OnStateChanged` method is invoked locally on each client.
 
 ```csharp
+using System.Runtime.CompilerServices;
+using Unity.Netcode;
+using UnityEngine;
+
 /// <summary>
-/// A basic NetworkVariable driven door state example.
+/// Example of using a <see cref="NetworkVariable{T}"/> to drive changes
+/// in state.
 /// </summary>
-public class Door : NetworkBehaviour
+/// <remarks>
+/// This is a simple state driven door example.
+/// This script was written with recommended usages patterns in mind.
+/// </remarks>
+public class Door : NetworkBehaviour, INetworkUpdateSystem
 {
     /// <summary>
-    /// Only for UI purposes.
-    /// This provides an initial configuration state for the door.
+    /// The two door states.
     /// </summary>
     public enum DoorStates
     {
@@ -170,9 +178,21 @@ public class Door : NetworkBehaviour
     public DoorStates InitialState = DoorStates.Closed;
 
     /// <summary>
+    /// Used for <see cref="CanPlayerToggleState"/> example purposes.
+    /// When true, only the server can open and close the door.
+    /// Clients will receive a console log saying they could not open the door.
+    /// </summary>
+    public bool IsLocked;
+
+    /// <summary>
     /// A simple door state where the server has write permissions and everyone has read permissions.
     /// </summary>
-    public NetworkVariable<bool> State = new NetworkVariable<bool>(default, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Server);
+    private NetworkVariable<DoorStates> m_State = new NetworkVariable<DoorStates>(default, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Server);
+
+    /// <summary>
+    /// The current state of the door.
+    /// </summary>
+    public DoorStates CurrentState => m_State.Value;
 
     /// <summary>
     /// Invoked while the <see cref="NetworkObject"/> is in the middle of
@@ -187,25 +207,50 @@ public class Door : NetworkBehaviour
         {
             // Host/Server:
             // Applies the configurable state upon spawning.
-            State.Value = InitialState == DoorStates.Open;
+            m_State.Value = InitialState;
         }
         else
         {
             // Clients:
             // Subscribe to changes in the door's state.
-            State.OnValueChanged += OnStateChanged;
+            m_State.OnValueChanged += OnStateChanged;
         }
     }
 
     /// <summary>
-    /// Invoked once the door and all associated <see cref="NetworkAnimator"/>
-    /// components have finished the spawn process.
+    /// Invoked once the door and all associated components
+    /// have finished the spawn process.
     /// </summary>
     protected override void OnNetworkPostSpawn()
     {
-        // Everyone updates their door state when finished spawning the door.
-        UpdateFromState(true);
+        // Everyone updates their door state when finished spawning the door
+        // in order to assure the door reflects (visually) its current state.
+        UpdateFromState();
+
+        // Begin to start updating this NetworkBehaviour instance once all 
+        // netcode related components have finished the spawn process.
+        NetworkUpdateLoop.RegisterNetworkUpdate(this, NetworkUpdateStage.Update);
         base.OnNetworkPostSpawn();
+    }
+
+    /// <summary>
+    /// Example of using the <see cref="INetworkUpdateSystem"/> usage pattern
+    /// where it only updates while spawned.
+    /// </summary>
+    /// <param name="updateStage">The current update stage being invoked.</param>
+    public void NetworkUpdate(NetworkUpdateStage updateStage)
+    {
+        switch (updateStage)
+        {
+            case NetworkUpdateStage.Update:
+                {
+                    if (Input.GetKeyDown(KeyCode.Space))
+                    {
+                        Interact();
+                    }
+                    break;
+                }
+        }
     }
 
     /// <summary>
@@ -216,56 +261,55 @@ public class Door : NetworkBehaviour
     {
         if (!IsServer)
         {
-            State.OnValueChanged -= OnStateChanged;
+            m_State.OnValueChanged -= OnStateChanged;
         }
+
+        // Stop updating this NetworkBehaviour instance prior to running
+        // through the de-spawn process.
+        NetworkUpdateLoop.RegisterNetworkUpdate(this, NetworkUpdateStage.Update);
         base.OnNetworkPreDespawn();
     }
 
     /// <summary>
-    /// Only clients invoke this.
     /// Server makes changes to the state.
+    /// Clients receive the changes in state.
     /// </summary>
     /// <remarks>
     /// When the previous state equals the current state, we are a client
     /// that is doing its 1st synchronization of this door instance.
     /// </remarks>
-    /// <param name="previous">The previous state.</param>
-    /// <param name="current">The current state.</param>
-    public void OnStateChanged(bool previous, bool current)
+    /// <param name="previous">The previous <see cref="DoorStates"/> state.</param>
+    /// <param name="current">The current <see cref="DoorStates"/> state.</param>
+    public void OnStateChanged(DoorStates previous, DoorStates current)
     {
-        // Update to the current state while also providing a catch for
-        // the first synchronization where previous == current.
         UpdateFromState();
     }
 
     /// <summary>
-    /// Common method used to update the actual door asset based on its current state.
+    /// Invoke when the state is updated in order to apply the change
+    /// in door state to the door asset itself.
     /// </summary>
-    /// <param name="isFirstSynchronization">only set upon first spawn by a client</param>
-    private void UpdateFromState(bool isFirstSynchronization = false)
+    private void UpdateFromState()
     {
-        if (State.Value)
+        switch(m_State.Value)
         {
-            // door is open:
-            //  - rotate door transform
-            //  - play animations, sound etc.
-            // if first sync, reset to open and don't play sound
+            case DoorStates.Closed:
+                {
+                    // door is open:
+                    //  - rotate door transform
+                    //  - play animations, sound etc.
+                    /// <see cref="Netcode.Components.Helpers.ComponentCont"
+                    break;
+                }
+            case DoorStates.Open:
+                {
+                    // door is closed:
+                    //  - rotate door transform
+                    //  - play animations, sound etc.
+                    break;
+                }
         }
-        else
-        {
-            // door is closed:
-            //  - rotate door transform
-            //  - play animations, sound etc.
-            // if first sync, reset to closed and don't play sound
-        }
-
-        // Don't log a message about a change in state when first
-        // synchronizing.
-        if (!isFirstSynchronization)
-        {
-            var openClosed = State.Value ? "open" : "closed";
-            Debug.Log($"[]The door is now {openClosed}.");
-        }
+        Debug.Log($"[{name}] Door is currently {m_State.Value}.");
     }
 
     /// <summary>
@@ -277,8 +321,9 @@ public class Door : NetworkBehaviour
     /// <returns></returns>
     protected virtual bool CanPlayerToggleState(NetworkObject player)
     {
-        // For this example, the door can always be toggled.
-        return true;
+        // For this example, if the door "is locked" then clients will
+        // not be able to open the door but the host-client's player can.
+        return !IsLocked || player.IsOwnedByServer;
     }
 
     /// <summary>
@@ -308,6 +353,12 @@ public class Door : NetworkBehaviour
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private DoorStates NextToggleState()
+    {
+        return m_State.Value == DoorStates.Open ? DoorStates.Closed : DoorStates.Open;
+    }
+
     /// <summary>
     /// Invoked only server-side
     /// Primary method to handle toggling the door state.
@@ -319,15 +370,16 @@ public class Door : NetworkBehaviour
         var playerObject = NetworkManager.SpawnManager.GetPlayerNetworkObject(clientId);
         if (playerObject != null)
         {
+            var nextToggleState = NextToggleState();
             if (CanPlayerToggleState(playerObject))
             {
                 // Host toggles the state
-                State.Value = !State.Value;
+                m_State.Value = nextToggleState;
                 UpdateFromState();
             }
             else
             {
-                ToggleStateFailRpc(RpcTarget.Single(clientId, RpcTargetUse.Temp));
+                ToggleStateFailRpc(nextToggleState, RpcTarget.Single(clientId, RpcTargetUse.Temp));
             }
         }
         else
@@ -363,11 +415,10 @@ public class Door : NetworkBehaviour
     /// </summary>
     /// <param name="rpcParams">includes <see cref="RpcReceiveParams.SenderClientId"/> that is automatically populated for you.</param>
     [Rpc(SendTo.SpecifiedInParams, InvokePermission = RpcInvokePermission.Server)]
-    private void ToggleStateFailRpc(RpcParams rpcParams = default)
+    private void ToggleStateFailRpc(DoorStates doorState, RpcParams rpcParams = default)
     {
         // Provide player feedback that toggling failed.
-        var openOrClose = State.Value ? "close" : "open";
-        Debug.Log($"Failed to {openOrClose} the door!");
+        Debug.Log($"Failed to {doorState} the door!");
     }
 }
 ```

--- a/com.unity.netcode.gameobjects/Documentation~/basics/networkvariable.md
+++ b/com.unity.netcode.gameobjects/Documentation~/basics/networkvariable.md
@@ -204,7 +204,7 @@ public class Door : NetworkBehaviour
     protected override void OnNetworkPostSpawn()
     {
         // Everyone updates their door state when finished spawning the door.
-        UpdateFromState();
+        UpdateFromState(true);
         base.OnNetworkPostSpawn();
     }
 
@@ -235,7 +235,7 @@ public class Door : NetworkBehaviour
     {
         // Update to the current state while also providing a catch for
         // the first synchronization where previous == current.
-        UpdateFromState(previous != current);
+        UpdateFromState();
     }
 
     /// <summary>
@@ -259,8 +259,8 @@ public class Door : NetworkBehaviour
             // if first sync, reset to closed and don't play sound
         }
 
-        // If 1st sync, don't log a message about a change in state
-        // since previous == current (i.e. no change in state)
+        // Don't log a message about a change in state when first
+        // synchronizing.
         if (!isFirstSynchronization)
         {
             var openClosed = State.Value ? "open" : "closed";

--- a/com.unity.netcode.gameobjects/Documentation~/basics/networkvariable.md
+++ b/com.unity.netcode.gameobjects/Documentation~/basics/networkvariable.md
@@ -195,13 +195,13 @@ public class Door : NetworkBehaviour, INetworkUpdateSystem
     public DoorStates CurrentState => m_State.Value;
 
     /// <summary>
-    /// Invoked while the <see cref="NetworkObject"/> is in the middle of
+    /// Invoked while the <see cref="NetworkObject"/> is in the process of
     /// being spawned.
     /// </summary>
     public override void OnNetworkSpawn()
     {
-        // The write authority (server) does not need to know about its
-        // own changes (for this example) since it is the "single point
+        // The write authority (server) doesn't need to know about its
+        // own changes (for this example) since it's the "single point
         // of truth" for the door instance.
         if (IsServer)
         {
@@ -224,10 +224,10 @@ public class Door : NetworkBehaviour, INetworkUpdateSystem
     protected override void OnNetworkPostSpawn()
     {
         // Everyone updates their door state when finished spawning the door
-        // in order to assure the door reflects (visually) its current state.
+        // to ensure the door reflects (visually) its current state.
         UpdateFromState();
 
-        // Begin to start updating this NetworkBehaviour instance once all
+        // Begin updating this NetworkBehaviour instance once all
         // netcode related components have finished the spawn process.
         NetworkUpdateLoop.RegisterNetworkUpdate(this, NetworkUpdateStage.Update);
         base.OnNetworkPostSpawn();
@@ -254,7 +254,7 @@ public class Door : NetworkBehaviour, INetworkUpdateSystem
     }
 
     /// <summary>
-    /// Invoked just before this instance runs through its de-spawn
+    /// Invoked just before this instance runs through its despawn
     /// sequence. A good time to unsubscribe from things.
     /// </summary>
     public override void OnNetworkPreDespawn()
@@ -265,7 +265,7 @@ public class Door : NetworkBehaviour, INetworkUpdateSystem
         }
 
         // Stop updating this NetworkBehaviour instance prior to running
-        // through the de-spawn process.
+        // through the despawn process.
         NetworkUpdateLoop.RegisterNetworkUpdate(this, NetworkUpdateStage.Update);
         base.OnNetworkPreDespawn();
     }
@@ -276,7 +276,7 @@ public class Door : NetworkBehaviour, INetworkUpdateSystem
     /// </summary>
     /// <remarks>
     /// When the previous state equals the current state, we are a client
-    /// that is doing its 1st synchronization of this door instance.
+    /// that is doing its first synchronization of this door instance.
     /// </remarks>
     /// <param name="previous">The previous <see cref="DoorStates"/> state.</param>
     /// <param name="current">The current <see cref="DoorStates"/> state.</param>
@@ -286,7 +286,7 @@ public class Door : NetworkBehaviour, INetworkUpdateSystem
     }
 
     /// <summary>
-    /// Invoke when the state is updated in order to apply the change
+    /// Invoke when the state is updated to apply the change
     /// in door state to the door asset itself.
     /// </summary>
     private void UpdateFromState()
@@ -327,7 +327,7 @@ public class Door : NetworkBehaviour, INetworkUpdateSystem
     }
 
     /// <summary>
-    /// Invoked by either a Host or clients to interact with the door.
+    /// Invoked by either a host or clients to interact with the door.
     /// </summary>
     public void Interact()
     {

--- a/com.unity.netcode.gameobjects/Documentation~/basics/networkvariable.md
+++ b/com.unity.netcode.gameobjects/Documentation~/basics/networkvariable.md
@@ -148,43 +148,226 @@ The [synchronization and notification example](#synchronization-and-notification
 The `OnValueChanged` example shows a simple server-authoritative `NetworkVariable` being used to track the state of a door (open or closed) using an RPC that's sent to the server. Each time the door is used by a client, the `Door.ToggleStateRpc` is invoked and the server-side toggles the state of the door. When the `Door.State.Value` changes, all connected clients are synchronized to the (new) current `Value` and the `OnStateChanged` method is invoked locally on each client.
 
 ```csharp
+/// <summary>
+/// A basic NetworkVariable driven door state example.
+/// </summary>
 public class Door : NetworkBehaviour
 {
-    public NetworkVariable<bool> State = new NetworkVariable<bool>();
+    /// <summary>
+    /// Only for UI purposes.
+    /// This provides an initial configuration state for the door.
+    /// </summary>
+    public enum DoorStates
+    {
+        Closed,
+        Open
+    }
 
+    /// <summary>
+    /// Initializes the door to a specific state (server side) when first spawned.
+    /// </summary>
+    [Tooltip("Configures the door's initial state when 1st spawned.")]
+    public DoorStates InitialState = DoorStates.Closed;
+
+    /// <summary>
+    /// A simple door state where the server has write permissions and everyone has read permissions.
+    /// </summary>
+    public NetworkVariable<bool> State = new NetworkVariable<bool>(default, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Server);
+
+    /// <summary>
+    /// Invoked while the <see cref="NetworkObject"/> is in the middle of
+    /// being spawned.
+    /// </summary>
     public override void OnNetworkSpawn()
     {
-        State.OnValueChanged += OnStateChanged;
+        // The write authority (server) does not need to know about its
+        // own changes (for this example) since it is the "single point
+        // of truth" for the door instance.
+        if (IsServer)
+        {
+            // Host/Server:
+            // Applies the configurable state upon spawning.
+            State.Value = InitialState == DoorStates.Open;
+        }
+        else
+        {
+            // Clients:
+            // Subscribe to changes in the door's state.
+            State.OnValueChanged += OnStateChanged;
+        }
     }
 
-    public override void OnNetworkDespawn()
+    /// <summary>
+    /// Invoked once the door and all associated <see cref="NetworkAnimator"/>
+    /// components have finished the spawn process.
+    /// </summary>
+    protected override void OnNetworkPostSpawn()
     {
-        State.OnValueChanged -= OnStateChanged;
+        // Everyone updates their door state when finished spawning the door.
+        UpdateFromState();
+        base.OnNetworkPostSpawn();
     }
 
+    /// <summary>
+    /// Invoked just before this instance runs through its de-spawn
+    /// sequence. A good time to unsubscribe from things.
+    /// </summary>
+    public override void OnNetworkPreDespawn()
+    {
+        if (!IsServer)
+        {
+            State.OnValueChanged -= OnStateChanged;
+        }
+        base.OnNetworkPreDespawn();
+    }
+
+    /// <summary>
+    /// Only clients invoke this.
+    /// Server makes changes to the state.
+    /// </summary>
+    /// <remarks>
+    /// When the previous state equals the current state, we are a client
+    /// that is doing its 1st synchronization of this door instance.
+    /// </remarks>
+    /// <param name="previous">The previous state.</param>
+    /// <param name="current">The current state.</param>
     public void OnStateChanged(bool previous, bool current)
     {
-        // note: `State.Value` will be equal to `current` here
+        // Update to the current state while also providing a catch for
+        // the first synchronization where previous == current.
+        UpdateFromState(previous != current);
+    }
+
+    /// <summary>
+    /// Common method used to update the actual door asset based on its current state.
+    /// </summary>
+    /// <param name="isFirstSynchronization">only set upon first spawn by a client</param>
+    private void UpdateFromState(bool isFirstSynchronization = false)
+    {
         if (State.Value)
         {
             // door is open:
             //  - rotate door transform
             //  - play animations, sound etc.
+            // if first sync, reset to open and don't play sound
         }
         else
         {
             // door is closed:
             //  - rotate door transform
             //  - play animations, sound etc.
+            // if first sync, reset to closed and don't play sound
+        }
+
+        // If 1st sync, don't log a message about a change in state
+        // since previous == current (i.e. no change in state)
+        if (!isFirstSynchronization)
+        {
+            var openClosed = State.Value ? "open" : "closed";
+            Debug.Log($"[]The door is now {openClosed}.");
         }
     }
 
-    [Rpc(SendTo.Server)]
-    public void ToggleStateRpc()
+    /// <summary>
+    /// Override to apply specific checks (like a player having the right 
+    /// key to open the door) or make it a non-virtual class and add logic 
+    /// directly to this method.
+    /// </summary>
+    /// <param name="player">The player attempting to open the door.</param>
+    /// <returns></returns>
+    protected virtual bool CanPlayerToggleState(NetworkObject player)
     {
-        // this will cause a replication over the network
-        // and ultimately invoke `OnValueChanged` on receivers
-        State.Value = !State.Value;
+        // For this example, the door can always be toggled.
+        return true;
+    }
+
+    /// <summary>
+    /// Invoked by either a Host or clients to interact with the door.
+    /// </summary>
+    public void Interact()
+    {
+        // Optional:
+        // This is only if you want clients to be able to
+        // interact with doors. A dedicated server would not
+        // be able to do this since it does not have a player.
+        if (IsServer && !IsHost)
+        {
+            // Optional to log a warning about this.
+            return;
+        }
+        
+        if (IsHost)
+        {
+            ToggleState(NetworkManager.LocalClientId);
+        }
+        else
+        {
+            // Clients send an RPC to server (write authority) who applies the
+            // change in state that will be synchronized with all client observers.
+            ToggleStateRpc();
+        }
+    }
+
+    /// <summary>
+    /// Invoked only server-side
+    /// Primary method to handle toggling the door state.
+    /// </summary>
+    /// <param name="clientId">The client toggling the door state.</param>
+    private void ToggleState(ulong clientId)
+    {
+        // Get the server-side client player instance
+        var playerObject = NetworkManager.SpawnManager.GetPlayerNetworkObject(clientId);
+        if (playerObject != null)
+        {
+            if (CanPlayerToggleState(playerObject))
+            {
+                // Host toggles the state 
+                State.Value = !State.Value;
+                UpdateFromState();
+            }
+            else
+            {
+                ToggleStateFailRpc(RpcTarget.Single(clientId, RpcTargetUse.Temp));
+            }
+        }
+        else
+        {
+            // Optional as to how you handle this. Since ToggleState is only invoked by
+            // sever-side only script, this could mean many things depending upon whether
+            // or not a client could interact with something and not have a player object.
+            // If that is the case, then don't even bother checking for a player object.
+            // If that is not the case, then there could be a timing issue between when 
+            // something can be "interacted with" and when a player is about to be de-spawned.
+            // For this example, we just log a warning as this example was built with 
+            // the requirement that a client has a spawned player object that is used for
+            // reference to determine if the client's player can toggle the state of the
+            // door or not.
+            NetworkLog.LogWarningServer($"Client-{clientId} has no spawned player object!");
+        }
+    }
+
+    /// <summary>
+    /// Invoked by clients.
+    /// Re-directs to the common <see cref="ToggleState(ulong)"/> method.
+    /// </summary>
+    /// <param name="rpcParams">includes <see cref="RpcReceiveParams.SenderClientId"/> that is automatically populated for you.</param>
+    [Rpc(SendTo.Server, InvokePermission = RpcInvokePermission.Everyone)]
+    private void ToggleStateRpc(RpcParams rpcParams = default)
+    {
+        ToggleState(rpcParams.Receive.SenderClientId);
+    }
+    
+    /// <summary>
+    /// Optional:
+    /// Handling when a player cannot open a door.
+    /// </summary>
+    /// <param name="rpcParams">includes <see cref="RpcReceiveParams.SenderClientId"/> that is automatically populated for you.</param>
+    [Rpc(SendTo.SpecifiedInParams, InvokePermission = RpcInvokePermission.Server)]
+    private void ToggleStateFailRpc(RpcParams rpcParams = default)
+    {
+        // Provide player feedback that toggling failed.
+        var openOrClose = State.Value ? "close" : "open";
+        Debug.Log($"Failed to {openOrClose} the door!");
     }
 }
 ```

--- a/com.unity.netcode.gameobjects/Documentation~/basics/networkvariable.md
+++ b/com.unity.netcode.gameobjects/Documentation~/basics/networkvariable.md
@@ -269,8 +269,8 @@ public class Door : NetworkBehaviour
     }
 
     /// <summary>
-    /// Override to apply specific checks (like a player having the right 
-    /// key to open the door) or make it a non-virtual class and add logic 
+    /// Override to apply specific checks (like a player having the right
+    /// key to open the door) or make it a non-virtual class and add logic
     /// directly to this method.
     /// </summary>
     /// <param name="player">The player attempting to open the door.</param>
@@ -295,7 +295,7 @@ public class Door : NetworkBehaviour
             // Optional to log a warning about this.
             return;
         }
-        
+
         if (IsHost)
         {
             ToggleState(NetworkManager.LocalClientId);
@@ -321,7 +321,7 @@ public class Door : NetworkBehaviour
         {
             if (CanPlayerToggleState(playerObject))
             {
-                // Host toggles the state 
+                // Host toggles the state
                 State.Value = !State.Value;
                 UpdateFromState();
             }
@@ -336,9 +336,9 @@ public class Door : NetworkBehaviour
             // sever-side only script, this could mean many things depending upon whether
             // or not a client could interact with something and not have a player object.
             // If that is the case, then don't even bother checking for a player object.
-            // If that is not the case, then there could be a timing issue between when 
+            // If that is not the case, then there could be a timing issue between when
             // something can be "interacted with" and when a player is about to be de-spawned.
-            // For this example, we just log a warning as this example was built with 
+            // For this example, we just log a warning as this example was built with
             // the requirement that a client has a spawned player object that is used for
             // reference to determine if the client's player can toggle the state of the
             // door or not.
@@ -356,7 +356,7 @@ public class Door : NetworkBehaviour
     {
         ToggleState(rpcParams.Receive.SenderClientId);
     }
-    
+
     /// <summary>
     /// Optional:
     /// Handling when a player cannot open a door.

--- a/com.unity.netcode.gameobjects/Documentation~/basics/networkvariable.md
+++ b/com.unity.netcode.gameobjects/Documentation~/basics/networkvariable.md
@@ -227,7 +227,7 @@ public class Door : NetworkBehaviour, INetworkUpdateSystem
         // in order to assure the door reflects (visually) its current state.
         UpdateFromState();
 
-        // Begin to start updating this NetworkBehaviour instance once all 
+        // Begin to start updating this NetworkBehaviour instance once all
         // netcode related components have finished the spawn process.
         NetworkUpdateLoop.RegisterNetworkUpdate(this, NetworkUpdateStage.Update);
         base.OnNetworkPostSpawn();


### PR DESCRIPTION


## Purpose of this PR
Updating the door example to provide a more recommended way of using OnValueChanged and how to update based on changes in state/value. The original door example could lead users to believe that OnValueChanged would be invoked on all clients upon spawn.

### Jira ticket

[MTT-14954](https://jira.unity3d.com/browse/MTT-14954)

### Changelog
[//]: # (updated with all public facing changes  - API changes, UI/UX changes, behaviour changes, bug fixes. Remove if not relevant.)

NA

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- Includes updates to existing documentation.

## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [x] `Manual testing done`
  - Reading over the change in documentation.

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports

Does not require a backport.
