### PR TITLE
fix: Exception thrown when player prefab is null

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -22,6 +22,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where if the `NetworkManager` player prefab is not assigned an exception is thrown upon starting a host and/or when a client joins. (#3965)
 
 ### Security
 

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -947,6 +947,37 @@ namespace Unity.Netcode
         }
 
         /// <summary>
+        /// The checks to find the right GlobalObjectIdHash value
+        /// are complex enough to deserve a method that includes
+        /// an easy to follow logical flow.
+        /// This also makes it a quick check to determine if there
+        /// even is a player prefab to spawn (it is valid to not
+        /// have any player spawned upon connection).
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private (bool IsValid, uint GlobalObjectIdHash) GetPlayerPrefabHash(uint? playerPrefabHash)
+        {
+            if (playerPrefabHash != null && playerPrefabHash.HasValue)
+            {
+                return (true, playerPrefabHash.Value);
+            }
+            else
+            if (NetworkManager.NetworkConfig.PlayerPrefab != null)
+            {
+                var networkObject = NetworkManager.NetworkConfig.PlayerPrefab.GetComponent<NetworkObject>();
+                if (networkObject != null)
+                {
+                    return (true, networkObject.GlobalObjectIdHash);
+                }
+                else
+                {
+                    NetworkManager.Log.Error(new Logging.Context(LogLevel.Error, $"Player prefab {NetworkManager.NetworkConfig.PlayerPrefab.name} has no {nameof(NetworkObject)}!"));
+                }
+            }
+            return (false, 0);
+        }
+
+        /// <summary>
         /// Server Side: Handles the approval of a client
         /// </summary>
         /// <remarks>
@@ -972,10 +1003,10 @@ namespace Unity.Netcode
             }
 
             // Server-side spawning (only if there is a prefab hash or player prefab provided)
-            var idHashToSpawn = playerPrefabHash ?? NetworkManager.NetworkConfig.PlayerPrefab?.GetComponent<NetworkObject>()?.GlobalObjectIdHash;
-            if (!NetworkManager.DistributedAuthorityMode && createPlayerObject && idHashToSpawn.HasValue)
+            var idHashToSpawn = GetPlayerPrefabHash(playerPrefabHash);
+            if (!NetworkManager.DistributedAuthorityMode && createPlayerObject && idHashToSpawn.IsValid)
             {
-                var playerObject = NetworkManager.SpawnManager.GetNetworkObjectToSpawn(idHashToSpawn.Value, ownerClientId, playerPosition, playerRotation);
+                var playerObject = NetworkManager.SpawnManager.GetNetworkObjectToSpawn(idHashToSpawn.GlobalObjectIdHash, ownerClientId, playerPosition, playerRotation);
 
                 if (playerObject == null)
                 {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerPlayerPrefab.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerPlayerPrefab.cs
@@ -1,0 +1,65 @@
+using System.Collections;
+using NUnit.Framework;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    /// <summary>
+    /// Generic <see cref="NetworkManager"/> test to validate clients can connect
+    /// without having set a player prefab.
+    /// </summary>
+    [TestFixture(HostOrServer.Server)]
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.DAHost)]
+    internal class NetworkManagerPlayerPrefab : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 1;
+
+        public NetworkManagerPlayerPrefab(HostOrServer hostOrServer) : base(hostOrServer)
+        {
+        }
+
+        /// <summary>
+        /// Assure no player prefab is assigned.
+        /// </summary>
+        protected override void OnServerAndClientsCreated()
+        {
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                networkManager.NetworkConfig.PlayerPrefab = null;
+            }
+            base.OnServerAndClientsCreated();
+        }
+
+        protected override void OnNewClientCreated(NetworkManager networkManager)
+        {
+            networkManager.NetworkConfig.PlayerPrefab = null;
+            base.OnNewClientCreated(networkManager);
+        }
+
+        /// <summary>
+        /// Do not wait for spawned players as there are none.
+        /// </summary>
+        /// <returns></returns>
+        protected override bool ShouldCheckForSpawnedPlayers()
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// Validates NetworkManager can start as a host and/or clients
+        /// can join when there is no player prefab assigned to the
+        /// NetworkManager.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator VerifyNetworkManagerHandlesNoPlayerPrefab()
+        {
+            // If we make it to here, then the 1st client and the authority
+            // connected with no exceptions.
+            // Now just late join a 2nd client.
+            yield return CreateAndStartNewClient();
+            // If it makes it to here without an exception then the test passes.
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerPlayerPrefab.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerPlayerPrefab.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b3132959e2f4cbe42b605770cb364a4e

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
@@ -1165,6 +1165,12 @@ namespace Unity.Netcode.TestHelpers.Runtime
         private void ClientNetworkManagerPostStart(NetworkManager networkManager)
         {
             networkManager.name = $"NetworkManager - Client - {networkManager.LocalClientId}";
+
+            // Always make sure we have a player to check.
+            if (!ShouldCheckForSpawnedPlayers())
+            {
+                return;
+            }
             Assert.NotNull(networkManager.LocalClient.PlayerObject, $"{nameof(StartServerAndClients)} detected that client {networkManager.LocalClientId} does not have an assigned player NetworkObject!");
 
             // Go ahead and create an entry for this new client


### PR DESCRIPTION


## Purpose of this PR
Fixes the issue where if the player prefab is null it will throw an exception.

### Jira ticket

[MTT-14953](https://jira.unity3d.com/browse/MTT-14953)
fix: #3964

### Changelog
[//]: # (updated with all public facing changes  - API changes, UI/UX changes, behaviour changes, bug fixes. Remove if not relevant.)

- Fixed: Issue where if the `NetworkManager` player prefab is not assigned an exception is thrown upon starting a host and/or when a client joins.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- No documentation changes or additions were necessary.


## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [x] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [x] `Covered by new automated tests` (wip)

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports

No backport is needed.
