### PR TITLE
ci: Update of CI dependencies and test fixes

### DIFF
--- a/.yamato/package-pack.yml
+++ b/.yamato/package-pack.yml
@@ -40,7 +40,7 @@ package_pack_-_ngo_{{ platform.name }}:
 {% endif %}
   timeout: 0.25
   variables:
-    XRAY_PROFILE: "gold ./pvpExceptions.json"
+    XRAY_PROFILE: "gold ./pvpExceptions.json rme"
   commands:
     - upm-pvp pack "com.unity.netcode.gameobjects" --output upm-ci~/packages
     - upm-pvp xray --packages "upm-ci~/packages/com.unity.netcode.gameobjects*.tgz" --results pvp-results

--- a/.yamato/package-tests.yml
+++ b/.yamato/package-tests.yml
@@ -36,7 +36,7 @@ package_test_-_ngo_{{ editor }}_{{ platform.name }}:
     model: {{ platform.model }} # This is set only in platforms where we want non-default model to use (more information in project.metafile)
 {% endif %}
   variables:
-    XRAY_PROFILE: "gold ./pvpExceptions.json"
+    XRAY_PROFILE: "gold ./pvpExceptions.json rme"
     UNITY_EXT_LOGGING: 1
   commands:
     - unity-downloader-cli --fast --wait -u {{ editor }} -c Editor {% if platform.name == "mac" %} --arch arm64 {% endif %} # For macOS we use ARM64 models.

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -24,7 +24,7 @@
 small_agent_platform:
     - name: ubuntu
       type: Unity::VM
-      image: package-ci/ubuntu-22.04:v4.83.0
+      image: package-ci/ubuntu-22.04:v4.85.0
       flavor: b1.small
 
 
@@ -39,13 +39,13 @@ test_platforms:
     default:
         - name: ubuntu
           type: Unity::VM
-          image: package-ci/ubuntu-22.04:v4.83.0
+          image: package-ci/ubuntu-22.04:v4.85.0
           flavor: b1.large
           standalone: StandaloneLinux64
     desktop:
         - name: ubuntu
           type: Unity::VM
-          image: package-ci/ubuntu-22.04:v4.83.0
+          image: package-ci/ubuntu-22.04:v4.85.0
           flavor: b1.large
           smaller_flavor: b1.medium
           larger_flavor: b1.xlarge

--- a/.yamato/wrench/api-validation-jobs.yml
+++ b/.yamato/wrench/api-validation-jobs.yml
@@ -60,8 +60,8 @@ api_validation_-_netcode_gameobjects_-_6000_0_-_win10:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
 

--- a/.yamato/wrench/package-pack-jobs.yml
+++ b/.yamato/wrench/package-pack-jobs.yml
@@ -29,5 +29,5 @@ package_pack_-_netcode_gameobjects:
     UPMCI_ACK_LARGE_PACKAGE: 1
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
 

--- a/.yamato/wrench/preview-a-p-v.yml
+++ b/.yamato/wrench/preview-a-p-v.yml
@@ -27,7 +27,7 @@ all_preview_apv_jobs:
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_6_-_win10
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
 
 # Functional tests for dependents found in the latest 6000.0 manifest (MacOS).
 preview_apv_-_6000_0_-_macos13:
@@ -82,10 +82,10 @@ preview_apv_-_6000_0_-_macos13:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
 
 # Functional tests for dependents found in the latest 6000.0 manifest (Ubuntu).
 preview_apv_-_6000_0_-_ubuntu2204:
@@ -140,10 +140,10 @@ preview_apv_-_6000_0_-_ubuntu2204:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
 
 # Functional tests for dependents found in the latest 6000.0 manifest (Windows).
 preview_apv_-_6000_0_-_win10:
@@ -199,10 +199,10 @@ preview_apv_-_6000_0_-_win10:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
 
 # Functional tests for dependents found in the latest 6000.3 manifest (MacOS).
 preview_apv_-_6000_3_-_macos13:
@@ -257,10 +257,10 @@ preview_apv_-_6000_3_-_macos13:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
 
 # Functional tests for dependents found in the latest 6000.3 manifest (Ubuntu).
 preview_apv_-_6000_3_-_ubuntu2204:
@@ -315,10 +315,10 @@ preview_apv_-_6000_3_-_ubuntu2204:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
 
 # Functional tests for dependents found in the latest 6000.3 manifest (Windows).
 preview_apv_-_6000_3_-_win10:
@@ -374,10 +374,10 @@ preview_apv_-_6000_3_-_win10:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
 
 # Functional tests for dependents found in the latest 6000.4 manifest (MacOS).
 preview_apv_-_6000_4_-_macos13:
@@ -432,10 +432,10 @@ preview_apv_-_6000_4_-_macos13:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
 
 # Functional tests for dependents found in the latest 6000.4 manifest (Ubuntu).
 preview_apv_-_6000_4_-_ubuntu2204:
@@ -490,10 +490,10 @@ preview_apv_-_6000_4_-_ubuntu2204:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
 
 # Functional tests for dependents found in the latest 6000.4 manifest (Windows).
 preview_apv_-_6000_4_-_win10:
@@ -549,10 +549,10 @@ preview_apv_-_6000_4_-_win10:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
 
 # Functional tests for dependents found in the latest 6000.5 manifest (MacOS).
 preview_apv_-_6000_5_-_macos13:
@@ -607,10 +607,10 @@ preview_apv_-_6000_5_-_macos13:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
 
 # Functional tests for dependents found in the latest 6000.5 manifest (Ubuntu).
 preview_apv_-_6000_5_-_ubuntu2204:
@@ -665,10 +665,10 @@ preview_apv_-_6000_5_-_ubuntu2204:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
 
 # Functional tests for dependents found in the latest 6000.5 manifest (Windows).
 preview_apv_-_6000_5_-_win10:
@@ -724,10 +724,10 @@ preview_apv_-_6000_5_-_win10:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
 
 # Functional tests for dependents found in the latest 6000.6 manifest (MacOS).
 preview_apv_-_6000_6_-_macos13:
@@ -782,10 +782,10 @@ preview_apv_-_6000_6_-_macos13:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
 
 # Functional tests for dependents found in the latest 6000.6 manifest (Ubuntu).
 preview_apv_-_6000_6_-_ubuntu2204:
@@ -840,10 +840,10 @@ preview_apv_-_6000_6_-_ubuntu2204:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
 
 # Functional tests for dependents found in the latest 6000.6 manifest (Windows).
 preview_apv_-_6000_6_-_win10:
@@ -899,8 +899,8 @@ preview_apv_-_6000_6_-_win10:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
 

--- a/.yamato/wrench/promotion-jobs.yml
+++ b/.yamato/wrench/promotion-jobs.yml
@@ -183,10 +183,10 @@ publish_dry_run_netcode_gameobjects:
         unzip: true
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
 
 # Publish  for netcode.gameobjects to https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-npm
 publish_netcode_gameobjects:
@@ -365,8 +365,9 @@ publish_netcode_gameobjects:
         unzip: true
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
+  allow_on: branch match "^release/.*"
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
 

--- a/.yamato/wrench/recipe-regeneration.yml
+++ b/.yamato/wrench/recipe-regeneration.yml
@@ -31,5 +31,5 @@ test_-_wrench_jobs_up_to_date:
     cancel_old_ci: true
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
 

--- a/.yamato/wrench/validation-jobs.yml
+++ b/.yamato/wrench/validation-jobs.yml
@@ -69,10 +69,10 @@ validate_-_netcode_gameobjects_-_6000_0_-_macos13:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
   labels:
   - Packages:netcode.gameobjects
 
@@ -139,10 +139,10 @@ validate_-_netcode_gameobjects_-_6000_0_-_ubuntu2204:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
   labels:
   - Packages:netcode.gameobjects
 
@@ -209,10 +209,10 @@ validate_-_netcode_gameobjects_-_6000_0_-_win10:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
   labels:
   - Packages:netcode.gameobjects
 
@@ -279,10 +279,10 @@ validate_-_netcode_gameobjects_-_6000_3_-_macos13:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
   labels:
   - Packages:netcode.gameobjects
 
@@ -349,10 +349,10 @@ validate_-_netcode_gameobjects_-_6000_3_-_ubuntu2204:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
   labels:
   - Packages:netcode.gameobjects
 
@@ -419,10 +419,10 @@ validate_-_netcode_gameobjects_-_6000_3_-_win10:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
   labels:
   - Packages:netcode.gameobjects
 
@@ -489,10 +489,10 @@ validate_-_netcode_gameobjects_-_6000_4_-_macos13:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
   labels:
   - Packages:netcode.gameobjects
 
@@ -559,10 +559,10 @@ validate_-_netcode_gameobjects_-_6000_4_-_ubuntu2204:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
   labels:
   - Packages:netcode.gameobjects
 
@@ -629,10 +629,10 @@ validate_-_netcode_gameobjects_-_6000_4_-_win10:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
   labels:
   - Packages:netcode.gameobjects
 
@@ -699,10 +699,10 @@ validate_-_netcode_gameobjects_-_6000_5_-_macos13:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
   labels:
   - Packages:netcode.gameobjects
 
@@ -769,10 +769,10 @@ validate_-_netcode_gameobjects_-_6000_5_-_ubuntu2204:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
   labels:
   - Packages:netcode.gameobjects
 
@@ -839,10 +839,10 @@ validate_-_netcode_gameobjects_-_6000_5_-_win10:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
   labels:
   - Packages:netcode.gameobjects
 
@@ -909,10 +909,10 @@ validate_-_netcode_gameobjects_-_6000_6_-_macos13:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
   labels:
   - Packages:netcode.gameobjects
 
@@ -979,10 +979,10 @@ validate_-_netcode_gameobjects_-_6000_6_-_ubuntu2204:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
   labels:
   - Packages:netcode.gameobjects
 
@@ -1049,10 +1049,10 @@ validate_-_netcode_gameobjects_-_6000_6_-_win10:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.7.0.0
+    UPMPVP_CONTEXT_WRENCH: 2.9.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.7.0.0
+    Wrench: 2.9.0.0
   labels:
   - Packages:netcode.gameobjects
 

--- a/.yamato/wrench/wrench_config.json
+++ b/.yamato/wrench/wrench_config.json
@@ -39,7 +39,7 @@
   },
   "publishing_job": ".yamato/wrench/promotion-jobs.yml#publish_netcode_gameobjects",
   "branch_pattern": "ReleaseSlash",
-  "wrench_version": "2.7.0.0",
+  "wrench_version": "2.9.0.0",
   "pvp_exemption_path": ".yamato/wrench/pvp-exemptions.json",
   "cs_project_path": "Tools/CI/NGO.Cookbook.csproj"
 }

--- a/Tools/CI/NGO.Cookbook.csproj
+++ b/Tools/CI/NGO.Cookbook.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="RecipeEngine.Api" Version="12.8.0" />
         <PackageReference Include="RecipeEngine.Api.Extensions" Version="7.2.1" />
         <PackageReference Include="RecipeEngine.Modules.Api" Version="5.1.0" />
-        <PackageReference Include="RecipeEngine.Modules.Wrench" Version="2.7.0" />
+        <PackageReference Include="RecipeEngine.Modules.Wrench" Version="2.9.0" />
     </ItemGroup>
 
 </Project>

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1013,7 +1013,7 @@ namespace Unity.Netcode
             var isParented = transform.root != transform;
             if (isParented)
             {
-                throw new Exception(GenerateNestedNetworkManagerMessage(transform));
+                Log.Error(new Context(LogLevel.Error, GenerateNestedNetworkManagerMessage(transform)));
             }
 #endif
             return isParented;


### PR DESCRIPTION
## Purpose of this PR
This PR was created mainly because I noticed failing **[Android](https://unity-ci.cds.internal.unity3d.com/job/67485946)** and **[WebGL](https://unity-ci.cds.internal.unity3d.com/job/67486000/logs)** jobs. While I was at it I also updated few CI deps (wrench + ubuntu image).
This PR is also addressing issues mentioned in **[THIS THREAD](https://unity.slack.com/archives/C04L97B0UB0/p1777991847543839)** and the fact that this check doesn't run for NGO, I will enable it and test that it's green

### As for Android issue (happens on all editors) 
It seems that it was caused by @EmandM https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3944 with case being 

> Before PR #3944, the test correctly handled the platform difference:
> 
```
// Old test (before #3944) — correct:
#if UNITY_EDITOR
    LogAssert.Expect(LogType.Error, messageToCheck);       // editor logs an error
#else
    LogAssert.Expect(LogType.Exception, $"Exception: {messageToCheck}");  // Android throws
#endif
```
> After PR #3944, the #else branch was removed:
> 
```
// New test (after #3944) — broken on Android:
LogAssert.Expect(LogType.Error, new Regex("NetworkManager cannot be nested"));
```

> But NetworkManagerCheckForParent in NetworkManager.cs was not updated — it still throws an exception on non-editor platforms:

```
NetworkManager.cs
Lines 1008-1020

internal bool NetworkManagerCheckForParent(bool ignoreNetworkManagerCache = false)
{
#if UNITY_EDITOR
    var isParented = NetworkManagerHelper.NotifyUserOfNestedNetworkManager(this, ignoreNetworkManagerCache);
#else
    var isParented = transform.root != transform;
    if (isParented)
    {
        throw new Exception(GenerateNestedNetworkManagerMessage(transform));
    }
#endif
    return isParented;
}
```
> On Android the #else branch runs: it throws an Exception, which Unity logs as LogType.Exception. The test now expects LogType.Error, so Unity's test runner sees an unhandled log message and fails.

To fix this I updated `NetworkManagerCheckForParent` to use the new Log system instead of throwing but @EmandM correct me on this

### As for WebGL issue (happens only for trunk) 
This seems unrelated to NGO, is partially duplicated by https://jira.unity3d.com/browse/UUM-141469 and seems to be caused by https://github.cds.internal.unity3d.com/unity/unity/pull/101284 (https://github.cds.internal.unity3d.com/unity/unity/pull/101284/commits/ca79fcd7d91fac415f57fb26b194b021a33f0c31). I will follow up on this

### Jira ticket
https://jira.unity3d.com/browse/MTT-14969

## Documentation
N/A

## Testing & QA (How your changes can be verified during release Playtest)
Green CI run of all jobs

## Backports
N/A
