### PR TITLE
ci: Added pinnedTrunk jobs and adjusted PR trigger

### DIFF
--- a/.yamato/_run-all.yml
+++ b/.yamato/_run-all.yml
@@ -37,7 +37,15 @@ run_all_package_tests_trunk:
   name: Run All Package Tests [Trunk only]
   dependencies:
 {% for platform in test_platforms.desktop -%}
-{% for editor in validation_editors.default -%}
+    - .yamato/package-tests.yml#package_test_-_ngo_trunk_{{ platform.name }}
+{% endfor -%}
+
+# Runs all package tests on pinned trunk editor (This is used for PR testing as we want to avoid blocking failures)
+run_all_package_tests_pinnedTrunk:
+  name: Run All Package Tests [Pinned Trunk only]
+  dependencies:
+{% for platform in test_platforms.desktop -%}
+{% for editor in validation_editors.pinnedTrunk -%}
     - .yamato/package-tests.yml#package_test_-_ngo_{{ editor }}_{{ platform.name }}
 {% endfor -%}
 {% endfor -%}
@@ -73,7 +81,19 @@ run_all_project_tests_trunk:
 {% for project in projects.all -%}
 {% if project.has_tests == "true" -%}
 {% for platform in test_platforms.desktop -%}
-{% for editor in validation_editors.default -%}
+    - .yamato/project-tests.yml#test_{{ project.name }}_{{ platform.name }}_trunk
+{% endfor -%}
+{% endif -%}
+{% endfor -%}
+
+# Runs all projects tests on pinned trunk editor (This is used for PR testing as we want to avoid blocking failures)
+run_all_project_tests_pinnedTrunk:
+  name: Run All Project Tests [Pinned Trunk only]
+  dependencies:
+{% for project in projects.all -%}
+{% if project.has_tests == "true" -%}
+{% for platform in test_platforms.desktop -%}
+{% for editor in validation_editors.pinnedTrunk -%}
     - .yamato/project-tests.yml#test_{{ project.name }}_{{ platform.name }}_{{ editor }}
 {% endfor -%}
 {% endfor -%}
@@ -125,7 +145,18 @@ run_all_webgl_builds_trunk:
   dependencies:
 {% for project in projects.default -%}
 {% for platform in test_platforms.desktop -%}
-{% for editor in validation_editors.default -%}
+    - .yamato/webgl-build.yml#webgl_build_{{ project.name }}_{{ platform.name }}_trunk
+{% endfor -%}
+{% endfor -%}
+
+
+# Runs all WebGL builds on pinned trunk editor (This is used for PR testing as we want to avoid blocking failures)
+run_all_webgl_builds_pinnedTrunk:
+  name: Run All WebGl Build [Pinned Trunk only]
+  dependencies:
+{% for project in projects.default -%}
+{% for platform in test_platforms.desktop -%}
+{% for editor in validation_editors.pinnedTrunk -%} 
     - .yamato/webgl-build.yml#webgl_build_{{ project.name }}_{{ platform.name }}_{{ editor }}
 {% endfor -%}
 {% endfor -%}
@@ -163,8 +194,20 @@ run_all_project_tests_desktop_standalone_trunk:
   dependencies:
 {% for project in projects.default -%}
 {% for platform in test_platforms.desktop -%}
-{% for editor in validation_editors.default -%}
 {% for backend in scripting_backends -%}
+    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}_trunk
+{% endfor -%}
+{% endfor -%}
+{% endfor -%}
+
+# Runs all Desktop tests on pinned trunk editor (This is used for PR testing as we want to avoid blocking failures)
+run_all_project_tests_desktop_standalone_pinnedTrunk:
+  name: Run All Standalone Tests - Desktop [Pinned Trunk only]
+  dependencies:
+{% for project in projects.default -%}
+{% for platform in test_platforms.desktop -%}
+{% for backend in scripting_backends -%}
+{% for editor in validation_editors.pinnedTrunk -%} 
     - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}_{{ editor }}
 {% endfor -%}
 {% endfor -%}
@@ -202,7 +245,17 @@ run_all_project_tests_mobile_standalone_trunk:
   dependencies:
 {% for project in projects.default -%}
 {% for platform in test_platforms.mobile_test -%}
-{% for editor in validation_editors.default -%}
+    - .yamato/mobile-standalone-test.yml#mobile_standalone_test_{{ project.name }}_{{ platform.name }}_trunk
+{% endfor -%}
+{% endfor -%}
+
+# Runs all Mobile tests on pinned trunk editor (This is used for PR testing as we want to avoid blocking failures)
+run_all_project_tests_mobile_standalone_pinnedTrunk:
+  name: Run All Standalone Tests - Mobile [Pinned Trunk only]
+  dependencies:
+{% for project in projects.default -%}
+{% for platform in test_platforms.mobile_test -%}
+{% for editor in validation_editors.pinnedTrunk -%} 
     - .yamato/mobile-standalone-test.yml#mobile_standalone_test_{{ project.name }}_{{ platform.name }}_{{ editor }}
 {% endfor -%}
 {% endfor -%}
@@ -238,7 +291,17 @@ run_all_project_tests_console_standalone_trunk:
   dependencies:
 {% for project in projects.default -%}
 {% for platform in test_platforms.console_test -%}
-{% for editor in validation_editors.default -%}
+    - .yamato/console-standalone-test.yml#console_standalone_test_{{ project.name }}_{{ platform.name }}_trunk
+{% endfor -%}
+{% endfor -%}
+
+# Runs all Console tests on pinned trunk editor (This is used for PR testing as we want to avoid blocking failures)
+run_all_project_tests_console_standalone_pinnedTrunk:
+  name: Run All Standalone Tests - Console [Pinned Trunk only]
+  dependencies:
+{% for project in projects.default -%}
+{% for platform in test_platforms.console_test -%}
+{% for editor in validation_editors.pinnedTrunk -%} 
     - .yamato/console-standalone-test.yml#console_standalone_test_{{ project.name }}_{{ platform.name }}_{{ editor }}
 {% endfor -%}
 {% endfor -%}
@@ -277,6 +340,20 @@ run_all_project_tests_cmb_service_trunk:
 {% for platform in test_platforms.default -%}
 {% for backend in scripting_backends -%}
     - .yamato/cmb-service-standalone-tests.yml#cmb_service_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}_trunk
+{% endfor -%}
+{% endfor -%}
+{% endfor -%}
+
+# Runs all CMB service tests on pinned trunk editor (This is used for PR testing as we want to avoid blocking failures)
+run_all_project_tests_cmb_service_pinnedTrunk:
+  name: Run All CMB Service Tests [Pinned Trunk only]
+  dependencies:
+{% for project in projects.default -%}
+{% for platform in test_platforms.default -%}
+{% for backend in scripting_backends -%}
+{% for editor in validation_editors.pinnedTrunk -%} 
+    - .yamato/cmb-service-standalone-tests.yml#cmb_service_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}_{{ editor }}
+{% endfor -%}
 {% endfor -%}
 {% endfor -%}
 {% endfor -%}

--- a/.yamato/_run-all.yml
+++ b/.yamato/_run-all.yml
@@ -45,9 +45,7 @@ run_all_package_tests_pinnedTrunk:
   name: Run All Package Tests [Pinned Trunk only]
   dependencies:
 {% for platform in test_platforms.desktop -%}
-{% for editor in validation_editors.pinnedTrunk -%}
-    - .yamato/package-tests.yml#package_test_-_ngo_{{ editor }}_{{ platform.name }}
-{% endfor -%}
+    - .yamato/package-tests.yml#package_test_-_ngo_{{ pinnedTrunk }}_{{ platform.name }}
 {% endfor -%}
 
 # Runs all package tests on mimimum supported editor (6000.0 in case of NGOv2.X)
@@ -93,9 +91,7 @@ run_all_project_tests_pinnedTrunk:
 {% for project in projects.all -%}
 {% if project.has_tests == "true" -%}
 {% for platform in test_platforms.desktop -%}
-{% for editor in validation_editors.pinnedTrunk -%}
-    - .yamato/project-tests.yml#test_{{ project.name }}_{{ platform.name }}_{{ editor }}
-{% endfor -%}
+    - .yamato/project-tests.yml#test_{{ project.name }}_{{ platform.name }}_{{ pinnedTrunk }}
 {% endfor -%}
 {% endif -%}
 {% endfor -%}
@@ -156,9 +152,7 @@ run_all_webgl_builds_pinnedTrunk:
   dependencies:
 {% for project in projects.default -%}
 {% for platform in test_platforms.desktop -%}
-{% for editor in validation_editors.pinnedTrunk -%} 
-    - .yamato/webgl-build.yml#webgl_build_{{ project.name }}_{{ platform.name }}_{{ editor }}
-{% endfor -%}
+    - .yamato/webgl-build.yml#webgl_build_{{ project.name }}_{{ platform.name }}_{{ pinnedTrunk }}
 {% endfor -%}
 {% endfor -%}
 
@@ -207,9 +201,7 @@ run_all_project_tests_desktop_standalone_pinnedTrunk:
 {% for project in projects.default -%}
 {% for platform in test_platforms.desktop -%}
 {% for backend in scripting_backends -%}
-{% for editor in validation_editors.pinnedTrunk -%} 
-    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}_{{ editor }}
-{% endfor -%}
+    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}_{{ pinnedTrunk }}
 {% endfor -%}
 {% endfor -%}
 {% endfor -%}
@@ -255,9 +247,7 @@ run_all_project_tests_mobile_standalone_pinnedTrunk:
   dependencies:
 {% for project in projects.default -%}
 {% for platform in test_platforms.mobile_test -%}
-{% for editor in validation_editors.pinnedTrunk -%} 
-    - .yamato/mobile-standalone-test.yml#mobile_standalone_test_{{ project.name }}_{{ platform.name }}_{{ editor }}
-{% endfor -%}
+    - .yamato/mobile-standalone-test.yml#mobile_standalone_test_{{ project.name }}_{{ platform.name }}_{{ pinnedTrunk }}
 {% endfor -%}
 {% endfor -%}
 
@@ -301,9 +291,7 @@ run_all_project_tests_console_standalone_pinnedTrunk:
   dependencies:
 {% for project in projects.default -%}
 {% for platform in test_platforms.console_test -%}
-{% for editor in validation_editors.pinnedTrunk -%} 
-    - .yamato/console-standalone-test.yml#console_standalone_test_{{ project.name }}_{{ platform.name }}_{{ editor }}
-{% endfor -%}
+    - .yamato/console-standalone-test.yml#console_standalone_test_{{ project.name }}_{{ platform.name }}_{{ pinnedTrunk }}
 {% endfor -%}
 {% endfor -%}
 
@@ -351,9 +339,7 @@ run_all_project_tests_cmb_service_pinnedTrunk:
 {% for project in projects.default -%}
 {% for platform in test_platforms.default -%}
 {% for backend in scripting_backends -%}
-{% for editor in validation_editors.pinnedTrunk -%} 
-    - .yamato/cmb-service-standalone-tests.yml#cmb_service_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}_{{ editor }}
-{% endfor -%}
+    - .yamato/cmb-service-standalone-tests.yml#cmb_service_standalone_test_{{ project.name }}_{{ platform.name }}_{{ backend }}_{{ pinnedTrunk }}
 {% endfor -%}
 {% endfor -%}
 {% endfor -%}

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -76,19 +76,19 @@ pr_code_changes_checks:
     - .yamato/vetting-test.yml#vetting_test
 
     # Run package EditMode and Playmode package tests on trunk and an older supported editor (6000.0)
-    - .yamato/package-tests.yml#package_test_-_ngo_trunk_mac
+    - .yamato/package-tests.yml#package_test_-_ngo_pinnedTrunk_mac
     - .yamato/package-tests.yml#package_test_-_ngo_6000.0_win
 
     # Run testproject EditMode and Playmode project tests on trunk and an older supported editor (6000.0)
-    - .yamato/project-tests.yml#test_testproject_win_trunk
+    - .yamato/project-tests.yml#test_testproject_win_pinnedTrunk
     - .yamato/project-tests.yml#test_testproject_mac_6000.0
 
     # Run standalone test. We run it only on Ubuntu since it's the fastest machine, and it was noted that for example distribution on macOS is taking 40m since we switched to Apple Silicon
     # Coverage on other standalone machines is present in Nightly job so it's enough to not run all of them for PRs
     # desktop_standalone_test and cmb_service_standalone_test are both reusing desktop_standalone_build dependency so we run those in the same configuration on PRs to reduce waiting time.
     # Note that our daily tests will anyway run both test configurations in "minimal supported" and "trunk" configurations
-    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_ubuntu_il2cpp_trunk
-    - .yamato/cmb-service-standalone-tests.yml#cmb_service_standalone_test_testproject_ubuntu_il2cpp_trunk
+    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_ubuntu_il2cpp_pinnedTrunk
+    - .yamato/cmb-service-standalone-tests.yml#cmb_service_standalone_test_testproject_ubuntu_il2cpp_pinnedTrunk
   triggers:
     expression: |-
       (pull_request.comment eq "ngo" OR

--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -76,19 +76,19 @@ pr_code_changes_checks:
     - .yamato/vetting-test.yml#vetting_test
 
     # Run package EditMode and Playmode package tests on trunk and an older supported editor (6000.0)
-    - .yamato/package-tests.yml#package_test_-_ngo_pinnedTrunk_mac
+    - .yamato/package-tests.yml#package_test_-_ngo_{{ pinnedTrunk }}_mac
     - .yamato/package-tests.yml#package_test_-_ngo_6000.0_win
 
     # Run testproject EditMode and Playmode project tests on trunk and an older supported editor (6000.0)
-    - .yamato/project-tests.yml#test_testproject_win_pinnedTrunk
+    - .yamato/project-tests.yml#test_testproject_win_{{ pinnedTrunk }}
     - .yamato/project-tests.yml#test_testproject_mac_6000.0
 
     # Run standalone test. We run it only on Ubuntu since it's the fastest machine, and it was noted that for example distribution on macOS is taking 40m since we switched to Apple Silicon
     # Coverage on other standalone machines is present in Nightly job so it's enough to not run all of them for PRs
     # desktop_standalone_test and cmb_service_standalone_test are both reusing desktop_standalone_build dependency so we run those in the same configuration on PRs to reduce waiting time.
     # Note that our daily tests will anyway run both test configurations in "minimal supported" and "trunk" configurations
-    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_ubuntu_il2cpp_pinnedTrunk
-    - .yamato/cmb-service-standalone-tests.yml#cmb_service_standalone_test_testproject_ubuntu_il2cpp_pinnedTrunk
+    - .yamato/desktop-standalone-tests.yml#desktop_standalone_test_testproject_ubuntu_il2cpp_{{ pinnedTrunk }}
+    - .yamato/cmb-service-standalone-tests.yml#cmb_service_standalone_test_testproject_ubuntu_il2cpp_{{ pinnedTrunk }}
   triggers:
     expression: |-
       (pull_request.comment eq "ngo" OR

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -184,8 +184,7 @@ validation_editors:
         - 77e2e2eea1be7153f85edac158fd663828839731
     minimal:
         - 6000.0
-    pinnedTrunk:
-        - 77e2e2eea1be7153f85edac158fd663828839731
+pinnedTrunk:  77e2e2eea1be7153f85edac158fd663828839731
 
 
 # Scripting backends used by Standalone RunTimeTests---------------------------------------------------

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -181,8 +181,11 @@ validation_editors:
         - 6000.4
         - 6000.5
         - trunk
+        - 77e2e2eea1be7153f85edac158fd663828839731
     minimal:
         - 6000.0
+    pinnedTrunk:
+        - 77e2e2eea1be7153f85edac158fd663828839731
 
 
 # Scripting backends used by Standalone RunTimeTests---------------------------------------------------

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -181,7 +181,7 @@ validation_editors:
         - 6000.4
         - 6000.5
         - trunk
-        - 77e2e2eea1be7153f85edac158fd663828839731
+        - a4ce83e807ca9aff8394d1cc07341168dc49df03
     minimal:
         - 6000.0
 pinnedTrunk:  77e2e2eea1be7153f85edac158fd663828839731

--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -184,7 +184,7 @@ validation_editors:
         - a4ce83e807ca9aff8394d1cc07341168dc49df03
     minimal:
         - 6000.0
-pinnedTrunk:  77e2e2eea1be7153f85edac158fd663828839731
+pinnedTrunk:  a4ce83e807ca9aff8394d1cc07341168dc49df03
 
 
 # Scripting backends used by Standalone RunTimeTests---------------------------------------------------


### PR DESCRIPTION
## Purpose of this PR
PR created as a response to events like in **[THIS THREAD](https://unity.slack.com/archives/C0QSF3JES/p1778175582173569?thread_ts=1777990117.588069&cid=C0QSF3JES)**

In essence we will switch testing on PRs to a pinned version of trunk and then normal trunk will still run nightly so we can be aware of any failures. 
For now I will be updating that pinned version manually but I will add a task to automate this

### Jira ticket
N/A

## Documentation
N/A

## Testing & QA (How your changes can be verified during release Playtest)
Green CI will be enough (so I also know that this will unblock other PRs)

## Backports
N/A