### PR TITLE
feat: Make custom driver construction smoother

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,11 +10,11 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
-- Added a new variant of `UnityTransport.GetDefaultPipelineConfigurations` that takes a reference to the created `NetworkDriver`. This will register all pipeline stages that `UnityTransport` requires, removing the need to manually register them in your own custom driver constructor.
+- Added a new variant of `UnityTransport.GetDefaultPipelineConfigurations` that takes a reference to the created `NetworkDriver`. This will register all pipeline stages that `UnityTransport` requires, removing the need to manually register them in your own custom driver constructor. (#3980)
 
 ### Changed
 
-- `NetworkMetricsPipelineStage` is now defined even when the multiplayer tools package is not installed, removing the need to guard its registration behind a version define when using a custom driver in `UnityTransport`.
+- `NetworkMetricsPipelineStage` is now defined even when the multiplayer tools package is not installed, removing the need to guard its registration behind a version define when using a custom driver in `UnityTransport`. (#3980)
 
 ### Deprecated
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -10,9 +10,11 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Added
 
+- Added a new variant of `UnityTransport.GetDefaultPipelineConfigurations` that takes a reference to the created `NetworkDriver`. This will register all pipeline stages that `UnityTransport` requires, removing the need to manually register them in your own custom driver constructor.
 
 ### Changed
 
+- `NetworkMetricsPipelineStage` is now defined even when the multiplayer tools package is not installed, removing the need to guard its registration behind a version define when using a custom driver in `UnityTransport`.
 
 ### Deprecated
 

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/INetworkStreamDriverConstructor.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/INetworkStreamDriverConstructor.cs
@@ -36,9 +36,8 @@ namespace Unity.Netcode.Transports.UTP
     ///             var settings = transport.GetDefaultNetworkSettings();
     ///             driver = NetworkDriver.Create(new IPCNetworkInterface(), settings);
     ///
-    ///             driver.RegisterPipelineStage(new NetworkMetricsPipelineStage());
-    ///
     ///             transport.GetDefaultPipelineConfigurations(
+    ///                 ref driver,
     ///                 out var unreliableFragmentedPipelineStages,
     ///                 out var unreliableSequencedFragmentedPipelineStages,
     ///                 out var reliableSequencedPipelineStages);

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/NetworkMetricsPipelineStage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/NetworkMetricsPipelineStage.cs
@@ -1,5 +1,3 @@
-#if MULTIPLAYER_TOOLS
-#if MULTIPLAYER_TOOLS_1_0_0_PRE_7
 using AOT;
 using Unity.Burst;
 using Unity.Collections.LowLevel.Unsafe;
@@ -70,5 +68,3 @@ namespace Unity.Netcode.Transports.UTP
         }
     }
 }
-#endif
-#endif

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -657,6 +657,23 @@ namespace Unity.Netcode.Transports.UTP
             reliableSequencedPipelineStages = new(reliableSequenced, Allocator.Temp);
         }
 
+        /// <inheritdoc cref="GetDefaultPipelineConfigurations(out NativeArray{NetworkPipelineStageId}, out NativeArray{NetworkPipelineStageId}, out NativeArray{NetworkPipelineStageId})"/>
+        /// <param name="driver">Driver for which the pipeline configurations are being retrieved.</param>
+        public void GetDefaultPipelineConfigurations(
+            ref NetworkDriver driver,
+            out NativeArray<NetworkPipelineStageId> unreliableFragmentedPipelineStages,
+            out NativeArray<NetworkPipelineStageId> unreliableSequencedFragmentedPipelineStages,
+            out NativeArray<NetworkPipelineStageId> reliableSequencedPipelineStages)
+        {
+#if MULTIPLAYER_TOOLS_1_0_0_PRE_7
+            driver.RegisterPipelineStage(new NetworkMetricsPipelineStage());
+#endif
+            GetDefaultPipelineConfigurations(
+                out unreliableFragmentedPipelineStages,
+                out unreliableSequencedFragmentedPipelineStages,
+                out reliableSequencedPipelineStages);
+        }
+
         private NetworkPipeline SelectSendPipeline(NetworkDelivery delivery)
         {
             switch (delivery)
@@ -1860,11 +1877,8 @@ namespace Unity.Netcode.Transports.UTP
 #endif
             }
 
-#if MULTIPLAYER_TOOLS_1_0_0_PRE_7
-            driver.RegisterPipelineStage(new NetworkMetricsPipelineStage());
-#endif
-
             GetDefaultPipelineConfigurations(
+                ref driver,
                 out var unreliableFragmentedPipelineStages,
                 out var unreliableSequencedFragmentedPipelineStages,
                 out var reliableSequencedPipelineStages);

--- a/com.unity.netcode.gameobjects/package.json
+++ b/com.unity.netcode.gameobjects/package.json
@@ -2,7 +2,7 @@
     "name": "com.unity.netcode.gameobjects",
     "displayName": "Netcode for GameObjects",
     "description": "Netcode for GameObjects is a high-level netcode SDK that provides networking capabilities to GameObject/MonoBehaviour workflows within Unity and sits on top of underlying transport layer.",
-    "version": "2.11.3",
+    "version": "2.12.0",
     "unity": "6000.0",
     "dependencies": {
         "com.unity.nuget.mono-cecil": "1.11.4",


### PR DESCRIPTION
## Purpose of this PR

Currently if you're using a custom driver constructor, you have to remember to register the metrics pipeline stage when the multiplayer tools package is installed. That can be a bit inconvenient since that pipeline stage is only defined when the tools package is installed, and also because it's not very intuitive that this needs doing.

This PR address that by:

- Always defining `NetworkMetricsPipelineStage` regardless of the multiplayer tools package being installed or not. This way users can always register it and don't need to add a version define to guard its registration. Worst case they'll just register a pipeline stage that will go unused, which costs nothing.
- Adding a new variant of `GetDefaultPipelineConfigurations` that takes a reference to the newly-constructed driver and will do the registration itself, completely removing the need for users to know about this quirk.

(The second change actually completely alleviates the need for the first, but I went ahead with both anyway just to make things easier on users no matter what API they're using to get the default pipeline configurations.)

### Jira ticket

N/A

### Changelog

- Added: Added a new variant of `UnityTransport.GetDefaultPipelineConfigurations` that takes a reference to the created `NetworkDriver`. This will register all pipeline stages that `UnityTransport` requires, removing the need to manually register them in your own custom driver constructor.
- Changed: `NetworkMetricsPipelineStage` is now defined even when the multiplayer tools package is not installed, removing the need to guard its registration behind a version define when using a custom driver in `UnityTransport`.

## Documentation

- Includes edits to existing public API documentation.

## Testing & QA

### Functional Testing

_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

## Backports

N/A
