### PR TITLE
chore: Change codeowners for UTP

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,4 +10,4 @@ AssemblyInfo.cs @NoelStephensUnity @EmandM @Unity-Technologies/netcode-qa
 .github/ @NoelStephensUnity @EmandM @Unity-Technologies/netcode-qa
 .yamato/ @NoelStephensUnity @EmandM @Unity-Technologies/netcode-qa
 com.unity.netcode.gameobjects/Documentation*/ @jabbacakes
-com.unity.netcode.gameobjects/Runtime/Transports/UTP/ @Unity-Technologies/multiplayer-workflows
+com.unity.netcode.gameobjects/Runtime/Transports/UTP/ @simon-lemay-unity


### PR DESCRIPTION
## Purpose of this PR

Workflows team is technically not responsible for UTP anymore, so it doesn't make sense for that team to be listed as code owners. Instead of updating this to the team that now owns UTP, I've opted to just list me. Realistically that's what this line in the code owners file was always about.

### Jira ticket

N/A

## Documentation

- No documentation changes or additions were necessary.

## Testing & QA

### Functional Testing

_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

## Backports

N/A
