### PR TITLE
chore: Add obsolete warnings to unused or invalid methods

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -16,6 +16,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Deprecated
 
+- Deprecated a number of methods that were no longer valid or being used. (#3987)
 
 ### Removed
 

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
@@ -47,9 +47,6 @@ namespace Unity.Netcode.Editor.CodeGen
 
                     switch (typeDefinition.Name)
                     {
-                        case nameof(NetworkManager):
-                            ProcessNetworkManager(typeDefinition, compiledAssembly.Defines);
-                            break;
                         case nameof(NetworkBehaviour):
                             ProcessNetworkBehaviour(typeDefinition);
                             break;
@@ -88,38 +85,6 @@ namespace Unity.Netcode.Editor.CodeGen
             assemblyDefinition.Write(pe, writerParameters);
 
             return new ILPostProcessResult(new InMemoryAssembly(pe.ToArray(), pdb.ToArray()), m_Diagnostics);
-        }
-
-        // TODO: Deprecate...
-        // This is changing accessibility for values that are no longer used, but since our validator runs
-        // after ILPP and sees those values as public, they cannot be removed until a major version change.
-        private void ProcessNetworkManager(TypeDefinition typeDefinition, string[] assemblyDefines)
-        {
-            foreach (var fieldDefinition in typeDefinition.Fields)
-            {
-                if (fieldDefinition.Name == nameof(NetworkManager.__rpc_func_table))
-                {
-                    fieldDefinition.IsPublic = true;
-                }
-
-                if (fieldDefinition.Name == nameof(NetworkManager.RpcReceiveHandler))
-                {
-                    fieldDefinition.IsPublic = true;
-                }
-
-                if (fieldDefinition.Name == nameof(NetworkManager.__rpc_name_table))
-                {
-                    fieldDefinition.IsPublic = true;
-                }
-            }
-
-            foreach (var nestedTypeDefinition in typeDefinition.NestedTypes)
-            {
-                if (nestedTypeDefinition.Name == nameof(NetworkManager.RpcReceiveHandler))
-                {
-                    nestedTypeDefinition.IsNestedPublic = true;
-                }
-            }
         }
 
         private void ProcessNetworkBehaviour(TypeDefinition typeDefinition)

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
@@ -47,6 +47,9 @@ namespace Unity.Netcode.Editor.CodeGen
 
                     switch (typeDefinition.Name)
                     {
+                        case nameof(NetworkManager):
+                            ProcessNetworkManager(typeDefinition, compiledAssembly.Defines);
+                            break;
                         case nameof(NetworkBehaviour):
                             ProcessNetworkBehaviour(typeDefinition);
                             break;
@@ -85,6 +88,46 @@ namespace Unity.Netcode.Editor.CodeGen
             assemblyDefinition.Write(pe, writerParameters);
 
             return new ILPostProcessResult(new InMemoryAssembly(pe.ToArray(), pdb.ToArray()), m_Diagnostics);
+        }
+
+        // TODO: Deprecate...
+        // This is changing accessibility for values that are no longer used, but since our validator runs
+        // after ILPP and sees those values as public, they cannot be removed until a major version change.
+        private void ProcessNetworkManager(TypeDefinition typeDefinition, string[] assemblyDefines)
+        {
+            foreach (var fieldDefinition in typeDefinition.Fields)
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                if (fieldDefinition.Name == nameof(NetworkManager.__rpc_func_table))
+#pragma warning restore CS0618 // Type or member is obsolete
+                {
+                    fieldDefinition.IsPublic = true;
+                }
+
+#pragma warning disable CS0618 // Type or member is obsolete
+                if (fieldDefinition.Name == nameof(NetworkManager.RpcReceiveHandler))
+#pragma warning restore CS0618 // Type or member is obsolete
+                {
+                    fieldDefinition.IsPublic = true;
+                }
+
+#pragma warning disable CS0618 // Type or member is obsolete
+                if (fieldDefinition.Name == nameof(NetworkManager.__rpc_name_table))
+#pragma warning restore CS0618 // Type or member is obsolete
+                {
+                    fieldDefinition.IsPublic = true;
+                }
+            }
+
+            foreach (var nestedTypeDefinition in typeDefinition.NestedTypes)
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                if (nestedTypeDefinition.Name == nameof(NetworkManager.RpcReceiveHandler))
+#pragma warning restore CS0618 // Type or member is obsolete
+                {
+                    nestedTypeDefinition.IsNestedPublic = true;
+                }
+            }
         }
 
         private void ProcessNetworkBehaviour(TypeDefinition typeDefinition)

--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -322,7 +322,8 @@ namespace Unity.Netcode.Editor
         }
 
         /// <summary>
-        /// Recursively finds the root parent of a <see cref="Transform"/>
+        /// Obsolete method to find root parent of a <see cref="Transform"/>.
+        /// Use <see cref="Transform.root"/> instead.
         /// </summary>
         /// <param name="transform">The current <see cref="Transform"/> we are inspecting for a parent</param>
         /// <returns>the root parent for the first <see cref="Transform"/> passed into the method</returns>

--- a/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkBehaviourEditor.cs
@@ -326,14 +326,8 @@ namespace Unity.Netcode.Editor
         /// </summary>
         /// <param name="transform">The current <see cref="Transform"/> we are inspecting for a parent</param>
         /// <returns>the root parent for the first <see cref="Transform"/> passed into the method</returns>
-        public static Transform GetRootParentTransform(Transform transform)
-        {
-            if (transform.parent == null || transform.parent == transform)
-            {
-                return transform;
-            }
-            return GetRootParentTransform(transform.parent);
-        }
+        [Obsolete("Use transform.root instead")]
+        public static Transform GetRootParentTransform(Transform transform) => transform.root;
 
         /// <summary>
         /// Used to determine if a GameObject has one or more NetworkBehaviours but
@@ -358,7 +352,7 @@ namespace Unity.Netcode.Editor
             }
 
             // Now get the root parent transform to the current GameObject (or itself)
-            var rootTransform = GetRootParentTransform(gameObject.transform);
+            var rootTransform = gameObject.transform.root;
             if (!rootTransform.TryGetComponent<NetworkManager>(out var networkManager))
             {
                 networkManager = rootTransform.GetComponentInChildren<NetworkManager>();

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -44,12 +44,15 @@ namespace Unity.Netcode
 #pragma warning disable IDE1006 // disable naming rule violation check
 
         // RuntimeAccessModifiersILPP will make this `public`
+        [Obsolete("This field is no longer used and will be removed in a future version.")]
         internal delegate void RpcReceiveHandler(NetworkBehaviour behaviour, FastBufferReader reader, __RpcParams parameters);
 
         // RuntimeAccessModifiersILPP will make this `public`
+        [Obsolete("This field is no longer used and will be removed in a future version.")]
         internal static readonly Dictionary<uint, RpcReceiveHandler> __rpc_func_table = new Dictionary<uint, RpcReceiveHandler>();
 
         // RuntimeAccessModifiersILPP will make this `public` (legacy table should be removed in v3.x.x)
+        [Obsolete("This field is no longer used and will be removed in a future version.")]
         internal static readonly Dictionary<uint, string> __rpc_name_table = new Dictionary<uint, string>();
 
 #pragma warning restore IDE1006 // restore naming rule violation check

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -683,14 +683,8 @@ namespace Unity.Netcode
         /// <summary>
         /// This method should not be used. It is left over from a previous interface
         /// </summary>
-        public int LastModifiedTick
-        {
-            get
-            {
-                // todo: implement proper network tick for NetworkList
-                return NetworkTickSystem.NoTick;
-            }
-        }
+        [Obsolete("This property is no longer used and will be removed in a future version.")]
+        public int LastModifiedTick => NetworkTickSystem.NoTick;
 
         /// <summary>
         /// Overridden <see cref="IDisposable"/> implementation.

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1000,7 +1000,7 @@ namespace Unity.Netcode
 
             networkObject.DestroyWithScene = serializedObject.DestroyWithScene;
             networkObject.NetworkSceneHandle = serializedObject.NetworkSceneHandle;
-            networkObject.DestroyWithOwner = serializedObject.DestroyWithOwner;
+            networkObject.DontDestroyWithOwner = serializedObject.DontDestroyWithOwner;
             networkObject.Ownership = (NetworkObject.OwnershipStatus)serializedObject.OwnershipFlags;
 
             var nonNetworkObjectParent = false;

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -448,6 +448,7 @@ namespace Unity.Netcode
         /// </summary>
         /// <param name="perviousOwner">not used</param>
         /// <param name="newOwner">not used</param>
+        [Obsolete("This method is no longer used and will be removed in a future version.")]
         protected virtual void InternalOnOwnershipChanged(ulong perviousOwner, ulong newOwner)
         {
 
@@ -999,7 +1000,7 @@ namespace Unity.Netcode
 
             networkObject.DestroyWithScene = serializedObject.DestroyWithScene;
             networkObject.NetworkSceneHandle = serializedObject.NetworkSceneHandle;
-            networkObject.DontDestroyWithOwner = serializedObject.DontDestroyWithOwner;
+            networkObject.DestroyWithOwner = serializedObject.DestroyWithOwner;
             networkObject.Ownership = (NetworkObject.OwnershipStatus)serializedObject.OwnershipFlags;
 
             var nonNetworkObjectParent = false;

--- a/testproject/Assets/Tests/Manual/NestedNetworkTransforms/ChildMover.cs
+++ b/testproject/Assets/Tests/Manual/NestedNetworkTransforms/ChildMover.cs
@@ -45,20 +45,11 @@ namespace TestProject.ManualTests
             }
         }
 
-        private Transform GetRootParentTransform(Transform transform)
-        {
-            if (transform.parent != null)
-            {
-                return GetRootParentTransform(transform.parent);
-            }
-            return transform;
-        }
-
         protected override void OnNetworkPostSpawn()
         {
             if (CanCommitToTransform)
             {
-                m_RootParentTransform = GetRootParentTransform(transform);
+                m_RootParentTransform = transform.root;
                 if (RandomizeScale)
                 {
                     transform.localScale = transform.localScale * Random.Range(0.5f, 1.5f);

--- a/testproject/Assets/Tests/Runtime/RpcTestsAutomated.cs
+++ b/testproject/Assets/Tests/Runtime/RpcTestsAutomated.cs
@@ -120,16 +120,16 @@ namespace TestProject.RuntimeTests
             Assert.IsFalse(m_TimedOut);
 
             // Log the output for visual confirmation (Acceptance Test for this test) that all RPC test types (tracked by counters) executed multiple times
-            Debug.Log("Final Host-Server Status Info:");
-            Debug.Log(serverRpcTests.GetCurrentServerStatusInfo());
+            VerboseDebug("Final Host-Server Status Info:");
+            VerboseDebug(serverRpcTests.GetCurrentServerStatusInfo());
 
             foreach (var rpcClientSideTest in clientRpcQueueManualTestInstsances)
             {
-                Debug.Log($"Final Client {rpcClientSideTest.NetworkManager.LocalClientId} Status Info:");
-                Debug.Log(rpcClientSideTest.GetCurrentClientStatusInfo());
+                VerboseDebug($"Final Client {rpcClientSideTest.NetworkManager.LocalClientId} Status Info:");
+                VerboseDebug(rpcClientSideTest.GetCurrentClientStatusInfo());
             }
 
-            Debug.Log($"Total frames updated = {Time.frameCount - startFrameCount} within {Time.realtimeSinceStartup - startTime} seconds.");
+            VerboseDebug($"Total frames updated = {Time.frameCount - startFrameCount} within {Time.realtimeSinceStartup - startTime} seconds.");
         }
     }
 }

--- a/testproject/Assets/Tests/Runtime/RpcTestsAutomated.cs
+++ b/testproject/Assets/Tests/Runtime/RpcTestsAutomated.cs
@@ -6,7 +6,6 @@ using Unity.Netcode;
 using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
 using UnityEngine.TestTools;
-using Debug = UnityEngine.Debug;
 
 namespace TestProject.RuntimeTests
 {


### PR DESCRIPTION
## Purpose of this PR

Adds obsolete warnings to unused/invalid methods

### Jira ticket

n/a

### Changelog
[//]: # (updated with all public facing changes  - API changes, UI/UX changes, behaviour changes, bug fixes. Remove if not relevant.)

### Deprecated API
- [x] An `[Obsolete]` attribute was added.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [x] Deprecation of the API is explained in the CHANGELOG.
- [x] The users can understand why this API was removed and what they should use instead.

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- No documentation changes or additions were necessary.
## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [x] `Manual testing done`

_Automated tests:_
- [x] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports
[//]: # (
This section is REQUIRED and should link to the PR that targets other NGO version which is either develop or develop-2.0.0 branch
Add the following to the PR title: "\[Backport\] ..."
If this is not needed, for example feature specific to NGOv2.X, then just mention this fact.
)
