### PR TITLE
fix: end TransportConnect profiler marker on early returns in ConnectEventHandler

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -522,6 +522,9 @@ namespace Unity.Netcode
                     {
                         NetworkLog.LogError($"[TransportApproval][Server] TransportId {transportId} is already connected to this server!");
                     }
+#if DEVELOPMENT_BUILD || UNITY_EDITOR
+                    s_TransportConnect.End();
+#endif
                     return;
                 }
 
@@ -536,6 +539,9 @@ namespace Unity.Netcode
                     {
                         NetworkLog.LogError("[TransportApproval][Client] Client received a transport connection event after already connecting!");
                     }
+#if DEVELOPMENT_BUILD || UNITY_EDITOR
+                    s_TransportConnect.End();
+#endif
                     return;
                 }
 


### PR DESCRIPTION
## Purpose of this PR
[//]: # (
Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. 
)

` s_TransportConnect.Begin(); ` was called at the top of ConnectEventHandler but two early return paths (duplicate server transport ID and duplicate client connect event) exited without calling EndSample, causing the 'Missing Profiler.EndSample' error surfaced by the MultipleConnectMessagesNoop playmode tests in multiplayer tools.

### Jira ticket
_Link to related jira ticket ([Use the smart commits](https://support.atlassian.com/bitbucket-cloud/docs/use-smart-commits/)). Short version (e.g. MTT-123) also works and gets auto-linked_

N/A

### Changelog

N/A

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- No documentation changes or additions were necessary.
- Includes documentation for previously-undocumented public API entry points.
- Includes edits to existing public API documentation.

## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [X] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports
Backport required for NGO 3, not for NGO 1 (no already connected early return case)