### PR TITLE
fix: Clear cached parent when AutoObjectParentSync is false.

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -2368,8 +2368,19 @@ namespace Unity.Netcode
         private void OnTransformParentChanged()
         {
             var networkManager = NetworkManager;
-            if (!AutoObjectParentSync || (networkManager != null && networkManager.ShutdownInProgress))
+            if (networkManager != null && networkManager.ShutdownInProgress)
             {
+                return;
+            }
+
+            if (!AutoObjectParentSync)
+            {
+                // If this setting is off, we shouldn't be tracking parenting changes
+                // Ensure any tracking we do have is cleared.
+                if (m_CachedParent != null)
+                {
+                    SetCachedParent(null);
+                }
                 return;
             }
 
@@ -2388,7 +2399,6 @@ namespace Unity.Netcode
 
             if (!IsSpawned)
             {
-                AuthorityAppliedParenting = false;
                 // and we are removing the parent, then go ahead and allow parenting to occur
                 if (transform.parent == null)
                 {
@@ -2398,6 +2408,7 @@ namespace Unity.Netcode
                 }
                 else
                 {
+                    AuthorityAppliedParenting = false;
                     transform.parent = m_CachedParent;
                     if (networkManager.LogLevel <= LogLevel.Error)
                     {


### PR DESCRIPTION
## Purpose of this PR

Clear `m_CachedParent` if it's set during a parenting change where `AutoObjectParentSync` is false.

### Jira ticket
[UUM-131542](https://jira.unity3d.com/browse/UUM-131542)

fixes: #3572

### Changelog

- Fixed: Ensures `AutoObjectParentSync` is cleared if parenting changes happen while it's turned off.

## Documentation

- No documentation changes or additions were necessary.

## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports
[//]: # (
This section is REQUIRED and should link to the PR that targets other NGO version which is either develop or develop-2.0.0 branch
Add the following to the PR title: "\[Backport\] ..."
If this is not needed, for example feature specific to NGOv2.X, then just mention this fact.
)
