### PR TITLE
fix: fastbufferreader string deserialization int overflow

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -21,6 +21,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 
 ### Fixed
+
+- Issue when FastBufferReader is attempting to read a string and all or a portion of the character count has already been read by user script, it could read a character length that results in a negative byte length which could result in an editor crash. (#4052)
 - Issue where NetworkRigidbodyBase was not applying rotation correctly when using Rigidbody2D. (#4012)
 - Issue where NetworkRigidbodyBase was always checking the 3D rigid body's interpolation mode when determining if it is kinematic and needs to put the rigid body to sleep and then switch to interpolation. (#4012)
 

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
@@ -572,6 +572,11 @@ namespace Unity.Netcode
         public unsafe void ReadValue(out string s, bool oneByteChars = false)
         {
             ReadLength(out int length);
+            var readSize = oneByteChars ? length : length * sizeof(char);
+            if (int.MaxValue < (uint)readSize)
+            {
+                throw new OverflowException($"Invalid reader position detected when trying to read a string of size {(uint)readSize}! This can result from reading the same serialized value more than once causing the position to be improperly offset.");
+            }
             s = "".PadRight(length);
             int target = s.Length;
             fixed (char* native = s)
@@ -616,6 +621,12 @@ namespace Unity.Netcode
             }
 
             ReadLength(out int length);
+
+            var readSize = oneByteChars ? length : length * sizeof(char);
+            if (int.MaxValue < (uint)readSize)
+            {
+                throw new OverflowException($"Invalid reader position detected when trying to read a string of size {(uint)readSize}! This can result from reading the same serialized value more than once causing the position to be improperly offset.");
+            }
 
             if (!TryBeginReadInternal(length * (oneByteChars ? 1 : sizeof(char))))
             {

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
@@ -577,7 +577,7 @@ namespace Unity.Netcode
             {
                 throw new OverflowException($"Invalid reader position detected when trying to read a string of size {(uint)readSize}! This can result from reading the same serialized value more than once causing the position to be improperly offset.");
             }
-            s = "".PadRight(readSize);
+            s = "".PadRight(length);
             int target = s.Length;
             fixed (char* native = s)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
@@ -646,14 +646,6 @@ namespace Unity.Netcode
         /// <param name="oneByteChars">If false(default) 2 byte characters and if true 1 byte characters.</param>
         public unsafe void ReadValueSafe(out string s, bool oneByteChars = false)
         {
-#if DEBUG
-            if (Handle->InBitwiseContext)
-            {
-                throw new InvalidOperationException(
-                    "Cannot use BufferReader in bytewise mode while in a bitwise context.");
-            }
-#endif
-
             ReadLengthSafe(out int length);
 
             // Validate the string's byte count based on the character count and if it is valid begin reading based on the returned

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
@@ -3,7 +3,6 @@ using System.Runtime.CompilerServices;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
-using UnityEngine.UIElements;
 
 namespace Unity.Netcode
 {

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
@@ -654,13 +654,7 @@ namespace Unity.Netcode
             }
 #endif
 
-            if (!TryBeginReadInternal(SizeOfLengthField()))
-            {
-                throw new OverflowException("Reading past the end of the buffer");
-            }
-
-
-            ReadLength(out int length);
+            ReadLengthSafe(out int length);
 
             // Validate the string's byte count based on the character count and if it is valid begin reading based on the returned
             // byte count.
@@ -672,9 +666,6 @@ namespace Unity.Netcode
             // Read the string
             ReadString(out s, length, oneByteChars);
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int SizeOfLengthField() => sizeof(uint);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ReadLengthSafe(out uint length) => ReadUnmanagedSafe(out length);

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
@@ -615,10 +615,10 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Reads a string without bounds checking.
-        /// NOTE: This mehtod ALLOCATES memory.
+        /// NOTE: This method ALLOCATES memory.
         /// </summary>
         /// <remarks>
-        /// This is the un-safe string read which requires invoking <see cref="TryBeginRead(int)"/> prior to invoking.<br />
+        /// This is the un-safe string read which requires invoking <see cref="TryBeginRead(int)"/> prior to invoking this method.<br />
         /// Using one byte characters only allows ASCII characters.
         /// </remarks>
         /// <param name="s">Stores the read string</param>
@@ -636,10 +636,10 @@ namespace Unity.Netcode
 
         /// <summary>
         /// Reads a string after it performs bounds checking automatically.
-        /// NOTE: This mehtod ALLOCATES memory.
+        /// NOTE: This method ALLOCATES memory.
         /// </summary>
         /// <remarks>
-        /// This is the safe string read which invokes <see cref = "TryBeginReadInternal(int)"/> prior to invoking. <br />
+        /// This is the safe string read which invokes <see cref = "TryBeginReadInternal(int)"/> prior to reading the string.<br />
         /// Using one byte characters only allows ASCII characters.
         /// </remarks>
         /// <param name="s">The string re the read string</param>

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
@@ -563,8 +563,19 @@ namespace Unity.Netcode
             value.NetworkSerialize(bufferSerializer);
         }
 
+        /// <summary>
+        /// Validates the string's total byte count based on whether we are
+        /// using one or two byte characters.
+        /// </summary>
+        /// <remarks>
+        /// Will throw an overflow exception if the size is greater than <see cref="int.MaxValue"/>.
+        /// </remarks>
+        /// <param name="length">Character count</param>
+        /// <param name="oneByteChars">If false(default) 2 byte characters and if true 1 byte characters</param>
+        /// <returns>total size in bytes to read</returns>
+        /// <exception cref="OverflowException"></exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private int CheckIfValidStringLength(int length, bool oneByteChars)
+        private int ValidateStringByteCount(int length, bool oneByteChars)
         {
             var readSize = oneByteChars ? length : length * sizeof(char);
             if (int.MaxValue < (uint)readSize)
@@ -574,6 +585,12 @@ namespace Unity.Netcode
             return readSize;
         }
 
+        /// <summary>
+        /// Commonly shared string read method between <see cref="ReadValue"/>.
+        /// </summary>
+        /// <param name="s">The output of the string read.</param>
+        /// <param name="length">The number of characters in the string.</param>
+        /// <param name="oneByteChars">If false(default) 2 byte characters and if true 1 byte characters.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe void ReadString(out string s, int length, bool oneByteChars)
         {
@@ -597,31 +614,36 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// Reads a string
-        /// NOTE: ALLOCATES
+        /// Reads a string without bounds checking.
+        /// NOTE: This mehtod ALLOCATES memory.
         /// </summary>
+        /// <remarks>
+        /// This is the un-safe string read which requires invoking <see cref="TryBeginRead(int)"/> prior to invoking.<br />
+        /// Using one byte characters only allows ASCII characters.
+        /// </remarks>
         /// <param name="s">Stores the read string</param>
-        /// <param name="oneByteChars">Whether or not to use one byte per character. This will only allow ASCII</param>
+        /// <param name="oneByteChars">If false(default) 2 byte characters and if true 1 byte characters.</param>
         public unsafe void ReadValue(out string s, bool oneByteChars = false)
         {
             ReadLength(out int length);
 
-            // Validate the string length
-            CheckIfValidStringLength(length, oneByteChars);
+            // Validate the string's byte count based on the character count.
+            ValidateStringByteCount(length, oneByteChars);
 
             // Read the string
             ReadString(out s, length, oneByteChars);
         }
 
         /// <summary>
-        /// Reads a string.
-        /// NOTE: ALLOCATES
-        ///
-        /// "Safe" version - automatically performs bounds checking. Less efficient than bounds checking
-        /// for multiple reads at once by calling TryBeginRead.
+        /// Reads a string after it performs bounds checking automatically.
+        /// NOTE: This mehtod ALLOCATES memory.
         /// </summary>
-        /// <param name="s">Stores the read string</param>
-        /// <param name="oneByteChars">Whether or not to use one byte per character. This will only allow ASCII</param>
+        /// <remarks>
+        /// This is the safe string read which invokes <see cref = "TryBeginReadInternal(int)"/> prior to invoking. <br />
+        /// Using one byte characters only allows ASCII characters.
+        /// </remarks>
+        /// <param name="s">The string re the read string</param>
+        /// <param name="oneByteChars">If false(default) 2 byte characters and if true 1 byte characters.</param>
         public unsafe void ReadValueSafe(out string s, bool oneByteChars = false)
         {
 #if DEBUG
@@ -640,9 +662,9 @@ namespace Unity.Netcode
 
             ReadLength(out int length);
 
-            // Validate string length and if it is valid begin reading based on the returned
-            // byte count
-            if (!TryBeginReadInternal(CheckIfValidStringLength(length, oneByteChars)))
+            // Validate the string's byte count based on the character count and if it is valid begin reading based on the returned
+            // byte count.
+            if (!TryBeginReadInternal(ValidateStringByteCount(length, oneByteChars)))
             {
                 throw new OverflowException("Reading past the end of the buffer");
             }

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
@@ -577,7 +577,7 @@ namespace Unity.Netcode
             {
                 throw new OverflowException($"Invalid reader position detected when trying to read a string of size {(uint)readSize}! This can result from reading the same serialized value more than once causing the position to be improperly offset.");
             }
-            s = "".PadRight(length);
+            s = "".PadRight(readSize);
             int target = s.Length;
             fixed (char* native = s)
             {
@@ -628,7 +628,7 @@ namespace Unity.Netcode
                 throw new OverflowException($"Invalid reader position detected when trying to read a string of size {(uint)readSize}! This can result from reading the same serialized value more than once causing the position to be improperly offset.");
             }
 
-            if (!TryBeginReadInternal(length * (oneByteChars ? 1 : sizeof(char))))
+            if (!TryBeginReadInternal(readSize))
             {
                 throw new OverflowException("Reading past the end of the buffer");
             }

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
+using UnityEngine.UIElements;
 
 namespace Unity.Netcode
 {
@@ -563,20 +564,20 @@ namespace Unity.Netcode
             value.NetworkSerialize(bufferSerializer);
         }
 
-        /// <summary>
-        /// Reads a string
-        /// NOTE: ALLOCATES
-        /// </summary>
-        /// <param name="s">Stores the read string</param>
-        /// <param name="oneByteChars">Whether or not to use one byte per character. This will only allow ASCII</param>
-        public unsafe void ReadValue(out string s, bool oneByteChars = false)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private int CheckIfValidStringLength(int length, bool oneByteChars)
         {
-            ReadLength(out int length);
             var readSize = oneByteChars ? length : length * sizeof(char);
             if (int.MaxValue < (uint)readSize)
             {
                 throw new OverflowException($"Invalid reader position detected when trying to read a string of size {(uint)readSize}! This can result from reading the same serialized value more than once causing the position to be improperly offset.");
             }
+            return readSize;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe void ReadString(out string s, int length, bool oneByteChars)
+        {
             s = "".PadRight(length);
             int target = s.Length;
             fixed (char* native = s)
@@ -594,6 +595,23 @@ namespace Unity.Netcode
                     ReadBytes((byte*)native, target * sizeof(char));
                 }
             }
+        }
+
+        /// <summary>
+        /// Reads a string
+        /// NOTE: ALLOCATES
+        /// </summary>
+        /// <param name="s">Stores the read string</param>
+        /// <param name="oneByteChars">Whether or not to use one byte per character. This will only allow ASCII</param>
+        public unsafe void ReadValue(out string s, bool oneByteChars = false)
+        {
+            ReadLength(out int length);
+
+            // Validate the string length
+            CheckIfValidStringLength(length, oneByteChars);
+
+            // Read the string
+            ReadString(out s, length, oneByteChars);
         }
 
         /// <summary>
@@ -620,35 +638,18 @@ namespace Unity.Netcode
                 throw new OverflowException("Reading past the end of the buffer");
             }
 
+
             ReadLength(out int length);
 
-            var readSize = oneByteChars ? length : length * sizeof(char);
-            if (int.MaxValue < (uint)readSize)
-            {
-                throw new OverflowException($"Invalid reader position detected when trying to read a string of size {(uint)readSize}! This can result from reading the same serialized value more than once causing the position to be improperly offset.");
-            }
-
-            if (!TryBeginReadInternal(readSize))
+            // Validate string length and if it is valid begin reading based on the returned
+            // byte count
+            if (!TryBeginReadInternal(CheckIfValidStringLength(length, oneByteChars)))
             {
                 throw new OverflowException("Reading past the end of the buffer");
             }
-            s = "".PadRight(length);
-            int target = s.Length;
-            fixed (char* native = s)
-            {
-                if (oneByteChars)
-                {
-                    for (int i = 0; i < target; ++i)
-                    {
-                        ReadByte(out byte b);
-                        native[i] = (char)b;
-                    }
-                }
-                else
-                {
-                    ReadBytes((byte*)native, target * sizeof(char));
-                }
-            }
+
+            // Read the string
+            ReadString(out s, length, oneByteChars);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Serialization/FastBufferReader.cs
@@ -580,7 +580,7 @@ namespace Unity.Netcode
             var readSize = oneByteChars ? length : length * sizeof(char);
             if (int.MaxValue < (uint)readSize)
             {
-                throw new OverflowException($"Invalid reader position detected when trying to read a string of size {(uint)readSize}! This can result from reading the same serialized value more than once causing the position to be improperly offset.");
+                throw new OverflowException($"Invalid reader position detected when trying to read a string of size {(uint)readSize}! This can result from an error in the serialization. Ensure deserialization exactly matches what was serialized!");
             }
             return readSize;
         }

--- a/com.unity.netcode.gameobjects/Tests/Editor/Serialization/FastBufferReaderTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Serialization/FastBufferReaderTests.cs
@@ -944,7 +944,7 @@ namespace Unity.Netcode.EditorTests
 
             var serializedValueSize = FastBufferWriter.GetWriteSize(valueToTest);
 
-            using var writer = new FastBufferWriter(serializedValueSize + 3, Allocator.Temp);
+            using var writer = new FastBufferWriter(serializedValueSize, Allocator.Temp);
             writer.WriteValueSafe(valueToTest);
 
             using var reader = new FastBufferReader(writer, Allocator.Temp);

--- a/com.unity.netcode.gameobjects/Tests/Editor/Serialization/FastBufferReaderTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Serialization/FastBufferReaderTests.cs
@@ -924,6 +924,40 @@ namespace Unity.Netcode.EditorTests
             }
         }
 
+        /// <summary>
+        /// This validates that <see cref="FastBufferReader"/> catches a potential
+        /// scenario where the string's character count value has already been read
+        /// due to an error within user script and the resultant character count
+        /// multiplied times 2 (when using 2 bytes vs 1) causes the length to roll over
+        /// to a negative value which, in turn, causes the reader to attempt to read
+        /// into restricted memory and causes the editor to crash.
+        /// </summary>
+        [Test]
+        public void ReadingStringAfterStringLengthHasAlreadyBeenRead()
+        {
+            // This was an issue uncovered in UUM-145752 that resulted
+            // in the below text to result in a length that when using
+            // 2 bytes per character would cause the skewed size to roll
+            // over into a negative value causing the editor to crash
+            // when it attempted to read a large negative offset value.
+            string valueToTest = "true";
+
+            var serializedValueSize = FastBufferWriter.GetWriteSize(valueToTest);
+
+            using var writer = new FastBufferWriter(serializedValueSize + 3, Allocator.Temp);
+            writer.WriteValueSafe(valueToTest);
+
+            using var reader = new FastBufferReader(writer, Allocator.Temp);
+
+            // Read the value of the character count before trying to read the string
+            // This mocks user code having read too far into a stream causing the position to be skewed such that
+            // the string reader reads the some of the bytes for the actual text as the length.
+            reader.ReadByteSafe(out byte count);
+            Assert.True(count == valueToTest.Length, $"Count ({count}) is not the expected size of {valueToTest.Length}!");
+
+            // This should throw an overflow exception but should not crash the editor.
+            Assert.Throws<OverflowException>(() => reader.ReadValueSafe(out string valueRead));
+        }
 
         [TestCase(1, 0)]
         [TestCase(2, 0)]

--- a/com.unity.netcode.gameobjects/Tests/Editor/Serialization/FastBufferReaderTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Editor/Serialization/FastBufferReaderTests.cs
@@ -933,7 +933,7 @@ namespace Unity.Netcode.EditorTests
         /// into restricted memory and causes the editor to crash.
         /// </summary>
         [Test]
-        public void ReadingStringAfterStringLengthHasAlreadyBeenRead()
+        public void ReadingStringAfterStringLengthHasAlreadyBeenRead([Values] bool isSafeRead)
         {
             // This was an issue uncovered in UUM-145752 that resulted
             // in the below text to result in a length that when using
@@ -954,9 +954,19 @@ namespace Unity.Netcode.EditorTests
             // the string reader reads the some of the bytes for the actual text as the length.
             reader.ReadByteSafe(out byte count);
             Assert.True(count == valueToTest.Length, $"Count ({count}) is not the expected size of {valueToTest.Length}!");
+            if (isSafeRead)
+            {
+                // This should throw an overflow exception but should not crash the editor.
+                Assert.Throws<OverflowException>(() => reader.ReadValueSafe(out string valueRead));
+            }
+            else
+            {
+                // Assume user does a pre-calculation of the size to be read:
+                Assert.IsTrue(reader.TryBeginRead(count), "Reader denied read permission");
 
-            // This should throw an overflow exception but should not crash the editor.
-            Assert.Throws<OverflowException>(() => reader.ReadValueSafe(out string valueRead));
+                // This should throw an overflow exception but should not crash the editor.
+                Assert.Throws<OverflowException>(() => reader.ReadValue(out string valueRead));
+            }
         }
 
         [TestCase(1, 0)]


### PR DESCRIPTION
## Purpose of this PR
This PR resolves an edge case scenario that can cause the Unity editor to crash.
The issue requires a portion of the character count of a serialized string to have been read prior to attempting to safely or unsafely read the string. When using 2 byte character values, this can result in the length exceeding the maximum integer size resulting in a negative size being read which, in turn, causes the FastBufferReader to attempt to read into restricted memory (most likely outside of the application domain) that results in a hard editor crash.

### Jira ticket

[UUM-145752](https://jira.unity3d.com/browse/UUM-145752)

### Changelog
[//]: # (updated with all public facing changes  - API changes, UI/UX changes, behaviour changes, bug fixes. Remove if not relevant.)

- Fixed: Issue when FastBufferReader is attempting to read a string and all or a portion of the character count has already been read by user script, it could read a character length that results in a negative byte length which could result in an editor crash.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- No documentation changes or additions were necessary.


## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [x] `Manual testing done`
  -  Validated against the users project in [UUM-145752](https://jira.unity3d.com/browse/UUM-145752)

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [x] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports

No back port is required.