### PR TITLE
fix: remove dead API doc links to internal scene event types

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -143,7 +143,7 @@ namespace Unity.Netcode
 
     /// <summary>
     /// Main class for managing network scenes when <see cref="NetworkConfig.EnableSceneManagement"/> is enabled.
-    /// Uses the <see cref="SceneEventMessage"/> message to communicate <see cref="SceneEventData"/> between the server and client(s)
+    /// Uses the <c>SceneEventMessage</c> message to communicate <c>SceneEventData</c> between the server and client(s)
     /// </summary>
     [Serializable]
     public class NetworkSceneManager : IDisposable
@@ -162,8 +162,7 @@ namespace Unity.Netcode
         /// <summary>
         /// The delegate callback definition for scene event notifications.<br />
         /// See also: <br />
-        /// <see cref="SceneEvent"/><br />
-        /// <see cref="SceneEventData"/>
+        /// <see cref="SceneEvent"/>
         /// </summary>
         /// <param name="sceneEvent">SceneEvent which contains information about the scene event, including type, progress, and scene details</param>
         public delegate void SceneEventDelegate(SceneEvent sceneEvent);


### PR DESCRIPTION
## Purpose of this PR
On the `NetworkSceneManager` manual/API page, the first paragraph contained hyperlinks for the `SceneEventMessage` and `SceneEventData` types. Clicking either link led to a **missing documentation page**.

`SceneEventMessage` (`internal struct`) and `SceneEventData` (`internal class`) are internal
implementation types, so they are excluded from the public DocFX-generated API documentation and
have no doc pages (Also they don't really have formatted description when you look at them). 
However, the public `NetworkSceneManager` XML docs referenced them with
`<see cref="..."/>`, which DocFX renders as hyperlinks resolving to non-existent pages:

I converted the descriptive references to inline code so it keeps the names readable without emitting a dead link.

### Jira ticket
https://jira.unity3d.com/browse/UUM-131558

### Changelog
N/A as this is only a docs change

## Documentation
Corrected docs links

## Testing & QA (How your changes can be verified during release Playtest)
Manually verified that it works now

## Backports
N/A
