### PR TITLE
ci: Fix code coverage command in YAML configuration

### DIFF
--- a/.yamato/_triggers.yml
+++ b/.yamato/_triggers.yml
@@ -157,6 +157,8 @@ develop_nightly:
     - .yamato/project-updated-dependencies-test.yml#updated-dependencies_testproject_NGO_win_6000.0
     # Run API validation to early-detect all new APIs that would force us to release new minor version of the package. Note that for this to work the package version in package.json must correspond to "actual package state" which means that it should be higher than last released version
     - .yamato/vetting-test.yml#vetting_test
+  # Run code coverage test
+    - .yamato/code-coverage.yml#code_coverage_ubuntu_{{ validation_editors.default }}
 
 
 # Run all tests on weekly bases
@@ -187,5 +189,3 @@ develop_weekly_trunk:
     - .yamato/_run-all.yml#run_all_webgl_builds
     # Run Runtime tests against CMB service
     - .yamato/_run-all.yml#run_all_project_tests_cmb_service
-    # Run code coverage test
-    - .yamato/code-coverage.yml#code_coverage_ubuntu_{{ validation_editors.default }}

--- a/.yamato/code-coverage.yml
+++ b/.yamato/code-coverage.yml
@@ -39,7 +39,7 @@ code_coverage_{{ platform.name }}_{{ editor }}:
   commands:
     - unity-downloader-cli --fast --wait -u {{ editor }} -c Editor {% if platform.name == "mac" %} --arch arm64 {% endif %} # For macOS we use ARM64 models
     - upm-pvp create-test-project test-project --packages "upm-ci~/packages/*.tgz" --unity .Editor
-    - UnifiedTestRunner --suite=editor --suite=playmode --editor-location=.Editor --testproject=test-project --enable-code-coverage coverage-upload-options="reportsDir:$PWD/test-results/CoverageResults;name:NGOv2_{{ platform.name }}_{{ editor }};flags:NGOv2_{{ platform.name }}_{{ editor }};verbose" --coverage-results-path=$PWD/test-results/CoverageResults --coverage-options="generateHtmlReport;generateAdditionalMetrics;assemblyFilters:+Unity.Netcode.Editor,+Unity.Netcode.Runtime" --extra-editor-arg=--burst-disable-compilation --timeout={{ test_timeout }} --rerun-strategy=Test --retry={{ num_test_retries }} --clean-library-on-rerun --artifacts-path=test-results
+    - UnifiedTestRunner --suite=editor --suite=playmode --editor-location=.Editor --testproject=test-project --enable-code-coverage --coverage-upload-options="reportsDir:$PWD/test-results/CoverageResults;name:NGOv2_{{ platform.name }}_{{ editor }};flags:NGOv2_{{ platform.name }}_{{ editor }};verbose" --coverage-results-path=$PWD/test-results/CoverageResults --coverage-options="generateHtmlReport;generateAdditionalMetrics;assemblyFilters:+Unity.Netcode.Editor,+Unity.Netcode.Runtime" --extra-editor-arg=--burst-disable-compilation --timeout={{ test_timeout }} --rerun-strategy=Test --retry={{ num_test_retries }} --clean-library-on-rerun --artifacts-path=test-results
   artifacts:
     logs:
       paths:


### PR DESCRIPTION
## Purpose of this PR

[CI] Fix code coverage command in YAML configuration

Coverage reporting was not setup due to this

Initiative was triggered from this [Discussions thread](https://unity.slack.com/archives/C0Q08HZJ6/p1783516827942249)

### Jira ticket

n/a

### Changelog

- Fixed: [CI] Fixed code coverage command in YAML configuration

## Documentation

- Please follow the [Codecov guide for packages](https://internaldocs.unity.com/editor_and_runtime_development_guide/TestAutomation/CodeCoverage/CodecovForPackages/), if you haven't

## Notes to reviewers

- [Code Coverage - NGO [ubuntu, 6000.3]](https://yamato.ds.unity3d.com/project/1201/branch/ci%2Ffix%2Fcoverage-reporting/jobDefinition/.yamato%2Fcode-coverage.yml%23code_coverage_ubuntu_6000.3/recent-jobs?nav=jobDefinitions) should run on PR trigger AND on pushing changes to master/develop/develop-2.0.0
- It will need to be ported to `develop` branch, I guess


## Testing & QA 

- [Code Coverage - NGO [ubuntu, 6000.3]](https://yamato.ds.unity3d.com/project/1201/branch/ci%2Ffix%2Fcoverage-reporting/jobDefinition/.yamato%2Fcode-coverage.yml%23code_coverage_ubuntu_6000.3/recent-jobs?nav=jobDefinitions)

- [com.unity.netcode.gameobjects](https://codecov.unity3d.com/github/Unity-Technologies/com.unity.netcode.gameobjects/tree/ci%2Ffix%2Fcoverage-reporting) in Codecov

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports

Needs to be ported to `develop` branch potentially
