### PR TITLE
fix: networkanimator does no bounds check when reading parameters

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -22,6 +22,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Issue where `NetworkAnimator` did no bounds check on the parameter index read prior to obtaining a pointer to the location within the array. (#4090)
 - Issue where scene migration in a distributed authority session would throw an exception on clients migrating their owned `NetworkObject` instances to a different scene.(#4086)
 - Issue where migrating a dynamically spawned or in-scene placed `NetworkObject` into a different scene during awake could result in that spawned instance to not be synchronized. (#4086)
 - Issue where a NullReferenceException was thrown when a non-authority failed to spawn a NetworkObject. (#4067)

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
@@ -1377,6 +1377,13 @@ namespace Unity.Netcode.Components
             while (totalParametersRead < totalParametersToRead)
             {
                 ByteUnpacker.ReadValuePacked(reader, out uint parameterIndex);
+
+                // Do bounds check prior to getting the element as a reference at that index.
+                if (parameterIndex >= m_CachedAnimatorParameters.Length)
+                {
+                    NetworkManager.Log.ErrorServer(new Logging.Context(LogLevel.Error, $"[{nameof(NetworkAnimator)}][{name}] Invalid index of {parameterIndex} was received when there are only {m_CachedAnimatorParameters.Length} parameters. Ignoring the remainger of this {nameof(ParametersUpdateMessage)}!"));
+                    return;
+                }
                 ref var cacheValue = ref UnsafeUtility.ArrayElementAsRef<AnimatorParamCache>(m_CachedAnimatorParameters.GetUnsafePtr(), (int)parameterIndex);
                 var hash = cacheValue.Hash;
                 if (cacheValue.Type == AnimationParamEnumWrapper.AnimatorControllerParameterInt)

--- a/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
@@ -342,9 +342,12 @@ namespace TestProject.RuntimeTests
         {
             writer.Seek(0);
             writer.Truncate();
+
             // Write out how many parameter entries to read
             BytePacker.WriteValuePacked(writer, (uint)1);
+            // Write an invalid index level (anything would be invalid with no parameters)
             BytePacker.WriteValuePacked(writer, (uint)1000);
+            // Write some value for the invalid parameter
             BytePacker.WriteValuePacked(writer, (uint)10);
         }
 
@@ -357,14 +360,16 @@ namespace TestProject.RuntimeTests
 
             var writer = new FastBufferWriter(40, Unity.Collections.Allocator.TempJob);
 
+            // Mock a parameter update with an invalid index
             MockWritingParameters(ref writer);
 
             var invalidParameters = new ParametersUpdateMessage()
             {
                 Parameters = writer.ToArray()
             };
-
+            // Expect an error message
             LogAssert.Expect(LogType.Error, new System.Text.RegularExpressions.Regex($"parameters. Ignoring the remainger of this {nameof(ParametersUpdateMessage)}!"));
+            // Pass in the invalid ParametersUpdateMessage
             networkAnimator.UpdateParameters(ref invalidParameters);
         }
 

--- a/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using Unity.Netcode;
+using Unity.Netcode.Components;
 using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
 using UnityEngine.TestTools;
+using static Unity.Netcode.Components.NetworkAnimator;
 
 
 namespace TestProject.RuntimeTests
@@ -336,7 +338,35 @@ namespace TestProject.RuntimeTests
             VerboseDebug($" ------------------ Parameter Test [{m_OwnerShipMode}] Stopping ------------------ ");
         }
 
+        private unsafe void MockWritingParameters(ref FastBufferWriter writer)
+        {
+            writer.Seek(0);
+            writer.Truncate();
+            // Write out how many parameter entries to read
+            BytePacker.WriteValuePacked(writer, (uint)1);
+            BytePacker.WriteValuePacked(writer, (uint)1000);
+            BytePacker.WriteValuePacked(writer, (uint)10);
+        }
 
+        [Test]
+        public void ParameterBoundsCheck()
+        {
+            var gameObject = new GameObject();
+            gameObject.AddComponent<NetworkObject>();
+            var networkAnimator = gameObject.AddComponent<NetworkAnimator>();
+
+            var writer = new FastBufferWriter(40, Unity.Collections.Allocator.TempJob);
+
+            MockWritingParameters(ref writer);
+
+            var invalidParameters = new ParametersUpdateMessage()
+            {
+                Parameters = writer.ToArray()
+            };
+
+            LogAssert.Expect(LogType.Error, new System.Text.RegularExpressions.Regex($"parameters. Ignoring the remainger of this {nameof(ParametersUpdateMessage)}!"));
+            networkAnimator.UpdateParameters(ref invalidParameters);
+        }
 
         private bool AllTriggersDetected(OwnerShipMode ownerShipMode)
         {


### PR DESCRIPTION
## Purpose of this PR
[//]: # (
Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. 
)
`NetworkAnimator` can cause an exception and/or crash if a parameter update is received with an invalid parameter index value.

### Jira ticket

[UUM-147271](https://jira.unity3d.com/browse/UUM-147271)

### Changelog
[//]: # (updated with all public facing changes  - API changes, UI/UX changes, behaviour changes, bug fixes. Remove if not relevant.)

- Fixed: Issue where `NetworkAnimator` did no bounds check on the parameter index read prior to obtaining a pointer to the location within the array.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- No documentation changes or additions were necessary.


## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [x] `Covered by new automated tests`
  - `NetworkAnimatorTests.ParameterBoundsCheck`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Backports

No back port is required.

## Up-port

This fix will be included in the last full merge after the v2.13.1 update.
