### PR TITLE
fix: spawn disabled in scene placed and network prefab registration

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -14,6 +14,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Changed
 
 
+
+
 ### Deprecated
 
 
@@ -21,6 +23,10 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 
 ### Fixed
+
+- Issue with not being able to spawn initially disabled in-scene placed objects. (#4093)
+- Issue with pre-instantiated network prefab instances being marked as in-scene placed. Now pre-instantiated network prefabs are dynamically spawned. (#4093)
+- Issue where a user could spawn runtime created `NetworkObject` that has a GlobalObjectIdHash of zero. These are not valid instances and will no longer be allowed to spawn. (#4093)
 
 
 ### Security

--- a/com.unity.netcode.gameobjects/Documentation~/basics/scenemanagement/inscene-placed-networkobjects.md
+++ b/com.unity.netcode.gameobjects/Documentation~/basics/scenemanagement/inscene-placed-networkobjects.md
@@ -184,9 +184,13 @@ public class MyInSceneNetworkObjectBehaviour : NetworkBehaviour
 > [!NOTE]
 > You only need to enable the NetworkObject on the server-side to be able to respawn it. Netcode for GameObjects only enables a disabled in-scene placed NetworkObject on the client-side if the server-side spawns it. This **does not** apply to dynamically spawned `NetworkObjects`. Refer to [the object pooling page](../../advanced-topics/object-pooling.md) for an example of recycling dynamically spawned NetworkObjects.
 
+### Pre-disabled in-scene placed NetworkObjects
+
+If you want to always have an in-scene placed NetworkObject start off as disabled and then spawn it at a later time, you only need to set its GameObject to inactive in the editor while the respective scene is open. Once you have started a networked session, you can re-enable it and then spawn it any time.
+
 ### Setting an in-scene placed NetworkObject to a despawned state when instantiating
 
-Since in-scene placed NetworkObjects are automatically spawned when their respective scene has finished loading during a network session, you might run into the scenario where you want it to start in a despawned state until a certain condition has been met. To do this, you need to add some additional code in the `OnNetworkSpawn` part of your NetworkBehaviour component:
+If you want to programmatically disable an in-scene placed NetworkObject you can add some additional code in the `OnNetworkSpawn` part of a NetworkBehaviour component:
 
 ```csharp
 using UnityEngine;

--- a/com.unity.netcode.gameobjects/Documentation~/basics/scenemanagement/inscene-placed-networkobjects.md
+++ b/com.unity.netcode.gameobjects/Documentation~/basics/scenemanagement/inscene-placed-networkobjects.md
@@ -186,11 +186,11 @@ public class MyInSceneNetworkObjectBehaviour : NetworkBehaviour
 
 ### Pre-disabled in-scene placed NetworkObjects
 
-If you want to always have an in-scene placed NetworkObject start off as disabled and then spawn it at a later time, you only need to set its GameObject to inactive in the editor while the respective scene is open. Once you have started a networked session, you can re-enable it and then spawn it any time.
+To initialize an in-scene placed NetworkObject in a disabled state and spawn it later, set its GameObject to inactive in the Editor while the respective scene is open. Once a networked session begins, you can re-enable and spawn it at any time.
 
 ### Setting an in-scene placed NetworkObject to a despawned state when instantiating
 
-If you want to programmatically disable an in-scene placed NetworkObject you can add some additional code in the `OnNetworkSpawn` part of a NetworkBehaviour component:
+To programmatically disable an in-scene placed NetworkObject, add some additional code in the `OnNetworkSpawn` part of a NetworkBehaviour component:
 
 ```csharp
 using UnityEngine;

--- a/com.unity.netcode.gameobjects/Documentation~/components/core/networkobject.md
+++ b/com.unity.netcode.gameobjects/Documentation~/components/core/networkobject.md
@@ -19,6 +19,23 @@ When spawning a NetworkObject, the `NetworkObject.GlobalObjectIdHash` value init
 
 You can use [NetworkBehaviours](networkbehaviour.md) to add your own custom Netcode logic to the associated NetworkObject.
 
+### What is a valid NetworkObject?
+
+There are basically two categories of NetworkObjects:
+
+- Dynamically instantiated network prefabs.
+  - Requirements:
+    - It must be a valid [network prefab](./networkobject.md#network-prefabs) created within the editor.
+    - It must be registered within a network prefab list that is assigned to your NetworkManager.
+- [In-scene placed](../../basics/scenemanagement/inscene-placed-networkobjects.md):
+  - Requirements:
+    - It can be a valid network prefab instance within a scene.
+    - It can be a GameObject with a `NetworkObject` component created within the scene while in the editor.
+
+### What is an invalid NetworkObject?
+
+Any GameObjects that have `NetworkObject` components added to them during runtime is **not supported** and will result in the NetworkObject's `GlobalObjectIdHash` being zero which would eventually result in synchronization issues. In the event you make this mistake, a warning message will be logged and the NetworkObject will not get spawned.
+
 ### Component order
 
 The order of components on a networked GameObject matters. When adding netcode components to a GameObject, ensure that the NetworkObject component is ordered before any NetworkBehaviour components.

--- a/com.unity.netcode.gameobjects/Documentation~/components/core/networkobject.md
+++ b/com.unity.netcode.gameobjects/Documentation~/components/core/networkobject.md
@@ -22,28 +22,28 @@ You can use [NetworkBehaviours](networkbehaviour.md) to add your own custom Netc
 ### What is a valid NetworkObject?
 
 There are two categories of NetworkObjects:
-* Dynamically intantiated
+* Dynamically instantiated
 * [In-scene placed](../../basics/scenemanagement/inscene-placed-networkobjects.md)
 
 The following provides the validity requirements for both types.
 
-#### Dynamically instantiated network prefabs.
+#### Dynamically instantiated network prefabs
 
-Requirements
+Dynamically instantiated network prefabs must:
 
-* It must be a valid [network prefab](./networkobject.md#network-prefabs) created within the editor.
-* It must be registered within a network prefab list that is assigned to your NetworkManager.
+* Be a valid [network prefab](./networkobject.md#network-prefabs) created within the Editor.
+* Be registered in a network prefab list that's assigned to your NetworkManager.
 
-#### In-scene placed
+#### In-scene placed network prefabs
 
-Requirements
+In-scene placed network prefabs must:
 
-* It can be a valid network prefab instance within a scene.
-* It can be a GameObject with a `NetworkObject` component created within the scene while in the editor.
+* Be a valid network prefab instance within a scene.
+* Be a GameObject with a NetworkObject component created within the scene while in the Editor.
 
 ### What is an invalid NetworkObject?
 
-Any GameObjects that have `NetworkObject` components added to them during runtime is **not supported** and will result in the NetworkObject's `GlobalObjectIdHash` being zero which would eventually result in synchronization issues. In the event you make this mistake, a warning message will be logged and the NetworkObject will not get spawned.
+GameObjects that have NetworkObject components added to them during runtime are **not supported** and will result in the NetworkObject's `GlobalObjectIdHash` being zero, which causes synchronization issues. In the event you make this mistake, a warning message will be logged and the NetworkObject won't be spawned.
 
 ### Component order
 

--- a/com.unity.netcode.gameobjects/Documentation~/components/core/networkobject.md
+++ b/com.unity.netcode.gameobjects/Documentation~/components/core/networkobject.md
@@ -21,16 +21,25 @@ You can use [NetworkBehaviours](networkbehaviour.md) to add your own custom Netc
 
 ### What is a valid NetworkObject?
 
-There are basically two categories of NetworkObjects:
+There are two categories of NetworkObjects:
+* Dynamically intantiated
+* [In-scene placed](../../basics/scenemanagement/inscene-placed-networkobjects.md)
 
-- Dynamically instantiated network prefabs.
-  - Requirements:
-    - It must be a valid [network prefab](./networkobject.md#network-prefabs) created within the editor.
-    - It must be registered within a network prefab list that is assigned to your NetworkManager.
-- [In-scene placed](../../basics/scenemanagement/inscene-placed-networkobjects.md):
-  - Requirements:
-    - It can be a valid network prefab instance within a scene.
-    - It can be a GameObject with a `NetworkObject` component created within the scene while in the editor.
+The following provides the validity requirements for both types.
+
+#### Dynamically instantiated network prefabs.
+
+Requirements
+
+* It must be a valid [network prefab](./networkobject.md#network-prefabs) created within the editor.
+* It must be registered within a network prefab list that is assigned to your NetworkManager.
+
+#### In-scene placed
+
+Requirements
+  
+* It can be a valid network prefab instance within a scene.
+* It can be a GameObject with a `NetworkObject` component created within the scene while in the editor.
 
 ### What is an invalid NetworkObject?
 

--- a/com.unity.netcode.gameobjects/Documentation~/components/core/networkobject.md
+++ b/com.unity.netcode.gameobjects/Documentation~/components/core/networkobject.md
@@ -37,7 +37,7 @@ Requirements
 #### In-scene placed
 
 Requirements
-  
+
 * It can be a valid network prefab instance within a scene.
 * It can be a GameObject with a `NetworkObject` component created within the scene while in the editor.
 

--- a/com.unity.netcode.gameobjects/Editor/InScenePlacedProcessor.cs
+++ b/com.unity.netcode.gameobjects/Editor/InScenePlacedProcessor.cs
@@ -24,6 +24,12 @@ namespace Unity.Netcode.Editor
             log.AddInfo(scene.name, scene.handle);
             foreach (var networkObject in FindObjects.FromSceneByType<NetworkObject>(scene, true))
             {
+                // Trap for users just creating things during runtime where this will be zero.
+                if (networkObject.GlobalObjectIdHash == 0)
+                {
+                    log.Warning(new Context(LogLevel.Developer, $"{nameof(NetworkObject)}'s GlobalObjectIdHash value is zero! Runtime creating of {nameof(NetworkObject)}s is not supported. Skipping processing.").AddNetworkObject(networkObject));
+                    continue;
+                }
                 if (networkObject.SceneOrigin.IsValid() && networkObject.SceneOrigin.handle != scene.handle)
                 {
                     log.Warning(new Context(LogLevel.Developer, $"{nameof(NetworkObject)}'s SceneOrigin doesn't match current scene being processed! Skipping processing.").AddInfo("SceneOrigin", networkObject.SceneOriginHandle).AddNetworkObject(networkObject));
@@ -36,7 +42,15 @@ namespace Unity.Netcode.Editor
                     continue;
                 }
 
+                // If already marked, the do nothing.
+                if (networkObject.InScenePlaced)
+                {
+                    continue;
+                }
+
                 networkObject.InScenePlaced = true;
+                // Will not be true when making a build and the values are serialized.
+                networkObject.InScenePlacedPostProcessorMarkedDuringRuntime = Application.isPlaying;
             }
         }
     }

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
@@ -768,10 +768,7 @@ namespace Unity.Netcode.Components
             if (!m_Animator)
             {
 #if !UNITY_EDITOR
-                if (!m_Animator)
-                {
-                    Debug.LogWarning($"{nameof(NetworkAnimator)} {name} does not have an {nameof(UnityEngine.Animator)} assigned to it. The {nameof(NetworkAnimator)} will not initialize properly.");
-                }
+                Debug.LogWarning($"{nameof(NetworkAnimator)} {name} does not have an {nameof(UnityEngine.Animator)} assigned to it. The {nameof(NetworkAnimator)} will not initialize properly.");
 #endif
                 return;
             }

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
@@ -770,7 +770,7 @@ namespace Unity.Netcode.Components
 #if !UNITY_EDITOR
                 if (!m_Animator)
                 {
-                    Debug.LogWarning($"{nameof(NetworkAnimator)} {name} does not have an {nameof(UnityEngine.Animator)} assigned to it. The {nameof(NetworkAnimator)} will not initialize properly.");                    
+                    Debug.LogWarning($"{nameof(NetworkAnimator)} {name} does not have an {nameof(UnityEngine.Animator)} assigned to it. The {nameof(NetworkAnimator)} will not initialize properly.");
                 }
 #endif
                 return;

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkAnimator.cs
@@ -768,7 +768,10 @@ namespace Unity.Netcode.Components
             if (!m_Animator)
             {
 #if !UNITY_EDITOR
-                Debug.LogError($"{nameof(NetworkAnimator)} {name} does not have an {nameof(UnityEngine.Animator)} assigned to it. The {nameof(NetworkAnimator)} will not initialize properly.");
+                if (!m_Animator)
+                {
+                    Debug.LogWarning($"{nameof(NetworkAnimator)} {name} does not have an {nameof(UnityEngine.Animator)} assigned to it. The {nameof(NetworkAnimator)} will not initialize properly.");                    
+                }
 #endif
                 return;
             }

--- a/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkPrefabs.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkPrefabs.cs
@@ -48,21 +48,80 @@ namespace Unity.Netcode
         private List<NetworkPrefab> m_Prefabs = new List<NetworkPrefab>();
 
         [NonSerialized]
+        private Dictionary<uint, NetworkPrefab> m_PrefabHashIds = new Dictionary<uint, NetworkPrefab>();
+
+        [NonSerialized]
         private List<NetworkPrefab> m_RuntimeAddedPrefabs = new List<NetworkPrefab>();
 
-        private void AddTriggeredByNetworkPrefabList(NetworkPrefab networkPrefab)
+        private bool InternalAddPrefab(NetworkPrefab networkPrefab)
         {
             if (AddPrefabRegistration(networkPrefab))
             {
                 // Don't add this to m_RuntimeAddedPrefabs
                 // This prefab is now in the PrefabList, so if we shutdown and initialize again, we'll pick it up from there.
                 m_Prefabs.Add(networkPrefab);
+
+                // We are not getting all potential overrides but just determining if the prefab has been registered.
+                if (!m_PrefabHashIds.ContainsKey(networkPrefab.SourcePrefabGlobalObjectIdHash))
+                {
+                    m_PrefabHashIds.Add(networkPrefab.SourcePrefabGlobalObjectIdHash, networkPrefab);
+                }
+                if (!m_PrefabHashIds.ContainsKey(networkPrefab.TargetPrefabGlobalObjectIdHash))
+                {
+                    m_PrefabHashIds.Add(networkPrefab.TargetPrefabGlobalObjectIdHash, networkPrefab);
+                }
+                return true;
             }
+            return false;
+        }
+
+        private void InternalRemovePrefab(NetworkPrefab networkPrefab)
+        {
+            m_Prefabs.Remove(networkPrefab);
+            m_PrefabHashIds.Remove(networkPrefab.SourcePrefabGlobalObjectIdHash);
+        }
+
+        internal bool IsBasedOnRegisteredPrefab(NetworkObject networkObject)
+        {
+
+
+            return m_PrefabHashIds.ContainsKey(networkObject.GlobalObjectIdHash);
+        }
+
+        internal bool IsActualPrefabAsset(NetworkObject networkObject)
+        {
+            var isActualPrefabAsset = false;
+            if (m_PrefabHashIds.TryGetValue(networkObject.GlobalObjectIdHash, out NetworkPrefab networkPrefab))
+            {
+                switch(networkPrefab.Override)
+                {
+                    case NetworkPrefabOverride.Prefab:
+                    case NetworkPrefabOverride.None:
+                        {
+                            isActualPrefabAsset = networkPrefab.Prefab != null && networkObject.gameObject == networkPrefab.Prefab;
+                            break;
+                        }
+                    case NetworkPrefabOverride.Hash:
+                        {
+                            isActualPrefabAsset = networkPrefab.SourceHashToOverride == networkObject.GlobalObjectIdHash;
+                            break;
+                        }
+                }
+            }
+            return isActualPrefabAsset;
+        }
+
+        private void AddTriggeredByNetworkPrefabList(NetworkPrefab networkPrefab)
+        {
+            // Don't add this to m_RuntimeAddedPrefabs
+            // This prefab is now in the PrefabList, so if we shutdown and initialize again, we'll pick it up from there.
+            InternalAddPrefab(networkPrefab);
+            // Log warning if this returns false?
         }
 
         private void RemoveTriggeredByNetworkPrefabList(NetworkPrefab networkPrefab)
         {
-            m_Prefabs.Remove(networkPrefab);
+            InternalRemovePrefab(networkPrefab);
         }
 
         /// <summary>
@@ -93,6 +152,7 @@ namespace Unity.Netcode
         /// <param name="warnInvalid">When true, logs warnings about invalid prefabs that are removed during initialization</param>
         public void Initialize(bool warnInvalid = true)
         {
+            m_PrefabHashIds.Clear();
             m_Prefabs.Clear();
             NetworkPrefabsLists.RemoveAll(x => x == null);
             foreach (var list in NetworkPrefabsLists)
@@ -113,7 +173,7 @@ namespace Unity.Netcode
                     prefabs.AddRange(list.PrefabList);
                 }
             }
-
+            m_PrefabHashIds = new Dictionary<uint, NetworkPrefab>();
             m_Prefabs = new List<NetworkPrefab>();
 
             List<NetworkPrefab> removeList = null;
@@ -124,11 +184,7 @@ namespace Unity.Netcode
 
             foreach (var networkPrefab in prefabs)
             {
-                if (AddPrefabRegistration(networkPrefab))
-                {
-                    m_Prefabs.Add(networkPrefab);
-                }
-                else
+                if (!InternalAddPrefab(networkPrefab))
                 {
                     removeList?.Add(networkPrefab);
                 }
@@ -136,11 +192,7 @@ namespace Unity.Netcode
 
             foreach (var networkPrefab in m_RuntimeAddedPrefabs)
             {
-                if (AddPrefabRegistration(networkPrefab))
-                {
-                    m_Prefabs.Add(networkPrefab);
-                }
-                else
+                if (!InternalAddPrefab(networkPrefab))
                 {
                     removeList?.Add(networkPrefab);
                 }
@@ -171,14 +223,12 @@ namespace Unity.Netcode
         /// </remarks>
         public bool Add(NetworkPrefab networkPrefab)
         {
-            if (AddPrefabRegistration(networkPrefab))
+            var added = InternalAddPrefab(networkPrefab);
+            if (added)
             {
-                m_Prefabs.Add(networkPrefab);
                 m_RuntimeAddedPrefabs.Add(networkPrefab);
-                return true;
             }
-
-            return false;
+            return added;
         }
 
         /// <summary>
@@ -197,8 +247,7 @@ namespace Unity.Netcode
             {
                 throw new ArgumentNullException(nameof(prefab));
             }
-
-            m_Prefabs.Remove(prefab);
+            InternalRemovePrefab(prefab);
             m_RuntimeAddedPrefabs.Remove(prefab);
             OverrideToNetworkPrefab.Remove(prefab.TargetPrefabGlobalObjectIdHash);
             NetworkPrefabOverrideLinks.Remove(prefab.SourcePrefabGlobalObjectIdHash);
@@ -294,14 +343,12 @@ namespace Unity.Netcode
 
             uint source = networkPrefab.SourcePrefabGlobalObjectIdHash;
             uint target = networkPrefab.TargetPrefabGlobalObjectIdHash;
-
             // Make sure the prefab isn't already registered.
             if (NetworkPrefabOverrideLinks.ContainsKey(source))
             {
-                var networkObject = networkPrefab.Prefab.GetComponent<NetworkObject>();
-
+                var nameOrHashOverride = networkPrefab.Override == NetworkPrefabOverride.Hash ? $"Hash: {networkPrefab.SourcePrefabGlobalObjectIdHash}" : networkPrefab.Prefab?.name;
                 // This should never happen, but in the case it somehow does log an error and remove the duplicate entry
-                Debug.LogError($"{nameof(NetworkPrefab)} ({networkObject.name}) has a duplicate {nameof(NetworkObject.GlobalObjectIdHash)} source entry value of: {source}!");
+                Debug.LogError($"{nameof(NetworkPrefab)} ({nameOrHashOverride}) has a duplicate {nameof(NetworkObject.GlobalObjectIdHash)} source entry value of: {source}!");
                 return false;
             }
 

--- a/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkPrefabs.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkPrefabs.cs
@@ -47,6 +47,8 @@ namespace Unity.Netcode
         [NonSerialized]
         private List<NetworkPrefab> m_Prefabs = new List<NetworkPrefab>();
 
+        internal List<NetworkPrefab> InternalPrefabs => m_Prefabs;
+
         [NonSerialized]
         private Dictionary<uint, NetworkPrefab> m_PrefabHashIds = new Dictionary<uint, NetworkPrefab>();
 
@@ -93,7 +95,7 @@ namespace Unity.Netcode
             var isActualPrefabAsset = false;
             if (m_PrefabHashIds.TryGetValue(networkObject.GlobalObjectIdHash, out NetworkPrefab networkPrefab))
             {
-                switch(networkPrefab.Override)
+                switch (networkPrefab.Override)
                 {
                     case NetworkPrefabOverride.Prefab:
                     case NetworkPrefabOverride.None:

--- a/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkPrefabs.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkPrefabs.cs
@@ -47,7 +47,34 @@ namespace Unity.Netcode
         [NonSerialized]
         private List<NetworkPrefab> m_Prefabs = new List<NetworkPrefab>();
 
-        internal List<NetworkPrefab> InternalPrefabs => m_Prefabs;
+        /// <summary>
+        /// Returns the last registered prefab.
+        /// </summary>
+        internal NetworkPrefab GetLastRegisteredPrefab()
+        {
+            if (m_Prefabs.Count == 0)
+            {
+                return null;
+            }
+            return m_Prefabs[m_Prefabs.Count - 1];
+        }
+
+        /// <summary>
+        /// Applies a network prefab at a specific index
+        /// </summary>
+        /// <param name="index">index to apply</param>
+        /// <param name="networkPrefab">network prefab to be applied</param>
+        /// <returns></returns>
+        internal bool AssignPrefabAtIndex(int index, NetworkPrefab networkPrefab)
+        {
+            if (index >= m_Prefabs.Count)
+            {
+                NetworkManager.Singleton.Log.Error(new Logging.Context(LogLevel.Normal, $"[{nameof(NetworkPrefabs)}][{nameof(AssignPrefabAtIndex)}] Cannot apply prefab to index {index} when the {nameof(m_Prefabs)} count is only {m_Prefabs.Count}!"));
+                return false;
+            }
+            m_Prefabs[index] = networkPrefab;
+            return true;
+        }
 
         [NonSerialized]
         private Dictionary<uint, NetworkPrefab> m_PrefabHashIds = new Dictionary<uint, NetworkPrefab>();

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1259,6 +1259,13 @@ namespace Unity.Netcode
         }
 
         /// <summary>
+        /// This provides a means to determine if the post processing had applied
+        /// the in-scene placed status or if it was already serialized. This is used
+        /// when determining if the thing being spawned is a valid thing to spawn.
+        /// </summary>
+        internal bool InScenePlacedPostProcessorMarkedDuringRuntime;
+
+        /// <summary>
         /// Sets whether this NetworkObject was instantiated as part of a scene
         /// </summary>
         /// <remarks>Only use this when using custom scene loading</remarks>
@@ -1877,6 +1884,13 @@ namespace Unity.Netcode
                 }
             }
 
+            // Trap for runtime generated instances as this is not valid
+            if (GlobalObjectIdHash == 0)
+            {
+                NetworkManager.Log.ErrorServer(new Context(LogLevel.Error, $"{name} has a {nameof(GlobalObjectIdHash)} value of {GlobalObjectIdHash}(zero)!" +
+                    $"This is typically a sign of runtime generated {nameof(NetworkObject)}s which is not supported."));
+                return;
+            }
 
             // Calculate the legacy IsSceneObject value as the public field is obsolete with warning
             // We can't break the public behavior of the field.
@@ -1884,11 +1898,13 @@ namespace Unity.Netcode
             var legacyIsSceneObject = IsSceneObject.HasValue && IsSceneObject.Value;
 #pragma warning restore CS0618 // Type or member is obsolete
 
-            // If SpawnInternal is being called on an object that is marked as InScenePlaced,
-            // The scene object was never automatically spawned when the scene was loaded.
-            // Count this object as a dynamically spawned object.
-            // TODO-[MTT-15388]: Actually support disabled/not spawned InScenePlaced NetworkObjects
-            if (InScenePlaced && !HasBeenSpawned)
+            // If the initial state of the GameObject was disabled and InScenePlaced is marked,
+            // then spawn it as in-scene placed.[MTT-15388]
+            // Otherwise:
+            // If we are marked as in-scene place, have never been spawned, and the root GameObject
+            // was not disabled upon being instantiated, then treat this as a dynamically spawned
+            // instance.
+            if (InScenePlaced && !m_GameObjectWasDisabledWhenInstantiated && !HasBeenSpawned)
             {
                 if (NetworkManagerOwner.NetworkConfig.EnableSceneManagement && NetworkManagerOwner.LogLevel <= LogLevel.Developer)
                 {
@@ -3701,10 +3717,13 @@ namespace Unity.Netcode
             }
         }
 
+        private bool m_GameObjectWasDisabledWhenInstantiated;
+
         private void Awake()
         {
             SetCachedParent(transform.parent);
             SceneOrigin = gameObject.scene;
+            m_GameObjectWasDisabledWhenInstantiated = gameObject.activeInHierarchy;
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1899,14 +1899,14 @@ namespace Unity.Netcode
 #pragma warning restore CS0618 // Type or member is obsolete
 
             // If the initial state of the GameObject was disabled and InScenePlaced is marked,
-            // then spawn it as in-scene placed.[MTT-15388]
+            // then spawn it as in-scene placed.
             // Otherwise:
             // If we are marked as in-scene place, have never been spawned, and the root GameObject
             // was not disabled upon being instantiated, then treat this as a dynamically spawned
             // instance.
             if (InScenePlaced && !m_GameObjectWasDisabledWhenInstantiated && !HasBeenSpawned)
             {
-                if (NetworkManagerOwner.NetworkConfig.EnableSceneManagement && NetworkManagerOwner.LogLevel <= LogLevel.Developer)
+                if (NetworkManagerOwner.NetworkConfig.EnableSceneManagement && NetworkManagerOwner.LogLevel <= LogLevel.Normal)
                 {
                     Debug.LogWarning($"[{name}][SceneOrigin={SceneOriginHandle}] Dynamically spawning InScenePlaced network object. This can cause issues!", this);
                 }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -350,9 +350,21 @@ namespace Unity.Netcode
 
                 // Default scene migration synchronization to false for in-scene placed NetworkObjects
                 SceneMigrationSynchronization = false;
+
+                // Set our disabled in-scene placed flag for spawning initially disabled in-scene placed objects.
+                m_InScenePlacedDisabledByDefault = gameObject.activeInHierarchy;
             }
         }
 #endif // UNITY_EDITOR
+
+        /// <summary>
+        /// Used to provide support for initially disabled in-scene placed objects.
+        /// This is only ever set on in-scene placed objects that are already disabled
+        /// in the scene asset itself.
+        /// </summary>
+        [HideInInspector]
+        [SerializeField]
+        private bool m_InScenePlacedDisabledByDefault;
 
         /// <summary>
         /// Gets the NetworkManager that owns this NetworkObject instance
@@ -1887,8 +1899,8 @@ namespace Unity.Netcode
             // Trap for runtime generated instances as this is not valid
             if (GlobalObjectIdHash == 0)
             {
-                NetworkManager.Log.ErrorServer(new Context(LogLevel.Error, $"{name} has a {nameof(GlobalObjectIdHash)} value of {GlobalObjectIdHash}(zero)!" +
-                    $"This is typically a sign of runtime generated {nameof(NetworkObject)}s which is not supported."));
+                NetworkManager.Log.ErrorServer(new Context(LogLevel.Error, $"Detected {nameof(NetworkObject)} {nameof(GlobalObjectIdHash)} value of 0!" +
+                    $"This is typically a sign of runtime generated network prefab assets which are not supported.").AddNetworkObject(this));
                 return;
             }
 
@@ -1904,7 +1916,7 @@ namespace Unity.Netcode
             // If we are marked as in-scene place, have never been spawned, and the root GameObject
             // was not disabled upon being instantiated, then treat this as a dynamically spawned
             // instance.
-            if (InScenePlaced && !m_GameObjectWasDisabledWhenInstantiated && !HasBeenSpawned)
+            if (InScenePlaced && !m_InScenePlacedDisabledByDefault && !HasBeenSpawned)
             {
                 if (NetworkManagerOwner.NetworkConfig.EnableSceneManagement && NetworkManagerOwner.LogLevel <= LogLevel.Developer)
                 {
@@ -3717,13 +3729,13 @@ namespace Unity.Netcode
             }
         }
 
-        private bool m_GameObjectWasDisabledWhenInstantiated;
+        
 
         private void Awake()
         {
             SetCachedParent(transform.parent);
             SceneOrigin = gameObject.scene;
-            m_GameObjectWasDisabledWhenInstantiated = gameObject.activeInHierarchy;
+            m_GameObjectWasDisabledWhenInstantiated = true;
         }
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -358,6 +358,15 @@ namespace Unity.Netcode
 #endif // UNITY_EDITOR
 
         /// <summary>
+        /// This is intentionally private since this is a sealed class.
+        /// </summary>
+        private void Awake()
+        {
+            SetCachedParent(transform.parent);
+            SceneOrigin = gameObject.scene;
+        }
+
+        /// <summary>
         /// Used to provide support for initially disabled in-scene placed objects.
         /// This is only ever set on in-scene placed objects that are already disabled
         /// in the scene asset itself.
@@ -3729,14 +3738,7 @@ namespace Unity.Netcode
             }
         }
 
-        
 
-        private void Awake()
-        {
-            SetCachedParent(transform.parent);
-            SceneOrigin = gameObject.scene;
-            m_GameObjectWasDisabledWhenInstantiated = true;
-        }
 
         /// <summary>
         /// Update

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -352,7 +352,7 @@ namespace Unity.Netcode
                 SceneMigrationSynchronization = false;
 
                 // Set our disabled in-scene placed flag for spawning initially disabled in-scene placed objects.
-                m_InScenePlacedDisabledByDefault = gameObject.activeInHierarchy;
+                m_InScenePlacedDisabledByDefault = !gameObject.activeInHierarchy;
             }
         }
 #endif // UNITY_EDITOR

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1121,7 +1121,9 @@ namespace Unity.Netcode
                 NetworkLog.LogError(new Context(LogLevel.Developer, "Player prefab is marked as belonging to a scene. This may cause issues.").AddNetworkObject(networkObject).AddInfo("SceneName", networkObject.SceneOrigin.name));
                 networkObject.InScenePlaced = false;
             }
-            NetworkLog.InternalAssert(sceneObject == networkObject.InScenePlaced, "Legacy sceneObject value should match calculated InScenePlaced value.");
+            // This logic is no longer true with the adjustments to spawn pre-disabled in-scene placed NetworkObjects.
+            // Leaving this for reference purposes.
+            //NetworkLog.InternalAssert(sceneObject == networkObject.InScenePlaced, "Legacy sceneObject value should match calculated InScenePlaced value.");
 
             if (!networkObject.InScenePlaced && NetworkManager.LogLevel <= LogLevel.Error)
             {
@@ -1580,10 +1582,52 @@ namespace Unity.Netcode
                     continue;
                 }
 
-                // This used to be two loops.
-                // The first added all NetworkObjects to a list and the second spawned all NetworkObjects in the list.
-                // Now, a parent will set its children's IsSceneObject value when spawned, so we check for null or for true.
-                if (networkObject.InScenePlaced)
+                // Do not attempt to spawn if it is the actual prefab asset itself:
+                // - This is not supported by NGO.
+                // - This will lead to other issues if it gets destroyed, when de-spawned, but the prefab is still registered.
+                // - This also prevents from spawning integration test prefabs.
+                if (NetworkManager.NetworkConfig.Prefabs.IsActualPrefabAsset(networkObject))
+                {
+                    NetworkManager.Log.Warning(new Context(LogLevel.Developer, $"Skipping {networkObject.name} as it is the actual prefab asset itself!"));
+                    continue;
+                }
+
+                // Determine if this is even a valid thing to spawn:
+                // - If it is not based on a registered prefab, it is invalid.
+                // - If the GlobalObjectIdHash is zero, it is invalid.
+                var isInvalidInstanceToSpawn = !NetworkManager.NetworkConfig.Prefabs.IsBasedOnRegisteredPrefab(networkObject) || networkObject.GlobalObjectIdHash == 0;
+
+                // If we are a valid prefab asset, marked as in-scene placed, but this was marked during runtime by the post processor.
+                if (!isInvalidInstanceToSpawn && networkObject.InScenePlaced && networkObject.InScenePlacedPostProcessorMarkedDuringRuntime)
+                {
+                    // Then it is not in-scene placed and was pre-instantiated. Spawn dynamically.
+                    networkObject.InScenePlaced = false;
+                }
+                else if(networkObject.InScenePlaced && !networkObject.InScenePlacedPostProcessorMarkedDuringRuntime)
+                {
+                    // If this was marked as in-scene placed within the editor, then it is valid.
+                    isInvalidInstanceToSpawn = false;
+                }
+
+                 var wasPreInstantiated = !networkObject.IsSpawned && !networkObject.InScenePlaced;
+
+                // Dynamically created NetworkObjects instances are not supported and will not be spawned during the sweep.
+                if (wasPreInstantiated && isInvalidInstanceToSpawn)
+                {
+                    // If this isn't the original prefab asset being skipped over (integration test would be a good example), then log the error.
+                    if (!NetworkManager.NetworkConfig.Prefabs.IsActualPrefabAsset(networkObject))
+                    {
+                        NetworkManager.Log.Error(new Context(LogLevel.Error, $"{networkObject.name} appears to be a pre-instantiated {nameof(GameObject)} " +
+                            $"with a {nameof(NetworkObject)} component instance that is not a registered prefab nor is it an in-scene placed {nameof(NetworkObject)}." +
+                            $" Dynamically creating unregistered {nameof(NetworkObject)}s is not supported! {networkObject.name} will not be spawned."));
+                    }
+                    continue;
+                }
+
+                // The only valid things to spawn during the sweep are:
+                // - In-scene placed NetworkObjects.
+                // - Pre-instantiated NetworkObjects that are registered with the NetworkManager's network prefab list(s).
+                if (networkObject.InScenePlaced || wasPreInstantiated)
                 {
                     var ownerId = networkObject.OwnerClientId;
                     if (NetworkManager.DistributedAuthorityMode)

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1121,9 +1121,6 @@ namespace Unity.Netcode
                 NetworkLog.LogError(new Context(LogLevel.Developer, "Player prefab is marked as belonging to a scene. This may cause issues.").AddNetworkObject(networkObject).AddInfo("SceneName", networkObject.SceneOrigin.name));
                 networkObject.InScenePlaced = false;
             }
-            // This logic is no longer true with the adjustments to spawn pre-disabled in-scene placed NetworkObjects.
-            // Leaving this for reference purposes.
-            //NetworkLog.InternalAssert(sceneObject == networkObject.InScenePlaced, "Legacy sceneObject value should match calculated InScenePlaced value.");
 
             if (!networkObject.InScenePlaced && NetworkManager.LogLevel <= LogLevel.Error)
             {
@@ -1595,10 +1592,10 @@ namespace Unity.Netcode
                 // Determine if this is even a valid thing to spawn:
                 // - If it is not based on a registered prefab, it is invalid.
                 // - If the GlobalObjectIdHash is zero, it is invalid.
-                var isInvalidInstanceToSpawn = !NetworkManager.NetworkConfig.Prefabs.IsBasedOnRegisteredPrefab(networkObject) || networkObject.GlobalObjectIdHash == 0;
+                var isValidInstanceToSpawn = NetworkManager.NetworkConfig.Prefabs.IsBasedOnRegisteredPrefab(networkObject) && networkObject.GlobalObjectIdHash != 0;
 
                 // If we are a valid prefab asset, marked as in-scene placed, but this was marked during runtime by the post processor.
-                if (!isInvalidInstanceToSpawn && networkObject.InScenePlaced && networkObject.InScenePlacedPostProcessorMarkedDuringRuntime)
+                if (isValidInstanceToSpawn && networkObject.InScenePlaced && networkObject.InScenePlacedPostProcessorMarkedDuringRuntime)
                 {
                     // Then it is not in-scene placed and was pre-instantiated. Spawn dynamically.
                     networkObject.InScenePlaced = false;
@@ -1606,21 +1603,17 @@ namespace Unity.Netcode
                 else if (networkObject.InScenePlaced && !networkObject.InScenePlacedPostProcessorMarkedDuringRuntime)
                 {
                     // If this was marked as in-scene placed within the editor, then it is valid.
-                    isInvalidInstanceToSpawn = false;
+                    isValidInstanceToSpawn = true;
                 }
 
                 var wasPreInstantiated = !networkObject.IsSpawned && !networkObject.InScenePlaced;
 
                 // Dynamically created NetworkObjects instances are not supported and will not be spawned during the sweep.
-                if (wasPreInstantiated && isInvalidInstanceToSpawn)
+                if (wasPreInstantiated && !isValidInstanceToSpawn)
                 {
-                    // If this isn't the original prefab asset being skipped over (integration test would be a good example), then log the error.
-                    if (!NetworkManager.NetworkConfig.Prefabs.IsActualPrefabAsset(networkObject))
-                    {
-                        NetworkManager.Log.Error(new Context(LogLevel.Error, $"Detected a pre-instantiated {nameof(GameObject)} " +
-                            $"with a {nameof(NetworkObject)} component instance that is not a registered prefab nor an in-scene placed {nameof(NetworkObject)}." +
-                            $" Dynamically creating unregistered {nameof(NetworkObject)}s is not supported! This {nameof(NetworkObject)} will not be spawned.").AddNetworkObject(networkObject));
-                    }
+                    NetworkManager.Log.Error(new Context(LogLevel.Error, $"Detected a pre-instantiated {nameof(GameObject)} " +
+                        $"with a {nameof(NetworkObject)} component instance that is not a registered prefab nor an in-scene placed {nameof(NetworkObject)}." +
+                        $" Dynamically creating unregistered {nameof(NetworkObject)}s is not supported! This {nameof(NetworkObject)} will not be spawned.").AddNetworkObject(networkObject));
                     continue;
                 }
 

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1603,13 +1603,13 @@ namespace Unity.Netcode
                     // Then it is not in-scene placed and was pre-instantiated. Spawn dynamically.
                     networkObject.InScenePlaced = false;
                 }
-                else if(networkObject.InScenePlaced && !networkObject.InScenePlacedPostProcessorMarkedDuringRuntime)
+                else if (networkObject.InScenePlaced && !networkObject.InScenePlacedPostProcessorMarkedDuringRuntime)
                 {
                     // If this was marked as in-scene placed within the editor, then it is valid.
                     isInvalidInstanceToSpawn = false;
                 }
 
-                 var wasPreInstantiated = !networkObject.IsSpawned && !networkObject.InScenePlaced;
+                var wasPreInstantiated = !networkObject.IsSpawned && !networkObject.InScenePlaced;
 
                 // Dynamically created NetworkObjects instances are not supported and will not be spawned during the sweep.
                 if (wasPreInstantiated && isInvalidInstanceToSpawn)

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1617,9 +1617,9 @@ namespace Unity.Netcode
                     // If this isn't the original prefab asset being skipped over (integration test would be a good example), then log the error.
                     if (!NetworkManager.NetworkConfig.Prefabs.IsActualPrefabAsset(networkObject))
                     {
-                        NetworkManager.Log.Error(new Context(LogLevel.Error, $"{networkObject.name} appears to be a pre-instantiated {nameof(GameObject)} " +
-                            $"with a {nameof(NetworkObject)} component instance that is not a registered prefab nor is it an in-scene placed {nameof(NetworkObject)}." +
-                            $" Dynamically creating unregistered {nameof(NetworkObject)}s is not supported! {networkObject.name} will not be spawned."));
+                        NetworkManager.Log.Error(new Context(LogLevel.Error, $"Detected a pre-instantiated {nameof(GameObject)} " +
+                            $"with a {nameof(NetworkObject)} component instance that is not a registered prefab nor an in-scene placed {nameof(NetworkObject)}." +
+                            $" Dynamically creating unregistered {nameof(NetworkObject)}s is not supported! This {nameof(NetworkObject)} will not be spawned.").AddNetworkObject(networkObject));
                     }
                     continue;
                 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Components/BufferDataValidationComponent.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Components/BufferDataValidationComponent.cs
@@ -38,8 +38,7 @@ namespace Unity.Netcode.RuntimeTests
         private List<byte> m_SendBuffer;
         private List<byte> m_PreCalculatedBufferValues;
 
-        // Start is called before the first frame update
-        private void Start()
+        protected override void OnNetworkPreSpawn(ref NetworkManager networkManager)
         {
             m_WaitForValidation = false;
             m_CurrentBufferSize = BufferSizeStart;
@@ -49,6 +48,7 @@ namespace Unity.Netcode.RuntimeTests
             {
                 m_PreCalculatedBufferValues.Add((byte)Random.Range(0, 255));
             }
+            base.OnNetworkPreSpawn(ref networkManager);
         }
 
         /// <summary>
@@ -67,7 +67,12 @@ namespace Unity.Netcode.RuntimeTests
         // Update is called once per frame
         private void Update()
         {
-            if (NetworkManager.Singleton.IsListening && EnableTesting && !IsTestComplete() && !m_WaitForValidation)
+            if (!EnableTesting || !IsSpawned)
+            {
+                return;
+            }
+
+            if (!m_WaitForValidation && !IsTestComplete())
             {
                 m_SendBuffer.Clear();
                 //Keep the current contents of the bufffer and fill the buffer with the delta difference of the buffer's current size and new size from the m_PreCalculatedBufferValues
@@ -77,16 +82,16 @@ namespace Unity.Netcode.RuntimeTests
                 m_WaitForValidation = true;
 
                 //Send the buffer
-                SendBufferServerRpc(m_SendBuffer.ToArray());
+                SendBufferRpc(m_SendBuffer.ToArray());
             }
+
         }
 
         /// <summary>
-        /// Server side RPC for testing
+        /// Sends to self for buffer queue testing
         /// </summary>
-        /// <param name="parameters">server rpc parameters</param>
-        [ServerRpc]
-        private void SendBufferServerRpc(byte[] buffer)
+        [Rpc(SendTo.Me)]
+        private void SendBufferRpc(byte[] buffer)
         {
             TestFailed = !NetworkManagerHelper.BuffersMatch(0, buffer.Length, buffer, m_SendBuffer.ToArray());
             if (!TestFailed)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Components/NetworkVariableTestComponent.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Components/NetworkVariableTestComponent.cs
@@ -242,7 +242,7 @@ namespace Unity.Netcode.RuntimeTests
         private float m_WaitForChangesTimeout;
 
         // Start is called before the first frame update
-        private void InitializeTest()
+        public void InitializeTest()
         {
             // Generic Constructor Test Coverage
             m_NetworkVariableBool = new NetworkVariable<bool>();
@@ -358,7 +358,7 @@ namespace Unity.Netcode.RuntimeTests
 
         public void Awake()
         {
-            InitializeTest();
+            //InitializeTest();
         }
 
         public void AssertAllValuesAreCorrect()
@@ -423,56 +423,52 @@ namespace Unity.Netcode.RuntimeTests
         // Update is called once per frame
         private void Update()
         {
-            if (EnableTesting)
+            if (!EnableTesting || !IsSpawned)
             {
-                //Added timeout functionality for near future changes to NetworkVariables
-                if (!m_FinishedTests && m_ChangesAppliedToNetworkVariables)
-                {
-                    //We finish testing if all NetworkVariables changed their value or we timed out waiting for
-                    //all NetworkVariables to change their value
-                    m_FinishedTests = DidAllValuesChange() || (m_WaitForChangesTimeout < Time.realtimeSinceStartup);
-                }
-                else
-                {
-                    if (NetworkManager != null && NetworkManager.IsListening)
-                    {
-                        //Now change all of the values to make sure we are at least testing the local callback
-                        m_NetworkVariableBool.Value = false;
-                        m_NetworkVariableByte.Value = 255;
-                        m_NetworkVariableColor.Value = new Color(100, 100, 100);
-                        m_NetworkVariableColor32.Value = new Color32(100, 100, 100, 100);
-                        m_NetworkVariableDouble.Value = 1000;
-                        m_NetworkVariableFloat.Value = 1000.0f;
-                        m_NetworkVariableInt.Value = 1000;
-                        m_NetworkVariableLong.Value = 100000;
-                        m_NetworkVariableSByte.Value = -127;
-                        m_NetworkVariableQuaternion.Value = new Quaternion(100, 100, 100, 100);
-                        m_NetworkVariablePose.Value = new Pose(new Vector3(100, 100, 100), new Quaternion(100, 100, 100, 100));
-                        m_NetworkVariableShort.Value = short.MaxValue;
-                        m_NetworkVariableVector4.Value = new Vector4(1000, 1000, 1000, 1000);
-                        m_NetworkVariableVector3.Value = new Vector3(1000, 1000, 1000);
-                        m_NetworkVariableVector2.Value = new Vector2(1000, 1000);
-                        m_NetworkVariableRay.Value = new Ray(Vector3.one, Vector3.right);
-                        m_NetworkVariableULong.Value = ulong.MaxValue;
-                        m_NetworkVariableUInt.Value = uint.MaxValue;
-                        m_NetworkVariableUShort.Value = ushort.MaxValue;
-                        m_NetworkVariableFixedString32.Value = new FixedString32Bytes("FixedString32Bytes");
-                        m_NetworkVariableFixedString64.Value = new FixedString64Bytes("FixedString64Bytes");
-                        m_NetworkVariableFixedString128.Value = new FixedString128Bytes("FixedString128Bytes");
-                        m_NetworkVariableFixedString512.Value = new FixedString512Bytes("FixedString512Bytes");
-                        m_NetworkVariableFixedString4096.Value = new FixedString4096Bytes("FixedString4096Bytes");
-                        m_NetworkVariableManaged.Value = new ManagedNetworkSerializableType
-                        {
-                            Str = "ManagedNetworkSerializableType",
-                            Ints = new[] { 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000 },
-                            Embedded = new EmbeddedManagedNetworkSerializableType { Int = 20000 }
-                        };
+                return;
+            }
 
-                        //Set the timeout (i.e. how long we will wait for all NetworkVariables to have registered their changes)
-                        m_WaitForChangesTimeout = Time.realtimeSinceStartup + 0.50f;
-                        m_ChangesAppliedToNetworkVariables = true;
-                    }
-                }
+            if (!m_ChangesAppliedToNetworkVariables)
+            {
+                //Now change all of the values to make sure we are at least testing the local callback
+                m_NetworkVariableBool.Value = false;
+                m_NetworkVariableByte.Value = 255;
+                m_NetworkVariableColor.Value = new Color(100, 100, 100);
+                m_NetworkVariableColor32.Value = new Color32(100, 100, 100, 100);
+                m_NetworkVariableDouble.Value = 1000;
+                m_NetworkVariableFloat.Value = 1000.0f;
+                m_NetworkVariableInt.Value = 1000;
+                m_NetworkVariableLong.Value = 100000;
+                m_NetworkVariableSByte.Value = -127;
+                m_NetworkVariableQuaternion.Value = new Quaternion(100, 100, 100, 100);
+                m_NetworkVariablePose.Value = new Pose(new Vector3(100, 100, 100), new Quaternion(100, 100, 100, 100));
+                m_NetworkVariableShort.Value = short.MaxValue;
+                m_NetworkVariableVector4.Value = new Vector4(1000, 1000, 1000, 1000);
+                m_NetworkVariableVector3.Value = new Vector3(1000, 1000, 1000);
+                m_NetworkVariableVector2.Value = new Vector2(1000, 1000);
+                m_NetworkVariableRay.Value = new Ray(Vector3.one, Vector3.right);
+                m_NetworkVariableULong.Value = ulong.MaxValue;
+                m_NetworkVariableUInt.Value = uint.MaxValue;
+                m_NetworkVariableUShort.Value = ushort.MaxValue;
+                m_NetworkVariableFixedString32.Value = new FixedString32Bytes("FixedString32Bytes");
+                m_NetworkVariableFixedString64.Value = new FixedString64Bytes("FixedString64Bytes");
+                m_NetworkVariableFixedString128.Value = new FixedString128Bytes("FixedString128Bytes");
+                m_NetworkVariableFixedString512.Value = new FixedString512Bytes("FixedString512Bytes");
+                m_NetworkVariableFixedString4096.Value = new FixedString4096Bytes("FixedString4096Bytes");
+                m_NetworkVariableManaged.Value = new ManagedNetworkSerializableType
+                {
+                    Str = "ManagedNetworkSerializableType",
+                    Ints = new[] { 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000 },
+                    Embedded = new EmbeddedManagedNetworkSerializableType { Int = 20000 }
+                };
+
+                //Set the timeout (i.e. how long we will wait for all NetworkVariables to have registered their changes)
+                m_WaitForChangesTimeout = Time.realtimeSinceStartup + 0.50f;
+                m_ChangesAppliedToNetworkVariables = true;
+            }
+            else if (!m_FinishedTests)
+            {
+                m_FinishedTests = DidAllValuesChange() || (m_WaitForChangesTimeout < Time.realtimeSinceStartup);
             }
         }
     }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Components/NetworkVariableTestComponent.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Components/NetworkVariableTestComponent.cs
@@ -356,11 +356,6 @@ namespace Unity.Netcode.RuntimeTests
             return m_FinishedTests;
         }
 
-        public void Awake()
-        {
-            //InitializeTest();
-        }
-
         public void AssertAllValuesAreCorrect()
         {
             Assert.AreEqual(false, m_NetworkVariableBool.Value);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Connection/ConnectionApproval.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Connection/ConnectionApproval.cs
@@ -40,6 +40,11 @@ namespace Unity.Netcode.RuntimeTests
 
         private string m_ValidationToken;
 
+        internal override bool ShouldCreatePlayerPrefab()
+        {
+            return m_PlayerCreation != PlayerCreation.NoPlayer && m_PlayerCreation != PlayerCreation.FailValidation;
+        }
+
         protected override bool ShouldCheckForSpawnedPlayers()
         {
             return m_PlayerCreation != PlayerCreation.NoPlayer;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
@@ -152,7 +152,7 @@ namespace Unity.Netcode.RuntimeTests
             // to the NetworkObject a warning is logged.
             var simpleNetworkBehaviour = validateInstance.GetComponent<SimpleNetworkBehaviour>();
             simpleNetworkBehaviour.IsSpawned = true;
-            
+
             // Verify the warning gets logged under normal conditions
             var isNull = simpleNetworkBehaviour.NetworkObject == null;
             LogAssert.Expect(LogType.Warning, $"[Netcode] Could not get {nameof(NetworkObject)} for the {nameof(NetworkBehaviour)}. Are you missing a {nameof(NetworkObject)} component?");
@@ -162,7 +162,7 @@ namespace Unity.Netcode.RuntimeTests
 
             // Destroy this test instance
             Object.DestroyImmediate(validateInstance);
-           
+
             // Now create a spawned instance (NetworkObject will exist)
             var instance = SpawnObject(m_PrefabToSpawn, GetAuthorityNetworkManager()).GetComponent<NetworkObject>();
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
@@ -39,6 +39,7 @@ namespace Unity.Netcode.RuntimeTests
         protected override void OnServerAndClientsCreated()
         {
             m_PrefabToSpawn = CreateNetworkObjectPrefab("TestPrefab");
+            m_PrefabToSpawn.AddComponent<SimpleNetworkBehaviour>();
 
             var childObject = new GameObject
             {
@@ -137,8 +138,6 @@ namespace Unity.Netcode.RuntimeTests
         public IEnumerator ValidateNoSpam()
         {
             m_AllowServerToStart = true;
-            var objectToTest = new GameObject();
-            var simpleNetworkBehaviour = objectToTest.AddComponent<SimpleNetworkBehaviour>();
 
             // Now just start the Host
             yield return StartServerAndClients();
@@ -146,23 +145,34 @@ namespace Unity.Netcode.RuntimeTests
             // set the log level to developer
             m_ServerNetworkManager.LogLevel = LogLevel.Developer;
 
-            // The only valid condition for this would be if the NetworkBehaviour is spawned.
-            simpleNetworkBehaviour.IsSpawned = true;
+            // We make an instance of the m_PrefabToSpawn
+            var validateInstance = Object.Instantiate(m_PrefabToSpawn);
+            // Then destroy the NetworkObject componwent of that instance.
+            Object.DestroyImmediate(validateInstance.GetComponent<NetworkObject>());
 
+            // Now get the Networkbehaviour and verify when you attempt to get a reference
+            // to the NetworkObject a warning is logged.
+            var simpleNetworkBehaviour = validateInstance.GetComponent<SimpleNetworkBehaviour>();
+            simpleNetworkBehaviour.IsSpawned = true;
+            
             // Verify the warning gets logged under normal conditions
             var isNull = simpleNetworkBehaviour.NetworkObject == null;
             LogAssert.Expect(LogType.Warning, $"[Netcode] Could not get {nameof(NetworkObject)} for the {nameof(NetworkBehaviour)}. Are you missing a {nameof(NetworkObject)} component?");
 
-            var networkObjectToTest = objectToTest.AddComponent<NetworkObject>();
-            networkObjectToTest.NetworkManagerOwner = m_ServerNetworkManager;
-            networkObjectToTest.Spawn();
+            simpleNetworkBehaviour.IsSpawned = false;
+            simpleNetworkBehaviour = null;
+            // Destroy this test instance
+            Object.DestroyImmediate(validateInstance);
+           
+            // Now create a spawned instance (NetworkObject will exist)
+            var instance = SpawnObject(m_PrefabToSpawn, GetAuthorityNetworkManager()).GetComponent<NetworkObject>();
 
             // Assure no log messages are logged when they should not be logged
-            isNull = simpleNetworkBehaviour.NetworkObject != null;
+            isNull = instance.GetComponent<SimpleNetworkBehaviour>().NetworkObject != null;
             LogAssert.NoUnexpectedReceived();
 
-            networkObjectToTest.Despawn();
-            Object.Destroy(networkObjectToTest);
+            instance.Despawn();
+            Object.Destroy(instance.gameObject);
         }
 
         /// <summary>
@@ -182,13 +192,11 @@ namespace Unity.Netcode.RuntimeTests
             // Now just start the Host
             yield return StartServerAndClients();
 
-            var parentObject = new GameObject();
-            var childObject = new GameObject();
-            childObject.transform.parent = parentObject.transform;
-            var parentNetworkObject = parentObject.AddComponent<NetworkObject>();
-            childObject.AddComponent<SimpleNetworkBehaviour>();
 
-            parentNetworkObject.Spawn();
+            var serverInstance = SpawnObject(m_PrefabToSpawn, GetAuthorityNetworkManager());
+            var parentNetworkObject = serverInstance.GetComponent<NetworkObject>();
+            var childObject = parentNetworkObject.transform.GetChild(0).gameObject;
+
             yield return s_DefaultWaitForTick;
 
             // Destroy the child object with child NetworkBehaviour
@@ -201,7 +209,7 @@ namespace Unity.Netcode.RuntimeTests
 
             // Destroy the parent object which should not cause any exceptions
             // (validating the fix)
-            Object.Destroy(parentObject);
+            Object.Destroy(serverInstance);
         }
 
         protected override void OnPlayerPrefabGameObjectCreated()

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkBehaviourGenericTests.cs
@@ -41,10 +41,7 @@ namespace Unity.Netcode.RuntimeTests
             m_PrefabToSpawn = CreateNetworkObjectPrefab("TestPrefab");
             m_PrefabToSpawn.AddComponent<SimpleNetworkBehaviour>();
 
-            var childObject = new GameObject
-            {
-                name = "ChildObject"
-            };
+            var childObject = new GameObject("ChildObject");
             childObject.transform.parent = m_PrefabToSpawn.transform;
             childObject.AddComponent<NetworkTransform>();
             base.OnServerAndClientsCreated();
@@ -147,6 +144,7 @@ namespace Unity.Netcode.RuntimeTests
 
             // We make an instance of the m_PrefabToSpawn
             var validateInstance = Object.Instantiate(m_PrefabToSpawn);
+
             // Then destroy the NetworkObject componwent of that instance.
             Object.DestroyImmediate(validateInstance.GetComponent<NetworkObject>());
 
@@ -161,6 +159,7 @@ namespace Unity.Netcode.RuntimeTests
 
             simpleNetworkBehaviour.IsSpawned = false;
             simpleNetworkBehaviour = null;
+
             // Destroy this test instance
             Object.DestroyImmediate(validateInstance);
            

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerPlayerPrefab.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerPlayerPrefab.cs
@@ -20,23 +20,29 @@ namespace Unity.Netcode.RuntimeTests
         {
         }
 
-        /// <summary>
-        /// Assure no player prefab is assigned.
-        /// </summary>
-        protected override void OnServerAndClientsCreated()
+        internal override bool ShouldCreatePlayerPrefab()
         {
-            foreach (var networkManager in m_NetworkManagers)
-            {
-                networkManager.NetworkConfig.PlayerPrefab = null;
-            }
-            base.OnServerAndClientsCreated();
+            return false;
         }
 
-        protected override void OnNewClientCreated(NetworkManager networkManager)
-        {
-            networkManager.NetworkConfig.PlayerPrefab = null;
-            base.OnNewClientCreated(networkManager);
-        }
+        ///// <summary>
+        ///// Assure no player prefab is assigned.
+        ///// </summary>
+        //protected override void OnServerAndClientsCreated()
+        //{
+        //    foreach (var networkManager in m_NetworkManagers)
+        //    {
+        //        networkManager.NetworkConfig.Prefabs.Remove(m_PlayerPrefab);
+        //        networkManager.NetworkConfig.PlayerPrefab = null;
+        //    }
+        //    base.OnServerAndClientsCreated();
+        //}
+
+        //protected override void OnNewClientCreated(NetworkManager networkManager)
+        //{
+        //    networkManager.NetworkConfig.PlayerPrefab = null;
+        //    base.OnNewClientCreated(networkManager);
+        //}
 
         /// <summary>
         /// Do not wait for spawned players as there are none.

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerPlayerPrefab.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkManagerPlayerPrefab.cs
@@ -25,25 +25,6 @@ namespace Unity.Netcode.RuntimeTests
             return false;
         }
 
-        ///// <summary>
-        ///// Assure no player prefab is assigned.
-        ///// </summary>
-        //protected override void OnServerAndClientsCreated()
-        //{
-        //    foreach (var networkManager in m_NetworkManagers)
-        //    {
-        //        networkManager.NetworkConfig.Prefabs.Remove(m_PlayerPrefab);
-        //        networkManager.NetworkConfig.PlayerPrefab = null;
-        //    }
-        //    base.OnServerAndClientsCreated();
-        //}
-
-        //protected override void OnNewClientCreated(NetworkManager networkManager)
-        //{
-        //    networkManager.NetworkConfig.PlayerPrefab = null;
-        //    base.OnNewClientCreated(networkManager);
-        //}
-
         /// <summary>
         /// Do not wait for spawned players as there are none.
         /// </summary>

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableTests.cs
@@ -368,20 +368,6 @@ namespace Unity.Netcode.RuntimeTests
                 StopOneClientWithTimeTravel(networkManager);
             }
 
-            // Create, instantiate, and host
-            // This would normally go in Setup, but since every other test but this one
-            //  uses NetworkManagerHelper, and it does its own NetworkManager setup / teardown,
-            //  for now we put this within this one test until we migrate it to MIH
-            //Assert.IsTrue(NetworkManagerHelper.StartNetworkManager(out NetworkManager server, useHost == HostOrServer.Host ? NetworkManagerHelper.NetworkManagerOperatingMode.Host : NetworkManagerHelper.NetworkManagerOperatingMode.Server));
-
-            //Assert.IsTrue(server.IsHost == (useHost == HostOrServer.Host), $"{nameof(useHost)} does not match the server.IsHost value!");
-
-            //Guid gameObjectId = NetworkManagerHelper.AddGameNetworkObject("NetworkVariableTestComponent");
-
-            //var networkVariableTestComponent = NetworkManagerHelper.AddComponentToObject<NetworkVariableTestComponent>(gameObjectId);
-
-            //NetworkManagerHelper.SpawnNetworkObject(gameObjectId);
-
             var instance = SpawnObject(prefabToSpawn, authority);
             var networkVariableTestComponent = instance.GetComponent<NetworkVariableTestComponent>();
 
@@ -400,16 +386,8 @@ namespace Unity.Netcode.RuntimeTests
             Assert.IsTrue(networkVariableTestComponent.DidAllValuesChange());
             networkVariableTestComponent.AssertAllValuesAreCorrect();
 
-            // Disable this once we are done.
-
-
-
-
-            // This would normally go in Teardown, but since every other test but this one
-            //  uses NetworkManagerHelper, and it does its own NetworkManager setup / teardown,
-            //  for now we put this within this one test until we migrate it to MIH
+            // Stop the authority NetworkManager instance
             StopOneClientWithTimeTravel(authority);
-            //NetworkManagerHelper.ShutdownNetworkManager();
         }
 
         [Test]

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableTests.cs
@@ -251,9 +251,17 @@ namespace Unity.Netcode.RuntimeTests
             m_EnsureLengthSafety = serialization == Serialization.EnsureLengthSafety;
         }
 
+        private bool m_CanStart = false;
+
         protected override bool CanStartServerAndClients()
         {
-            return false;
+            return m_CanStart;
+        }
+
+        protected override void OnInlineSetup()
+        {
+            m_CanStart = false;
+            base.OnInlineSetup();
         }
 
         protected override void OnOneTimeSetup()
@@ -343,21 +351,44 @@ namespace Unity.Netcode.RuntimeTests
         [Test]
         public void AllNetworkVariableTypes([Values] HostOrServer useHost)
         {
+            var prefabToSpawn = CreateNetworkObjectPrefab("NetVarTest");
+            prefabToSpawn.AddComponent<NetworkVariableTestComponent>();
+
+            m_CanStart = true;
+            StartServerAndClientsWithTimeTravel();
+            var authority = GetAuthorityNetworkManager();
+
+            // Shutdown the other clients
+            foreach(var networkManager in m_NetworkManagers)
+            {
+                if (networkManager == authority)
+                {
+                    continue;
+                }
+                StopOneClientWithTimeTravel(networkManager);
+            }
+
             // Create, instantiate, and host
             // This would normally go in Setup, but since every other test but this one
             //  uses NetworkManagerHelper, and it does its own NetworkManager setup / teardown,
             //  for now we put this within this one test until we migrate it to MIH
-            Assert.IsTrue(NetworkManagerHelper.StartNetworkManager(out NetworkManager server, useHost == HostOrServer.Host ? NetworkManagerHelper.NetworkManagerOperatingMode.Host : NetworkManagerHelper.NetworkManagerOperatingMode.Server));
+            //Assert.IsTrue(NetworkManagerHelper.StartNetworkManager(out NetworkManager server, useHost == HostOrServer.Host ? NetworkManagerHelper.NetworkManagerOperatingMode.Host : NetworkManagerHelper.NetworkManagerOperatingMode.Server));
 
-            Assert.IsTrue(server.IsHost == (useHost == HostOrServer.Host), $"{nameof(useHost)} does not match the server.IsHost value!");
+            //Assert.IsTrue(server.IsHost == (useHost == HostOrServer.Host), $"{nameof(useHost)} does not match the server.IsHost value!");
 
-            Guid gameObjectId = NetworkManagerHelper.AddGameNetworkObject("NetworkVariableTestComponent");
+            //Guid gameObjectId = NetworkManagerHelper.AddGameNetworkObject("NetworkVariableTestComponent");
 
-            var networkVariableTestComponent = NetworkManagerHelper.AddComponentToObject<NetworkVariableTestComponent>(gameObjectId);
+            //var networkVariableTestComponent = NetworkManagerHelper.AddComponentToObject<NetworkVariableTestComponent>(gameObjectId);
 
-            NetworkManagerHelper.SpawnNetworkObject(gameObjectId);
+            //NetworkManagerHelper.SpawnNetworkObject(gameObjectId);
+            
+            var instance = SpawnObject(prefabToSpawn, authority);
+            var networkVariableTestComponent = instance.GetComponent<NetworkVariableTestComponent>();
+
+            Assert.IsTrue(networkVariableTestComponent.IsSpawned, $"Failed to spawn {instance.name}!");
 
             // Start Testing
+            networkVariableTestComponent.InitializeTest();
             networkVariableTestComponent.EnableTesting = true;
 
             var success = WaitForConditionOrTimeOutWithTimeTravel(() => true == networkVariableTestComponent.IsTestComplete());
@@ -370,12 +401,15 @@ namespace Unity.Netcode.RuntimeTests
             networkVariableTestComponent.AssertAllValuesAreCorrect();
 
             // Disable this once we are done.
-            networkVariableTestComponent.gameObject.SetActive(false);
+
+            
+
 
             // This would normally go in Teardown, but since every other test but this one
             //  uses NetworkManagerHelper, and it does its own NetworkManager setup / teardown,
             //  for now we put this within this one test until we migrate it to MIH
-            NetworkManagerHelper.ShutdownNetworkManager();
+            StopOneClientWithTimeTravel(authority);
+            //NetworkManagerHelper.ShutdownNetworkManager();
         }
 
         [Test]

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkVariable/NetworkVariableTests.cs
@@ -359,7 +359,7 @@ namespace Unity.Netcode.RuntimeTests
             var authority = GetAuthorityNetworkManager();
 
             // Shutdown the other clients
-            foreach(var networkManager in m_NetworkManagers)
+            foreach (var networkManager in m_NetworkManagers)
             {
                 if (networkManager == authority)
                 {
@@ -381,7 +381,7 @@ namespace Unity.Netcode.RuntimeTests
             //var networkVariableTestComponent = NetworkManagerHelper.AddComponentToObject<NetworkVariableTestComponent>(gameObjectId);
 
             //NetworkManagerHelper.SpawnNetworkObject(gameObjectId);
-            
+
             var instance = SpawnObject(prefabToSpawn, authority);
             var networkVariableTestComponent = instance.GetComponent<NetworkVariableTestComponent>();
 
@@ -402,7 +402,7 @@ namespace Unity.Netcode.RuntimeTests
 
             // Disable this once we are done.
 
-            
+
 
 
             // This would normally go in Teardown, but since every other test but this one

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/AddNetworkPrefabTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/AddNetworkPrefabTests.cs
@@ -25,14 +25,12 @@ namespace Unity.Netcode.RuntimeTests
             yield return null;
         }
 
-        protected override void OnServerAndClientsCreated()
+        private GameObject GenerateAndRegisterPrefab()
         {
-            m_Prefab = new GameObject("Object");
-            var networkObject = m_Prefab.AddComponent<NetworkObject>();
-            m_Prefab.AddComponent<EmptyComponent>();
-
+            var originalPrefabInstance = NetcodeIntegrationTestHelpers.CreateNetworkObject("PrefabTest");
             // Make it a prefab
-            NetcodeIntegrationTestHelpers.MakeNetworkObjectTestPrefab(networkObject);
+            NetcodeIntegrationTestHelpers.MakeNetworkObjectTestPrefab(originalPrefabInstance.GetComponent<NetworkObject>());
+            
 
             m_ServerNetworkManager.NetworkConfig.SpawnTimeout = 0;
             m_ServerNetworkManager.NetworkConfig.ForceSamePrefabs = false;
@@ -41,6 +39,12 @@ namespace Unity.Netcode.RuntimeTests
                 client.NetworkConfig.SpawnTimeout = 0;
                 client.NetworkConfig.ForceSamePrefabs = false;
             }
+            return originalPrefabInstance;
+        }
+
+        protected override void OnServerAndClientsCreated()
+        {
+            RegisterPrefab();
         }
 
         private EmptyComponent GetObjectForClient(ulong clientId)
@@ -50,15 +54,25 @@ namespace Unity.Netcode.RuntimeTests
             {
                 if (component.IsSpawned && component.NetworkManager.LocalClientId == clientId)
                 {
-                    return component;
+                    var prefabGlobalObjectIdHash = m_Prefab.GetComponent<NetworkObject>().GlobalObjectIdHash;
+                    var componentGlobalObjectIdHash = m_Prefab.GetComponent<NetworkObject>().GlobalObjectIdHash;
+                    if (prefabGlobalObjectIdHash == componentGlobalObjectIdHash)
+                    {
+                        return component;
+                    }
                 }
             }
             return null;
         }
 
-        private void RegisterPrefab()
+        private void RegisterPrefab(bool includeClients = true)
         {
+            m_Prefab = GenerateAndRegisterPrefab();
             m_ServerNetworkManager.AddNetworkPrefab(m_Prefab);
+            if (!includeClients)
+            {
+                return;
+            }
             foreach (var client in m_ClientNetworkManagers)
             {
                 client.AddNetworkPrefab(m_Prefab);
@@ -89,7 +103,7 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator WhenSpawningAfterAddingServerPrefabButBeforeAddingClientPrefab_SpawnFails()
         {
-            m_ServerNetworkManager.AddNetworkPrefab(m_Prefab);
+            RegisterPrefab(false);
 
             var serverObject = Object.Instantiate(m_Prefab);
             serverObject.GetComponent<NetworkObject>().NetworkManagerOwner = m_ServerNetworkManager;
@@ -104,10 +118,12 @@ namespace Unity.Netcode.RuntimeTests
             RegisterPrefab();
 
             var serverObject = Object.Instantiate(m_Prefab);
-            serverObject.GetComponent<NetworkObject>().NetworkManagerOwner = m_ServerNetworkManager;
-            serverObject.GetComponent<NetworkObject>().Spawn();
-            yield return NetcodeIntegrationTestHelpers.WaitForMessageOfTypeHandled<CreateObjectMessage>(m_ClientNetworkManagers[0]);
-            Assert.IsNotNull(GetObjectForClient(m_ClientNetworkManagers[0].LocalClientId));
+            var serverNetworkObject = serverObject.GetComponent<NetworkObject>();
+            serverNetworkObject.NetworkManagerOwner = m_ServerNetworkManager;
+            serverNetworkObject.Spawn();
+            yield return WaitForSpawnedOnAllOrTimeOut(serverObject);
+            AssertOnTimeout($"{serverObject.name} did not spawn on all clients!");
+            Assert.IsTrue(m_ClientNetworkManagers[0].SpawnManager.SpawnedObjects.ContainsKey(serverNetworkObject.NetworkObjectId), $"Client did not spawn object!");
         }
 
         [UnityTest]
@@ -116,10 +132,13 @@ namespace Unity.Netcode.RuntimeTests
             RegisterPrefab();
 
             var serverObject = Object.Instantiate(m_Prefab);
+            var serverNetworkObject = serverObject.GetComponent<NetworkObject>();
+
             serverObject.GetComponent<NetworkObject>().NetworkManagerOwner = m_ServerNetworkManager;
             serverObject.GetComponent<NetworkObject>().Spawn();
-            yield return NetcodeIntegrationTestHelpers.WaitForMessageOfTypeReceived<CreateObjectMessage>(m_ClientNetworkManagers[0]);
-            Assert.IsNotNull(GetObjectForClient(m_ClientNetworkManagers[0].LocalClientId));
+            yield return WaitForSpawnedOnAllOrTimeOut(serverObject);
+            AssertOnTimeout($"{serverObject.name} did not spawn on all clients!");
+            Assert.IsTrue(m_ClientNetworkManagers[0].SpawnManager.SpawnedObjects.ContainsKey(serverNetworkObject.NetworkObjectId), $"Client did not spawn object!");
 
             serverObject.GetComponent<NetworkObject>().Despawn();
             yield return NetcodeIntegrationTestHelpers.WaitForMessageOfTypeReceived<DestroyObjectMessage>(m_ClientNetworkManagers[0]);

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/AddNetworkPrefabTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/AddNetworkPrefabTests.cs
@@ -30,7 +30,7 @@ namespace Unity.Netcode.RuntimeTests
             var originalPrefabInstance = NetcodeIntegrationTestHelpers.CreateNetworkObject("PrefabTest");
             // Make it a prefab
             NetcodeIntegrationTestHelpers.MakeNetworkObjectTestPrefab(originalPrefabInstance.GetComponent<NetworkObject>());
-            
+
 
             m_ServerNetworkManager.NetworkConfig.SpawnTimeout = 0;
             m_ServerNetworkManager.NetworkConfig.ForceSamePrefabs = false;

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/NetworkPrefabHandlerSynchronizationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/NetworkPrefabHandlerSynchronizationTests.cs
@@ -35,7 +35,10 @@ namespace Unity.Netcode.RuntimeTests
 
             var networkObjectToSpawnOnClient = m_ClientSideValidPrefab.GetComponent<NetworkObject>();
             nonAuthority.PrefabHandler.AddHandler(m_ClientSideExceptionPrefab, new NetworkPrefabExceptionThrower());
-            nonAuthority.PrefabHandler.AddHandler(m_ValidPrefab, new NetworkPrefabInstanceHandler(networkObjectToSpawnOnClient));
+            var prefabHandlerObject = new GameObject();
+            var prefabHandler = prefabHandlerObject.AddComponent<NetworkPrefabInstanceHandler>();
+            prefabHandler.Initialize(nonAuthority, m_ValidPrefab.GetComponent<NetworkObject>());
+            //nonAuthority.PrefabHandler.AddHandler(m_ValidPrefab, new NetworkPrefabInstanceHandler(networkObjectToSpawnOnClient));
 
             var authority = GetAuthorityNetworkManager();
 
@@ -60,8 +63,14 @@ namespace Unity.Netcode.RuntimeTests
 
             // Create a new client and register the same PrefabHandlers on the client
             var newClient = CreateNewClient();
+            var prefabHandlerObject2 = new GameObject();
+            var prefabHandler2 = prefabHandlerObject2.AddComponent<NetworkPrefabExceptionThrower>();
+
             newClient.PrefabHandler.AddHandler(m_ClientSideExceptionPrefab, new NetworkPrefabExceptionThrower());
-            newClient.PrefabHandler.AddHandler(m_ValidPrefab, new NetworkPrefabInstanceHandler(networkObjectToSpawnOnClient));
+
+            var prefabHandlerObject3 = new GameObject();
+            var prefabHandler3 = prefabHandlerObject3.AddComponent<NetworkPrefabInstanceHandler>();
+            prefabHandler3.Initialize(nonAuthority, networkObjectToSpawnOnClient);
 
             // Expect assertions from the new client
             LogAssert.Expect(LogType.Exception, "Exception: exception while instantiating");
@@ -92,6 +101,8 @@ namespace Unity.Netcode.RuntimeTests
                     Assert.That(networkManager.SpawnManager.SpawnedObjects.ContainsKey(exceptionObject.NetworkObjectId), Is.False, "Non authority should not have spawned exception object!");
                 }
             }
+
+            Object.Destroy(prefabHandlerObject);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/NetworkPrefabHandlerSynchronizationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/NetworkPrefabHandlerSynchronizationTests.cs
@@ -19,6 +19,28 @@ namespace Unity.Netcode.RuntimeTests
         private GameObject m_ClientSideValidPrefab;
         private GameObject m_ClientSideExceptionPrefab;
 
+        public class VerifyLastClientSentRpcToServer : NetworkBehaviour
+        {
+            public bool RpcReceived { get; private set; }
+
+            protected override void OnNetworkPreSpawn(ref NetworkManager networkManager)
+            {
+                RpcReceived = false;
+                base.OnNetworkPreSpawn(ref networkManager);
+            }
+
+            public void DelayUntilOneMessageReceivedRpc(RpcParams rpcParams = default)
+            {
+                RpcReceived = true;
+            }
+        }
+
+        protected override void OnCreatePlayerPrefab()
+        {
+            m_PlayerPrefab.AddComponent<VerifyLastClientSentRpcToServer>();
+            base.OnCreatePlayerPrefab();
+        }
+
         protected override void OnServerAndClientsCreated()
         {
             m_ValidPrefab = CreateNetworkObjectPrefab("ValidPrefab");
@@ -28,17 +50,22 @@ namespace Unity.Netcode.RuntimeTests
         }
 
         [UnityTest]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.IPhonePlayer, RuntimePlatform.OSXPlayer, RuntimePlatform.OSXEditor })] // Ignored test tracked in MTT-15473
         public IEnumerator NetworkPrefabHandlerSpawnAndSynchronizeTests()
         {
             var nonAuthority = GetNonAuthorityNetworkManager();
 
             var networkObjectToSpawnOnClient = m_ClientSideValidPrefab.GetComponent<NetworkObject>();
-            nonAuthority.PrefabHandler.AddHandler(m_ClientSideExceptionPrefab, new NetworkPrefabExceptionThrower());
-            var prefabHandlerObject = new GameObject();
-            var prefabHandler = prefabHandlerObject.AddComponent<NetworkPrefabInstanceHandler>();
-            prefabHandler.Initialize(nonAuthority, m_ValidPrefab.GetComponent<NetworkObject>());
-            //nonAuthority.PrefabHandler.AddHandler(m_ValidPrefab, new NetworkPrefabInstanceHandler(networkObjectToSpawnOnClient));
+
+            var clientSideHandler = new GameObject();
+            var clientPrefabHandler = clientSideHandler.AddComponent<NetworkPrefabInstanceHandler>();
+            clientPrefabHandler.Initialize(nonAuthority, m_ClientSideValidPrefab.GetComponent<NetworkObject>());
+
+            nonAuthority.PrefabHandler.AddHandler(m_ValidPrefab, clientPrefabHandler);
+
+            var clientSideExceptionHandler = new GameObject();
+            var clientSideExceptionPrefabHandler = clientSideExceptionHandler.AddComponent<NetworkPrefabExceptionThrower>();
+
+            nonAuthority.PrefabHandler.AddHandler(m_ClientSideExceptionPrefab, clientSideExceptionPrefabHandler);
 
             var authority = GetAuthorityNetworkManager();
 
@@ -63,14 +90,16 @@ namespace Unity.Netcode.RuntimeTests
 
             // Create a new client and register the same PrefabHandlers on the client
             var newClient = CreateNewClient();
-            var prefabHandlerObject2 = new GameObject();
-            var prefabHandler2 = prefabHandlerObject2.AddComponent<NetworkPrefabExceptionThrower>();
 
-            newClient.PrefabHandler.AddHandler(m_ClientSideExceptionPrefab, new NetworkPrefabExceptionThrower());
+            var lateJoinClientSideHandler = new GameObject();
+            var lateJoinClientPrefabHandler = clientSideHandler.AddComponent<NetworkPrefabInstanceHandler>();
+            var lateJoinExceptionHandler = new GameObject();
+            var lateJoinClientExceptionHandler = lateJoinExceptionHandler.AddComponent<NetworkPrefabExceptionThrower>();
 
-            var prefabHandlerObject3 = new GameObject();
-            var prefabHandler3 = prefabHandlerObject3.AddComponent<NetworkPrefabInstanceHandler>();
-            prefabHandler3.Initialize(nonAuthority, networkObjectToSpawnOnClient);
+            lateJoinClientPrefabHandler.Initialize(newClient, m_ClientSideValidPrefab.GetComponent<NetworkObject>());
+
+            newClient.PrefabHandler.AddHandler(m_ClientSideExceptionPrefab, lateJoinClientExceptionHandler);
+            newClient.PrefabHandler.AddHandler(m_ValidPrefab, lateJoinClientPrefabHandler);
 
             // Expect assertions from the new client
             LogAssert.Expect(LogType.Exception, "Exception: exception while instantiating");
@@ -82,6 +111,8 @@ namespace Unity.Netcode.RuntimeTests
 
             // Start and synchronize the new client
             yield return StartClient(newClient);
+            AssertOnTimeout($"Timed out waiting for the late joining client, {newClient.name}, to connect!");
+
 
             // Validate the valid prefab spawned on all clients without issue
             var expectedAuthorityHash = m_ValidPrefab.GetComponent<NetworkObject>().GlobalObjectIdHash;
@@ -102,7 +133,20 @@ namespace Unity.Netcode.RuntimeTests
                 }
             }
 
-            Object.Destroy(prefabHandlerObject);
+            // Assure this test continues to run until we verify the late joining client has sent 1 message to the server
+            // This should be the fix for MTT-15473 where the test finishes/exits before the message from the client has been received and processed by the server.
+            Assert.IsTrue(authority.SpawnManager.SpawnedObjects.ContainsKey(newClient.LocalClient.PlayerObject.NetworkObjectId), $"Server does not have a player for Client-{newClient.LocalClientId}!");
+
+            // Get server and late joining client's VerifyLastClientSentRpcToServer NetworkBehaviour
+            var serverLateClientInstance = authority.SpawnManager.SpawnedObjects[newClient.LocalClient.PlayerObject.NetworkObjectId].GetComponent<VerifyLastClientSentRpcToServer>();
+            var sendRpc = newClient.LocalClient.PlayerObject.GetComponent<VerifyLastClientSentRpcToServer>();
+
+            // Send a message from the late joining client to the server
+            sendRpc.DelayUntilOneMessageReceivedRpc();
+
+            // Wait for the server to have received this message before exiting the test.
+            // If the log message has not been received by the server at this point, then there is some other type of bug specific to iOS and Mac.
+            yield return WaitForConditionOrTimeOut(() => serverLateClientInstance.RpcReceived);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/NetworkPrefabHandlerTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/NetworkPrefabHandlerTests.cs
@@ -1,6 +1,6 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using NUnit.Framework;
 using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
@@ -15,20 +15,35 @@ namespace Unity.Netcode.RuntimeTests
     /// Destroying a newly spawned NetworkObject instance works
     /// Removing a INetworkPrefabInstanceHandler is removed and can be verified (very last check)
     /// </summary>
-    internal class NetworkPrefabHandlerTests
+    internal class NetworkPrefabHandlerTests : NetcodeIntegrationTest
     {
-        [OneTimeSetUp]
-        public void OneTimeSetup()
+        protected override int NumberOfClients => 0;
+
+        protected override void OnOneTimeSetup()
         {
             // TODO: [CmbServiceTests] if this test is deemed needed to test against the CMB server then update this test.
             NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+            base.OnOneTimeSetup();
         }
 
         private const string k_TestPrefabObjectName = "NetworkPrefabTestObject";
-        private uint m_ObjectId = 1;
+        private uint m_ObjectId = 0;
+
+        private bool m_CanStart;
+
+
+
+        protected override bool CanStartServerAndClients()
+        {
+            return m_CanStart;
+        }
+
         private GameObject MakeValidNetworkPrefab()
         {
-            return GenerateAndRegisterPrefab();
+            m_ObjectId++;
+            return CreateNetworkObjectPrefab(k_TestPrefabObjectName + m_ObjectId.ToString());
+
+            //return GenerateAndRegisterPrefab();
             //Guid baseObjectID = NetworkManagerHelper.AddGameNetworkObject(k_TestPrefabObjectName + m_ObjectId.ToString());
             //NetworkObject validPrefab = NetworkManagerHelper.InstantiatedNetworkObjects[baseObjectID];
             //NetcodeIntegrationTestHelpers.MakeNetworkObjectTestPrefab(validPrefab);
@@ -52,94 +67,112 @@ namespace Unity.Netcode.RuntimeTests
         /// Tests the NetwokConfig NetworkPrefabsList initialization during NetworkManager's Init method to make sure that
         /// it will still initialize but remove the invalid prefabs
         /// </summary>
-        [Test]
-        public void NetworkConfigInvalidNetworkPrefabTest()
+        [UnityTest]
+        public IEnumerator NetworkConfigInvalidNetworkPrefabTest()
         {
+            var authority = GetAuthorityNetworkManager();
 
             // Add null entry
-            NetworkManagerHelper.NetworkManagerObject.NetworkConfig.Prefabs.Add(null);
+            authority.NetworkConfig.Prefabs.Add(null);
 
             // Add a NetworkPrefab with no prefab
-            NetworkManagerHelper.NetworkManagerObject.NetworkConfig.Prefabs.Add(new NetworkPrefab());
+            authority.NetworkConfig.Prefabs.Add(new NetworkPrefab());
 
             // Add a NetworkPrefab override with an invalid hash
-            NetworkManagerHelper.NetworkManagerObject.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Hash, SourceHashToOverride = 0 });
+            authority.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Hash, SourceHashToOverride = 0 });
 
             // Add a NetworkPrefab override with a valid hash but an invalid target prefab
-            NetworkManagerHelper.NetworkManagerObject.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Hash, SourceHashToOverride = 654321, OverridingTargetPrefab = null });
+            authority.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Hash, SourceHashToOverride = 654321, OverridingTargetPrefab = null });
 
             // Add a NetworkPrefab override with a valid hash to override but an invalid target prefab
-            NetworkManagerHelper.NetworkManagerObject.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Prefab, SourceHashToOverride = 654321, OverridingTargetPrefab = null });
+            authority.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Prefab, SourceHashToOverride = 654321, OverridingTargetPrefab = null });
 
             // Add a NetworkPrefab override with an invalid source prefab to override
-            NetworkManagerHelper.NetworkManagerObject.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Prefab, SourcePrefabToOverride = null });
+            authority.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Prefab, SourcePrefabToOverride = null });
 
 
             // Create a valid network prefab "asset".
             var validPrefabAsset = MakeValidNetworkPrefab().GetComponent<NetworkObject>();
 
             // Add a NetworkPrefab override with a valid source prefab to override but an invalid target prefab.
-            NetworkManagerHelper.NetworkManagerObject.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Prefab, SourcePrefabToOverride = validPrefabAsset.gameObject, OverridingTargetPrefab = null });
+            authority.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Prefab, SourcePrefabToOverride = validPrefabAsset.gameObject, OverridingTargetPrefab = null });
 
             // Now add the valid asset as a network prefab with no override.
-            NetworkManagerHelper.NetworkManagerObject.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Prefab = validPrefabAsset.gameObject });
+            //authority.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Prefab = validPrefabAsset.gameObject });
 
             var validPrefabForSourceHash = MakeValidNetworkPrefab().GetComponent<NetworkObject>();
             // This would be the scenario that a hash would be used (typically when scene management is disabled)
             validPrefabForSourceHash.InScenePlaced = true;
-            
-            // Add a NetworkPrefab override with a valid hash and valid target prefab
-            NetworkManagerHelper.NetworkManagerObject.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Hash, SourceHashToOverride = validPrefabForSourceHash.GlobalObjectIdHash, OverridingTargetPrefab = validPrefabAsset.gameObject });
 
+            var networkPrefab = authority.NetworkConfig.Prefabs.InternalPrefabs[authority.NetworkConfig.Prefabs.InternalPrefabs.Count - 1];
+            networkPrefab.SourceHashToOverride = validPrefabForSourceHash.GlobalObjectIdHash;
+            networkPrefab.OverridingTargetPrefab = validPrefabAsset.gameObject;
+            networkPrefab.Override = NetworkPrefabOverride.Hash;
+            authority.NetworkConfig.Prefabs.InternalPrefabs[authority.NetworkConfig.Prefabs.InternalPrefabs.Count - 1] = networkPrefab;
+
+            // Add a NetworkPrefab override with a valid hash and valid target prefab
+            //authority.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Hash, SourceHashToOverride = validPrefabForSourceHash.GlobalObjectIdHash, OverridingTargetPrefab = validPrefabAsset.gameObject });
+            var sourcePrefab = MakeValidNetworkPrefab();
+            networkPrefab = authority.NetworkConfig.Prefabs.InternalPrefabs[authority.NetworkConfig.Prefabs.InternalPrefabs.Count - 1];
+            var index = authority.NetworkConfig.Prefabs.Prefabs.Count - 1;
+            var targetPrefab = MakeValidNetworkPrefab();
+            networkPrefab.Prefab = sourcePrefab;
+            networkPrefab.SourcePrefabToOverride = sourcePrefab;
+            networkPrefab.OverridingTargetPrefab = targetPrefab;
+            authority.NetworkConfig.Prefabs.InternalPrefabs[index] = networkPrefab;
 
             // Add a NetworkPrefab override with a valid prefab and valid target prefab
-            NetworkManagerHelper.NetworkManagerObject.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Prefab, SourcePrefabToOverride = MakeValidNetworkPrefab(), OverridingTargetPrefab = MakeValidNetworkPrefab() });
+            //authority.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Prefab, SourcePrefabToOverride = MakeValidNetworkPrefab(), OverridingTargetPrefab = MakeValidNetworkPrefab() });
 
-            var exceptionOccurred = false;
-            try
-            {
-                NetworkManagerHelper.NetworkManagerObject.StartHost();
-            }
-            catch
-            {
-                exceptionOccurred = true;
-            }
+            m_CanStart = true;
+            yield return StartServerAndClients();
 
-            Assert.False(exceptionOccurred);
+            //var exceptionOccurred = false;
+            //try
+            //{
+            //    Assert.IsTrue(NetworkManagerHelper.StartNetworkManager(out var server, NetworkManagerHelper.NetworkManagerOperatingMode.Host, authority.NetworkConfig), "Failed to start host!");
+            //}
+            //catch
+            //{
+            //    exceptionOccurred = true;
+            //}
+
+            //Assert.False(exceptionOccurred);
 
             // In the end we should only have 3 valid registered network prefabs
-            Assert.AreEqual(3, NetworkManagerHelper.NetworkManagerObject.NetworkConfig.Prefabs.NetworkPrefabOverrideLinks.Count);
+            Assert.AreEqual(5, authority.NetworkConfig.Prefabs.NetworkPrefabOverrideLinks.Count);
         }
 
         private const string k_PrefabObjectName = "NetworkPrefabHandlerTestObject";
 
-        [Test]
-        public void NetworkPrefabHandlerClass([Values] NetworkTopologyTypes topologyType)
+
+        [UnityTest]
+        public IEnumerator NetworkPrefabHandlerClass([Values] NetworkTopologyTypes topologyType)
         {
-            var networkConfig = new NetworkConfig()
-            {
-                NetworkTopology = topologyType,
-            };
+            var authority = GetAuthorityNetworkManager();
+            authority.NetworkConfig.NetworkTopology = topologyType;
+            var baseObject = MakeValidNetworkPrefab().GetComponent<NetworkObject>();
 
-            Assert.IsTrue(NetworkManagerHelper.StartNetworkManager(out _, networkConfig: networkConfig));
-            var testPrefabObjectName = k_PrefabObjectName;
+            m_CanStart = true;
+            yield return StartServerAndClients();
 
-            Guid baseObjectID = NetworkManagerHelper.AddGameNetworkObject(testPrefabObjectName);
-            NetworkObject baseObject = NetworkManagerHelper.InstantiatedNetworkObjects[baseObjectID];
+            var testPrefabObjectName = k_TestPrefabObjectName;
 
-            var networkPrefabHandler = new NetworkPrefabHandler();
-            var networkPrefabInstanceHandler = new NetworkPrefabInstanceHandler(baseObject);
+            var networkPrefabHandler = authority.PrefabHandler;
+            var prefabHandlerObject = new GameObject();
+            var networkPrefabInstanceHandler = prefabHandlerObject.AddComponent<NetworkPrefabInstanceHandler>();
+            networkPrefabInstanceHandler.Initialize(authority, baseObject);
 
             var prefabPosition = new Vector3(1.0f, 5.0f, 3.0f);
             var prefabRotation = new Quaternion(1.0f, 0.5f, 0.4f, 0.1f);
 
             //Register via GameObject
-            var gameObjectRegistered = networkPrefabHandler.AddHandler(baseObject.gameObject, networkPrefabInstanceHandler);
+            var gameObjectRegistered = authority.PrefabHandler.ContainsHandler(baseObject);
 
             //Test result of registering via GameObject reference
             Assert.True(gameObjectRegistered);
 
-            var spawnedObject = networkPrefabHandler.HandleNetworkPrefabSpawn(baseObject.GlobalObjectIdHash, 0, prefabPosition, prefabRotation);
+            var spawnedObject = authority.PrefabHandler.HandleNetworkPrefabSpawn(baseObject.GlobalObjectIdHash, 0, prefabPosition, prefabRotation);
 
             //Test that something was instantiated
             Assert.NotNull(spawnedObject);
@@ -151,11 +184,11 @@ namespace Unity.Netcode.RuntimeTests
             Assert.True(prefabPosition == spawnedObject.transform.position);
             Assert.True(prefabRotation == spawnedObject.transform.rotation);
 
-            networkPrefabHandler.HandleNetworkPrefabDestroy(spawnedObject);     //Destroy our prefab instance
-            networkPrefabHandler.RemoveHandler(baseObject);                     //Remove our handler
+            authority.PrefabHandler.HandleNetworkPrefabDestroy(spawnedObject);     //Destroy our prefab instance
+            authority.PrefabHandler.RemoveHandler(baseObject);                     //Remove our handler
 
             //Register via NetworkObject
-            gameObjectRegistered = networkPrefabHandler.AddHandler(baseObject, networkPrefabInstanceHandler);
+            gameObjectRegistered = authority.PrefabHandler.AddHandler(baseObject, networkPrefabInstanceHandler);
 
             //Test result of registering via NetworkObject reference
             Assert.True(gameObjectRegistered);
@@ -164,7 +197,7 @@ namespace Unity.Netcode.RuntimeTests
             prefabPosition = new Vector3(2.0f, 1.0f, 5.0f);
             prefabRotation = new Quaternion(4.0f, 1.5f, 5.4f, 5.1f);
 
-            spawnedObject = networkPrefabHandler.HandleNetworkPrefabSpawn(baseObject.GlobalObjectIdHash, 0, prefabPosition, prefabRotation);
+            spawnedObject = authority.PrefabHandler.HandleNetworkPrefabSpawn(baseObject.GlobalObjectIdHash, 0, prefabPosition, prefabRotation);
 
             //Test that something was instantiated
             Assert.NotNull(spawnedObject);
@@ -176,11 +209,11 @@ namespace Unity.Netcode.RuntimeTests
             Assert.True(prefabPosition == spawnedObject.transform.position);
             Assert.True(prefabRotation == spawnedObject.transform.rotation);
 
-            networkPrefabHandler.HandleNetworkPrefabDestroy(spawnedObject);     //Destroy our prefab instance
-            networkPrefabHandler.RemoveHandler(baseObject);                     //Remove our handler
+            authority.PrefabHandler.HandleNetworkPrefabDestroy(spawnedObject);     //Destroy our prefab instance
+            authority.PrefabHandler.RemoveHandler(baseObject);                     //Remove our handler
 
             //Register via GlobalObjectIdHash
-            gameObjectRegistered = networkPrefabHandler.AddHandler(baseObject.GlobalObjectIdHash, networkPrefabInstanceHandler);
+            gameObjectRegistered = authority.PrefabHandler.AddHandler(baseObject.GlobalObjectIdHash, networkPrefabInstanceHandler);
 
             //Test result of registering via GlobalObjectIdHash reference
             Assert.True(gameObjectRegistered);
@@ -189,7 +222,7 @@ namespace Unity.Netcode.RuntimeTests
             prefabPosition = new Vector3(6.0f, 4.0f, 1.0f);
             prefabRotation = new Quaternion(3f, 2f, 4f, 1f);
 
-            spawnedObject = networkPrefabHandler.HandleNetworkPrefabSpawn(baseObject.GlobalObjectIdHash, 0, prefabPosition, prefabRotation);
+            spawnedObject = authority.PrefabHandler.HandleNetworkPrefabSpawn(baseObject.GlobalObjectIdHash, 0, prefabPosition, prefabRotation);
 
             //Test that something was instantiated
             Assert.NotNull(spawnedObject);
@@ -201,59 +234,69 @@ namespace Unity.Netcode.RuntimeTests
             Assert.True(prefabPosition == spawnedObject.transform.position);
             Assert.True(prefabRotation == spawnedObject.transform.rotation);
 
-            networkPrefabHandler.HandleNetworkPrefabDestroy(spawnedObject);     //Destroy our prefab instance
-            networkPrefabHandler.RemoveHandler(baseObject);                     //Remove our handler
+            authority.PrefabHandler.HandleNetworkPrefabDestroy(spawnedObject);     //Destroy our prefab instance
+            authority.PrefabHandler.RemoveHandler(baseObject);                     //Remove our handler
 
             // Register a handler that throws an exception
             var networkPrefabExceptionThrower = new NetworkPrefabExceptionThrower();
-            gameObjectRegistered = networkPrefabHandler.AddHandler(baseObject, networkPrefabExceptionThrower);
+            gameObjectRegistered = authority.PrefabHandler.AddHandler(baseObject, networkPrefabExceptionThrower);
             //Test result of registering exception handler
             Assert.True(gameObjectRegistered);
 
             LogAssert.Expect(LogType.Exception, "Exception: exception while instantiating");
-            spawnedObject = networkPrefabHandler.HandleNetworkPrefabSpawn(baseObject.GlobalObjectIdHash, 0, prefabPosition, prefabRotation);
+            spawnedObject = authority.PrefabHandler.HandleNetworkPrefabSpawn(baseObject.GlobalObjectIdHash, 0, prefabPosition, prefabRotation);
 
             // No object should have been spawned, but test should have continued
             Assert.Null(spawnedObject);
 
-            networkPrefabHandler.RemoveHandler(baseObject);                     //Remove our handler
+            authority.PrefabHandler.RemoveHandler(baseObject);                     //Remove our handler
 
             Assert.False(networkPrefabInstanceHandler.StillHasInstances());
+
+            UnityEngine.Object.Destroy(prefabHandlerObject);
         }
 
-        [SetUp]
-        public void Setup()
+        //[SetUp]
+        //public void Setup()
+        //{
+        //    //Create, instantiate, and host
+        //    NetworkManagerHelper.StartNetworkManager(out _, NetworkManagerHelper.NetworkManagerOperatingMode.None);
+        //}
+
+        protected override IEnumerator OnTearDown()
         {
-            //Create, instantiate, and host
-            NetworkManagerHelper.StartNetworkManager(out _, NetworkManagerHelper.NetworkManagerOperatingMode.None);
+            m_CanStart = false;
+            return base.OnTearDown();
         }
 
-        [TearDown]
-        public void TearDown()
-        {
-            //Stop, shutdown, and destroy
-            NetworkManagerHelper.ShutdownNetworkManager();
-            var networkObjects = FindObjects.ByType<NetworkObject>();
-            var networkObjectsList = networkObjects.Where(c => c.name.Contains(k_PrefabObjectName));
-            foreach (var networkObject in networkObjectsList)
-            {
-                UnityEngine.Object.DestroyImmediate(networkObject);
-            }
-        }
+        //[TearDown]
+        //public void TearDown()
+        //{
+        //    //Stop, shutdown, and destroy
+        //    NetworkManagerHelper.ShutdownNetworkManager();
+        //    var networkObjects = FindObjects.ByType<NetworkObject>();
+        //    var networkObjectsList = networkObjects.Where(c => c.name.Contains(k_PrefabObjectName));
+        //    foreach (var networkObject in networkObjectsList)
+        //    {
+        //        UnityEngine.Object.DestroyImmediate(networkObject);
+        //    }
+        //}
     }
 
     /// <summary>
     /// The Prefab instance handler to use for this test
     /// </summary>
-    internal class NetworkPrefabInstanceHandler : INetworkPrefabInstanceHandler
+    internal class NetworkPrefabInstanceHandler : MonoBehaviour, INetworkPrefabInstanceHandler
     {
         private NetworkObject m_NetworkObject;
 
         private List<NetworkObject> m_Instances;
 
+        private NetworkManager m_NetworkManager;
+
         public NetworkObject Instantiate(ulong ownerClientId, Vector3 position, Quaternion rotation)
         {
-            var networkObjectInstance = UnityEngine.Object.Instantiate(m_NetworkObject.gameObject).GetComponent<NetworkObject>();
+            var networkObjectInstance = Instantiate(m_NetworkObject.gameObject).GetComponent<NetworkObject>();
             networkObjectInstance.transform.SetPositionAndRotation(position, rotation);
             m_Instances.Add(networkObjectInstance);
             return networkObjectInstance;
@@ -261,10 +304,13 @@ namespace Unity.Netcode.RuntimeTests
 
         public void Destroy(NetworkObject networkObject)
         {
-            var instancesContainsNetworkObject = m_Instances.Contains(networkObject);
-            Assert.True(instancesContainsNetworkObject);
-            m_Instances.Remove(networkObject);
-            UnityEngine.Object.Destroy(networkObject.gameObject);
+            if (m_Instances == null || m_Instances.Count > 0)
+            {
+                var instancesContainsNetworkObject = m_Instances.Contains(networkObject);
+                Assert.True(instancesContainsNetworkObject);
+                m_Instances.Remove(networkObject);
+                Destroy(networkObject.gameObject);
+            }
         }
 
         public bool StillHasInstances()
@@ -272,17 +318,29 @@ namespace Unity.Netcode.RuntimeTests
             return (m_Instances.Count > 0);
         }
 
-        public NetworkPrefabInstanceHandler(NetworkObject networkObject)
+        private void OnDestroy()
         {
+            if (m_NetworkManager != null)
+            {
+                m_NetworkManager.PrefabHandler.RemoveHandler(m_NetworkObject);
+            }
+            m_Instances.Clear();
+            m_Instances = null;
+        }
+
+        public void Initialize(NetworkManager networkManager, NetworkObject networkObject)
+        {
+            m_NetworkManager = networkManager;
             m_NetworkObject = networkObject;
             m_Instances = new List<NetworkObject>();
+            networkManager.PrefabHandler.AddHandler(networkObject, this);
         }
     }
 
     /// <summary>
     /// Causes an exception during client connection
     /// </summary>
-    internal class NetworkPrefabExceptionThrower : INetworkPrefabInstanceHandler
+    internal class NetworkPrefabExceptionThrower : MonoBehaviour, INetworkPrefabInstanceHandler
     {
         public NetworkObject Instantiate(ulong ownerClientId, Vector3 position, Quaternion rotation)
         {
@@ -291,7 +349,7 @@ namespace Unity.Netcode.RuntimeTests
 
         public void Destroy(NetworkObject networkObject)
         {
-            UnityEngine.Object.Destroy(networkObject.gameObject);
+            Destroy(networkObject.gameObject);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/NetworkPrefabHandlerTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/NetworkPrefabHandlerTests.cs
@@ -258,10 +258,7 @@ namespace Unity.Netcode.RuntimeTests
 
         private void OnDestroy()
         {
-            if (m_NetworkManager != null)
-            {
-                m_NetworkManager.PrefabHandler.RemoveHandler(m_NetworkObject);
-            }
+            m_NetworkManager?.PrefabHandler.RemoveHandler(m_NetworkObject);
             m_Instances.Clear();
             m_Instances = null;
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/NetworkPrefabHandlerTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/NetworkPrefabHandlerTests.cs
@@ -79,20 +79,20 @@ namespace Unity.Netcode.RuntimeTests
             // This would be the scenario that a hash would be used (typically when scene management is disabled)
             validPrefabForSourceHash.InScenePlaced = true;
 
-            var networkPrefab = authority.NetworkConfig.Prefabs.InternalPrefabs[authority.NetworkConfig.Prefabs.InternalPrefabs.Count - 1];
+            var networkPrefab = authority.NetworkConfig.Prefabs.GetLastRegisteredPrefab();
             networkPrefab.SourceHashToOverride = validPrefabForSourceHash.GlobalObjectIdHash;
             networkPrefab.OverridingTargetPrefab = validPrefabAsset.gameObject;
             networkPrefab.Override = NetworkPrefabOverride.Hash;
-            authority.NetworkConfig.Prefabs.InternalPrefabs[authority.NetworkConfig.Prefabs.InternalPrefabs.Count - 1] = networkPrefab;
+            Assert.True(authority.NetworkConfig.Prefabs.AssignPrefabAtIndex(authority.NetworkConfig.Prefabs.Prefabs.Count - 1, networkPrefab), $"Failed to assign network prefab!");
 
             var sourcePrefab = MakeValidNetworkPrefab();
-            networkPrefab = authority.NetworkConfig.Prefabs.InternalPrefabs[authority.NetworkConfig.Prefabs.InternalPrefabs.Count - 1];
+            networkPrefab = authority.NetworkConfig.Prefabs.GetLastRegisteredPrefab();
             var index = authority.NetworkConfig.Prefabs.Prefabs.Count - 1;
             var targetPrefab = MakeValidNetworkPrefab();
             networkPrefab.Prefab = sourcePrefab;
             networkPrefab.SourcePrefabToOverride = sourcePrefab;
             networkPrefab.OverridingTargetPrefab = targetPrefab;
-            authority.NetworkConfig.Prefabs.InternalPrefabs[index] = networkPrefab;
+            Assert.True(authority.NetworkConfig.Prefabs.AssignPrefabAtIndex(index, networkPrefab), $"Failed to assign network prefab!");
 
             m_CanStart = true;
             yield return StartServerAndClients();
@@ -100,8 +100,6 @@ namespace Unity.Netcode.RuntimeTests
             // In the end we should only have 3 valid registered network prefabs
             Assert.AreEqual(5, authority.NetworkConfig.Prefabs.NetworkPrefabOverrideLinks.Count);
         }
-
-        private const string k_PrefabObjectName = "NetworkPrefabHandlerTestObject";
 
 
         [UnityTest]

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/NetworkPrefabHandlerTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/NetworkPrefabHandlerTests.cs
@@ -28,11 +28,22 @@ namespace Unity.Netcode.RuntimeTests
         private uint m_ObjectId = 1;
         private GameObject MakeValidNetworkPrefab()
         {
-            Guid baseObjectID = NetworkManagerHelper.AddGameNetworkObject(k_TestPrefabObjectName + m_ObjectId.ToString());
-            NetworkObject validPrefab = NetworkManagerHelper.InstantiatedNetworkObjects[baseObjectID];
-            NetcodeIntegrationTestHelpers.MakeNetworkObjectTestPrefab(validPrefab);
+            return GenerateAndRegisterPrefab();
+            //Guid baseObjectID = NetworkManagerHelper.AddGameNetworkObject(k_TestPrefabObjectName + m_ObjectId.ToString());
+            //NetworkObject validPrefab = NetworkManagerHelper.InstantiatedNetworkObjects[baseObjectID];
+            //NetcodeIntegrationTestHelpers.MakeNetworkObjectTestPrefab(validPrefab);
+            //m_ObjectId++;
+            //return validPrefab.gameObject;
+        }
+
+        private GameObject GenerateAndRegisterPrefab()
+        {
+            // We must migrate this into the DDOL to avoid being
+            var originalPrefabInstance = NetcodeIntegrationTestHelpers.CreateNetworkObject(k_TestPrefabObjectName + m_ObjectId.ToString());
+            // Make it a prefab
+            NetcodeIntegrationTestHelpers.MakeNetworkObjectTestPrefab(originalPrefabInstance.GetComponent<NetworkObject>());
             m_ObjectId++;
-            return validPrefab.gameObject;
+            return originalPrefabInstance;
         }
 
 
@@ -63,14 +74,23 @@ namespace Unity.Netcode.RuntimeTests
             // Add a NetworkPrefab override with an invalid source prefab to override
             NetworkManagerHelper.NetworkManagerObject.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Prefab, SourcePrefabToOverride = null });
 
-            // Add a NetworkPrefab override with a valid source prefab to override but an invalid target prefab
-            NetworkManagerHelper.NetworkManagerObject.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Prefab, SourcePrefabToOverride = MakeValidNetworkPrefab(), OverridingTargetPrefab = null });
 
-            // Add a valid prefab
-            NetworkManagerHelper.NetworkManagerObject.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Prefab = MakeValidNetworkPrefab() });
+            // Create a valid network prefab "asset".
+            var validPrefabAsset = MakeValidNetworkPrefab().GetComponent<NetworkObject>();
 
+            // Add a NetworkPrefab override with a valid source prefab to override but an invalid target prefab.
+            NetworkManagerHelper.NetworkManagerObject.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Prefab, SourcePrefabToOverride = validPrefabAsset.gameObject, OverridingTargetPrefab = null });
+
+            // Now add the valid asset as a network prefab with no override.
+            NetworkManagerHelper.NetworkManagerObject.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Prefab = validPrefabAsset.gameObject });
+
+            var validPrefabForSourceHash = MakeValidNetworkPrefab().GetComponent<NetworkObject>();
+            // This would be the scenario that a hash would be used (typically when scene management is disabled)
+            validPrefabForSourceHash.InScenePlaced = true;
+            
             // Add a NetworkPrefab override with a valid hash and valid target prefab
-            NetworkManagerHelper.NetworkManagerObject.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Hash, SourceHashToOverride = 11111111, OverridingTargetPrefab = MakeValidNetworkPrefab() });
+            NetworkManagerHelper.NetworkManagerObject.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Hash, SourceHashToOverride = validPrefabForSourceHash.GlobalObjectIdHash, OverridingTargetPrefab = validPrefabAsset.gameObject });
+
 
             // Add a NetworkPrefab override with a valid prefab and valid target prefab
             NetworkManagerHelper.NetworkManagerObject.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Prefab, SourcePrefabToOverride = MakeValidNetworkPrefab(), OverridingTargetPrefab = MakeValidNetworkPrefab() });
@@ -88,7 +108,7 @@ namespace Unity.Netcode.RuntimeTests
             Assert.False(exceptionOccurred);
 
             // In the end we should only have 3 valid registered network prefabs
-            Assert.True(NetworkManagerHelper.NetworkManagerObject.NetworkConfig.Prefabs.NetworkPrefabOverrideLinks.Count == 3);
+            Assert.AreEqual(3, NetworkManagerHelper.NetworkManagerObject.NetworkConfig.Prefabs.NetworkPrefabOverrideLinks.Count);
         }
 
         private const string k_PrefabObjectName = "NetworkPrefabHandlerTestObject";

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/NetworkPrefabHandlerTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/NetworkPrefabHandlerTests.cs
@@ -31,8 +31,6 @@ namespace Unity.Netcode.RuntimeTests
 
         private bool m_CanStart;
 
-
-
         protected override bool CanStartServerAndClients()
         {
             return m_CanStart;
@@ -42,26 +40,7 @@ namespace Unity.Netcode.RuntimeTests
         {
             m_ObjectId++;
             return CreateNetworkObjectPrefab(k_TestPrefabObjectName + m_ObjectId.ToString());
-
-            //return GenerateAndRegisterPrefab();
-            //Guid baseObjectID = NetworkManagerHelper.AddGameNetworkObject(k_TestPrefabObjectName + m_ObjectId.ToString());
-            //NetworkObject validPrefab = NetworkManagerHelper.InstantiatedNetworkObjects[baseObjectID];
-            //NetcodeIntegrationTestHelpers.MakeNetworkObjectTestPrefab(validPrefab);
-            //m_ObjectId++;
-            //return validPrefab.gameObject;
         }
-
-        private GameObject GenerateAndRegisterPrefab()
-        {
-            // We must migrate this into the DDOL to avoid being
-            var originalPrefabInstance = NetcodeIntegrationTestHelpers.CreateNetworkObject(k_TestPrefabObjectName + m_ObjectId.ToString());
-            // Make it a prefab
-            NetcodeIntegrationTestHelpers.MakeNetworkObjectTestPrefab(originalPrefabInstance.GetComponent<NetworkObject>());
-            m_ObjectId++;
-            return originalPrefabInstance;
-        }
-
-
 
         /// <summary>
         /// Tests the NetwokConfig NetworkPrefabsList initialization during NetworkManager's Init method to make sure that
@@ -90,15 +69,11 @@ namespace Unity.Netcode.RuntimeTests
             // Add a NetworkPrefab override with an invalid source prefab to override
             authority.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Prefab, SourcePrefabToOverride = null });
 
-
             // Create a valid network prefab "asset".
             var validPrefabAsset = MakeValidNetworkPrefab().GetComponent<NetworkObject>();
 
             // Add a NetworkPrefab override with a valid source prefab to override but an invalid target prefab.
             authority.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Prefab, SourcePrefabToOverride = validPrefabAsset.gameObject, OverridingTargetPrefab = null });
-
-            // Now add the valid asset as a network prefab with no override.
-            //authority.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Prefab = validPrefabAsset.gameObject });
 
             var validPrefabForSourceHash = MakeValidNetworkPrefab().GetComponent<NetworkObject>();
             // This would be the scenario that a hash would be used (typically when scene management is disabled)
@@ -110,8 +85,6 @@ namespace Unity.Netcode.RuntimeTests
             networkPrefab.Override = NetworkPrefabOverride.Hash;
             authority.NetworkConfig.Prefabs.InternalPrefabs[authority.NetworkConfig.Prefabs.InternalPrefabs.Count - 1] = networkPrefab;
 
-            // Add a NetworkPrefab override with a valid hash and valid target prefab
-            //authority.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Hash, SourceHashToOverride = validPrefabForSourceHash.GlobalObjectIdHash, OverridingTargetPrefab = validPrefabAsset.gameObject });
             var sourcePrefab = MakeValidNetworkPrefab();
             networkPrefab = authority.NetworkConfig.Prefabs.InternalPrefabs[authority.NetworkConfig.Prefabs.InternalPrefabs.Count - 1];
             var index = authority.NetworkConfig.Prefabs.Prefabs.Count - 1;
@@ -121,23 +94,8 @@ namespace Unity.Netcode.RuntimeTests
             networkPrefab.OverridingTargetPrefab = targetPrefab;
             authority.NetworkConfig.Prefabs.InternalPrefabs[index] = networkPrefab;
 
-            // Add a NetworkPrefab override with a valid prefab and valid target prefab
-            //authority.NetworkConfig.Prefabs.Add(new NetworkPrefab() { Override = NetworkPrefabOverride.Prefab, SourcePrefabToOverride = MakeValidNetworkPrefab(), OverridingTargetPrefab = MakeValidNetworkPrefab() });
-
             m_CanStart = true;
             yield return StartServerAndClients();
-
-            //var exceptionOccurred = false;
-            //try
-            //{
-            //    Assert.IsTrue(NetworkManagerHelper.StartNetworkManager(out var server, NetworkManagerHelper.NetworkManagerOperatingMode.Host, authority.NetworkConfig), "Failed to start host!");
-            //}
-            //catch
-            //{
-            //    exceptionOccurred = true;
-            //}
-
-            //Assert.False(exceptionOccurred);
 
             // In the end we should only have 3 valid registered network prefabs
             Assert.AreEqual(5, authority.NetworkConfig.Prefabs.NetworkPrefabOverrideLinks.Count);
@@ -256,31 +214,11 @@ namespace Unity.Netcode.RuntimeTests
             UnityEngine.Object.Destroy(prefabHandlerObject);
         }
 
-        //[SetUp]
-        //public void Setup()
-        //{
-        //    //Create, instantiate, and host
-        //    NetworkManagerHelper.StartNetworkManager(out _, NetworkManagerHelper.NetworkManagerOperatingMode.None);
-        //}
-
         protected override IEnumerator OnTearDown()
         {
             m_CanStart = false;
             return base.OnTearDown();
         }
-
-        //[TearDown]
-        //public void TearDown()
-        //{
-        //    //Stop, shutdown, and destroy
-        //    NetworkManagerHelper.ShutdownNetworkManager();
-        //    var networkObjects = FindObjects.ByType<NetworkObject>();
-        //    var networkObjectsList = networkObjects.Where(c => c.name.Contains(k_PrefabObjectName));
-        //    foreach (var networkObject in networkObjectsList)
-        //    {
-        //        UnityEngine.Object.DestroyImmediate(networkObject);
-        //    }
-        //}
     }
 
     /// <summary>
@@ -315,7 +253,7 @@ namespace Unity.Netcode.RuntimeTests
 
         public bool StillHasInstances()
         {
-            return (m_Instances.Count > 0);
+            return m_Instances.Count > 0;
         }
 
         private void OnDestroy()

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/NetworkPrefabHandlerWithDataTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/NetworkPrefabHandlerWithDataTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
 using UnityEngine.TestTools;
+using Object = UnityEngine.Object;
 
 namespace Unity.Netcode.RuntimeTests
 {
@@ -73,8 +74,6 @@ namespace Unity.Netcode.RuntimeTests
             yield return WaitForSpawnedOnAllOrTimeOut(spawned);
             AssertOnTimeout($"Not all clients spawned {spawned.name}!");
 
-
-
             // When running with Distributed Authority, test a late-joiner after an ownership change
             // The object owner will synchronize the late joining client, showing that the instantiationData will survive host migration.
             if (m_DistributedAuthority)
@@ -111,8 +110,8 @@ namespace Unity.Netcode.RuntimeTests
         private NetworkObject SpawnPrefabWithData(NetworkSerializableTest data)
         {
             var authority = GetAuthorityNetworkManager();
-            var instance = UnityEngine.Object.Instantiate(m_Prefab).GetComponent<NetworkObject>();
-            
+            var instance = Object.Instantiate(m_Prefab).GetComponent<NetworkObject>();
+
             GetAuthorityNetworkManager().PrefabHandler.SetInstantiationData(instance, data);
 
             SpawnObjectInstance(instance, authority);
@@ -137,12 +136,12 @@ namespace Unity.Netcode.RuntimeTests
             public override NetworkObject Instantiate(ulong ownerClientId, Vector3 position, Quaternion rotation, NetworkSerializableTest data)
             {
                 InstantiationData = data;
-                return UnityEngine.Object.Instantiate(m_Prefab, position, rotation).GetComponent<NetworkObject>();
+                return Object.Instantiate(m_Prefab, position, rotation).GetComponent<NetworkObject>();
             }
 
             public override void Destroy(NetworkObject networkObject)
             {
-                UnityEngine.Object.DestroyImmediate(networkObject.gameObject);
+                Object.DestroyImmediate(networkObject.gameObject);
             }
         }
 
@@ -158,7 +157,9 @@ namespace Unity.Netcode.RuntimeTests
             }
 
             public bool IsSynchronizedWith(NetworkSerializableTest other)
-                => Value == other.Value && Math.Abs(Value2 - other.Value2) < 0.0001f;
+            {
+                return Value == other.Value && Math.Abs(Value2 - other.Value2) < 0.0001f;
+            }
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/NetworkPrefabHandlerWithDataTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Prefabs/NetworkPrefabHandlerWithDataTests.cs
@@ -24,7 +24,7 @@ namespace Unity.Netcode.RuntimeTests
         protected override void OnServerAndClientsCreated()
         {
             // Creates a network object prefab and registers it to all clients.
-            m_Prefab = CreateNetworkObjectPrefab(k_TestPrefabObjectName).gameObject;
+            m_Prefab = CreateNetworkObjectPrefab(k_TestPrefabObjectName);
             var authority = GetAuthorityNetworkManager();
 
             m_ClientHandlers = new PrefabInstanceHandlerWithData[NumberOfClients];
@@ -67,8 +67,13 @@ namespace Unity.Netcode.RuntimeTests
             var data = new NetworkSerializableTest { Value = 42, Value2 = 2.71f };
             var spawned = SpawnPrefabWithData(data);
 
+            Debug.Log("Spawn");
             yield return WaitForConditionOrTimeOut(() => AllHandlersSynchronized(data));
             AssertOnTimeout("Not all handlers synchronized");
+            yield return WaitForSpawnedOnAllOrTimeOut(spawned);
+            AssertOnTimeout($"Not all clients spawned {spawned.name}!");
+
+
 
             // When running with Distributed Authority, test a late-joiner after an ownership change
             // The object owner will synchronize the late joining client, showing that the instantiationData will survive host migration.
@@ -88,7 +93,7 @@ namespace Unity.Netcode.RuntimeTests
                 });
                 AssertOnTimeout($"Timed out while waiting for Client-{newOwner.LocalClientId} to own object");
             }
-
+            Debug.Log("Late client...");
             // Late join a client
             yield return CreateAndStartNewClient();
 
@@ -105,9 +110,12 @@ namespace Unity.Netcode.RuntimeTests
 
         private NetworkObject SpawnPrefabWithData(NetworkSerializableTest data)
         {
+            var authority = GetAuthorityNetworkManager();
             var instance = UnityEngine.Object.Instantiate(m_Prefab).GetComponent<NetworkObject>();
+            
             GetAuthorityNetworkManager().PrefabHandler.SetInstantiationData(instance, data);
-            instance.Spawn();
+
+            SpawnObjectInstance(instance, authority);
             return instance;
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Profiling/NetworkVariableNameTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Profiling/NetworkVariableNameTests.cs
@@ -1,41 +1,41 @@
-using System;
+using System.Collections;
 using NUnit.Framework;
 using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace Unity.Netcode.RuntimeTests
 {
-    internal sealed class NetworkVariableNameTests
+    internal class NetworkVariableNameTests : NetcodeIntegrationTest
     {
+        protected override int NumberOfClients => 1;
         private NetworkVariableNameComponent m_NetworkVariableNameComponent;
 
-        [OneTimeSetUp]
-        public void OneTimeSetup()
+        private GameObject m_PrefabToTest;
+
+        protected override void OnServerAndClientsCreated()
         {
-            // TODO: [CmbServiceTests] if this test is deemed needed to test against the CMB server then update this test.
-            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+            m_PrefabToTest = CreateNetworkObjectPrefab("NetVarNameTest");
+            m_PrefabToTest.AddComponent<NetworkVariableNameComponent>();
+            base.OnServerAndClientsCreated();
         }
 
-        [SetUp]
-        public void SetUp()
+        [UnityTest]
+        public IEnumerator VerifyNetworkVariableNameInitialization()
         {
-            NetworkManagerHelper.StartNetworkManager(out _);
+            var authority = GetAuthorityNetworkManager();
+            var authorityInstance = SpawnObject(m_PrefabToTest, authority);
+            var authorityNetworkObject = authorityInstance.GetComponent<NetworkVariableNameComponent>();
 
-            var gameObjectId = NetworkManagerHelper.AddGameNetworkObject(Guid.NewGuid().ToString());
-            m_NetworkVariableNameComponent = NetworkManagerHelper.AddComponentToObject<NetworkVariableNameComponent>(gameObjectId);
-            NetworkManagerHelper.SpawnNetworkObject(gameObjectId);
-        }
+            yield return WaitForSpawnedOnAllOrTimeOut(authorityInstance);
+            AssertOnTimeout($"Not all clients spawned {authorityInstance.name}!");
 
-        [TearDown]
-        public void TearDown()
-        {
-            NetworkManagerHelper.ShutdownNetworkManager();
-        }
-
-        [Test]
-        public void VerifyNetworkVariableNameInitialization()
-        {
-            // Fields have regular naming
-            Assert.AreEqual(nameof(NetworkVariableNameComponent.NetworkVarList), m_NetworkVariableNameComponent.NetworkVarList.Name);
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                var componentInstance = networkManager.SpawnManager.SpawnedObjects[authorityNetworkObject.NetworkObjectId].GetComponent<NetworkVariableNameComponent>();
+                // Verify fields have regular naming
+                Assert.AreEqual(nameof(NetworkVariableNameComponent.NetworkVarList), componentInstance.NetworkVarList.Name);
+            }
         }
 
         private class NetworkVariableNameComponent : NetworkBehaviour

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Rpc/RpcQueueTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Rpc/RpcQueueTests.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections;
-using NUnit.Framework;
 using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -13,62 +11,47 @@ namespace Unity.Netcode.RuntimeTests
     ///     - That all RPCs invoke at the appropriate `NetworkUpdateStage` (Client and Server)
     ///     - A lower level `MessageQueueContainer` test that validates `MessageQueueFrameItems` after they have been put into the queue
     /// </summary>
-    internal class RpcQueueTests
+    internal class RpcQueueTests : NetcodeIntegrationTest
     {
-        [OneTimeSetUp]
-        public void OneTimeSetup()
+        protected override int NumberOfClients => 0;
+
+        private GameObject m_TestPrefab;
+
+        protected override void OnOneTimeSetup()
         {
             // TODO: [CmbServiceTests] if this test is deemed needed to test against the CMB server then update this test.
             NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+            base.OnOneTimeSetup();
         }
 
-        [SetUp]
-        public void Setup()
+        protected override void OnServerAndClientsCreated()
         {
-            // Create, instantiate, and host
-            Assert.IsTrue(NetworkManagerHelper.StartNetworkManager(out _));
+            m_TestPrefab = CreateNetworkObjectPrefab("RpcQueueTest");
+            m_TestPrefab.AddComponent<BufferDataValidationComponent>();
+            base.OnServerAndClientsCreated();
         }
 
         /// <summary>
         /// This tests the RPC Queue outbound and inbound buffer capabilities.
         /// </summary>
         /// <returns>IEnumerator</returns>
-        [UnityTest, Order(2)]
+        [UnityTest]
         public IEnumerator BufferDataValidation()
         {
-            Guid gameObjectId = NetworkManagerHelper.AddGameNetworkObject("GrowingBufferObject");
+            var authority = GetAuthorityNetworkManager();
+            var instance = SpawnObject(m_TestPrefab, authority);
 
-            var growingRpcBufferSizeComponent = NetworkManagerHelper.AddComponentToObject<BufferDataValidationComponent>(gameObjectId);
+            yield return WaitForSpawnedOnAllOrTimeOut(instance);
+            AssertOnTimeout($"Not all clients spawned {instance.name}!");
 
-            NetworkManagerHelper.SpawnNetworkObject(gameObjectId);
+            var bufferDataValidationComponent = instance.GetComponent<BufferDataValidationComponent>();
 
             // Start Testing
-            growingRpcBufferSizeComponent.EnableTesting = true;
+            bufferDataValidationComponent.EnableTesting = true;
 
-            var testsAreComplete = growingRpcBufferSizeComponent.IsTestComplete();
+            yield return WaitForConditionOrTimeOut(() => bufferDataValidationComponent.IsTestComplete());
+            AssertOnTimeout($"Timed out waiting for the {nameof(BufferDataValidationComponent)} tests to complete!");
 
-            // Wait for the RPC pipeline test to complete or if we exceeded the maximum iterations bail
-            while (!testsAreComplete)
-            {
-                yield return new WaitForSeconds(0.003f);
-
-                testsAreComplete = growingRpcBufferSizeComponent.IsTestComplete();
-            }
-
-            // Stop Testing
-            growingRpcBufferSizeComponent.EnableTesting = false;
-
-            // Just disable this once we are done.
-            growingRpcBufferSizeComponent.gameObject.SetActive(false);
-
-            Assert.IsTrue(testsAreComplete);
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            // Stop, shutdown, and destroy
-            NetworkManagerHelper.ShutdownNetworkManager();
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/BaseReferenceTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/BaseReferenceTests.cs
@@ -1,0 +1,373 @@
+using System.Collections;
+using System.Runtime.CompilerServices;
+using System.Text;
+using NUnit.Framework;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine;
+
+
+namespace Unity.Netcode.RuntimeTests
+{
+    [TestFixture(HostOrServer.DAHost)]
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    internal class BaseReferenceTests : NetcodeIntegrationTest
+    {
+        protected struct GroupedComponents
+        {
+            public GameObject GameObject;
+            public NetworkObject NetworkObject;
+            public TestNetworkBehaviour TestNetworkBehaviour;
+        }
+
+        protected override int NumberOfClients => 1;
+
+        protected GameObject m_TestPrefab;
+
+        protected GroupedComponents m_ValidatingInstance
+        {
+            get;
+            private set;
+        }
+        protected GroupedComponents m_ReferenceToUse
+        {
+            get;
+            private set;
+        }
+
+        public BaseReferenceTests(HostOrServer hostOrServer) : base(hostOrServer)
+        {
+        }
+
+        protected override void OnServerAndClientsCreated()
+        {
+            m_TestPrefab = CreateNetworkObjectPrefab("ReferenceTest");
+            m_TestPrefab.AddComponent<TestNetworkBehaviour>();
+            base.OnServerAndClientsCreated();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected GroupedComponents GetGroup(GameObject gameObject)
+        {
+            return new GroupedComponents()
+            {
+                GameObject = gameObject,
+                NetworkObject = gameObject.GetComponent<NetworkObject>(),
+                TestNetworkBehaviour = gameObject.GetComponent<TestNetworkBehaviour>()
+            };
+        }
+
+        protected IEnumerator SpawnTestPrefabInstance(bool spawnSingle = false)
+        {
+            var authority = GetAuthorityNetworkManager();
+            m_ValidatingInstance = GetGroup(SpawnObject(m_TestPrefab, authority));
+
+            yield return WaitForSpawnedOnAllOrTimeOut(m_ValidatingInstance.GameObject);
+            AssertOnTimeout($"[{GetType().Name}][Validating Instance] Faild to spawn {m_ValidatingInstance.GameObject.name} on all clients!");
+
+            if (!spawnSingle)
+            {
+                m_ReferenceToUse = GetGroup(SpawnObject(m_TestPrefab, authority));
+
+                yield return WaitForSpawnedOnAllOrTimeOut(m_ReferenceToUse.GameObject);
+                AssertOnTimeout($"[{GetType().Name}][Reference to use] Faild to spawn {m_ReferenceToUse.GameObject.name} on all clients!");
+            }
+        }
+
+        #region NetworkBehaviour specific conditional methods
+        protected bool RpcWasReceivedAndBehaviourValidated(StringBuilder stringBuilder)
+        {
+            var authorityValidatingId = m_ValidatingInstance.NetworkObject.NetworkObjectId;
+            var authorityReferenceId = m_ReferenceToUse.NetworkObject.NetworkObjectId;
+            var validatingNetworkObject = (NetworkObject)null;
+            var referenceNetworkObject = (NetworkObject)null;
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                if (networkManager.SpawnManager.SpawnedObjects.TryGetValue(authorityValidatingId, out validatingNetworkObject)
+                    && networkManager.SpawnManager.SpawnedObjects.TryGetValue(authorityReferenceId, out referenceNetworkObject))
+                {
+                    var validatingBehaviour = validatingNetworkObject.GetComponent<TestNetworkBehaviour>();
+                    var referenceBehaviour = referenceNetworkObject.GetComponent<TestNetworkBehaviour>();
+
+                    if (!validatingBehaviour.ReceivedRPC)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} has not received the RPC!");
+                        continue;
+                    }
+                    if (!validatingBehaviour.AcquiredReference)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} failed to acquire the reference!");
+                        continue;
+                    }
+                    if (referenceBehaviour != validatingBehaviour.RpcReceivedBehaviour)
+                    {
+                        var currentReferenceBehaviour = validatingBehaviour.RpcReceivedBehaviour != null ? validatingBehaviour.RpcReceivedBehaviour.name : "null";
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} expected behaviour reference {referenceBehaviour.name} but was {currentReferenceBehaviour}!");
+                    }
+                }
+                else
+                {
+                    var wasNotSpawned = validatingNetworkObject == null ? m_ValidatingInstance.GameObject.name : m_ReferenceToUse.GameObject.name;
+                    stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} has not yet spawned {wasNotSpawned}!");
+                }
+                validatingNetworkObject = null;
+                referenceNetworkObject = null;
+            }
+
+            return stringBuilder.Length == 0;
+        }
+
+        protected bool NetworkVariableChangedAndBehaviourValidated(StringBuilder stringBuilder)
+        {
+            var authorityValidatingId = m_ValidatingInstance.NetworkObject.NetworkObjectId;
+            var authorityReferenceId = m_ReferenceToUse.NetworkObject.NetworkObjectId;
+            var validatingNetworkObject = (NetworkObject)null;
+            var referenceNetworkObject = (NetworkObject)null;
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                if (networkManager.SpawnManager.SpawnedObjects.TryGetValue(authorityValidatingId, out validatingNetworkObject)
+                    && networkManager.SpawnManager.SpawnedObjects.TryGetValue(authorityReferenceId, out referenceNetworkObject))
+                {
+                    var validatingBehaviour = validatingNetworkObject.GetComponent<TestNetworkBehaviour>();
+                    var referenceBehaviour = referenceNetworkObject.GetComponent<TestNetworkBehaviour>();
+
+                    if (!validatingBehaviour.TestVariableChanged)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} has not received the NetworkVariable update!");
+                        continue;
+                    }
+                    if (!validatingBehaviour.AcquiredReference)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} failed to acquire a reference!");
+                        continue;
+                    }
+                    if (referenceBehaviour != validatingBehaviour.TestVariableBehaviour)
+                    {
+                        var currentReferenceBehaviour = validatingBehaviour.TestVariableBehaviour != null ? validatingBehaviour.RpcReceivedBehaviour.name : "null";
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} expected behaviour reference {referenceBehaviour.name} but was {currentReferenceBehaviour}!");
+                    }
+                }
+                else
+                {
+                    var wasNotSpawned = validatingNetworkObject == null ? m_ValidatingInstance.GameObject.name : m_ReferenceToUse.GameObject.name;
+                    stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} has not yet spawned {wasNotSpawned}!");
+                }
+                validatingNetworkObject = null;
+                referenceNetworkObject = null;
+            }
+            return stringBuilder.Length == 0;
+        }
+
+        protected bool RpcSerializingNullValidated(StringBuilder stringBuilder)
+        {
+            var authorityValidatingId = m_ValidatingInstance.NetworkObject.NetworkObjectId;
+            var validatingNetworkObject = (NetworkObject)null;
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                if (networkManager.SpawnManager.SpawnedObjects.TryGetValue(authorityValidatingId, out validatingNetworkObject))
+                {
+                    var validatingBehaviour = validatingNetworkObject.GetComponent<TestNetworkBehaviour>();
+
+                    if (!validatingBehaviour.ReceivedRPC)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} has not received the RPC!");
+                        continue;
+                    }
+                    if (validatingBehaviour.AcquiredReference)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} Acquired a reference when it should not have!");
+                        continue;
+                    }
+                    if (validatingBehaviour.RpcReceivedBehaviour != null)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} expected behaviour reference NULL but was {validatingBehaviour.RpcReceivedBehaviour.name}!");
+                    }
+                }
+                else
+                {
+                    stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} has not yet spawned {m_ValidatingInstance.GameObject.name}!");
+                }
+                validatingNetworkObject = null;
+            }
+            return stringBuilder.Length == 0;
+        }
+
+        protected bool NetworkVariableSerializingNullValidated(StringBuilder stringBuilder)
+        {
+            var authorityValidatingId = m_ValidatingInstance.NetworkObject.NetworkObjectId;
+            var validatingNetworkObject = (NetworkObject)null;
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                if (networkManager.SpawnManager.SpawnedObjects.TryGetValue(authorityValidatingId, out validatingNetworkObject))
+                {
+                    var validatingBehaviour = validatingNetworkObject.GetComponent<TestNetworkBehaviour>();
+
+                    if (!validatingBehaviour.TestVariableChanged)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} has not detected a change in the NetworkVariable!");
+                        continue;
+                    }
+                    if (validatingBehaviour.AcquiredReference)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} Acquired a reference when it should not have!");
+                        continue;
+                    }
+                    if (validatingBehaviour.TestVariableBehaviour != null)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} expected behaviour reference NULL but was {validatingBehaviour.TestVariableBehaviour.name}!");
+                    }
+                }
+                else
+                {
+                    stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} has not yet spawned {m_ValidatingInstance.GameObject.name}!");
+                }
+                validatingNetworkObject = null;
+            }
+            return stringBuilder.Length == 0;
+        }
+        #endregion
+
+        protected bool NetworkObjectSerializedValidation(StringBuilder stringBuilder)
+        {
+            var authorityValidatingId = m_ValidatingInstance.NetworkObject.NetworkObjectId;
+            var authorityReferenceId = m_ReferenceToUse.NetworkObject.NetworkObjectId;
+            var validatingNetworkObject = (NetworkObject)null;
+            var referenceNetworkObject = (NetworkObject)null;
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                if (networkManager.SpawnManager.SpawnedObjects.TryGetValue(authorityReferenceId, out referenceNetworkObject) &&
+                    networkManager.SpawnManager.SpawnedObjects.TryGetValue(authorityValidatingId, out validatingNetworkObject))
+                {
+                    var validatingBehaviour = validatingNetworkObject.GetComponent<TestNetworkBehaviour>();
+                    var referenceBehaviour = referenceNetworkObject.GetComponent<TestNetworkBehaviour>();
+
+                    if (!validatingBehaviour.AcquiredReference)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingNetworkObject.name} failed to acquire the reference!");
+                        continue;
+                    }
+                    if (referenceNetworkObject != validatingBehaviour.RpcReceivedNetworkObject)
+                    {
+                        var currentReferencedObject = validatingBehaviour.RpcReceivedNetworkObject != null ? validatingBehaviour.RpcReceivedNetworkObject.name : "null";
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} expected {nameof(NetworkObject)} reference " +
+                            $"{referenceNetworkObject.name} but was {currentReferencedObject}!");
+                    }
+                }
+                else
+                {
+                    var wasNotSpawned = validatingNetworkObject == null ? m_ValidatingInstance.GameObject.name : m_ReferenceToUse.GameObject.name;
+                    stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} has not yet spawned {wasNotSpawned}!");
+                }
+                validatingNetworkObject = null;
+                referenceNetworkObject = null;
+            }
+
+            return stringBuilder.Length == 0;
+        }
+
+        protected bool SerializingNullNetworkObjectValidated(StringBuilder stringBuilder)
+        {
+            var authorityValidatingId = m_ValidatingInstance.NetworkObject.NetworkObjectId;
+            var validatingNetworkObject = (NetworkObject)null;
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                if (networkManager.SpawnManager.SpawnedObjects.TryGetValue(authorityValidatingId, out validatingNetworkObject))
+                {
+                    var validatingBehaviour = validatingNetworkObject.GetComponent<TestNetworkBehaviour>();
+
+                    if (!validatingBehaviour.ReceivedRPC)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} has not received the RPC!");
+                        continue;
+                    }
+                    if (validatingBehaviour.AcquiredReference)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} Acquired a reference when it should not have!");
+                        continue;
+                    }
+                    if (validatingBehaviour.RpcReceivedNetworkObject != null)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} expected {nameof(NetworkObjectReference)} to be NULL but was {validatingBehaviour.RpcReceivedNetworkObject.name}!");
+                    }
+                }
+                else
+                {
+                    stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} has not yet spawned {m_ValidatingInstance.GameObject.name}!");
+                }
+                validatingNetworkObject = null;
+            }
+            return stringBuilder.Length == 0;
+        }
+
+
+        protected class TestNetworkBehaviour : NetworkBehaviour
+        {
+            public bool ReceivedRPC;
+            public bool TestVariableChanged;
+            public bool AcquiredReference;
+
+            public NetworkVariable<NetworkBehaviourReference> NetworkBehaviourVariable = new NetworkVariable<NetworkBehaviourReference>();
+
+            public TestNetworkBehaviour TestVariableBehaviour;
+
+            public TestNetworkBehaviour RpcReceivedBehaviour;
+            public TestNetworkBehaviour RpcReceived;
+
+            public NetworkVariable<NetworkObjectReference> NetworkObjectVariable = new NetworkVariable<NetworkObjectReference>();
+
+            public NetworkObject TestVariableNetworkObject;
+            public GameObject TestVariableGameObject;
+
+            public NetworkObject RpcReceivedNetworkObject;
+            public GameObject RpcReceivedGameObject;
+
+            protected override void OnNetworkPreSpawn(ref NetworkManager networkManager)
+            {
+                // Set it to ourself so we can validate serializing null too.
+                RpcReceivedBehaviour = this;
+                TestVariableBehaviour = null;
+                base.OnNetworkPreSpawn(ref networkManager);
+            }
+
+            public override void OnNetworkSpawn()
+            {
+                NetworkBehaviourVariable.OnValueChanged += OnTestVariableChanged;
+                NetworkObjectVariable.OnValueChanged += OnNetworkObjectVariableChanged;
+                base.OnNetworkSpawn();
+            }
+
+            public override void OnNetworkPreDespawn()
+            {
+                NetworkBehaviourVariable.OnValueChanged -= OnTestVariableChanged;
+                NetworkObjectVariable.OnValueChanged -= OnNetworkObjectVariableChanged;
+                base.OnNetworkPreDespawn();
+            }
+            private void OnTestVariableChanged(NetworkBehaviourReference previous, NetworkBehaviourReference current)
+            {
+                TestVariableChanged = true;
+                AcquiredReference = current.TryGet(out TestVariableBehaviour, NetworkManager);
+            }
+
+            private void OnNetworkObjectVariableChanged(NetworkObjectReference previous, NetworkObjectReference current)
+            {
+                TestVariableChanged = true;
+                AcquiredReference = current.TryGet(out TestVariableNetworkObject, NetworkManager);
+            }
+
+            [Rpc(SendTo.Everyone)]
+            public void SendNetworkBehaviourReferenceRpc(NetworkBehaviourReference value)
+            {
+                AcquiredReference = value.TryGet(out RpcReceivedBehaviour, NetworkManager);
+                ReceivedRPC = true;
+            }
+
+            [Rpc(SendTo.Everyone)]
+            public void SendNetworkObjectReferenceRpc(NetworkObjectReference value)
+            {
+                ReceivedRPC = true;
+                AcquiredReference = value.TryGet(out RpcReceivedNetworkObject, NetworkManager);
+                RpcReceivedGameObject = value;
+            }
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/BaseReferenceTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/BaseReferenceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 87bdaa820aaed704f8309de710e9153f

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/NetworkBehaviourReferenceTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/NetworkBehaviourReferenceTests.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Text;
 using NUnit.Framework;
 using Unity.Netcode.TestHelpers.Runtime;
-using UnityEngine;
 using UnityEngine.TestTools;
 using Object = UnityEngine.Object;
 
@@ -12,95 +9,25 @@ namespace Unity.Netcode.RuntimeTests
 {
     /// <summary>
     /// Unit tests to test:
-    /// - Serializing NetworkObject to NetworkObjectReference
-    /// - Deserializing NetworkObjectReference to NetworkObject
-    /// - Implicit operators of NetworkObjectReference
+    /// - Serializing NetworkBehaviour to NetworkBehaviourReference
+    /// - Deserializing NetworkBehaviourReference to NetworkBehaviour
+    /// - Implicit operators of NetworkBehaviourReference
     /// </summary>
-    [TestFixture(HostOrServer.DAHost)]
-    [TestFixture(HostOrServer.Host)]
-    [TestFixture(HostOrServer.Server)]
-    internal class NetworkBehaviourReferenceTests : NetcodeIntegrationTest
+    internal class NetworkBehaviourReferenceTests : BaseReferenceTests
     {
-        protected override int NumberOfClients => 1;
-
-        private GameObject m_TestPrefab;
-
-        private TestNetworkBehaviour m_AuthorityValidatingInstance;
-        private TestNetworkBehaviour m_BehaviourToUseAsReference;
-
         public NetworkBehaviourReferenceTests(HostOrServer hostOrServer) : base(hostOrServer)
         {
         }
 
-        protected override void OnServerAndClientsCreated()
-        {
-            m_TestPrefab = CreateNetworkObjectPrefab("TestBehaviour");
-            m_TestPrefab.AddComponent<TestNetworkBehaviour>();
-            base.OnServerAndClientsCreated();
-        }
-
         #region Tests using non-null NetworkBehaviours and RPCs
-        private bool RpcWasReceivedAndBehaviourValidated(StringBuilder stringBuilder)
-        {
-            var authorityValidatingId = m_AuthorityValidatingInstance.NetworkObjectId;
-            var authorityReferenceId = m_BehaviourToUseAsReference.NetworkObjectId;
-            var validatingNetworkObject = (NetworkObject)null;
-            var referenceNetworkObject = (NetworkObject)null;
-            foreach (var networkManager in m_NetworkManagers)
-            {
-                if (networkManager.SpawnManager.SpawnedObjects.TryGetValue(authorityValidatingId, out validatingNetworkObject)
-                    && networkManager.SpawnManager.SpawnedObjects.TryGetValue(authorityReferenceId, out referenceNetworkObject))
-                {
-                    var validatingBehaviour = validatingNetworkObject.GetComponent<TestNetworkBehaviour>();
-                    var referenceBehaviour = referenceNetworkObject.GetComponent<TestNetworkBehaviour>();
-
-                    if (!validatingBehaviour.ReceivedRPC)
-                    {
-                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} has not received the RPC!");
-                        continue;
-                    }
-                    if (!validatingBehaviour.AcquiredReference)
-                    {
-                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} failed to acquire the reference!");
-                        continue;
-                    }
-                    if (referenceBehaviour != validatingBehaviour.RpcReceivedBehaviour)
-                    {
-                        var currentReferenceBehaviour = validatingBehaviour.RpcReceivedBehaviour != null ? validatingBehaviour.RpcReceivedBehaviour.name : "null";
-                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} expected behaviour reference {referenceBehaviour.name} but was {currentReferenceBehaviour}!");
-                    }
-                }
-                else
-                {
-                    var wasNotSpawned = validatingNetworkObject == null ? m_AuthorityValidatingInstance.name : m_BehaviourToUseAsReference.name;
-                    stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} has not yet spawned {wasNotSpawned}!");
-                }
-                validatingNetworkObject = null;
-                referenceNetworkObject = null;
-            }
-
-            return stringBuilder.Length == 0;
-        }
-
 
         [UnityTest]
         public IEnumerator TestRpc()
         {
-            var authority = GetAuthorityNetworkManager();
-            m_AuthorityValidatingInstance = SpawnObject(m_TestPrefab, authority).GetComponent<TestNetworkBehaviour>();
-            m_BehaviourToUseAsReference = SpawnObject(m_TestPrefab, authority).GetComponent<TestNetworkBehaviour>();
-            var objectsToSpawn = new List<NetworkObject>()
-            {
-                m_AuthorityValidatingInstance.NetworkObject,
-                m_BehaviourToUseAsReference.NetworkObject
-            };
-
-            // Spawn the instances
-            yield return WaitForSpawnedOnAllOrTimeOut(objectsToSpawn);
-            AssertOnTimeout($"[{nameof(TestSerializeNull)}] Not all clients spawned all instances of {m_AuthorityValidatingInstance.name} or {m_BehaviourToUseAsReference.name}");
+            yield return SpawnTestPrefabInstance();
 
             // Explicitly send the NetworkBehaviour as a reference
-            m_AuthorityValidatingInstance.SendReferenceRpc(new NetworkBehaviourReference(m_BehaviourToUseAsReference));
+            m_ValidatingInstance.TestNetworkBehaviour.SendNetworkBehaviourReferenceRpc(new NetworkBehaviourReference(m_ReferenceToUse.TestNetworkBehaviour));
 
             // Validated the reference
             yield return WaitForConditionOrTimeOut(RpcWasReceivedAndBehaviourValidated);
@@ -111,21 +38,10 @@ namespace Unity.Netcode.RuntimeTests
         [UnityTest]
         public IEnumerator TestRpcImplicitNetworkBehaviour()
         {
-            var authority = GetAuthorityNetworkManager();
-            m_AuthorityValidatingInstance = SpawnObject(m_TestPrefab, authority).GetComponent<TestNetworkBehaviour>();
-            m_BehaviourToUseAsReference = SpawnObject(m_TestPrefab, authority).GetComponent<TestNetworkBehaviour>();
-            var objectsToSpawn = new List<NetworkObject>()
-            {
-                m_AuthorityValidatingInstance.NetworkObject,
-                m_BehaviourToUseAsReference.NetworkObject
-            };
-
-            // Spawn the instances
-            yield return WaitForSpawnedOnAllOrTimeOut(objectsToSpawn);
-            AssertOnTimeout($"[{nameof(TestSerializeNull)}] Not all clients spawned all instances of {m_AuthorityValidatingInstance.name} or {m_BehaviourToUseAsReference.name}");
+            yield return SpawnTestPrefabInstance();
 
             // Implicitly send the NetworkBehaviour as a reference
-            m_AuthorityValidatingInstance.SendReferenceRpc(m_BehaviourToUseAsReference);
+            m_ValidatingInstance.TestNetworkBehaviour.SendNetworkBehaviourReferenceRpc(m_ReferenceToUse.TestNetworkBehaviour);
 
             // Validated the reference
             yield return WaitForConditionOrTimeOut(RpcWasReceivedAndBehaviourValidated);
@@ -134,187 +50,73 @@ namespace Unity.Netcode.RuntimeTests
         #endregion
 
         #region Tests using non-null NetworkBehaviours and NetworkVariable
-        private bool NetworkVariableChangedAndBehaviourValidated(StringBuilder stringBuilder)
-        {
-            var authorityValidatingId = m_AuthorityValidatingInstance.NetworkObjectId;
-            var authorityReferenceId = m_BehaviourToUseAsReference.NetworkObjectId;
-            var validatingNetworkObject = (NetworkObject)null;
-            var referenceNetworkObject = (NetworkObject)null;
-            foreach (var networkManager in m_NetworkManagers)
-            {
-                if (networkManager.SpawnManager.SpawnedObjects.TryGetValue(authorityValidatingId, out validatingNetworkObject)
-                    && networkManager.SpawnManager.SpawnedObjects.TryGetValue(authorityReferenceId, out referenceNetworkObject))
-                {
-                    var validatingBehaviour = validatingNetworkObject.GetComponent<TestNetworkBehaviour>();
-                    var referenceBehaviour = referenceNetworkObject.GetComponent<TestNetworkBehaviour>();
-
-                    if (!validatingBehaviour.TestVariableChanged)
-                    {
-                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} has not received the NetworkVariable update!");
-                        continue;
-                    }
-                    if (!validatingBehaviour.AcquiredReference)
-                    {
-                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} failed to acquire a reference!");
-                        continue;
-                    }
-                    if (referenceBehaviour != validatingBehaviour.TestVariableBehaviour)
-                    {
-                        var currentReferenceBehaviour = validatingBehaviour.TestVariableBehaviour != null ? validatingBehaviour.RpcReceivedBehaviour.name : "null";
-                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} expected behaviour reference {referenceBehaviour.name} but was {currentReferenceBehaviour}!");
-                    }
-                }
-                else
-                {
-                    var wasNotSpawned = validatingNetworkObject == null ? m_AuthorityValidatingInstance.name : m_BehaviourToUseAsReference.name;
-                    stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} has not yet spawned {wasNotSpawned}!");
-                }
-                validatingNetworkObject = null;
-                referenceNetworkObject = null;
-            }
-            return stringBuilder.Length == 0;
-        }
-
-
         [UnityTest]
         public IEnumerator TestNetworkVariable()
         {
-            var authority = GetAuthorityNetworkManager();
-            m_AuthorityValidatingInstance = SpawnObject(m_TestPrefab, authority).GetComponent<TestNetworkBehaviour>();
-            m_BehaviourToUseAsReference = SpawnObject(m_TestPrefab, authority).GetComponent<TestNetworkBehaviour>();
-            var objectsToSpawn = new List<NetworkObject>()
-            {
-                m_AuthorityValidatingInstance.NetworkObject,
-                m_BehaviourToUseAsReference.NetworkObject
-            };
-
-            // Spawn the instances
-            yield return WaitForSpawnedOnAllOrTimeOut(objectsToSpawn);
-            AssertOnTimeout($"[{nameof(TestSerializeNull)}] Not all clients spawned all instances of {m_AuthorityValidatingInstance.name} or {m_BehaviourToUseAsReference.name}");
+            yield return SpawnTestPrefabInstance();
 
             // Assure the authority instance's value is the default (null) value
-            Assert.IsNull((NetworkBehaviour)m_AuthorityValidatingInstance.TestVariable.Value);
+            Assert.IsNull((NetworkBehaviour)m_ValidatingInstance.TestNetworkBehaviour.NetworkBehaviourVariable.Value);
 
             // Implicitly assign the NetworkBehaviourReference by assigning the NetworkBehaviour to the NetworkVariable.
-            m_AuthorityValidatingInstance.TestVariable.Value = m_BehaviourToUseAsReference;
+            m_ValidatingInstance.TestNetworkBehaviour.NetworkBehaviourVariable.Value = m_ReferenceToUse.TestNetworkBehaviour;
 
             // Validated the NetworkVariable reference propogates to clients
             yield return WaitForConditionOrTimeOut(NetworkVariableChangedAndBehaviourValidated);
-            AssertOnTimeout($"[{nameof(TestRpc)}] Failed to validate reference!");
+            AssertOnTimeout($"[{nameof(TestNetworkVariable)}] Failed to validate reference!");
         }
         #endregion
 
         #region Validating using NULL as a NetworkBehaviourReference
-        private bool RpcSerializingNullValidated(StringBuilder stringBuilder)
-        {
-            var authorityValidatingId = m_AuthorityValidatingInstance.NetworkObjectId;
-            var validatingNetworkObject = (NetworkObject)null;
-            foreach (var networkManager in m_NetworkManagers)
-            {
-                if (networkManager.SpawnManager.SpawnedObjects.TryGetValue(authorityValidatingId, out validatingNetworkObject))
-                {
-                    var validatingBehaviour = validatingNetworkObject.GetComponent<TestNetworkBehaviour>();
-
-                    if (!validatingBehaviour.ReceivedRPC)
-                    {
-                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} has not received the RPC!");
-                        continue;
-                    }
-                    if (validatingBehaviour.AcquiredReference)
-                    {
-                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} Acquired a reference when it should not have!");
-                        continue;
-                    }
-                    if (validatingBehaviour.RpcReceivedBehaviour != null)
-                    {
-                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} expected behaviour reference NULL but was {validatingBehaviour.RpcReceivedBehaviour.name}!");
-                    }
-                }
-                else
-                {
-                    stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} has not yet spawned {m_AuthorityValidatingInstance.name}!");
-                }
-                validatingNetworkObject = null;
-            }
-            return stringBuilder.Length == 0;
-        }
-
-        private bool NetworkVariableSerializingNullValidated(StringBuilder stringBuilder)
-        {
-            var authorityValidatingId = m_AuthorityValidatingInstance.NetworkObjectId;
-            var validatingNetworkObject = (NetworkObject)null;
-            foreach (var networkManager in m_NetworkManagers)
-            {
-                if (networkManager.SpawnManager.SpawnedObjects.TryGetValue(authorityValidatingId, out validatingNetworkObject))
-                {
-                    var validatingBehaviour = validatingNetworkObject.GetComponent<TestNetworkBehaviour>();
-
-                    if (!validatingBehaviour.TestVariableChanged)
-                    {
-                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} has not detected a change in the NetworkVariable!");
-                        continue;
-                    }
-                    if (validatingBehaviour.AcquiredReference)
-                    {
-                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} Acquired a reference when it should not have!");
-                        continue;
-                    }
-                    if (validatingBehaviour.TestVariableBehaviour != null)
-                    {
-                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} expected behaviour reference NULL but was {validatingBehaviour.TestVariableBehaviour.name}!");
-                    }
-                }
-                else
-                {
-                    stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} has not yet spawned {m_AuthorityValidatingInstance.name}!");
-                }
-                validatingNetworkObject = null;
-            }
-            return stringBuilder.Length == 0;
-        }
-
-
         [UnityTest]
         public IEnumerator TestSerializeNull()
         {
-            var authority = GetAuthorityNetworkManager();
-            m_AuthorityValidatingInstance = SpawnObject(m_TestPrefab, authority).GetComponent<TestNetworkBehaviour>();
-            yield return WaitForSpawnedOnAllOrTimeOut(m_AuthorityValidatingInstance.gameObject);
-            AssertOnTimeout($"[{nameof(TestSerializeNull)}] Not all clients spawned {m_AuthorityValidatingInstance.name}");
+            yield return SpawnTestPrefabInstance(true);
+
             // Initialize with NULL parameter
             var initializeWithNull = new NetworkBehaviourReference(null);
+            // Initialize with no parameter
             var initializeWithNothing = new NetworkBehaviourReference();
 
-            m_AuthorityValidatingInstance.SendReferenceRpc(initializeWithNull);
+            // Initialized with NULL parameter
+            // Explicitly send the NetworkBehaviour as a reference
+            m_ValidatingInstance.TestNetworkBehaviour.SendNetworkBehaviourReferenceRpc(initializeWithNull);
+
+            // Validated the reference
             yield return WaitForConditionOrTimeOut(RpcSerializingNullValidated);
-            AssertOnTimeout($"[{nameof(TestSerializeNull)}][Initialize with null parameter] Failed to validate null {nameof(NetworkBehaviour)} reference!");
+            AssertOnTimeout($"[{nameof(TestRpc)}] Failed to validate reference!");
 
             // Reset the RPC NetworkBehaviourReference to the local instance for all spawned instances.
             foreach (var networkManager in m_NetworkManagers)
             {
-                var testBehaviour = networkManager.SpawnManager.SpawnedObjects[m_AuthorityValidatingInstance.NetworkObjectId].GetComponent<TestNetworkBehaviour>();
+                var testBehaviour = networkManager.SpawnManager.SpawnedObjects[m_ValidatingInstance.NetworkObject.NetworkObjectId].GetComponent<TestNetworkBehaviour>();
                 testBehaviour.RpcReceivedBehaviour = testBehaviour;
             }
 
-            // Initialize with no parameter
-            m_AuthorityValidatingInstance.SendReferenceRpc(initializeWithNothing);
-            yield return WaitForConditionOrTimeOut(RpcSerializingNullValidated);
-            AssertOnTimeout($"[{nameof(TestSerializeNull)}][Initialize with no parameter] Failed to validate null {nameof(NetworkBehaviour)} reference!");
+            // Initialized with no parameter
+            // Explicitly send the NetworkBehaviour as a reference
+            m_ValidatingInstance.TestNetworkBehaviour.SendNetworkBehaviourReferenceRpc(initializeWithNothing);
 
-            m_AuthorityValidatingInstance.TestVariable.Value = initializeWithNull;
+            // Validated the reference
+            yield return WaitForConditionOrTimeOut(RpcSerializingNullValidated);
+            AssertOnTimeout($"[{nameof(TestRpc)}] Failed to validate reference!");
+
+
+            // Initialize NetworkBehaviourVariable with NULL parameter
+            m_ValidatingInstance.TestNetworkBehaviour.NetworkBehaviourVariable.Value = initializeWithNull;
             yield return WaitForConditionOrTimeOut(NetworkVariableSerializingNullValidated);
             AssertOnTimeout($"[{nameof(TestSerializeNull)}][Initialize with null parameter] Failed to validate null {nameof(NetworkBehaviour)} reference!");
 
             // Reset the NetworkVaraible NetworkBehaviourReference to the local instance for all spawned instances.
             foreach (var networkManager in m_NetworkManagers)
             {
-                var testBehaviour = networkManager.SpawnManager.SpawnedObjects[m_AuthorityValidatingInstance.NetworkObjectId].GetComponent<TestNetworkBehaviour>();
+                var testBehaviour = networkManager.SpawnManager.SpawnedObjects[m_ValidatingInstance.NetworkObject.NetworkObjectId].GetComponent<TestNetworkBehaviour>();
                 testBehaviour.TestVariableBehaviour = testBehaviour;
                 testBehaviour.TestVariableChanged = false;
             }
 
-            // Initialize with no parameter
-            m_AuthorityValidatingInstance.TestVariable.Value = initializeWithNothing;
+            // Initialize NetworkBehaviourVariable with no parameter
+            m_ValidatingInstance.TestNetworkBehaviour.NetworkBehaviourVariable.Value = initializeWithNothing;
             yield return WaitForConditionOrTimeOut(NetworkVariableSerializingNullValidated);
             AssertOnTimeout($"[{nameof(TestSerializeNull)}][Initialize with no parameter] Failed to validate null {nameof(NetworkBehaviour)} reference!");
         }
@@ -352,56 +154,6 @@ namespace Unity.Netcode.RuntimeTests
             });
 
             Object.Destroy(instance);
-        }
-
-        #endregion
-
-        #region TestNetworkBehaviour component script
-
-        private class TestNetworkBehaviour : NetworkBehaviour
-        {
-            public bool ReceivedRPC;
-            public bool TestVariableChanged;
-            public bool AcquiredReference;
-
-            public NetworkVariable<NetworkBehaviourReference> TestVariable = new NetworkVariable<NetworkBehaviourReference>();
-
-            public TestNetworkBehaviour TestVariableBehaviour;
-
-            public TestNetworkBehaviour RpcReceivedBehaviour;
-
-            protected override void OnNetworkPreSpawn(ref NetworkManager networkManager)
-            {
-                // Set it to ourself so we can validate serializing null too.
-                RpcReceivedBehaviour = this;
-                TestVariableBehaviour = null;
-                base.OnNetworkPreSpawn(ref networkManager);
-            }
-
-            public override void OnNetworkSpawn()
-            {
-                TestVariable.OnValueChanged += OnTestVariableChanged;
-                base.OnNetworkSpawn();
-            }
-
-            public override void OnNetworkPreDespawn()
-            {
-                TestVariable.OnValueChanged -= OnTestVariableChanged;
-                base.OnNetworkPreDespawn();
-            }
-
-            private void OnTestVariableChanged(NetworkBehaviourReference previous, NetworkBehaviourReference current)
-            {
-                TestVariableChanged = true;
-                AcquiredReference = current.TryGet(out TestVariableBehaviour, NetworkManager);
-            }
-
-            [Rpc(SendTo.Everyone)]
-            public void SendReferenceRpc(NetworkBehaviourReference value)
-            {
-                AcquiredReference = value.TryGet(out RpcReceivedBehaviour, NetworkManager);
-                ReceivedRPC = true;
-            }
         }
         #endregion
     }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/NetworkBehaviourReferenceTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/NetworkBehaviourReferenceTests.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Text;
 using NUnit.Framework;
 using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
 using UnityEngine.TestTools;
+using Object = UnityEngine.Object;
 
 namespace Unity.Netcode.RuntimeTests
 {
@@ -13,180 +16,394 @@ namespace Unity.Netcode.RuntimeTests
     /// - Deserializing NetworkObjectReference to NetworkObject
     /// - Implicit operators of NetworkObjectReference
     /// </summary>
-    internal class NetworkBehaviourReferenceTests : IDisposable
+    [TestFixture(HostOrServer.DAHost)]
+    [TestFixture(HostOrServer.Host)]
+    [TestFixture(HostOrServer.Server)]
+    internal class NetworkBehaviourReferenceTests : NetcodeIntegrationTest
     {
-        [OneTimeSetUp]
-        public void OneTimeSetup()
+        protected override int NumberOfClients => 1;
+
+        private GameObject m_TestPrefab;
+
+        private TestNetworkBehaviour m_AuthorityValidatingInstance;
+        private TestNetworkBehaviour m_BehaviourToUseAsReference;
+
+        public NetworkBehaviourReferenceTests(HostOrServer hostOrServer) : base(hostOrServer)
         {
-            // TODO: [CmbServiceTests] if this test is deemed needed to test against the CMB server then update this test.
-            NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
         }
 
-        private class TestNetworkBehaviour : NetworkBehaviour
+        protected override void OnServerAndClientsCreated()
         {
-            public static bool ReceivedRPC;
+            m_TestPrefab = CreateNetworkObjectPrefab("TestBehaviour");
+            m_TestPrefab.AddComponent<TestNetworkBehaviour>();
+            base.OnServerAndClientsCreated();
+        }
 
-            public NetworkVariable<NetworkBehaviourReference> TestVariable = new NetworkVariable<NetworkBehaviourReference>();
-
-            public TestNetworkBehaviour RpcReceivedBehaviour;
-
-            [ServerRpc]
-            public void SendReferenceServerRpc(NetworkBehaviourReference value)
+        #region Tests using non-null NetworkBehaviours and RPCs
+        private bool RpcWasReceivedAndBehaviourValidated(StringBuilder stringBuilder)
+        {
+            var authorityValidatingId = m_AuthorityValidatingInstance.NetworkObjectId;
+            var authorityReferenceId = m_BehaviourToUseAsReference.NetworkObjectId;
+            var validatingNetworkObject = (NetworkObject)null;
+            var referenceNetworkObject = (NetworkObject)null;
+            foreach (var networkManager in m_NetworkManagers)
             {
-                RpcReceivedBehaviour = (TestNetworkBehaviour)value;
-                ReceivedRPC = true;
+                if (networkManager.SpawnManager.SpawnedObjects.TryGetValue(authorityValidatingId, out validatingNetworkObject)
+                    && networkManager.SpawnManager.SpawnedObjects.TryGetValue(authorityReferenceId, out referenceNetworkObject))
+                {
+                    var validatingBehaviour = validatingNetworkObject.GetComponent<TestNetworkBehaviour>();
+                    var referenceBehaviour = referenceNetworkObject.GetComponent<TestNetworkBehaviour>();
+
+                    if (!validatingBehaviour.ReceivedRPC)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} has not received the RPC!");
+                        continue;
+                    }
+                    if (!validatingBehaviour.AcquiredReference)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} failed to acquire the reference!");
+                        continue;
+                    }
+                    if (referenceBehaviour != validatingBehaviour.RpcReceivedBehaviour)
+                    {
+                        var currentReferenceBehaviour = validatingBehaviour.RpcReceivedBehaviour != null ? validatingBehaviour.RpcReceivedBehaviour.name : "null";
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} expected behaviour reference {referenceBehaviour.name} but was {currentReferenceBehaviour}!");
+                    }
+                }
+                else
+                {
+                    var wasNotSpawned = validatingNetworkObject == null ? m_AuthorityValidatingInstance.name : m_BehaviourToUseAsReference.name;
+                    stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} has not yet spawned {wasNotSpawned}!");
+                }
+                validatingNetworkObject = null;
+                referenceNetworkObject = null;
             }
+
+            return stringBuilder.Length == 0;
         }
+
 
         [UnityTest]
         public IEnumerator TestRpc()
         {
-            using var networkObjectContext = UnityObjectContext.CreateNetworkObject();
-            var testNetworkBehaviour = networkObjectContext.Object.gameObject.AddComponent<TestNetworkBehaviour>();
-            networkObjectContext.Object.Spawn();
-
-            using var otherObjectContext = UnityObjectContext.CreateNetworkObject();
-            otherObjectContext.Object.Spawn();
-
-            testNetworkBehaviour.SendReferenceServerRpc(new NetworkBehaviourReference(testNetworkBehaviour));
-
-            // wait for rpc completion
-            float t = 0;
-            while (testNetworkBehaviour.RpcReceivedBehaviour == null)
+            var authority = GetAuthorityNetworkManager();
+            m_AuthorityValidatingInstance = SpawnObject(m_TestPrefab, authority).GetComponent<TestNetworkBehaviour>();
+            m_BehaviourToUseAsReference = SpawnObject(m_TestPrefab, authority).GetComponent<TestNetworkBehaviour>();
+            var objectsToSpawn = new List<NetworkObject>()
             {
-                t += Time.deltaTime;
-                if (t > 5f)
-                {
-                    new AssertionException("RPC with NetworkBehaviour reference hasn't been received");
-                }
+                m_AuthorityValidatingInstance.NetworkObject,
+                m_BehaviourToUseAsReference.NetworkObject
+            };
 
-                yield return null;
-            }
+            // Spawn the instances
+            yield return WaitForSpawnedOnAllOrTimeOut(objectsToSpawn);
+            AssertOnTimeout($"[{nameof(TestSerializeNull)}] Not all clients spawned all instances of {m_AuthorityValidatingInstance.name} or {m_BehaviourToUseAsReference.name}");
 
-            // validate
-            Assert.AreEqual(testNetworkBehaviour, testNetworkBehaviour.RpcReceivedBehaviour);
+            // Explicitly send the NetworkBehaviour as a reference
+            m_AuthorityValidatingInstance.SendReferenceRpc(new NetworkBehaviourReference(m_BehaviourToUseAsReference));
+
+            // Validated the reference
+            yield return WaitForConditionOrTimeOut(RpcWasReceivedAndBehaviourValidated);
+            AssertOnTimeout($"[{nameof(TestRpc)}] Failed to validate reference!");
         }
 
-        [UnityTest]
-        public IEnumerator TestSerializeNull([Values] bool initializeWithNull)
-        {
-            TestNetworkBehaviour.ReceivedRPC = false;
-            using var networkObjectContext = UnityObjectContext.CreateNetworkObject();
-            var testNetworkBehaviour = networkObjectContext.Object.gameObject.AddComponent<TestNetworkBehaviour>();
-            networkObjectContext.Object.Spawn();
-
-            using var otherObjectContext = UnityObjectContext.CreateNetworkObject();
-            otherObjectContext.Object.Spawn();
-
-            // If not initializing with null, then use the default constructor with no assigned NetworkBehaviour
-            if (!initializeWithNull)
-            {
-                testNetworkBehaviour.SendReferenceServerRpc(new NetworkBehaviourReference());
-            }
-            else // Otherwise, initialize and pass in null as the reference
-            {
-                testNetworkBehaviour.SendReferenceServerRpc(new NetworkBehaviourReference(null));
-            }
-
-            // wait for rpc completion
-            float t = 0;
-            while (!TestNetworkBehaviour.ReceivedRPC)
-            {
-                t += Time.deltaTime;
-                if (t > 5f)
-                {
-                    new AssertionException("RPC with NetworkBehaviour reference hasn't been received");
-                }
-
-                yield return null;
-            }
-
-            // validate
-            Assert.AreEqual(null, testNetworkBehaviour.RpcReceivedBehaviour);
-        }
 
         [UnityTest]
         public IEnumerator TestRpcImplicitNetworkBehaviour()
         {
-            using var networkObjectContext = UnityObjectContext.CreateNetworkObject();
-            var testNetworkBehaviour = networkObjectContext.Object.gameObject.AddComponent<TestNetworkBehaviour>();
-            networkObjectContext.Object.Spawn();
-
-            using var otherObjectContext = UnityObjectContext.CreateNetworkObject();
-            otherObjectContext.Object.Spawn();
-
-            testNetworkBehaviour.SendReferenceServerRpc(testNetworkBehaviour);
-
-            // wait for rpc completion
-            float t = 0;
-            while (testNetworkBehaviour.RpcReceivedBehaviour == null)
+            var authority = GetAuthorityNetworkManager();
+            m_AuthorityValidatingInstance = SpawnObject(m_TestPrefab, authority).GetComponent<TestNetworkBehaviour>();
+            m_BehaviourToUseAsReference = SpawnObject(m_TestPrefab, authority).GetComponent<TestNetworkBehaviour>();
+            var objectsToSpawn = new List<NetworkObject>()
             {
-                t += Time.deltaTime;
-                if (t > 5f)
-                {
-                    new AssertionException("RPC with NetworkBehaviour reference hasn't been received");
-                }
+                m_AuthorityValidatingInstance.NetworkObject,
+                m_BehaviourToUseAsReference.NetworkObject
+            };
 
-                yield return null;
+            // Spawn the instances
+            yield return WaitForSpawnedOnAllOrTimeOut(objectsToSpawn);
+            AssertOnTimeout($"[{nameof(TestSerializeNull)}] Not all clients spawned all instances of {m_AuthorityValidatingInstance.name} or {m_BehaviourToUseAsReference.name}");
+
+            // Implicitly send the NetworkBehaviour as a reference
+            m_AuthorityValidatingInstance.SendReferenceRpc(m_BehaviourToUseAsReference);
+
+            // Validated the reference
+            yield return WaitForConditionOrTimeOut(RpcWasReceivedAndBehaviourValidated);
+            AssertOnTimeout($"[{nameof(TestRpc)}] Failed to validate reference!");
+        }
+        #endregion
+
+        #region Tests using non-null NetworkBehaviours and NetworkVariable
+        private bool NetworkVariableChangedAndBehaviourValidated(StringBuilder stringBuilder)
+        {
+            var authorityValidatingId = m_AuthorityValidatingInstance.NetworkObjectId;
+            var authorityReferenceId = m_BehaviourToUseAsReference.NetworkObjectId;
+            var validatingNetworkObject = (NetworkObject)null;
+            var referenceNetworkObject = (NetworkObject)null;
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                if (networkManager.SpawnManager.SpawnedObjects.TryGetValue(authorityValidatingId, out validatingNetworkObject)
+                    && networkManager.SpawnManager.SpawnedObjects.TryGetValue(authorityReferenceId, out referenceNetworkObject))
+                {
+                    var validatingBehaviour = validatingNetworkObject.GetComponent<TestNetworkBehaviour>();
+                    var referenceBehaviour = referenceNetworkObject.GetComponent<TestNetworkBehaviour>();
+
+                    if (!validatingBehaviour.TestVariableChanged)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} has not received the NetworkVariable update!");
+                        continue;
+                    }
+                    if (!validatingBehaviour.AcquiredReference)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} failed to acquire a reference!");
+                        continue;
+                    }
+                    if (referenceBehaviour != validatingBehaviour.TestVariableBehaviour)
+                    {
+                        var currentReferenceBehaviour = validatingBehaviour.TestVariableBehaviour != null ? validatingBehaviour.RpcReceivedBehaviour.name : "null";
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} expected behaviour reference {referenceBehaviour.name} but was {currentReferenceBehaviour}!");
+                    }
+                }
+                else
+                {
+                    var wasNotSpawned = validatingNetworkObject == null ? m_AuthorityValidatingInstance.name : m_BehaviourToUseAsReference.name;
+                    stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} has not yet spawned {wasNotSpawned}!");
+                }
+                validatingNetworkObject = null;
+                referenceNetworkObject = null;
+            }
+            return stringBuilder.Length == 0;
+        }
+
+
+        [UnityTest]
+        public IEnumerator TestNetworkVariable()
+        {
+            var authority = GetAuthorityNetworkManager();
+            m_AuthorityValidatingInstance = SpawnObject(m_TestPrefab, authority).GetComponent<TestNetworkBehaviour>();
+            m_BehaviourToUseAsReference = SpawnObject(m_TestPrefab, authority).GetComponent<TestNetworkBehaviour>();
+            var objectsToSpawn = new List<NetworkObject>()
+            {
+                m_AuthorityValidatingInstance.NetworkObject,
+                m_BehaviourToUseAsReference.NetworkObject
+            };
+
+            // Spawn the instances
+            yield return WaitForSpawnedOnAllOrTimeOut(objectsToSpawn);
+            AssertOnTimeout($"[{nameof(TestSerializeNull)}] Not all clients spawned all instances of {m_AuthorityValidatingInstance.name} or {m_BehaviourToUseAsReference.name}");
+
+            // Assure the authority instance's value is the default (null) value
+            Assert.IsNull((NetworkBehaviour)m_AuthorityValidatingInstance.TestVariable.Value);
+
+            // Implicitly assign the NetworkBehaviourReference by assigning the NetworkBehaviour to the NetworkVariable.
+            m_AuthorityValidatingInstance.TestVariable.Value = m_BehaviourToUseAsReference;
+
+            // Validated the NetworkVariable reference propogates to clients
+            yield return WaitForConditionOrTimeOut(NetworkVariableChangedAndBehaviourValidated);
+            AssertOnTimeout($"[{nameof(TestRpc)}] Failed to validate reference!");
+        }
+        #endregion
+
+        #region Validating using NULL as a NetworkBehaviourReference
+        private bool RpcSerializingNullValidated(StringBuilder stringBuilder)
+        {
+            var authorityValidatingId = m_AuthorityValidatingInstance.NetworkObjectId;
+            var validatingNetworkObject = (NetworkObject)null;
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                if (networkManager.SpawnManager.SpawnedObjects.TryGetValue(authorityValidatingId, out validatingNetworkObject))
+                {
+                    var validatingBehaviour = validatingNetworkObject.GetComponent<TestNetworkBehaviour>();
+
+                    if (!validatingBehaviour.ReceivedRPC)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} has not received the RPC!");
+                        continue;
+                    }
+                    if (validatingBehaviour.AcquiredReference)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} Acquired a reference when it should not have!");
+                        continue;
+                    }
+                    if (validatingBehaviour.RpcReceivedBehaviour != null)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} expected behaviour reference NULL but was {validatingBehaviour.RpcReceivedBehaviour.name}!");
+                    }
+                }
+                else
+                {
+                    stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} has not yet spawned {m_AuthorityValidatingInstance.name}!");
+                }
+                validatingNetworkObject = null;
+            }
+            return stringBuilder.Length == 0;
+        }
+
+        private bool NetworkVariableSerializingNullValidated(StringBuilder stringBuilder)
+        {
+            var authorityValidatingId = m_AuthorityValidatingInstance.NetworkObjectId;
+            var validatingNetworkObject = (NetworkObject)null;
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                if (networkManager.SpawnManager.SpawnedObjects.TryGetValue(authorityValidatingId, out validatingNetworkObject))
+                {
+                    var validatingBehaviour = validatingNetworkObject.GetComponent<TestNetworkBehaviour>();
+
+                    if (!validatingBehaviour.TestVariableChanged)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} has not detected a change in the NetworkVariable!");
+                        continue;
+                    }
+                    if (validatingBehaviour.AcquiredReference)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} Acquired a reference when it should not have!");
+                        continue;
+                    }
+                    if (validatingBehaviour.TestVariableBehaviour != null)
+                    {
+                        stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} {validatingBehaviour.name} expected behaviour reference NULL but was {validatingBehaviour.TestVariableBehaviour.name}!");
+                    }
+                }
+                else
+                {
+                    stringBuilder.AppendLine($"Client-{networkManager.LocalClientId} has not yet spawned {m_AuthorityValidatingInstance.name}!");
+                }
+                validatingNetworkObject = null;
+            }
+            return stringBuilder.Length == 0;
+        }
+
+
+        [UnityTest]
+        public IEnumerator TestSerializeNull()
+        {
+            var authority = GetAuthorityNetworkManager();
+            m_AuthorityValidatingInstance = SpawnObject(m_TestPrefab, authority).GetComponent<TestNetworkBehaviour>();
+            yield return WaitForSpawnedOnAllOrTimeOut(m_AuthorityValidatingInstance.gameObject);
+            AssertOnTimeout($"[{nameof(TestSerializeNull)}] Not all clients spawned {m_AuthorityValidatingInstance.name}");
+            // Initialize with NULL parameter
+            var initializeWithNull = new NetworkBehaviourReference(null);
+            var initializeWithNothing = new NetworkBehaviourReference();
+
+            m_AuthorityValidatingInstance.SendReferenceRpc(initializeWithNull);
+            yield return WaitForConditionOrTimeOut(RpcSerializingNullValidated);
+            AssertOnTimeout($"[{nameof(TestSerializeNull)}][Initialize with null parameter] Failed to validate null {nameof(NetworkBehaviour)} reference!");
+
+            // Reset the RPC NetworkBehaviourReference to the local instance for all spawned instances.
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                var testBehaviour = networkManager.SpawnManager.SpawnedObjects[m_AuthorityValidatingInstance.NetworkObjectId].GetComponent<TestNetworkBehaviour>();
+                testBehaviour.RpcReceivedBehaviour = testBehaviour;
             }
 
-            // validate
-            Assert.AreEqual(testNetworkBehaviour, testNetworkBehaviour.RpcReceivedBehaviour);
+            // Initialize with no parameter
+            m_AuthorityValidatingInstance.SendReferenceRpc(initializeWithNothing);
+            yield return WaitForConditionOrTimeOut(RpcSerializingNullValidated);
+            AssertOnTimeout($"[{nameof(TestSerializeNull)}][Initialize with no parameter] Failed to validate null {nameof(NetworkBehaviour)} reference!");
+
+            m_AuthorityValidatingInstance.TestVariable.Value = initializeWithNull;
+            yield return WaitForConditionOrTimeOut(NetworkVariableSerializingNullValidated);
+            AssertOnTimeout($"[{nameof(TestSerializeNull)}][Initialize with null parameter] Failed to validate null {nameof(NetworkBehaviour)} reference!");
+
+            // Reset the NetworkVaraible NetworkBehaviourReference to the local instance for all spawned instances.
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                var testBehaviour = networkManager.SpawnManager.SpawnedObjects[m_AuthorityValidatingInstance.NetworkObjectId].GetComponent<TestNetworkBehaviour>();
+                testBehaviour.TestVariableBehaviour = testBehaviour;
+                testBehaviour.TestVariableChanged = false;
+            }
+
+            // Initialize with no parameter
+            m_AuthorityValidatingInstance.TestVariable.Value = initializeWithNothing;
+            yield return WaitForConditionOrTimeOut(NetworkVariableSerializingNullValidated);
+            AssertOnTimeout($"[{nameof(TestSerializeNull)}][Initialize with no parameter] Failed to validate null {nameof(NetworkBehaviour)} reference!");
         }
+        #endregion
 
-        [Test]
-        public void TestNetworkVariable()
+        #region Serialization Failure validation tests
+
+        /// <summary>
+        /// This test is ok to create but not spawn.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator FailSerializeNonSpawnedNetworkObject()
         {
-            using var networkObjectContext = UnityObjectContext.CreateNetworkObject();
-            var testNetworkBehaviour = networkObjectContext.Object.gameObject.AddComponent<TestNetworkBehaviour>();
-            networkObjectContext.Object.Spawn();
-
-            using var otherObjectContext = UnityObjectContext.CreateNetworkObject();
-            otherObjectContext.Object.Spawn();
-
-            // check default value is null
-            Assert.IsNull((NetworkBehaviour)testNetworkBehaviour.TestVariable.Value);
-
-            testNetworkBehaviour.TestVariable.Value = testNetworkBehaviour;
-
-            Assert.AreEqual((NetworkBehaviour)testNetworkBehaviour.TestVariable.Value, testNetworkBehaviour);
-        }
-
-        [Test]
-        public void FailSerializeNonSpawnedNetworkObject()
-        {
-            using var networkObjectContext = UnityObjectContext.CreateNetworkObject();
-            var component = networkObjectContext.Object.gameObject.AddComponent<TestNetworkBehaviour>();
+            yield return s_DefaultWaitForTick;
+            var instance = Object.Instantiate(m_TestPrefab);
 
             Assert.Throws<ArgumentException>(() =>
             {
-                NetworkBehaviourReference outReference = component;
+                NetworkBehaviourReference outReference = instance.GetComponent<TestNetworkBehaviour>();
             });
+
+            Object.Destroy(instance);
         }
 
-        [Test]
-        public void FailSerializeGameObjectWithoutNetworkObject()
+        [UnityTest]
+        public IEnumerator FailSerializeGameObjectWithoutNetworkObject()
         {
-            using var gameObjectContext = UnityObjectContext.CreateGameObject();
-            var component = gameObjectContext.Object.gameObject.AddComponent<TestNetworkBehaviour>();
+            yield return s_DefaultWaitForTick;
+            var instance = Object.Instantiate(m_TestPrefab);
+            Object.Destroy(instance.GetComponent<NetworkObject>());
 
             Assert.Throws<ArgumentException>(() =>
             {
-                NetworkBehaviourReference outReference = component;
+                NetworkBehaviourReference outReference = instance.GetComponent<TestNetworkBehaviour>();
             });
+
+            Object.Destroy(instance);
         }
 
-        public void Dispose()
-        {
-            //Stop, shutdown, and destroy
-            NetworkManagerHelper.ShutdownNetworkManager();
-        }
+        #endregion
 
-        public NetworkBehaviourReferenceTests()
+        #region TestNetworkBehaviour component script
+
+        private class TestNetworkBehaviour : NetworkBehaviour
         {
-            //Create, instantiate, and host
-            NetworkManagerHelper.StartNetworkManager(out _);
+            public bool ReceivedRPC;
+            public bool TestVariableChanged;
+            public bool AcquiredReference;
+
+            public NetworkVariable<NetworkBehaviourReference> TestVariable = new NetworkVariable<NetworkBehaviourReference>();
+
+            public TestNetworkBehaviour TestVariableBehaviour;
+
+            public TestNetworkBehaviour RpcReceivedBehaviour;
+
+            protected override void OnNetworkPreSpawn(ref NetworkManager networkManager)
+            {
+                // Set it to ourself so we can validate serializing null too.
+                RpcReceivedBehaviour = this;
+                TestVariableBehaviour = null;
+                base.OnNetworkPreSpawn(ref networkManager);
+            }
+
+            public override void OnNetworkSpawn()
+            {
+                TestVariable.OnValueChanged += OnTestVariableChanged;
+                base.OnNetworkSpawn();
+            }
+
+            public override void OnNetworkPreDespawn()
+            {
+                TestVariable.OnValueChanged -= OnTestVariableChanged;
+                base.OnNetworkPreDespawn();
+            }
+
+            private void OnTestVariableChanged(NetworkBehaviourReference previous, NetworkBehaviourReference current)
+            {
+                TestVariableChanged = true;
+                AcquiredReference = current.TryGet(out TestVariableBehaviour, NetworkManager);
+            }
+
+            [Rpc(SendTo.Everyone)]
+            public void SendReferenceRpc(NetworkBehaviourReference value)
+            {
+                AcquiredReference = value.TryGet(out RpcReceivedBehaviour, NetworkManager);
+                ReceivedRPC = true;
+            }
         }
+        #endregion
     }
 
     /// <summary>

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/NetworkObjectReferenceTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Serialization/NetworkObjectReferenceTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using NUnit.Framework;
-using Unity.Collections;
 using Unity.Netcode.TestHelpers.Runtime;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -15,415 +15,154 @@ namespace Unity.Netcode.RuntimeTests
     /// - Deserializing NetworkObjectReference to NetworkObject
     /// - Implicit operators of NetworkObjectReference
     /// </summary>
-    internal class NetworkObjectReferenceTests : IDisposable
+    internal class NetworkObjectReferenceTests : BaseReferenceTests
     {
-        [OneTimeSetUp]
-        public void OneTimeSetup()
+        protected override int NumberOfClients => 1;
+
+
+        public NetworkObjectReferenceTests(HostOrServer hostOrServer) : base(hostOrServer)
+        {
+        }
+
+        protected override void OnOneTimeSetup()
         {
             // TODO: [CmbServiceTests] if this test is deemed needed to test against the CMB server then update this test.
             NetcodeIntegrationTestHelpers.IgnoreIfServiceEnviromentVariableSet();
+            base.OnOneTimeSetup();
         }
 
-        private class TestNetworkBehaviour : NetworkBehaviour
+        [UnityTest]
+        public IEnumerator TestSerializeNetworkObject()
         {
-            public static bool ReceivedRPC;
+            yield return SpawnTestPrefabInstance();
 
-            public NetworkVariable<NetworkObjectReference> TestVariable = new NetworkVariable<NetworkObjectReference>();
+            // Explicitly send the NetworkObject as a reference
+            m_ValidatingInstance.TestNetworkBehaviour.SendNetworkObjectReferenceRpc(new NetworkObjectReference(m_ReferenceToUse.NetworkObject));
 
-            public NetworkObject RpcReceivedNetworkObject;
+            // Validated the reference
+            yield return WaitForConditionOrTimeOut(NetworkObjectSerializedValidation);
+            AssertOnTimeout($"[{nameof(TestSerializeNetworkObject)}][Explicit reference] Failed to validate {nameof(NetworkObjectReference)} serialization!");
 
-            public GameObject RpcReceivedGameObject;
+            // Implicitly send the NetworkObject as a reference
+            m_ValidatingInstance.TestNetworkBehaviour.SendNetworkObjectReferenceRpc(m_ReferenceToUse.NetworkObject);
 
-            [ServerRpc]
-            public void SendReferenceServerRpc(NetworkObjectReference value)
+            // Validated the reference
+            yield return WaitForConditionOrTimeOut(NetworkObjectSerializedValidation);
+            AssertOnTimeout($"[{nameof(TestSerializeNetworkObject)}][Implicit reference] Failed to validate {nameof(NetworkObjectReference)} serialization!");
+
+            // Use the GameObject to set the NetworkObjet reference
+            m_ValidatingInstance.TestNetworkBehaviour.SendNetworkObjectReferenceRpc(new NetworkObjectReference(m_ReferenceToUse.GameObject));
+
+            // Validated the reference
+            yield return WaitForConditionOrTimeOut(NetworkObjectSerializedValidation);
+            AssertOnTimeout($"[{nameof(TestSerializeNetworkObject)}][GameObject reference] Failed to validate {nameof(NetworkObjectReference)} serialization!");
+        }
+
+        [UnityTest]
+        public IEnumerator TestSerializeNull()
+        {
+            yield return SpawnTestPrefabInstance(true);
+
+            // Initialize with NULL parameter
+            var initializeWithNullGameObject = new NetworkObjectReference((GameObject)null);
+            var initializeWithNullNetworkObject = new NetworkObjectReference((NetworkObject)null);
+            // Initialize with no parameter
+            var initializeWithNothing = new NetworkObjectReference();
+
+            // Initialize with NULL GameObject parameter
+            m_ValidatingInstance.TestNetworkBehaviour.SendNetworkObjectReferenceRpc(initializeWithNullGameObject);
+
+            // Validated the reference
+            yield return WaitForConditionOrTimeOut(SerializingNullNetworkObjectValidated);
+            AssertOnTimeout($"[{nameof(TestSerializeNetworkObject)}][GameObject as NULL] Failed to validate {nameof(NetworkObjectReference)} serialization!");
+
+            // Reset the RPC NetworkObjectReference to the local instance for all spawned instances.
+            foreach (var networkManager in m_NetworkManagers)
             {
-                ReceivedRPC = true;
-                RpcReceivedGameObject = value;
-                RpcReceivedNetworkObject = value;
+                var testBehaviour = networkManager.SpawnManager.SpawnedObjects[m_ValidatingInstance.NetworkObject.NetworkObjectId].GetComponent<TestNetworkBehaviour>();
+                testBehaviour.RpcReceivedNetworkObject = testBehaviour.NetworkObject;
             }
-        }
 
-        [Test]
-        public void TestSerializeNetworkObject()
-        {
-            using var networkObjectContext = UnityObjectContext.CreateNetworkObject();
-            networkObjectContext.Object.Spawn();
-            var outWriter = new FastBufferWriter(1300, Allocator.Temp);
-            try
+            // Initialize with NULL NetworkObject parameter
+            m_ValidatingInstance.TestNetworkBehaviour.SendNetworkObjectReferenceRpc(initializeWithNullNetworkObject);
+
+            // Validated the reference
+            yield return WaitForConditionOrTimeOut(SerializingNullNetworkObjectValidated);
+            AssertOnTimeout($"[{nameof(TestSerializeNetworkObject)}][NetworkObject as NULL] Failed to validate {nameof(NetworkObjectReference)} serialization!");
+
+            // Reset the RPC NetworkObjectReference to the local instance for all spawned instances.
+            foreach (var networkManager in m_NetworkManagers)
             {
-                // serialize
-                var outSerializer = new BufferSerializer<BufferSerializerWriter>(new BufferSerializerWriter(outWriter));
-                NetworkObjectReference outReference = networkObjectContext.Object;
-                outReference.NetworkSerialize(outSerializer);
-
-                // deserialize
-                NetworkObjectReference inReference = default;
-                var inReader = new FastBufferReader(outWriter, Allocator.Temp);
-                try
-                {
-                    var inSerializer =
-                        new BufferSerializer<BufferSerializerReader>(new BufferSerializerReader(inReader));
-                    inReference.NetworkSerialize(inSerializer);
-                }
-                finally
-                {
-                    inReader.Dispose();
-                }
-
-                // validate
-                Assert.NotNull((NetworkObject)inReference);
-                Assert.AreEqual(inReference.NetworkObjectId, networkObjectContext.Object.NetworkObjectId);
-                Assert.AreEqual(outReference, inReference);
-                Assert.AreEqual(networkObjectContext.Object, (NetworkObject)inReference);
+                var testBehaviour = networkManager.SpawnManager.SpawnedObjects[m_ValidatingInstance.NetworkObject.NetworkObjectId].GetComponent<TestNetworkBehaviour>();
+                testBehaviour.RpcReceivedNetworkObject = testBehaviour.NetworkObject;
             }
-            finally
-            {
-                outWriter.Dispose();
-            }
+
+            // Initialize with no parameter
+            m_ValidatingInstance.TestNetworkBehaviour.SendNetworkObjectReferenceRpc(initializeWithNothing);
+
+            // Validated the reference
+            yield return WaitForConditionOrTimeOut(SerializingNullNetworkObjectValidated);
+            AssertOnTimeout($"[{nameof(TestSerializeNetworkObject)}][No Parameter] Failed to validate {nameof(NetworkObjectReference)} serialization!");
         }
 
-        [Test]
-        public void TestSerializeGameObject()
+        [UnityTest]
+        public IEnumerator TestGetReferenceAndConversion()
         {
-            using var networkObjectContext = UnityObjectContext.CreateNetworkObject();
-            networkObjectContext.Object.Spawn();
-            var outWriter = new FastBufferWriter(1300, Allocator.Temp);
-            try
-            {
-                // serialize
-                var outSerializer = new BufferSerializer<BufferSerializerWriter>(new BufferSerializerWriter(outWriter));
-                NetworkObjectReference outReference = networkObjectContext.Object.gameObject;
-                outReference.NetworkSerialize(outSerializer);
+            yield return SpawnTestPrefabInstance();
 
-                // deserialize
-                NetworkObjectReference inReference = default;
-                var inReader = new FastBufferReader(outWriter, Allocator.Temp);
-                try
-                {
-                    var inSerializer =
-                        new BufferSerializer<BufferSerializerReader>(new BufferSerializerReader(inReader));
-                    inReference.NetworkSerialize(inSerializer);
-                }
-                finally
-                {
-                    inReader.Dispose();
-                }
-                GameObject gameObject = inReference;
+            var referenceToUse = new NetworkObjectReference(m_ReferenceToUse.NetworkObject);
 
-                // validate
-                Assert.AreEqual(outReference, inReference);
-                Assert.AreEqual(networkObjectContext.Object.gameObject, gameObject);
-            }
-            finally
-            {
-                outWriter.Dispose();
-            }
-        }
+            Assert.True(referenceToUse.TryGet(out NetworkObject networkObject));
+            Assert.NotNull(networkObject, $"TryGet succeeded but value returned is null!");
 
-        [Test]
-        public void TestImplicitConversionToGameObject()
-        {
-            using var networkObjectContext = UnityObjectContext.CreateNetworkObject();
-            networkObjectContext.Object.Spawn();
-
-            NetworkObjectReference outReference = networkObjectContext.Object.gameObject;
-
-            GameObject go = outReference;
-            Assert.AreEqual(networkObjectContext.Object.gameObject, go);
-        }
-
-        [Test]
-        public void TestImplicitToGameObjectIsNullWhenNotFound()
-        {
-            using var networkObjectContext = UnityObjectContext.CreateNetworkObject();
-            networkObjectContext.Object.Spawn();
-
-            NetworkObjectReference outReference = networkObjectContext.Object.gameObject;
-
-            networkObjectContext.Object.Despawn();
-            Object.DestroyImmediate(networkObjectContext.Object.gameObject);
-
-            GameObject go = outReference;
-            Assert.IsNull(go);
-        }
-        [Test]
-        public void TestTryGet()
-        {
-            using var networkObjectContext = UnityObjectContext.CreateNetworkObject();
-            networkObjectContext.Object.Spawn();
-
-            NetworkObjectReference networkObjectReference = networkObjectContext.Object;
-
-            Assert.True(networkObjectReference.TryGet(out NetworkObject networkObject));
-            Assert.NotNull(networkObject);
-            networkObjectReference.TryGet(out NetworkObject result);
+            // TODO: Revisit this to determine if this portion of the test is actually needed
+            referenceToUse.TryGet(out NetworkObject result);
             Assert.AreEqual(networkObject, result);
+
+            // Now implicitly convert from a NetworkObjectReference to a GameObject
+            GameObject fromReference = referenceToUse;
+            Assert.IsTrue(fromReference == m_ReferenceToUse.GameObject, $"Implicitly converting {nameof(NetworkObjectReference)} to {nameof(GameObject)} failed!");
+
+            // Despawn
+            m_ReferenceToUse.NetworkObject.Despawn();
+            var referenceName = m_ReferenceToUse.GameObject.name;
+            yield return WaitForDespawnedOnAllOrTimeOut(new List<NetworkObject>() { m_ReferenceToUse.NetworkObject });
+            AssertOnTimeout($"Timed out waiting for {referenceName} to de-spawn!");
+
+            // Destroy
+            Object.DestroyImmediate(m_ReferenceToUse.GameObject);
+
+            // Validate trying to implicitly convert returns a null value when the GameObject
+            // no longer exists
+            fromReference = referenceToUse;
+            Assert.IsTrue(fromReference == null, $"Implicitly converting {nameof(NetworkObjectReference)} to {nameof(GameObject)} failed when destroyed!");
         }
 
-        public enum NetworkObjectConstructorTypes
-        {
-            None,
-            NullNetworkObject,
-            NullGameObject
-        }
 
         [UnityTest]
-        public IEnumerator TestSerializeNull([Values] NetworkObjectConstructorTypes networkObjectConstructorTypes)
+        public IEnumerator FailSerializeNonSpawnedNetworkObject()
         {
-            TestNetworkBehaviour.ReceivedRPC = false;
-            using var networkObjectContext = UnityObjectContext.CreateNetworkObject();
-            var testNetworkBehaviour = networkObjectContext.Object.gameObject.AddComponent<TestNetworkBehaviour>();
-            networkObjectContext.Object.Spawn();
+            yield return s_DefaultWaitForTick;
+            var instance = Object.Instantiate(m_TestPrefab);
 
-            switch (networkObjectConstructorTypes)
-            {
-                case NetworkObjectConstructorTypes.None:
-                    {
-                        testNetworkBehaviour.SendReferenceServerRpc(new NetworkObjectReference());
-                        break;
-                    }
-                case NetworkObjectConstructorTypes.NullNetworkObject:
-                    {
-                        testNetworkBehaviour.SendReferenceServerRpc(new NetworkObjectReference((NetworkObject)null));
-                        break;
-                    }
-                case NetworkObjectConstructorTypes.NullGameObject:
-                    {
-                        testNetworkBehaviour.SendReferenceServerRpc(new NetworkObjectReference((GameObject)null));
-                        break;
-                    }
-            }
-
-
-            // wait for rpc completion
-            float t = 0;
-            while (!TestNetworkBehaviour.ReceivedRPC)
-            {
-
-                t += Time.deltaTime;
-                if (t > 5f)
-                {
-                    new AssertionException("RPC with NetworkBehaviour reference hasn't been received");
-                }
-
-                yield return null;
-            }
-
-            // validate
-            Assert.AreEqual(null, testNetworkBehaviour.RpcReceivedNetworkObject);
-            Assert.AreEqual(null, testNetworkBehaviour.RpcReceivedGameObject);
-        }
-
-        [UnityTest]
-        public IEnumerator TestRpc()
-        {
-            using var networkObjectContext = UnityObjectContext.CreateNetworkObject();
-            var testNetworkBehaviour = networkObjectContext.Object.gameObject.AddComponent<TestNetworkBehaviour>();
-            networkObjectContext.Object.Spawn();
-
-            using var otherObjectContext = UnityObjectContext.CreateNetworkObject();
-            otherObjectContext.Object.Spawn();
-
-            testNetworkBehaviour.SendReferenceServerRpc(new NetworkObjectReference(otherObjectContext.Object));
-
-            // wait for rpc completion
-            float t = 0;
-            while (testNetworkBehaviour.RpcReceivedGameObject == null)
-            {
-                t += Time.deltaTime;
-                if (t > 5f)
-                {
-                    new AssertionException("RPC with NetworkBehaviour reference hasn't been received");
-                }
-
-                yield return null;
-            }
-
-            // validate
-            Assert.AreEqual(otherObjectContext.Object, testNetworkBehaviour.RpcReceivedNetworkObject);
-            Assert.AreEqual(otherObjectContext.Object.gameObject, testNetworkBehaviour.RpcReceivedGameObject);
-        }
-
-        [UnityTest]
-        public IEnumerator TestRpcImplicitNetworkObject()
-        {
-            using var networkObjectContext = UnityObjectContext.CreateNetworkObject();
-            var testNetworkBehaviour = networkObjectContext.Object.gameObject.AddComponent<TestNetworkBehaviour>();
-            networkObjectContext.Object.Spawn();
-
-            using var otherObjectContext = UnityObjectContext.CreateNetworkObject();
-            otherObjectContext.Object.Spawn();
-
-            testNetworkBehaviour.SendReferenceServerRpc(otherObjectContext.Object);
-
-            // wait for rpc completion
-            float t = 0;
-            while (testNetworkBehaviour.RpcReceivedGameObject == null)
-            {
-                t += Time.deltaTime;
-                if (t > 5f)
-                {
-                    new AssertionException("RPC with NetworkBehaviour reference hasn't been received");
-                }
-
-                yield return null;
-            }
-
-            // validate
-            Assert.AreEqual(otherObjectContext.Object, testNetworkBehaviour.RpcReceivedNetworkObject);
-            Assert.AreEqual(otherObjectContext.Object.gameObject, testNetworkBehaviour.RpcReceivedGameObject);
-        }
-
-        [UnityTest]
-        public IEnumerator TestRpcImplicitGameObject()
-        {
-            using var networkObjectContext = UnityObjectContext.CreateNetworkObject();
-            var testNetworkBehaviour = networkObjectContext.Object.gameObject.AddComponent<TestNetworkBehaviour>();
-            networkObjectContext.Object.Spawn();
-
-            using var otherObjectContext = UnityObjectContext.CreateNetworkObject();
-            otherObjectContext.Object.Spawn();
-
-            testNetworkBehaviour.SendReferenceServerRpc(otherObjectContext.Object.gameObject);
-
-            // wait for rpc completion
-            float t = 0;
-            while (testNetworkBehaviour.RpcReceivedGameObject == null)
-            {
-                t += Time.deltaTime;
-                if (t > 5f)
-                {
-                    new AssertionException("RPC with NetworkBehaviour reference hasn't been received");
-                }
-
-                yield return null;
-            }
-
-            // validate
-            Assert.AreEqual(otherObjectContext.Object, testNetworkBehaviour.RpcReceivedNetworkObject);
-            Assert.AreEqual(otherObjectContext.Object.gameObject, testNetworkBehaviour.RpcReceivedGameObject);
-        }
-
-        [Test]
-        public void TestNetworkVariable()
-        {
-            using var networkObjectContext = UnityObjectContext.CreateNetworkObject();
-            var testNetworkBehaviour = networkObjectContext.Object.gameObject.AddComponent<TestNetworkBehaviour>();
-            networkObjectContext.Object.Spawn();
-
-            using var otherObjectContext = UnityObjectContext.CreateNetworkObject();
-            otherObjectContext.Object.Spawn();
-
-            // check default value is null
-            Assert.IsNull((NetworkObject)testNetworkBehaviour.TestVariable.Value);
-
-            testNetworkBehaviour.TestVariable.Value = networkObjectContext.Object;
-
-            Assert.AreEqual((GameObject)testNetworkBehaviour.TestVariable.Value, networkObjectContext.Object.gameObject);
-            Assert.AreEqual((NetworkObject)testNetworkBehaviour.TestVariable.Value, networkObjectContext.Object);
-        }
-
-        [Test]
-        public void TestDespawn()
-        {
-            using var networkObjectContext = UnityObjectContext.CreateNetworkObject();
-            networkObjectContext.Object.Spawn();
-            var originalId = networkObjectContext.Object.NetworkObjectId;
-
-            NetworkObjectReference networkObjectReference = networkObjectContext.Object;
-            Assert.AreEqual(networkObjectContext.Object, (NetworkObject)networkObjectReference);
-
-            networkObjectContext.Object.Despawn();
-            Assert.IsFalse(networkObjectReference.TryGet(out NetworkObject _));
-
-            networkObjectContext.Object.Spawn();
-
-            // After spawning again the reference will still no longer work as it still points to the old object
-            Assert.AreNotEqual(originalId, networkObjectContext.Object.NetworkObjectId);
-            Assert.IsFalse(networkObjectReference.TryGet(out NetworkObject _));
-
-            // creating a new reference will make it work again
-            networkObjectReference = networkObjectContext.Object;
-            Assert.AreEqual(networkObjectContext.Object, (NetworkObject)networkObjectReference);
-        }
-
-        [Test]
-        public void FailSerializeNonSpawnedNetworkObject()
-        {
-            using var networkObjectContext = UnityObjectContext.CreateNetworkObject();
 
             Assert.Throws<ArgumentException>(() =>
             {
-                NetworkObjectReference outReference = networkObjectContext.Object;
+                NetworkObjectReference outReference = instance.GetComponent<NetworkObject>();
             });
         }
 
-        [Test]
-        public void FailSerializeGameObjectWithoutNetworkObject()
+        [UnityTest]
+        public IEnumerator FailSerializeGameObjectWithoutNetworkObject()
         {
-            using var gameObjectContext = UnityObjectContext.CreateGameObject();
+            yield return s_DefaultWaitForTick;
+            var instance = Object.Instantiate(m_TestPrefab);
+
 
             Assert.Throws<ArgumentException>(() =>
             {
-                NetworkObjectReference outReference = gameObjectContext.Object;
+                NetworkObjectReference outReference = instance;
             });
-        }
-
-        public void Dispose()
-        {
-            //Stop, shutdown, and destroy
-            NetworkManagerHelper.ShutdownNetworkManager();
-        }
-
-        public NetworkObjectReferenceTests()
-        {
-            //Create, instantiate, and host
-            NetworkManagerHelper.StartNetworkManager(out _);
-        }
-    }
-
-    /// <summary>
-    /// Helper method for tests to create and destroy Unity Objects.
-    /// </summary>
-    /// <typeparam name="T">The type of Object this context incorporates.</typeparam>
-    internal class UnityObjectContext<T> : UnityObjectContext where T : Object
-    {
-        private T m_Object;
-
-        internal UnityObjectContext(T unityObject, Object root)
-            : base(root)
-        {
-            m_Object = unityObject;
-        }
-
-        public T Object => m_Object;
-    }
-
-    internal class UnityObjectContext : IDisposable
-    {
-        private Object m_Root;
-
-        protected UnityObjectContext(Object root)
-        {
-            m_Root = root;
-        }
-
-        public static UnityObjectContext<GameObject> CreateGameObject(string name = "")
-        {
-            var gameObject = new GameObject(name);
-            return new UnityObjectContext<GameObject>(gameObject, gameObject);
-        }
-
-        public static UnityObjectContext<NetworkObject> CreateNetworkObject(string name = "")
-        {
-            var gameObject = new GameObject(name);
-            var networkObject = gameObject.AddComponent<NetworkObject>();
-            return new UnityObjectContext<NetworkObject>(networkObject, gameObject);
-        }
-
-        public void Dispose()
-        {
-            Object.DestroyImmediate(m_Root);
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
@@ -794,7 +794,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             {
                 CreatePlayerPrefab();
             }
-            
+
 
             if (m_EnableTimeTravel)
             {

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
@@ -777,6 +777,11 @@ namespace Unity.Netcode.TestHelpers.Runtime
             CreateServerAndClients(NumberOfClients);
         }
 
+        internal virtual bool ShouldCreatePlayerPrefab()
+        {
+            return true;
+        }
+
         /// <summary>
         /// Creates the server and clients
         /// </summary>
@@ -785,7 +790,11 @@ namespace Unity.Netcode.TestHelpers.Runtime
         {
             VerboseDebug($"Entering {nameof(CreateServerAndClients)}");
 
-            CreatePlayerPrefab();
+            if (ShouldCreatePlayerPrefab())
+            {
+                CreatePlayerPrefab();
+            }
+            
 
             if (m_EnableTimeTravel)
             {

--- a/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
+++ b/testproject/Assets/Tests/Runtime/Animation/NetworkAnimatorTests.cs
@@ -356,6 +356,7 @@ namespace TestProject.RuntimeTests
         {
             var gameObject = new GameObject();
             gameObject.AddComponent<NetworkObject>();
+            gameObject.AddComponent<Animator>();
             var networkAnimator = gameObject.AddComponent<NetworkAnimator>();
 
             var writer = new FastBufferWriter(40, Unity.Collections.Allocator.TempJob);
@@ -371,6 +372,8 @@ namespace TestProject.RuntimeTests
             LogAssert.Expect(LogType.Error, new System.Text.RegularExpressions.Regex($"parameters. Ignoring the remainger of this {nameof(ParametersUpdateMessage)}!"));
             // Pass in the invalid ParametersUpdateMessage
             networkAnimator.UpdateParameters(ref invalidParameters);
+
+            Object.DestroyImmediate(gameObject);
         }
 
         private bool AllTriggersDetected(OwnerShipMode ownerShipMode)
@@ -1078,27 +1081,18 @@ namespace TestProject.RuntimeTests
 
             TimeTravelToNextTick();
 
-            WaitForConditionOrTimeOutWithTimeTravel(() => !m_ServerNetworkManager.ShutdownInProgress);
+            WaitForConditionOrTimeOutWithTimeTravel(() => !m_ServerNetworkManager.ShutdownInProgress && m_ServerNetworkManager.IsConnectedClient);
 
             Assert.IsTrue(m_ServerTestHelperDespawned, $"Server-Side {nameof(AnimatorTestHelper)} did not have a valid IsServer setting!");
             AssertOnTimeout($"Timed out waiting for the server to shutdown!");
 
             VerboseDebug($" ++++++++++++++++++ Disconnect-Reconnect Restarting Server and Client ++++++++++++++++++ ");
-            // Since the dynamically generated PlayerPrefab is destroyed when the server shuts down,
-            // we need to create a new one and assign it to NetworkPrefab index 0
-            m_PlayerPrefab = new GameObject("Player");
-            NetworkObject networkObject = m_PlayerPrefab.AddComponent<NetworkObject>();
-            NetcodeIntegrationTestHelpers.MakeNetworkObjectTestPrefab(networkObject);
-            m_ServerNetworkManager.NetworkConfig.Prefabs.Prefabs[playerPrefabIndex].Prefab = m_PlayerPrefab;
-            m_ServerNetworkManager.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
 
             // Now, restart the server and the client
             m_ServerNetworkManager.StartHost();
 
             foreach (var clientNetworkManager in m_ClientNetworkManagers)
             {
-                clientNetworkManager.NetworkConfig.Prefabs.Prefabs[playerPrefabIndex].Prefab = m_PlayerPrefab;
-                clientNetworkManager.NetworkConfig.PlayerPrefab = m_PlayerPrefab;
                 clientNetworkManager.StartClient();
             }
 


### PR DESCRIPTION
## Purpose of this PR

This is a continuation of the fixes for the initial spawn sequence on the session owner/server side. 
This PR includes:

- A fix for not being able to spawn an in-scene placed `NetworkObject` if it is initially disabled in the scene.
- A fix for not allowing users to spawn dynamically generated `NetworkObject`s during runtime where the `NetworkObject.GlobalObjectIdHash` is zero.
- Some potential edge case exceptions.
- Overhauled several integration tests that were not properly creating network prefabs.


### Jira ticket

NA

### Changelog
[//]: # (updated with all public facing changes  - API changes, UI/UX changes, behaviour changes, bug fixes. Remove if not relevant.)

- Fixed: issue with not being able to spawn initially disabled in-scene placed objects.
- Fixed: issue with pre-instantiated network prefab instances being marked as in-scene placed. Now pre-instantiated network prefabs are dynamically spawned.
- Fixed: issue where a user could spawn runtime created `NetworkObject` that has a GlobalObjectIdHash of zero. These are not valid instances and will no longer be allowed to spawn.


<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- Documentation changes are necessary.
  - In-scene placed NetworkObjects section was updated to include pre-disabled in-scene placed NetworkObjects.
  - NetworkObject section was updated to provide a high-level overview of what is and is not a valid NetworkObject.

## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [x] `Manual testing done`
  - [NGO Examples scene troubleshooting](https://github.cds.internal.unity3d.com/noel-stephens/ngo-examples/tree/chore%2Fscene-loading-troubleshooting)

_Automated tests:_
- [x] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Up-port

Up-port is required.

## Backports

No back port is required.

