### PR TITLE
chore: change ghostadapter to ghostobject

### DIFF
--- a/com.unity.netcode.gameobjects/Editor/NetworkObjectEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkObjectEditor.cs
@@ -29,18 +29,18 @@ namespace Unity.Netcode.GameObjects.Editor
 
 #if UNIFIED_NETCODE
         /// <summary>
-        /// Register for the GhostAdapter removal event.
+        /// Register for the GhostObject removal event.
         /// </summary>
         [InitializeOnLoadMethod]
         private static void OnApplicationStart()
         {
-            GhostAdapterEditor.OnGhostAdapterPreRemoval = OnGhostAdapterPreRemoval;
+            GhostObjectEditor.OnGhostAdapterPreRemoval = OnGhostAdapterPreRemoval;
         }
 
         /// <summary>
-        /// Callback to remove the GhostBehaviours prior to removing GhostAdapter.
+        /// Callback to remove the GhostBehaviours prior to removing GhostObject.
         /// </summary>
-        /// <param name="gameObject">The <see cref="GameObject"/> with the <see cref="GhostAdapter"/> component being removed.</param>
+        /// <param name="gameObject">The <see cref="GameObject"/> with the <see cref="GhostObject"/> component being removed.</param>
         private static void OnGhostAdapterPreRemoval(GameObject gameObject)
         {
             var ghostBehaviours = gameObject.GetComponentsInChildren<GhostBehaviour>();
@@ -49,7 +49,7 @@ namespace Unity.Netcode.GameObjects.Editor
                 DestroyImmediate(ghostBehaviours[i], true);
             }
             var networkObject = gameObject.GetComponent<NetworkObject>();
-            networkObject.GhostAdapter = null;
+            networkObject.GhostObject = null;
             networkObject.HasGhost = false;
             networkObject.HadBridge = true;
         }

--- a/com.unity.netcode.gameobjects/Editor/NetworkObjectEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkObjectEditor.cs
@@ -34,14 +34,14 @@ namespace Unity.Netcode.GameObjects.Editor
         [InitializeOnLoadMethod]
         private static void OnApplicationStart()
         {
-            GhostObjectEditor.OnGhostAdapterPreRemoval = OnGhostAdapterPreRemoval;
+            GhostObjectEditor.OnGhostObjectPreRemoval = OnGhostObjectPreRemoval;
         }
 
         /// <summary>
         /// Callback to remove the GhostBehaviours prior to removing GhostObject.
         /// </summary>
         /// <param name="gameObject">The <see cref="GameObject"/> with the <see cref="GhostObject"/> component being removed.</param>
-        private static void OnGhostAdapterPreRemoval(GameObject gameObject)
+        private static void OnGhostObjectPreRemoval(GameObject gameObject)
         {
             var ghostBehaviours = gameObject.GetComponentsInChildren<GhostBehaviour>();
             for (int i = ghostBehaviours.Length - 1; i >= 0; i--)

--- a/com.unity.netcode.gameobjects/Runtime/Components/Helpers/NetworkObjectBridge.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Helpers/NetworkObjectBridge.cs
@@ -11,7 +11,7 @@ namespace Unity.Netcode
     /// specific to the N4E-spawned hybrid prefab instance that has the matching <see cref="NetworkObjectId"/>.
     /// </summary>
 
-    [DefaultExecutionOrder(GhostAdapterExecutionOrder.ExecutionOrder + 1)]
+    [DefaultExecutionOrder(GhostObjectExecutionOrder.ExecutionOrder + 1)]
     //BREAK --- Fix this on UNIFIED side 1st
     public partial class NetworkObjectBridge : GhostBehaviour
     {
@@ -23,7 +23,7 @@ namespace Unity.Netcode
         {
             hideFlags = HideFlags.HideInInspector;
 
-            var ghostAdapter = GetComponent<GhostAdapter>();
+            var ghostAdapter = GetComponent<GhostObject>();
             if (ghostAdapter == null)
             {
                 return;

--- a/com.unity.netcode.gameobjects/Runtime/Components/Helpers/NetworkObjectBridge.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Helpers/NetworkObjectBridge.cs
@@ -16,8 +16,8 @@ namespace Unity.Netcode
     public partial class NetworkObjectBridge : GhostBehaviour
     {
         // DefaultExecutionOrder
-        // TODO: Define a const for the value used on GhostAdapter and use that value
-        // to set the execution order so if it changes on GhostAdapter it updates here.
+        // TODO: Define a const for the value used on GhostObject and use that value
+        // to set the execution order so if it changes on GhostObject it updates here.
 #if UNITY_EDITOR
         private void OnValidate()
         {

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkClient.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkClient.cs
@@ -52,7 +52,7 @@ namespace Unity.Netcode
         /// <summary>
         /// The ClientId of the NetworkClient
         /// </summary>
-        public ulong ClientId;
+        public ulong ClientId { get; internal set; }
 
         /// <summary>
         /// The PlayerObject of the Client

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -365,7 +365,7 @@ namespace Unity.Netcode
 #if UNIFIED_NETCODE
         [HideInInspector]
         [SerializeField]
-        internal GhostAdapter GhostAdapter;
+        internal GhostObject GhostObject;
 
         [HideInInspector]
         [SerializeField]
@@ -388,16 +388,16 @@ namespace Unity.Netcode
         internal void UnifiedValidation()
         {
             NetworkObjectBridge = GetComponent<NetworkObjectBridge>();
-            GhostAdapter = GetComponent<GhostAdapter>();
+            GhostObject = GetComponent<GhostObject>();
 
-            HasGhost = GhostAdapter != null;
+            HasGhost = GhostObject != null;
             if (HasGhost)
             {
                 //TODO: Needs to be validated once develop-2.0.0 is merged.
                 if (InScenePlaced)
                 {
                     Debug.LogError($"This experimental version of NGO does not support hybrid in-scene placed objects.");
-                    Destroy(GhostAdapter);
+                    Destroy(GhostObject);
                     HasGhost = false;
                     return;
                 }
@@ -420,7 +420,7 @@ namespace Unity.Netcode
         {
             if (HasGhost)
             {
-                GhostAdapter.ApplyPostTransformMatrixScale(scale);
+                GhostObject.ApplyPostTransformMatrixScale(scale);
             }
         }
 #endif
@@ -3933,7 +3933,7 @@ namespace Unity.Netcode
                 return;
             }
 
-            if (!HasGhost || !NetworkObjectBridge || GhostAdapter.IsPrefab())
+            if (!HasGhost || !NetworkObjectBridge || GhostObject.IsPrefab())
             {
                 // Nothing to register
                 return;
@@ -3944,7 +3944,7 @@ namespace Unity.Netcode
             {
                 Debug.Log($"[{nameof(NetworkObject)}] GhostBridge {name} detected and instantiated.");
             }
-            if (GhostAdapter.WasInitialized && NetworkObjectBridge.NetworkObjectId.Value != 0)
+            if (GhostObject.WasInitialized && NetworkObjectBridge.NetworkObjectId.Value != 0)
             {
                 NetworkManager.SpawnManager.GhostSpawnManager.RegisterGhostBridge(NetworkObjectBridge.NetworkObjectId.Value, this);
             }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -3043,7 +3043,7 @@ namespace Unity.Netcode
             {
 #if COM_UNITY_MODULES_PHYSICS || COM_UNITY_MODULES_PHYSICS2D
                 // TODO-UNIFIED: This needs to be updated to make it "opt-in".
-                // If the GhostAdapter is not configured for prediction but is still using a Rigidbody, then go ahead and remove it on
+                // If the GhostObject is not configured for prediction but is still using a Rigidbody, then go ahead and remove it on
                 // the client side to improve performance by default.
                 // TODO-UNIFIED: Determine if recent unified physics updates does not require checking for prediction.
                 if (NetworkRigidbodies != null)
@@ -3084,8 +3084,8 @@ namespace Unity.Netcode
 #if UNIFIED_NETCODE_DESTROY
                 // When hybrid spawning, the transform is synchronized by the GhostObject.
                 // As a convenience, we remove and destroy all NetworkTransforms.
-                // TODO-Parenting-Related-Area: We need to replicate this functionality in a GhostAdapter
-                // Possibly use a "Synchronize" property and display only on children of a root parent GhostAdapter.
+                // TODO-Parenting-Related-Area: We need to replicate this functionality in a GhostObject
+                // Possibly use a "Synchronize" property and display only on children of a root parent GhostObject.
                 if (NetworkTransforms != null)
                 {
                     NetworkManager.Log.Warning(new Logging.Context(LogLevel.Developer, $"[]{name} Hybrid spawned objects do not support {nameof(NetworkTransform)} and " +
@@ -3896,7 +3896,7 @@ namespace Unity.Netcode
             Debug.Log("Disabled!");
             if (IsSpawned || HasGhost)
             {
-                if (HasGhost && GhostAdapter.IsPrefab())
+                if (HasGhost && GhostObject.IsPrefab())
                 {
                     return;
                 }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ParentSyncMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ParentSyncMessage.cs
@@ -125,7 +125,7 @@ namespace Unity.Netcode
 #if UNIFIED_NETCODE
             if (networkObject.HasGhost)
             {
-                // Handles the GhostAdapter side of things for parenting
+                // Handles the GhostObject side of things for parenting
                 networkObject.NetworkObjectBridge.HybridParentUpdate(Scale);
             }
             else

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -2781,7 +2781,7 @@ namespace Unity.Netcode
 
                 // We check to make sure the NetworkManager instance is the same one to be "NetcodeIntegrationTestHelpers" compatible and filter the list on a per-scene basis (for additive scenes)
 #if UNIFIED_NETCODE
-                // TODO: When we solve for GhostAdapter in-scene placed.
+                // TODO: When we solve for GhostObject in-scene placed.
                 if (!networkObjectInstance.HasGhost && networkObjectInstance.NetworkManagerOwner == NetworkManager && networkObjectInstance.isActiveAndEnabled)
 #else
                 if (networkObjectInstance.NetworkManagerOwner == NetworkManager && networkObjectInstance.isActiveAndEnabled)

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
@@ -2455,7 +2455,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
             // NetworkObject Ghost specific settings
             no.HasGhost = true;
-            no.GhostAdapter = adapter;
+            no.GhostObject = adapter;
             no.HadBridge = true;
             no.NetworkObjectBridge = bridge;
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTest.cs
@@ -733,8 +733,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
 #if UNIFIED_NETCODE
         private void RegisterPendingGhost(NetworkObject networkObject, ulong networkObjectId)
         {
-            var ghost = networkObject.GetComponent<GhostAdapter>();
-            Assert.IsNotNull(ghost, $"[RegisterPendingGhost][NetworkObject-{networkObjectId}] Has no {nameof(GhostAdapter)}!");
+            var ghost = networkObject.GetComponent<GhostObject>();
+            Assert.IsNotNull(ghost, $"[RegisterPendingGhost][NetworkObject-{networkObjectId}] Has no {nameof(GhostObject)}!");
             foreach (var networkManager in m_NetworkManagers)
             {
                 // If the world matches, then register the instance with this NetworkManager's spawn manager.
@@ -1837,9 +1837,9 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 {
 #if UNIFIED_NETCODE
                     // Handle removing the prefab reference and destroying it
-                    // and then destroying the ghostAdapter prior to destroying
+                    // and then destroying the GhostObject prior to destroying
                     // a hybrid prefab.
-                    var ghostAdapter = networkObject.GetComponent<GhostAdapter>();
+                    var ghostAdapter = networkObject.GetComponent<GhostObject>();
                     if (ghostAdapter != null)
                     {
                         if (ghostAdapter.prefabReference != null)
@@ -2423,10 +2423,10 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
             // When adding a Hybrid/Ghost prefab:
             // - We disabled the GameObject prior to adding the GhostPrefabReference (so IsPrefab() == true).
-            // - Add the GhostAdapter and GhostPrefabReference
+            // - Add the GhostObject and GhostPrefabReference
             // - Then set it back to active.
             gameObject.SetActive(false);
-            var adapter = gameObject.AddComponent<GhostAdapter>();
+            var adapter = gameObject.AddComponent<GhostObject>();
             // Mark the reference as post processing to avoid registering this instance automatically.
             GhostPrefabReference.s_IsPostProcessing = true;
             adapter.prefabReference = ScriptableObject.CreateInstance<GhostPrefabReference>();
@@ -2443,7 +2443,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             // with the dependency to prediction manual test).
             adapter.SupportedGhostModes = GhostModeMask.Interpolated;
 
-            // Once done with setting up the GhostAdapter, we can set it back to active in the hierarchy
+            // Once done with setting up the GhostObject, we can set it back to active in the hierarchy
             gameObject.SetActive(true);
 
             // GhostBehaviours that are part of a prefab will not invoke Ghost.InternalAcquireEntityReference
@@ -2460,7 +2460,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             no.NetworkObjectBridge = bridge;
 
             // Disable transform synchronization for NetworkObject serialization
-            // since that is handled by the GhostAdapter.
+            // since that is handled by the GhostObject.
             no.SynchronizeTransform = false;
 
             // Turn it into a test prefab


### PR DESCRIPTION
## Purpose of this PR

Changing GhostAdapter to GhostObject

### Jira ticket
_Link to related jira ticket ([Use the smart commits](https://support.atlassian.com/bitbucket-cloud/docs/use-smart-commits/)). Short version (e.g. MTT-123) also works and gets auto-linked_

### Changelog
[//]: # (updated with all public facing changes  - API changes, UI/UX changes, behaviour changes, bug fixes. Remove if not relevant.)

- Added: The package whose Changelog should be added to should be in the header. Delete the changelog section entirely if it's not needed.
- Fixed: If you update multiple packages, create a new section with a new header for the other package.
- Removed/Deprecated/Changed: Each bullet should be prefixed with Added, Fixed, Removed, Deprecated, or Changed to indicate where the entry should go.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- No documentation changes or additions were necessary.
- Includes documentation for previously-undocumented public API entry points.
- Includes edits to existing public API documentation.

## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Up-port
N/A

## Backports
N/A
