### PR TITLE
fix: NetworkVariable change prior to ownership change using distributed authority topology fails to sync NetworkVariable

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/FindObjects.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/FindObjects.cs
@@ -69,8 +69,8 @@ namespace Unity.Netcode
             internal ObjectsInSceneEnumerator(Scene scene, bool includeInactive)
             {
                 m_IncludeInactive = includeInactive;
-
-                m_RootObjects = scene.GetRootGameObjects();
+                // If the scene is invalid, use an empty array.
+                m_RootObjects = scene.IsValid() ? scene.GetRootGameObjects() : new UnityEngine.GameObject[0];
                 m_RootIndex = 0;
                 m_CurrentChildObjects = null;
                 m_CurrentChildIndex = 0;

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -2961,7 +2961,7 @@ namespace Unity.Netcode
         /// </remarks>
         /// <param name="originalOwnerId">the owner prior to beginning the change in ownership change.</param>
         /// <param name="originalPreviousOwnerId">the previous owner prior to beginning the change in ownership change.</param>
-        internal void SynchronizeOwnerNetworkVariables(ulong originalOwnerId, ulong originalPreviousOwnerId)
+        internal void SynchronizeOwnerNetworkVariables(ulong originalOwnerId, ulong originalPreviousOwnerId, bool authorityChangedOwnership = false)
         {
             var currentOwnerId = OwnerClientId;
             OwnerClientId = originalOwnerId;
@@ -2971,17 +2971,31 @@ namespace Unity.Netcode
                 childBehaviour.MarkOwnerReadDirtyAndCheckOwnerWriteIsDirty();
             }
 
+            // If the spawn authority of a distributed authority network topology has invoked a change in ownership,
+            // then we want to invoke the NetworkBehaviourUpdate prior to changing the owner back.
+            if (authorityChangedOwnership && NetworkManager.DistributedAuthorityMode)
+            {
+                // Force send a state update for all owner read NetworkVariables  and any currently dirty
+                // owner write NetworkVariables.
+                NetworkManagerOwner.BehaviourUpdater.NetworkBehaviourUpdate(true);
+            }
+
             // Now set the new owner and previous owner identifiers back to their original new values
-            // before we run the NetworkBehaviourUpdate. For owner read only permissions this order of
-            // operations is **particularly important** as we need to first (above) mark things as dirty
-            // from the context of the original owner and then second (below) we need to send the messages
-            // which requires the new owner to be set for owner read permission NetworkVariables.
+            // after we run the NetworkBehaviourUpdate.
             OwnerClientId = currentOwnerId;
             PreviousOwnerId = originalOwnerId;
 
-            // Force send a state update for all owner read NetworkVariables  and any currently dirty
-            // owner write NetworkVariables.
-            NetworkManagerOwner.BehaviourUpdater.NetworkBehaviourUpdate(true);
+            // For owner read only permissions this order of operations is **particularly important** as
+            // we need to first (above) mark things as dirty from the context of the original owner and
+            // then second (below) we need to send the messages which requires the new owner to be set.
+            // Note: Owner read only NetworkVariables do not make sense in a distributed authority topology
+            // since the only instance that can write is the owner.
+            if (!NetworkManager.DistributedAuthorityMode)
+            {
+                // Force send a state update for all owner read NetworkVariables and any currently dirty
+                // owner write NetworkVariables.
+                NetworkManagerOwner.BehaviourUpdater.NetworkBehaviourUpdate(true);
+            }
         }
 
         // NGO currently guarantees that the client will receive spawn data for all objects in one network tick.

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -2961,7 +2961,7 @@ namespace Unity.Netcode
         /// </remarks>
         /// <param name="originalOwnerId">the owner prior to beginning the change in ownership change.</param>
         /// <param name="originalPreviousOwnerId">the previous owner prior to beginning the change in ownership change.</param>
-        internal void SynchronizeOwnerNetworkVariables(ulong originalOwnerId, ulong originalPreviousOwnerId, bool authorityChangedOwnership = false)
+        internal void SynchronizeOwnerNetworkVariables(ulong originalOwnerId, ulong originalPreviousOwnerId)
         {
             var currentOwnerId = OwnerClientId;
             OwnerClientId = originalOwnerId;
@@ -2973,7 +2973,7 @@ namespace Unity.Netcode
 
             // If the spawn authority of a distributed authority network topology has invoked a change in ownership,
             // then we want to invoke the NetworkBehaviourUpdate prior to changing the owner back.
-            if (authorityChangedOwnership && NetworkManager.DistributedAuthorityMode)
+            if (NetworkManager.DistributedAuthorityMode)
             {
                 // Force send a state update for all owner read NetworkVariables  and any currently dirty
                 // owner write NetworkVariables.

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ChangeOwnershipMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ChangeOwnershipMessage.cs
@@ -241,7 +241,7 @@ namespace Unity.Netcode
             if (!distributedAuthorityMode && originalOwner == networkManager.LocalClientId)
             {
                 // Fully synchronize NetworkVariables with either read or write ownership permissions.
-                networkObject.SynchronizeOwnerNetworkVariables(originalOwner, networkObject.PreviousOwnerId);
+                networkObject.SynchronizeOwnerNetworkVariables(originalOwner, networkObject.PreviousOwnerId, true);
             }
 
             // Always invoke ownership change notifications

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ChangeOwnershipMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ChangeOwnershipMessage.cs
@@ -241,7 +241,7 @@ namespace Unity.Netcode
             if (!distributedAuthorityMode && originalOwner == networkManager.LocalClientId)
             {
                 // Fully synchronize NetworkVariables with either read or write ownership permissions.
-                networkObject.SynchronizeOwnerNetworkVariables(originalOwner, networkObject.PreviousOwnerId, true);
+                networkObject.SynchronizeOwnerNetworkVariables(originalOwner, networkObject.PreviousOwnerId);
             }
 
             // Always invoke ownership change notifications


### PR DESCRIPTION
## Purpose of this PR
This resolves the issue where in a distributed authority session changing a NetworkVariable prior to changing ownership in the same call-stack would result in the NetworkVariable not being synchronized.

### Jira ticket

[UUM-148291](https://jira.unity3d.com/browse/UUM-148291)

### Changelog

- Fixed: Issue where in a distributed authority session changing a `NetworkVariable` prior to changing ownership in the same call-stack would result in the `NetworkVariable` not being synchronized.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- No documentation changes or additions were necessary.


## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [x] `Manual testing done`
  - [NGO Examples UUM-148291 branch](https://github.cds.internal.unity3d.com/noel-stephens/ngo-examples/tree/replication%2FUUM-148291)

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [x] `Covered by new automated tests`
  - WIP

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Up-port

This will require an up-port.

## Backports

No backport is required.