### PR TITLE
chore: remove setting GhostField value work around

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Components/Helpers/NetworkObjectBridge.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Helpers/NetworkObjectBridge.cs
@@ -61,11 +61,6 @@ namespace Unity.Netcode
         /// N4E-spawned hybrid prefab instances.
         /// </summary>
         internal GhostField<ulong> NetworkObjectId = new GhostField<ulong>();
-        public void SetNetworkObjectId(ulong networkObjectId)
-        {
-            NetworkObjectId.PresetValue(networkObjectId);
-            NetworkObjectId.Value = networkObjectId;
-        }
 
         /// <summary>
         /// Currently, NGO provides the parenting event handling via <see cref="ParentSyncMessage"/>.

--- a/com.unity.netcode.gameobjects/Runtime/Components/Helpers/NetworkObjectBridge.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Helpers/NetworkObjectBridge.cs
@@ -11,7 +11,7 @@ namespace Unity.Netcode
     /// specific to the N4E-spawned hybrid prefab instance that has the matching <see cref="NetworkObjectId"/>.
     /// </summary>
 
-    [DefaultExecutionOrder(GhostObjectExecutionOrder.ExecutionOrder + 1)]
+    [DefaultExecutionOrder(GhostObject.ExecutionOrder + 1)]
     //BREAK --- Fix this on UNIFIED side 1st
     public partial class NetworkObjectBridge : GhostBehaviour
     {

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1176,7 +1176,7 @@ namespace Unity.Netcode
             // the NetworkObject is fully spawned.
             if (networkObject.HasGhost)
             {
-                networkObject.NetworkObjectBridge.SetNetworkObjectId(networkObject.NetworkObjectId);
+                networkObject.NetworkObjectBridge.NetworkObjectId.Value = networkObject.NetworkObjectId;
             }
 #endif
 


### PR DESCRIPTION
## Purpose of this PR

Removing the work around method as setting GhostField<T>.Value after instantiating works now.

### Jira ticket
NA

### Changelog
[//]: # (updated with all public facing changes  - API changes, UI/UX changes, behaviour changes, bug fixes. Remove if not relevant.)

NA

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- No documentation changes or additions were necessary.


## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [x] `Manual testing done`
  - Used NGO Examples unified branch.

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Up-port
N/A

## Backports
N/A
