### PR TITLE
chore: update permissions with note about Multiplayer Services

### DIFF
--- a/com.unity.netcode.gameobjects/Documentation~/components/core/networkmanager.md
+++ b/com.unity.netcode.gameobjects/Documentation~/components/core/networkmanager.md
@@ -19,6 +19,15 @@ The NetworkManager is a required Netcode for GameObjects component that has all 
 - **Enable Scene Management**: When checked, Netcode for GameObjects will handle scene management and client synchronization for you.  When not checked, you will have to create your own scene management scripts and handle client synchronization.
 - **Load Scene Time Out**: When Enable Scene Management is checked, this specifies the period of time the `NetworkSceneManager` will wait while a scene is being loaded asynchronously before `NetworkSceneManager` considers the load/unload scene event to have failed/timed out.
 
+### Distributed authority network topology
+
+> [!NOTE]
+> The distributed authority network topology requires Multiplayer Services. If the Multiplayer Services package is not installed, the **Network Topology** property will not be displayed.
+
+- **Network Topology**:  Defines the network topology to use.
+  - **Client-Server**: Selects the client-server network topology.
+  - **Distributed authority**: Selects the distributed authority network topology.
+
 ## NetworkManager sub-systems
 NetworkManager is also where you can find references to other Netcode related management systems:<br/>
 

--- a/com.unity.netcode.gameobjects/Documentation~/components/core/networkobject-ownership.md
+++ b/com.unity.netcode.gameobjects/Documentation~/components/core/networkobject-ownership.md
@@ -112,7 +112,7 @@ The authority of any NetworkObject can always change ownership, as outlined in [
 ### Ownership permission settings
 
 > [!NOTE]
-> Permissions are only valid when using the distributed authority network topology that requires Multiplayer Services. If the Multiplayer Services package is not installed, the permissions setting will not be displayed.
+> Permissions are only valid when using the distributed authority network topology, which requires Multiplayer Services. If the Multiplayer Services package is not installed, the permissions setting will not be displayed.
 
 The following ownership permission settings, defined by [`NetworkObject.OwnershipStatus`](xref:Unity.Netcode.NetworkObject.OwnershipStatus), control how ownership of NetworkObjects can be changed during a distributed authority session:
 

--- a/com.unity.netcode.gameobjects/Documentation~/components/core/networkobject-ownership.md
+++ b/com.unity.netcode.gameobjects/Documentation~/components/core/networkobject-ownership.md
@@ -111,6 +111,9 @@ The authority of any NetworkObject can always change ownership, as outlined in [
 
 ### Ownership permission settings
 
+> [!NOTE]
+> Permissions are only valid when using the distributed authority network topology that requires Multiplayer Services. If the Multiplayer Services package is not installed, the permissions setting will not be displayed.
+
 The following ownership permission settings, defined by [`NetworkObject.OwnershipStatus`](xref:Unity.Netcode.NetworkObject.OwnershipStatus), control how ownership of NetworkObjects can be changed during a distributed authority session:
 
 |**Ownership setting**|Description|Related Property|Multi-select|


### PR DESCRIPTION
## Purpose of this PR

Adding note about permissions not displaying if the Multiplayer Services is not installed.

### Jira ticket

[DOCMP-1669](https://jira.unity3d.com/browse/DOCMP-1669)

### Changelog
[//]: # (updated with all public facing changes  - API changes, UI/UX changes, behaviour changes, bug fixes. Remove if not relevant.)

NA

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- Includes edits to existing public API documentation.

## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Up-port

This requires an up-port to develop-3.x.x.

## Backports

N/A